### PR TITLE
Make flightmode, switch and system file names case insensitive

### DIFF
--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -274,7 +274,7 @@ void referenceSystemAudioFiles()
 
       for (int i=0; i<AU_FRSKY_FIRST; i++) {
         getSystemAudioFile(path, i);
-        if (!strcmp(filename, fn)) {
+        if (!strcmpi(filename, fn)) {
           availableAudioFiles |= MASK_SYSTEM_AUDIO_FILE(i);
           break;
         }
@@ -372,7 +372,7 @@ void referenceModelAudioFiles()
       for (int i=0; i<MAX_PHASES && !found; i++) {
         for (int event=0; event<2; event++) {
           getPhaseAudioFile(path, i, event);
-          if (!strcmp(filename, fn)) {
+          if (!strcmpi(filename, fn)) {
             sdAvailablePhaseAudioFiles |= MASK_PHASE_AUDIO_FILE(i, event);
             found = true;
             break;
@@ -383,7 +383,7 @@ void referenceModelAudioFiles()
       // Switches Audio Files <switchname>-[up|mid|down].wav
       for (int i=0; i<SWSRC_LAST_SWITCH+NUM_XPOTS*XPOTS_MULTIPOS_COUNT && !found; i++) {
         getSwitchAudioFile(path, i);
-        if (!strcmp(filename, fn)) {
+        if (!strcmpi(filename, fn)) {
           sdAvailableSwitchAudioFiles |= MASK_SWITCH_AUDIO_FILE(i);
           found = true;
         }
@@ -393,7 +393,7 @@ void referenceModelAudioFiles()
       for (int i=0; i<NUM_LOGICAL_SWITCH && !found; i++) {
         for (int event=0; event<2; event++) {
           getLogicalSwitchAudioFile(path, i, event);
-          if (!strcmp(filename, fn)) {
+          if (!strcmpi(filename, fn)) {
             sdAvailableLogicalSwitchAudioFiles |= MASK_LOGICAL_SWITCH_AUDIO_FILE(i, event);
             found = true;
             break;


### PR DESCRIPTION
Consider this enhancement that makes openTX sound files case insensitive. 

The FAT file-system itself is case insensitive, but it nonetheless preserves filename case. The openTX was case sensitive, which resulted in slight problem, for example:
- flight mode name: Speed
- filename for that flight mode: speed-ON.wav

OpenTX searched for "Speed-on.wav" an was unable to find it, but it was in fact available under different case. This pull corrects that.
