### PR TITLE
Fixed problem on Linux. Hopfully did not break Windows.

### DIFF
--- a/companion/src/main.cpp
+++ b/companion/src/main.cpp
@@ -116,14 +116,15 @@ int main(int argc, char *argv[])
     current_firmware_variant = GetFirmwareVariant(firmware_id);
     // qDebug() << current_firmware_variant;
 
+    MainWindow mainWin;
+	
     if (showSplash) {
       splash->show();
-      splash->showMessage(QObject::tr(""));
-      sleep(SPLASH_TIME);
+      QTimer::singleShot(1000*SPLASH_TIME, splash, SLOT(close()));
+      QTimer::singleShot(1000*SPLASH_TIME, &mainWin, SLOT(show()));
     }
-
-    MainWindow mainWin;
-    mainWin.show();
-    splash->finish(&mainWin);
+    else  {
+      mainWin.show();
+    }
     return app.exec();
 }

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -112,9 +112,15 @@ downloadDialog_forWait(NULL)
     QNetworkProxyFactory::setUseSystemConfiguration(true);
     setAcceptDrops(true);
     
-    // give time to the main windows to open before starting updates, delay 1s
-    QTimer::singleShot(1000, this, SLOT(doAutoUpdates()));
-    QTimer::singleShot(1000, this, SLOT(displayWarnings()));
+    // give time to the splash to disappear and main window to open before starting updates
+    int updateDelay = 1000;
+    QSettings settings("companion9x", "companion9x");
+    bool showSplash = settings.value("show_splash", true).toBool();
+    if (showSplash) 
+	updateDelay += (SPLASH_TIME*1000); 
+    QTimer::singleShot(updateDelay, this, SLOT(doAutoUpdates()));
+    QTimer::singleShot(updateDelay, this, SLOT(displayWarnings()));
+
     QStringList strl = QApplication::arguments();
     QString str;
     QString printfilename;

--- a/companion/src/translations/companion9x_sv.ts
+++ b/companion/src/translations/companion9x_sv.ts
@@ -322,7 +322,7 @@ Gasen reverseras om alternativet väljs. Tomgång ligger då uppåt. Trim och ga
     <message>
         <location line="+528"/>
         <source>Show Splash Screen on Startup</source>
-        <translation>Visa bild vid start av sändare</translation>
+        <translation>Visa Startbild</translation>
     </message>
     <message>
         <location line="+182"/>
@@ -9450,7 +9450,7 @@ Tryck på Avbryt för att avburyta kalibreringen</translation>
     <message>
         <location line="-233"/>
         <source>Show Splash Screen</source>
-        <translation>Visa bild vid start av sändare</translation>
+        <translation>Visa Startbild</translation>
     </message>
     <message>
         <location line="+767"/>


### PR DESCRIPTION
Fixed splash display problem on Linux.
Also fixed error in Swedish translation that had to do with the PC splash screen (I had mixed up radio and PC splash)
