### PR TITLE
On Taranis, the eeprom is called TARANIS.BIN.

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1052,7 +1052,10 @@ bool MainWindow::readEepromFromRadio(const QString filename, const QString messa
   }
 
   if (IS_ARM(GetCurrentFirmware()->getBoard())) {
-    QString path = FindMassstoragePath("EEPROM.BIN");
+    QString path = FindMassstoragePath("TARANIS.BIN");
+    if (path.isEmpty()) {
+      path = FindMassstoragePath("EEPROM.BIN");
+    }
     if (path.isEmpty()) {
       // Mike's bootloader calls the EEPROM file "ERSKY9X.BIN" :(
       path = FindMassstoragePath("ERSKY9X.BIN");
@@ -1097,7 +1100,10 @@ bool MainWindow::writeEepromToRadio(const QString filename, const QString messag
   bool result = false;
 
   if (IS_ARM(GetCurrentFirmware()->getBoard())) {
-    QString path = FindMassstoragePath("EEPROM.BIN");
+    QString path = FindMassstoragePath("TARANIS.BIN");
+    if (path.isEmpty()) {
+      path = FindMassstoragePath("EEPROM.BIN");
+    }
     if (path.isEmpty()) {
       // Mike's bootloader calls the EEPROM file "ERSKY9X.BIN" :(
       path = FindMassstoragePath("ERSKY9X.BIN");


### PR DESCRIPTION
The TARANIS.BIN file name got lost in 72dc69086cf63831c377f86baee9182b6a437c95.

We probably could use the Radio Type from the Radio Profile to minimize the guessing ... but this pull request should serve as quick way to fix the regression.
