### PR TITLE
Telemetry output to Taranis serial port

### DIFF
--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -157,6 +157,12 @@ NOINLINE void processSerialData(uint8_t data)
   btPushByte(data);
 #endif
 
+#if defined(PCBTARANIS)
+    if (g_eeGeneral.uart3Mode == UART_MODE_SPORT) {
+      uart3Putc(data);
+    }
+#endif
+
   switch (dataState)
   {
     case STATE_DATA_START:


### PR DESCRIPTION
It was gone after telemtry refactoring. Is there a reason?
