### PR TITLE
Display of calibration data and time stamp added to profile tab

### DIFF
--- a/companion/src/appdata.cpp
+++ b/companion/src/appdata.cpp
@@ -296,6 +296,7 @@ QString Profile::display()       const { return _display;       }
 QString Profile::haptic()        const { return _haptic;        }
 QString Profile::speaker()       const { return _speaker;       }
 QString Profile::stickPotCalib() const { return _stickPotCalib; }
+QString Profile::timeStamp()     const { return _timeStamp;     }
 QString Profile::trainerCalib()  const { return _trainerCalib;  }
 int     Profile::currentCalib()  const { return _currentCalib;  }
 int     Profile::gsStickMode()   const { return _gsStickMode;   }
@@ -320,6 +321,7 @@ void Profile::display       (const QString x) { store(x, _display,       "Displa
 void Profile::haptic        (const QString x) { store(x, _haptic,        "Haptic"                ,"Profiles", QString("profile%1").arg(index));}
 void Profile::speaker       (const QString x) { store(x, _speaker,       "Speaker"               ,"Profiles", QString("profile%1").arg(index));}
 void Profile::stickPotCalib (const QString x) { store(x, _stickPotCalib, "StickPotCalib"         ,"Profiles", QString("profile%1").arg(index));}
+void Profile::timeStamp     (const QString x) { store(x, _timeStamp,     "TimeStamp"             ,"Profiles", QString("profile%1").arg(index));}
 void Profile::trainerCalib  (const QString x) { store(x, _trainerCalib,  "TrainerCalib"          ,"Profiles", QString("profile%1").arg(index));}
 void Profile::currentCalib  (const int     x) { store(x, _currentCalib,  "currentCalib"          ,"Profiles", QString("profile%1").arg(index));}
 void Profile::gsStickMode   (const int     x) { store(x, _gsStickMode,   "GSStickMode"           ,"Profiles", QString("profile%1").arg(index));}
@@ -385,6 +387,24 @@ bool Profile::existsOnDisk()
     return (keyList.length() > 0);
 }
 
+void Profile::initFwVariables()
+{
+    _beeper =        "";
+    _countryCode =   "";
+    _display =       "";
+    _haptic =        "";
+    _speaker =       "";
+    _stickPotCalib = "";
+    _timeStamp =     "";
+    _trainerCalib =  "";
+
+    _currentCalib =  0;
+    _gsStickMode =   0;
+    _ppmMultiplier = 0;
+    _vBatCalib =     0;
+    _vBatWarn =      0;
+}
+
 void Profile::init(int newIndex)
 {
     index = newIndex;
@@ -399,19 +419,7 @@ void Profile::init(int newIndex)
     _channelOrder =  0;
     _defaultMode =   1;
 
-    _beeper =        "";
-    _countryCode =   "";
-    _display =       "";
-    _haptic =        "";
-    _speaker =       "";
-    _stickPotCalib = "";
-    _trainerCalib =  "";
-
-    _currentCalib =  0;
-    _gsStickMode =   0;
-    _ppmMultiplier = 0;
-    _vBatCalib =     0;
-    _vBatWarn =      0;
+    initFwVariables();
 
     // Do not write empty profiles to disk except the default (0) profile.
     if ( index > 0 && !existsOnDisk())
@@ -439,6 +447,7 @@ void Profile::flush()
     getset( _haptic,        "Haptic"                ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _speaker,       "Speaker"               ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _stickPotCalib, "StickPotCalib"         ,""     ,"Profiles", QString("profile%1").arg(index));
+    getset( _timeStamp,     "TimeStamp"             ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _trainerCalib,  "TrainerCalib"          ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _currentCalib,  "currentCalib"          ,0      ,"Profiles", QString("profile%1").arg(index));
     getset( _gsStickMode,   "GSStickMode"           ,0      ,"Profiles", QString("profile%1").arg(index));

--- a/companion/src/appdata.h
+++ b/companion/src/appdata.h
@@ -109,6 +109,7 @@ class Profile: protected CompStoreObj
     QString _haptic;
     QString _speaker;
     QString _stickPotCalib;
+    QString _timeStamp;
     QString _trainerCalib;
     int     _currentCalib;
     int     _gsStickMode;
@@ -134,6 +135,7 @@ class Profile: protected CompStoreObj
     QString haptic() const;
     QString speaker() const;
     QString stickPotCalib() const;
+    QString timeStamp() const;
     QString trainerCalib() const;
     int     currentCalib() const;
     int     gsStickMode() const;
@@ -158,6 +160,7 @@ class Profile: protected CompStoreObj
     void haptic        (const QString);
     void speaker       (const QString);
     void stickPotCalib (const QString);
+    void timeStamp     (const QString);
     void trainerCalib  (const QString);
     void currentCalib  (const int);
     void gsStickMode   (const int);
@@ -170,6 +173,7 @@ class Profile: protected CompStoreObj
     void remove();
     bool existsOnDisk();
     void init(int newIndex);
+    void initFwVariables();
     void flush();
 };
 

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -69,12 +69,13 @@ void appPreferencesDialog::writeValues()
   else
     g.profile[g.id()].name(ui->profileNameLE->text());
 
-  // If a new radio type has been choosen, several things need to change
+  // If a new radio type has been choosen, several things need to reset
   if ( initialRadioType != ui->radioCB->currentIndex())
   {
     g.profile[g.id()].fwName("");
     g.profile[g.id()].fwType(getDefaultFwType(ui->radioCB->currentIndex()));
-    current_firmware_variant = GetFirmwareVariant(g.profile[g.id()].fwType());  
+    current_firmware_variant = GetFirmwareVariant(g.profile[g.id()].fwType());
+    g.profile[g.id()].initFwVariables();
   }
 }
 
