### PR TITLE
Two visual enhancements to mixes tab in companion

### DIFF
--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -42,7 +42,7 @@ class MixesPanel : public ModelPanel
   private:
     MixersList *MixerlistWidget;
     bool mixInserted;
-    unsigned int HighlightedSource;
+    unsigned int highlightedSource;
 
     int getMixerIndex(unsigned int dch);
     bool gm_insertMix(int idx);


### PR DESCRIPTION
Changes:
- Added space between channels in mixers tab, amount defined by MIX_ROW_HEIGHT_INCREASE
- Added highlighting of selected channel when used as source in other channels (Ctrl+T or context menu->Toogle highlight)
- Added leading zero to channel name for ch_number < 10 (better alignment for CH1 to CH9)

Here is my rationale:

I have some models with quite complex mixer setup based on full house glider by Mike Shellim's F3F setup. So I got an idea how to make mixers more readable.

First I added some space between each new output channel, so mixers for one channel are more grouped together.

Secondly I added possibility to define an output channel that is highlighted. That channel is then also highlighted (using bold text) in all other mixes if it appears a source there. I find this very helpful.

Here is an example of highlighted channel 10:
![screenshot](https://cloud.githubusercontent.com/assets/5950438/2700214/9565212a-c410-11e3-8234-3be404a0f0f5.png)
