### PR TITLE
Correct URL for Voice Download

### DIFF
--- a/companion/src/fwpreferencesdialog.cpp
+++ b/companion/src/fwpreferencesdialog.cpp
@@ -50,7 +50,7 @@ void FirmwarePreferencesDialog::on_voice_dnld_clicked()
   QString fwType = g.profile[g.id()].fwType();
   QStringList list = fwType.split("-");
   QString firmware = QString("%1-%2").arg(list[0]).arg(list[1]);
-  url.append(QString("%1/%2/").arg(firmware).arg(ui->voiceCombo->currentText()));
+  url.append(QString("%1/%2/").arg(firmware).arg(ui->voiceCombo->currentText().toLower()));
   QDesktopServices::openUrl(url);
 }
 


### PR DESCRIPTION
The Language Part of the Url needs to be Lowercase. Otherwise you get a "Not Found" Error when following the Url.
