### PR TITLE
CN - Couple of bug fixes in USB code. This functions the bugs were in do...

### DIFF
--- a/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_core.c
+++ b/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_core.c
@@ -1961,7 +1961,7 @@ void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
       if(pdev->cfg.low_power)
       {
         /* un-gate USB Core clock */
-        power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+        power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
         power.b.gatehclk = 0;
         power.b.stoppclk = 0;
         USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);
@@ -1995,7 +1995,7 @@ void USB_OTG_UngateClock(USB_OTG_CORE_HANDLE *pdev)
     if(dsts.b.suspsts == 1)
     {
       /* un-gate USB Core clock */
-      power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+      power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
       power.b.gatehclk = 0;
       power.b.stoppclk = 0;
       USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);

--- a/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_dcd_int.c
+++ b/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_OTG_Driver/src/usb_dcd_int.c
@@ -358,7 +358,7 @@ static uint32_t DCD_HandleResume_ISR(USB_OTG_CORE_HANDLE *pdev)
   if(pdev->cfg.low_power)
   {
     /* un-gate USB Core clock */
-    power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+    power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
     power.b.gatehclk = 0;
     power.b.stoppclk = 0;
     USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);


### PR DESCRIPTION
...n't appear to be called by any of the OpenTX code.
When compiling 'next' branch, I noticed a few compiler warnings like this...
usb_dcd_int.c:361:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
Upon investigating the code, it seemed to me that the macro USB_OTG_READ_REG32 was incorrectly being passed the address of pdev->regs.PCGCCTL. I think that pdev->regs.PCGCCTL is already a pointer pointing to the appropriate memory address, so passing the address of this pointer to the macro is a mistake.
This commit removes the compiler warnings, and (I think) fixes a bug.
It looks like the functions that I have altered aren't actually called by the OpenTX code, so I think all I have done is remove the compiler warnings.

Please review the changes and apply them to the OpenTX code if you agree that they fix a problem.
