### PR TITLE
Mirroring SmartPort data over Taranis UART3 ( next )

### DIFF
--- a/radio/src/Makefile
+++ b/radio/src/Makefile
@@ -63,6 +63,10 @@ PCBREV =
 # Values = STD, FRSKY, JETI, NMEA, ARDUPILOT, MAVLINK, TELEMETREZ
 EXT = STD
 
+# Enable mirroring Smarport data on serial port ( Taranis )
+# Dont' use it with DEBUG enabled
+SMARTPORT2SERIAL = NO
+
 # FAI mode
 # Values = YES, NO, CHOICE
 FAI = NO
@@ -644,7 +648,11 @@ ifeq ($(PCB), TARANIS)
     CPPDEFS += -DVOICE
     INCDIRS += FatFs FatFs/option
   endif
-    
+  
+  ifeq ($(SMARTPORT2SERIAL), YES)
+  	CPPDEFS += -DSMARTPORT2SERIAL
+  endif  
+  
   ifeq ($(RTCLOCK), YES)
     CPPDEFS += -DRTCLOCK
     CPPSRC += rtc.cpp targets/taranis/rtc_driver.cpp

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -166,6 +166,12 @@
 #define IF_SDCARD(x)
 #endif
 
+#if defined(SMARTPORT2SERIAL)
+#define IF_SMARTPORT2SERIAL(x) x,
+#else
+#define IF_SMARTPORT2SERIAL(x)
+#endif
+
 #if defined(BLUETOOTH)
 #define IF_BLUETOOTH(x) x,
 #else

--- a/radio/src/targets/taranis/board_taranis.cpp
+++ b/radio/src/targets/taranis/board_taranis.cpp
@@ -195,6 +195,9 @@ void boardInit()
 #if defined(DEBUG)
   uartInit(DEBUG_UART_BAUDRATE);
 #endif
+#if defined(SMARTPORT2SERIAL) && !defined(DEBUG)
+  uartInit(SPORT_BAUDRATE);
+#endif
   init5msTimer();
   __enable_irq();
   eepromInit();

--- a/radio/src/targets/taranis/uart_driver.cpp
+++ b/radio/src/targets/taranis/uart_driver.cpp
@@ -69,7 +69,7 @@ void uartInit(uint32_t baudrate)
   USART_ITConfig(UART3, USART_IT_TXE, DISABLE);
 
   NVIC_EnableIRQ(USART3_IRQn);
-  NVIC_SetPriority(USART3_IRQn, 8);
+  NVIC_SetPriority(USART3_IRQn, 7);
 }
 
 #if defined(DEBUG)
@@ -85,6 +85,29 @@ extern "C" void USART3_IRQHandler(void)
   if (USART_GetITStatus(UART3, USART_IT_TXE) != RESET) {
     uint8_t txchar;
     if (debugTxFifo.pop(txchar)) {
+      /* Write one byte to the transmit data register */
+      USART_SendData(UART3, txchar);
+    }
+    else {
+      USART_ITConfig(UART3, USART_IT_TXE, DISABLE);
+    }
+  }
+}
+#endif
+
+#if defined(SMARTPORT2SERIAL) && !defined(DEBUG)
+Fifo<512> sp2sTxFifo;
+void sp2sPutc(const char c)
+{
+  sp2sTxFifo.push(c);
+  USART_ITConfig(UART3, USART_IT_TXE, ENABLE);
+}
+
+extern "C" void USART3_IRQHandler(void)
+{
+  if (USART_GetITStatus(UART3, USART_IT_TXE) != RESET) {
+    uint8_t txchar;
+    if (sp2sTxFifo.pop(txchar)) {
       /* Write one byte to the transmit data register */
       USART_SendData(UART3, txchar);
     }

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -526,6 +526,10 @@ void processSerialData(uint8_t data)
   btPushByte(data);
 #endif
 
+#if defined(SMARTPORT2SERIAL) && !defined(DEBUG)
+  sp2sPutc(data);
+#endif
+
   if (data == START_STOP) {
     dataState = STATE_DATA_IN_FRAME;
     numPktBytes = 0;


### PR DESCRIPTION
Resubmitting for Next branch.

This fix #83 issue.
Still needs an inverter behind serial port. This makes me wonder if this patch is really necessary then.
Would be the same thing to solder directly on smartport pad in the radio.

Anyway, if people asked for it, here is it.
