### PR TITLE
Partial fix for 1212 - Only Windows

### DIFF
--- a/companion/targets/windows/companion-msys.nsi.in
+++ b/companion/targets/windows/companion-msys.nsi.in
@@ -95,6 +95,10 @@ Section "OpenTX companion" SecDummy
   File "@CMAKE_CURRENT_SOURCE_DIR@\..\targets\windows\avrdude.conf"
   File "@CMAKE_CURRENT_SOURCE_DIR@\..\targets\windows\libusb0.dll"
   File "@CMAKE_CURRENT_SOURCE_DIR@\..\targets\windows\dfu-util.exe"
+   
+  CreateDirectory "$INSTDIR\phonon_backend"
+  SetOutPath "$INSTDIR\phonon_backend"
+  File "@QT_BINARY_DIR@\..\plugins\phonon_backend\Phonon_ds94.dll"
   
   CreateDirectory "$INSTDIR\lang"
   SetOutPath "$INSTDIR\lang"

--- a/companion/targets/windows/companion-vs.nsi.in
+++ b/companion/targets/windows/companion-vs.nsi.in
@@ -123,6 +123,10 @@ Section "OpenTX Companion" SecDummy
   File "@CMAKE_CURRENT_SOURCE_DIR@\..\targets\windows\dfu-util.exe"
   File "@CMAKE_CURRENT_SOURCE_DIR@\..\targets\windows\libusb-1.0.dll"
   
+  CreateDirectory "$INSTDIR\phonon_backend"
+  SetOutPath "$INSTDIR\phonon_backend"
+  File "@QT_BINARY_DIR@\..\plugins\phonon_backend\Phonon_ds94.dll"
+
   CreateDirectory "$INSTDIR\lang"
   SetOutPath "$INSTDIR\lang"
   File "*.qm"


### PR DESCRIPTION
I have tested this by building and installing the package. The voice files now play in Companion. Hopefully there is not any more tricks to installing PHONON besides placing the files in the right place (there very well might be).
I used VisualStudio to build but updated the build files for both Windows build environments.
