### PR TITLE
Andreas/bring back flash savings

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1375,7 +1375,7 @@ uint16_t anaIn(uint8_t chan)
 #else
   static const pm_char crossAna[] PROGMEM = {3,1,2,0,4,5,6,7};
 #if defined(FRSKY_STICKS)
-  uint16_t temp = s_anaFilt[pgm_read_byte(crossAna+chan)];
+  volatile uint16_t temp = s_anaFilt[pgm_read_byte(crossAna+chan)];  // volatile saves here 40 bytes; maybe removed for newer AVR when available
   if (chan < NUM_STICKS && (g_eeGeneral.stickReverse & (1 << chan))) {
     temp = 2048 - temp;
   }


### PR DESCRIPTION
brings back 68 bytes flash memory for stock and about 40 bytes if FRSKY_STICKS are activated.
