### PR TITLE
CN - 1) Added support for requiring the SwH (AKA Trainer)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -246,6 +246,12 @@ GVARS = NO
 # Values = NO, POT1, POT2, POT3,
 3POS = NO
 
+# Enable support for newlines in strings output to the LCD (allows multi-line popup box message)
+PUTS_NEWLINE_SUPPORT = NO
+
+# Enable support for requiring the SwH switch to be on before enabling the range test (PCBTARANIS only)
+SWH_RANGE_TEST = NO
+
 #------- END BUILD OPTIONS ---------------------------
 
 # Define programs and commands.
@@ -964,6 +970,14 @@ endif
 ifeq ($(3POS), POT3)
   CPPDEFS += -DEXTRA_3POS=3
   # EEPROM_VARIANT += ${3POS_VARIANT}
+endif
+
+ifeq ($(PUTS_NEWLINE_SUPPORT), YES)
+  CPPDEFS += -DPUTS_NEWLINE_SUPPORT
+endif
+
+ifeq ($(SWH_RANGE_TEST), YES)
+  CPPDEFS += -DSWH_RANGE_TEST
 endif
 
 #---------------- Compiler Options C++ ----------------

--- a/src/gui/menu_general.cpp
+++ b/src/gui/menu_general.cpp
@@ -174,6 +174,9 @@ enum menuGeneralSetupItems {
 #if defined(SPLASH) && !defined(FSPLASH)
   ITEM_SETUP_DISABLE_SPLASH,
 #endif
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+  ITEM_SETUP_ENABLE_SWH_FOR_RANGE_TEST,
+#endif
   IF_GPS(ITEM_SETUP_TIMEZONE)
   IF_GPS(ITEM_SETUP_GPSFORMAT)
   IF_PXX(ITEM_SETUP_COUNTRYCODE)
@@ -520,6 +523,11 @@ void menuGeneralSetup(uint8_t event)
         g_eeGeneral.splashMode = 1 - onoffMenuItem(b, RADIO_SETUP_2ND_COLUMN, y, STR_SPLASHSCREEN, attr, event);
         break;
       }
+#endif
+#if defined (PCBTARANIS) && defined(SWH_RANGE_TEST)
+      case ITEM_SETUP_ENABLE_SWH_FOR_RANGE_TEST:
+        g_eeGeneral.rangeNeedsSwH = onoffMenuItem(g_eeGeneral.rangeNeedsSwH, RADIO_SETUP_2ND_COLUMN, y, "Range test needs SwH", attr, event ) ;
+        break;
 #endif
 
 #if defined(FRSKY) && defined(FRSKY_HUB) && defined(GPS)

