### PR TITLE
USB library fixes according to ST's published known bugs list

### DIFF
--- a/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Core/src/usbd_core.c
+++ b/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Core/src/usbd_core.c
@@ -153,6 +153,9 @@ void USBD_Init(USB_OTG_CORE_HANDLE *pdev,
   /* Upon Init call usr callback */
   pdev->dev.usr_cb->Init();
   
+  /* Force Device Mode*/
+  USB_OTG_SetCurrentMode(pdev, DEVICE_MODE);
+
   /* Enable Interrupts */
   USB_OTG_BSP_EnableInterrupt(pdev);
 }

--- a/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_dcd_int.c
+++ b/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_dcd_int.c
@@ -195,6 +195,12 @@ uint32_t USBD_OTG_EP1IN_ISR_Handler (USB_OTG_CORE_HANDLE *pdev)
   {
     DCD_WriteEmptyTxFifo(pdev , 1);
     CLEAR_IN_EP_INTR(1, emptyintr);
+    /*
+    Notice: this probabbly needs the same fix as DCD_HandleInEP_ISR(), but
+    leaving this out, we don't use this part of code
+    fifoemptymsk = 0x1 << 1;
+    USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DIEPEMPMSK, fifoemptymsk, 0);
+    */
   }
   return 1;
 }


### PR DESCRIPTION
Fixes https://github.com/opentx/opentx/issues/919

In the end it turns out that majority of bugs are not related to opentx code, so nothing mayor has changed. 

Tested boot bootloader (mass storage mode) and opentx (joystick mode), works ok.
