### PR TITLE
Com ports listed in Configuration window don't reflect those available on the system.

### DIFF
--- a/companion/src/burnconfigdialog.ui
+++ b/companion/src/burnconfigdialog.ui
@@ -503,6 +503,61 @@ Please only use this if you know what you are doing.  There are no error checks 
        </item>
        <item>
         <property name="text">
+         <string notr="true">com5</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com6</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com7</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com8</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com9</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com10</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com11</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com12</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com13</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com14</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string notr="true">com15</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string notr="true">lpt1</string>
         </property>
        </item>


### PR DESCRIPTION
the AVRDUDE Configuration window only allows a choice of com ports 1 through 4 which appears to be a hardcoded list in this application.

I feel the correct solution would be to detect the available ports and display those but I am insufficiently familiar with c++ to achieve that. Instead I figured that adding ports 5 through 15 would help out anyone else in my situation (I currently have com1 through com11 on my system, and my programmer is com7) pending someone with the requisite skills making a better solution.