--- a/src/myeeprom.h
+++ b/src/myeeprom.h
@@ -283,7 +283,11 @@ PACK(typedef struct t_EEGeneral {
   uint8_t   disableAlarmWarning:1;
   uint8_t   stickMode:2;
   int8_t    timezone:5;
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+  uint8_t   rangeNeedsSwH:1;    // SwH needs to be held on before range test is enabled
+#else
   uint8_t   spare1:1;
+#endif
   uint8_t   inactivityTimer;
   uint8_t   mavbaud:3;
   SPLASH_MODE; /* 3bits */

--- a/src/opentx.h
+++ b/src/opentx.h
@@ -377,6 +377,7 @@ enum EnumKeys {
   #define SWSRC_ID1     SWSRC_SA1
   #define SWSRC_ID2     SWSRC_SA2
   #define SW_DSM2_BIND  SW_SH2
+  #define SW_RANGE  	SW_SH2	// RANGE test only enabled when this switch is active
 #else
   #define NUM_SWITCHES  7
   #define IS_3POS(sw)   ((sw) == 0)

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -471,6 +471,9 @@ const pm_char STR_PATH_TOO_LONG[] PROGMEM = "Path too long";
 #if defined(PCBTARANIS) || defined(DSM2)
   const pm_char STR_MODULE_RANGE[] PROGMEM = TR_MODULE_RANGE;
 #endif
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+    const pm_char STR_HOLD_TRAINER_KEY[] PROGMEM = TR_HOLD_TRAINER_KEY;
+#endif
 
 #if defined(MAVLINK)
   const pm_char STR_MAVLINK_RC_RSSI_SCALE_LABEL[] PROGMEM = TR_MAVLINK_RC_RSSI_SCALE_LABEL;

--- a/src/translations.h
+++ b/src/translations.h
@@ -72,6 +72,12 @@
   #define TR(x,y) x
 #endif
 
+#if defined(PUTS_NEWLINE_SUPPORT)
+  #define NL(x,y) x // string x may contain NL ('\n') characters
+#else
+  #define NL(x,y) y
+#endif
+
 // The non-0-terminated-strings
 
 extern const pm_char STR_OPEN9X[];
@@ -652,6 +658,9 @@ extern const pm_char STR_PATH_TOO_LONG[];
 
 #if defined(PCBTARANIS) || defined(DSM2)
   extern const pm_char STR_MODULE_RANGE[];
+#endif
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+  extern const pm_char STR_HOLD_TRAINER_KEY[];
 #endif
 
 #if defined(MAVLINK)

--- a/src/translations/cz.h.txt
+++ b/src/translations/cz.h.txt
@@ -646,6 +646,9 @@
 #define TR_BYTES               "[B]"
 #define TR_MODULE_BIND         "[Bind]"
 #define TR_MODULE_RANGE        "[Range]"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_RESET               "[Reset]"
 #define TR_SET                 "[Volby]"
 #define TR_TRAINER             "Trenér"

--- a/src/translations/de.h.txt
+++ b/src/translations/de.h.txt
@@ -646,6 +646,9 @@
 #define TR_BYTES               "bytes"
 #define TR_MODULE_BIND         "[Bind]"
 #define TR_MODULE_RANGE        "[Range]"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_RESET               "[Reset]"
 #define TR_SET                 "[Set]"
 #define TR_TRAINER             "----Trainer Buchse Einst.------" //DSC Buchse Funktion

--- a/src/translations/en.h
+++ b/src/translations/en.h
@@ -646,6 +646,9 @@
 #define TR_BYTES               "bytes"
 #define TR_MODULE_BIND         "[Bind]"
 #define TR_MODULE_RANGE        "[Range]"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key ON to\nenable the range test","Hold Trainer key ON to enable")
+#endif
 #define TR_RESET               "[Reset]"
 #define TR_SET                 "[Set]"
 #define TR_TRAINER             "Trainer"

--- a/src/translations/es.h.txt
+++ b/src/translations/es.h.txt
@@ -436,6 +436,9 @@
 #define TR_GV                  "GV"
 #define TR_ACHANNEL            "A\004canal"
 #define TR_RANGE               INDENT"Alcance"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key ON to\nenable the range test","Hold Trainer key ON to enable")
+#endif
 #define TR_BAR                 "Bar"
 #define TR_ALARM               INDENT"Alarma"
 #define TR_USRDATA             "UsrData"

--- a/src/translations/fr.h.txt
+++ b/src/translations/fr.h.txt
@@ -436,6 +436,9 @@
 #define TR_GV                  "VG"
 #define TR_ACHANNEL            "A"
 #define TR_RANGE               INDENT"Plage"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_BAR                 "Barre"
 #define TR_ALARM               INDENT"Alarme"
 #define TR_USRDATA             "Données"

--- a/src/translations/it.h.txt
+++ b/src/translations/it.h.txt
@@ -436,6 +436,9 @@
 #define TR_GV                  "GV"
 #define TR_ACHANNEL            "A\002ingresso"
 #define TR_RANGE               INDENT"Interv."
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_BAR                 "Barra"
 #define TR_ALARM               INDENT"Allarme"
 #define TR_USRDATA             "Dati"

--- a/src/translations/pt.h.txt
+++ b/src/translations/pt.h.txt
@@ -436,6 +436,9 @@
 #define TR_GV                  "GV"
 #define TR_ACHANNEL            "A\004Canal"
 #define TR_RANGE               INDENT"Range"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_BAR                 "Bar"
 #define TR_ALARM               INDENT"Alarme"
 #define TR_USRDATA             "UsrData"

--- a/src/translations/se.h.txt
+++ b/src/translations/se.h.txt
@@ -436,6 +436,9 @@
 #define TR_GV                  "GV"
 #define TR_ACHANNEL            "A\004kanal  "
 #define TR_RANGE               INDENT"MinMax"
+#if defined(PCBTARANIS) && defined(SWH_RANGE_TEST)
+#define TR_HOLD_TRAINER_KEY    NL("Hold the Trainer key to\nenable the range test","Hold Trainer key to enable")
+#endif
 #define TR_BAR                 "Data"
 #define TR_ALARM               INDENT"Alarm"
 #define TR_USRDATA             "Användardata"


### PR DESCRIPTION
 switch to be ON before enabling the range test. This
 feature may be enabled/disabled in the main setup menu and
 will apply to all models. When enabled, a popup box appears
 when the range test feature is turned on that prompts the
 user to turn the Tranier switch ON to enable the range
 test. Added so that the user is less likely to leave the
 range test feature on by accident, and also allows the user
 to easily switch the range test on and off. Only included
 when PCB=TARANIS. Set the compile time option
 SWH_RANGE_TEST=YES to include this functionality. Could be
 used to resolve issue #159.
2) Added support for including '\n' characters in popup box
 messages. Used by the SWH_RANGE_TEST option when displaying
 the range test enable prompt.