@@ -156,11 +157,23 @@ void appPreferencesDialog::initSettings()
   ui->sdPath->setText(g.profile[g.id()].sdPath());
   ui->profileNameLE->setText(g.profile[g.id()].name());
   ui->SplashFileName->setText(g.profile[g.id()].splashFile());
-
   initialRadioType = getRadioType(g.profile[g.id()].fwType());
   ui->radioCB->setCurrentIndex(initialRadioType);
-
   displayImage( g.profile[g.id()].splashFile() );
+
+  QString hwSettings;
+  if (g.profile[g.id()].stickPotCalib() == "" ) {
+    hwSettings = QString(tr("EMPTY: No radio settings stored in profile"));
+  }
+  else  {
+    QString str = g.profile[g.id()].timeStamp();
+    if (str.isEmpty())
+      hwSettings = QString(tr("AVAILABLE: Radio settings of unknown age"));
+    else
+      hwSettings = QString(tr("AVAILABLE: Radio settings stored %1").arg(str));
+  }
+  ui->lblGeneralSettings->setText(hwSettings);
+
 }
 
 void appPreferencesDialog::on_libraryPathButton_clicked()

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>734</width>
-    <height>492</height>
+    <width>640</width>
+    <height>499</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,22 +26,21 @@
    <string>Edit Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
    <property name="verticalSpacing">
     <number>2</number>
    </property>
-   <property name="margin">
-    <number>6</number>
-   </property>
-   <item row="2" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -52,7 +51,20 @@
        <string>Radio Profile</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="10" column="1" colspan="3">
+       <item row="20" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="12" column="1" colspan="3">
         <widget class="QComboBox" name="stickmodeCB">
          <property name="maximumSize">
           <size>
@@ -106,7 +118,7 @@ Mode 4:
          </item>
         </widget>
        </item>
-       <item row="12" column="1" colspan="3">
+       <item row="14" column="1" colspan="3">
         <widget class="QComboBox" name="channelorderCB">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -256,7 +268,7 @@ This is used by the templated to determine which channel goes to what number out
          </item>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_14">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -276,20 +288,7 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_8">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -302,7 +301,7 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_13">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -318,14 +317,14 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="13" column="1" colspan="3">
+       <item row="15" column="1" colspan="3">
         <widget class="QCheckBox" name="renameFirmware">
          <property name="text">
           <string>Append version number to FW file name</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="sdPathLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -341,7 +340,7 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="2" column="1" colspan="2">
+       <item row="4" column="1" colspan="2">
         <widget class="QLineEdit" name="sdPath">
          <property name="enabled">
           <bool>true</bool>
