### PR TITLE
Print dialog Close button was not working

### DIFF
--- a/companion/src/printdialog.cpp
+++ b/companion/src/printdialog.cpp
@@ -805,6 +805,11 @@ void PrintDialog::printFrSky()
       te->append(str);    
 }
 
+void PrintDialog::on_closeButton_clicked()
+{
+    this->close();
+}
+
 void PrintDialog::on_printButton_clicked()
 {
     QPrinter printer;

--- a/companion/src/printdialog.h
+++ b/companion/src/printdialog.h
@@ -50,6 +50,7 @@ private:
     QDir *qd;
     
 private slots:
+    void on_closeButton_clicked();
     void on_printButton_clicked();
     void on_printFileButton_clicked();
     void autoClose();

--- a/companion/src/printdialog.ui
+++ b/companion/src/printdialog.ui
@@ -76,22 +76,5 @@
  <resources>
   <include location="companion.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>closeButton</sender>
-   <signal>clicked()</signal>
-   <receiver>printDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>739</x>
-     <y>636</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>565</x>
-     <y>623</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
I am not sure this is an optimal fix, but the Close button on Linux was not working. Now it works.
