### PR TITLE
Bugfix for GVARS in weight for stock and ranges for ARM based transmitter

### DIFF
--- a/radio/src/gui/menu_model.cpp
+++ b/radio/src/gui/menu_model.cpp
@@ -3077,7 +3077,7 @@ void gvarWeightItem(xcoord_t x, uint8_t y, MixData *md, uint8_t attr, uint8_t ev
 {
   u_int8int16_t weight;
   MD_WEIGHT_TO_UNION(md, weight);
-  weight.word = GVAR_MENU_ITEM(x, y, weight.word, -500, 500, attr, 0, event);
+  weight.word = GVAR_MENU_ITEM(x, y, weight.word, GV_RANGELARGE_WEIGHT_NEG, GV_RANGELARGE_WEIGHT, attr, 0, event);
   MD_UNION_TO_WEIGHT(weight, md);
 }
 
@@ -3155,7 +3155,7 @@ void menuModelMixOne(uint8_t event)
         lcd_putsColumnLeft(COLUMN_X, y, NO_INDENT(STR_OFFSET));
         u_int8int16_t offset;
         MD_OFFSET_TO_UNION(md2, offset);
-        offset.word = GVAR_MENU_ITEM(COLUMN_X+MIXES_2ND_COLUMN, y, offset.word, GV_RANGELARGE_NEG, GV_RANGELARGE, attr|LEFT, 0, event);
+        offset.word = GVAR_MENU_ITEM(COLUMN_X+MIXES_2ND_COLUMN, y, offset.word, GV_RANGELARGE_OFFSET_NEG, GV_RANGELARGE_OFFSET, attr|LEFT, 0, event);
         MD_UNION_TO_OFFSET(offset, md2);
         break;
       }

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -519,6 +519,16 @@ PACK(typedef struct t_LimitData {
 #define MLTPX_REP   2
 
 #if defined(CPUARM)
+// highest bit used for small values in mix 128 --> 8 bit is enough
+#define GV1_SMALL  128
+// highest bit used for large values in mix 4096 --> 12 bits is used (type for weight and offset has even 16 bits)
+#define GV1_LARGE  4096
+// the define GV1_LARGE marks the highest bit value used for this variables
+// because this would give too big numbers for ARM, we limit it further for offset and weight
+// must be smaller than GV1_LARGE - RESERVE_RANGE_FOR_GVARS -1
+#define GV_RANGE_WEIGHT 500
+#define GV_RANGE_OFFSET 490
+
 #define DELAY_STEP  10
 #define SLOW_STEP   10
 #define DELAY_MAX   (25*DELAY_STEP) /* 25 seconds */
@@ -584,6 +594,12 @@ PACK( union u_int8int16_t {
 // #define MD_SETOFFSET(md, val) md->offset = val
 
 #else
+
+// highest bit used for small values in mix 128 --> 8 bit is enough
+#define GV1_SMALL  128
+// highest bit used for large values in mix 256 --> 9 bits is used (8 bits + 1 extra bit from weightMode/offsetMode)
+#define GV1_LARGE  256
+
 #define DELAY_STEP  2
 #define SLOW_STEP   2
 #define DELAY_MAX   15 /* 7.5 seconds */

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -906,13 +906,9 @@ void setTrimValue(uint8_t phase, uint8_t idx, int trim);
 #endif
 
 #if defined(CPUARM)
-  #define GV1_SMALL  128
-  #define GV1_LARGE  4096
   #define GV_GET_GV1_VALUE(max)        ( (max<=GV_RANGESMALL && min>=GV_RANGESMALL_NEG) ? GV1_SMALL : GV1_LARGE )
   #define GV_INDEX_CALCULATION(x,max)  ( (max<=GV_RANGESMALL && min>=GV_RANGESMALL_NEG) ? (uint8_t) x-GV1_SMALL : ((x&(GV1_LARGE*2-1))-GV1_LARGE) )
 #else
-  #define GV1_SMALL  128
-  #define GV1_LARGE  256
   #define GV_GET_GV1_VALUE(max)        ( (max<=GV_RANGESMALL) ? GV1_SMALL : GV1_LARGE )
   #define GV_INDEX_CALCULATION(x,max)  ( (max<=GV1_SMALL) ? (uint8_t) x-GV1_SMALL : ((x&(GV1_LARGE*2-1))-GV1_LARGE) )
 #endif
@@ -927,6 +923,21 @@ void setTrimValue(uint8_t phase, uint8_t idx, int trim);
 #define GV_RANGESMALL_NEG  (-GV1_SMALL + (RESERVE_RANGE_FOR_GVARS+1))
 #define GV_RANGELARGE      (GV1_LARGE - (RESERVE_RANGE_FOR_GVARS+1))
 #define GV_RANGELARGE_NEG  (-GV1_LARGE + (RESERVE_RANGE_FOR_GVARS+1))
+#if defined(CPUARM)
+  // the define GV1_LARGE marks the highest bit value used for this variables
+  // because this would give too big numbers for ARM, we limit it further for
+  // offset and weight
+  #define GV_RANGELARGE_WEIGHT      (GV_RANGE_WEIGHT)
+  #define GV_RANGELARGE_WEIGHT_NEG (-GV_RANGE_WEIGHT)
+  #define GV_RANGELARGE_OFFSET      (GV_RANGE_OFFSET)
+  #define GV_RANGELARGE_OFFSET_NEG (-GV_RANGE_OFFSET)
+#else
+  // for stock we just use as much as possible
+  #define GV_RANGELARGE_WEIGHT      GV_RANGELARGE
+  #define GV_RANGELARGE_WEIGHT_NEG  GV_RANGELARGE_NEG
+  #define GV_RANGELARGE_OFFSET      GV_RANGELARGE
+  #define GV_RANGELARGE_OFFSET_NEG  GV_RANGELARGE_NEG
+#endif
 
 extern uint16_t s_timeCumTot;
 extern uint16_t s_timeCumThr;


### PR DESCRIPTION
For All:
- GV1_XXX constants are now in myeeprom.h to be close to the mixer defines
  (they need to match to the defined types, e.g. needs to have enough bits)

For Stock:
- bugfix gvars not working for weight for stock transmitter

For ARM based Transmitter:
- limits offset now to 490 (instead of 4085)
- limits for weight and offset can be easily changed in myeeprom.h, with defines
  #define GV_RANGE_WEIGHT 500
  #define GV_RANGE_OFFSET 490
  (be sure they are not bigger than something about 4000)

No code cost