@@ -363,35 +362,28 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="14" column="1" colspan="3">
+       <item row="16" column="1" colspan="3">
         <widget class="QCheckBox" name="burnFirmware">
          <property name="text">
           <string>Offer to write FW to Tx after download</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="5">
-        <widget class="QPushButton" name="removeProfileButton">
-         <property name="text">
-          <string>Remove Profile</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="5">
+       <item row="4" column="5">
         <widget class="QPushButton" name="sdPathButton">
          <property name="text">
           <string>Open Folder</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="1" colspan="5">
+       <item row="11" column="1" colspan="5">
         <widget class="Line" name="line_6">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="4" column="1" colspan="2">
+       <item row="6" column="1" colspan="2">
         <widget class="QLineEdit" name="SplashFileName">
          <property name="enabled">
           <bool>true</bool>
@@ -413,14 +405,14 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="7" column="5">
+       <item row="9" column="5">
         <widget class="QPushButton" name="clearImageButton">
          <property name="text">
           <string>Clear Image</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="5">
+       <item row="6" column="5">
         <widget class="QPushButton" name="SplashSelect">
          <property name="text">
           <string>Select Image</string>
@@ -434,7 +426,7 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="3" column="1" colspan="5">
+       <item row="5" column="1" colspan="5">
         <widget class="Line" name="line_3">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -457,7 +449,7 @@ This is used by the templated to determine which channel goes to what number out
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="9" column="1">
         <widget class="QLabel" name="imageLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -533,7 +525,7 @@ This is used by the templated to determine which channel goes to what number out
          </item>
         </widget>
        </item>
-       <item row="2" column="4">
+       <item row="4" column="4">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -545,6 +537,46 @@ This is used by the templated to determine which channel goes to what number out
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="16" column="5">
+        <widget class="QPushButton" name="removeProfileButton">
+         <property name="text">
+          <string>Remove Profile</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1" colspan="5">
+        <widget class="Line" name="line_7">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>General Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="lblGeneralSettings">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -963,6 +995,16 @@ This is used by the templated to determine which channel goes to what number out
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/companion/src/generaledit.cpp
+++ b/companion/src/generaledit.cpp
@@ -2,6 +2,7 @@
 #include "ui_generaledit.h"
 #include "helpers.h"
 #include "appdata.h"
+#include <QDateTime>
 #include <QtGui>
 
 #define BIT_WARN_THR     ( 0x01 )
@@ -1356,6 +1357,9 @@ void GeneralEdit::on_calstore_PB_clicked()
     g.profile[profile_id].haptic( QString("%1%2%3").arg(((uint8_t)g_eeGeneral.hapticMode), 2, 16, QChar('0')).arg((uint8_t)g_eeGeneral.hapticStrength, 2, 16, QChar('0')).arg((uint8_t)g_eeGeneral.hapticLength, 2, 16, QChar('0')));
     g.profile[profile_id].speaker( QString("%1%2%3").arg((uint8_t)g_eeGeneral.speakerMode, 2, 16, QChar('0')).arg((uint8_t)g_eeGeneral.speakerPitch, 2, 16, QChar('0')).arg((uint8_t)g_eeGeneral.speakerVolume, 2, 16, QChar('0')));
     g.profile[profile_id].countryCode( QString("%1%2%3").arg((uint8_t)g_eeGeneral.countryCode, 2, 16, QChar('0')).arg((uint8_t)g_eeGeneral.imperial, 2, 16, QChar('0')).arg(g_eeGeneral.ttsLanguage));
+
+    QDateTime dateTime = QDateTime::currentDateTime();
+    g.profile[profile_id].timeStamp(dateTime.toString("yyyy-MM-dd hh:mm"));
     QMessageBox::information(this, "Companion", tr("Calibration and HW parameters saved."));
   }
 }


### PR DESCRIPTION
The profile tab now shows if there is radio settings like calibration data in the profile or not. It also displays a storage date for the data.

The radio settings are time stamped when they are saved to profile. I would prefer to stamp them when they are retrieved from the sender, but this is not possible in any good way with the current file format. I intended to use file storage times, but this turned out to be a bad idea since the date can get screwed up in a lot of different ways.
