### PR TITLE
Andreas/issue 888 throttle trace calc not very accurate

### DIFF
--- a/radio/src/Makefile
+++ b/radio/src/Makefile
@@ -127,9 +127,8 @@ CORRECT_NEGATIVE_VALUES = YES
 ARITHMETIC_OVERFLOW_CHECK = NO
 
 # increases resolution for throttle statistics and throttle counting, in very rare cases.
-# most important effect is, it prevents throttle counting faster than actual time for 100%. 
 # this will be only true if an output channel is used for throttle calculation, and this chanenel has changed limits, e.g. -90% to +80%
-# if you use standard limits for throttle or directly the throttle stick you do not bother about this option
+# if you use standard limits for throttle or directly the throttle stick you do not need to bother about this option
 # not valid for ARM based transmitters like Taranis, They do not have this rounding issue at all
 # Values = YES, NO
 ACCURAT_THROTTLE_STATS = NO

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -4204,9 +4204,10 @@ void doMixerCalculations()
     // usually max is 1024 min is -1024 --> max-min = 2048 full range
 
 #ifdef ACCURAT_THROTTLE_TIMER
-    if (gModelMax!=0 && gModelMax!=2048) val = (int32_t) (val << 11) / (gModelMax); // recaling only needed if Min, Max differs
+    if (gModelMax!=0 && gModelMax!=2048) val = (int32_t) (val << 11) / (gModelMax); // rescaling only needed if Min, Max differs
 #else
     // @@@ open.20.fsguruh  optimized calculation; now *8 /8 instead of 10 base; (*16/16 already cause a overrun; unsigned calculation also not possible, because v may be negative)
+    gModelMax+=255; // force rounding up --> gModelMax is bigger --> val is smaller
     gModelMax >>= (10-2);
 
     if (gModelMax!=0 && gModelMax!=8) {


### PR DESCRIPTION
added make option ACCURAT_THROTTLE_STATS
This option is set by default for all ARM based transmitters as there is no reason for inaccurate calculation.
For stock transmitters (like Turnigy) this option activates accurat calculation with timing and code cost.
Bad rounding issue which make throttle counter quicker than 100% time is solved anyway.
