### PR TITLE
Fixes #1269 - RSSI Tx should be hidden in companion if radio is Taranis.

### DIFF
--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -1372,6 +1372,8 @@ class FirmwareInterface {
 
     virtual int getCapability(const Capability) = 0;
 
+    virtual bool isTelemetrySourceAvailable(int source) = 0;
+
     virtual SimulatorInterface * getSimulator()
     {
       return NULL;

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -680,6 +680,17 @@ int OpenTxFirmware::getCapability(const Capability capability)
   }
 }
 
+bool OpenTxFirmware::isTelemetrySourceAvailable(int source)
+{
+  if (IS_TARANIS(board) && (source == TELEMETRY_SOURCE_RSSI_TX))
+    return false;
+
+  if (source == TELEMETRY_SOURCE_DTE)
+    return false;
+
+  return true;
+}
+
 int OpenTxEepromInterface::isAvailable(Protocol proto, int port)
 {
   if (IS_TARANIS(board)) {

--- a/companion/src/firmwares/opentx/opentxinterface.h
+++ b/companion/src/firmwares/opentx/opentxinterface.h
@@ -114,6 +114,8 @@ class OpenTxFirmware: public FirmwareInterface {
 
     virtual int getCapability(const Capability);
 
+    virtual bool isTelemetrySourceAvailable(int source);
+
     virtual SimulatorInterface * getSimulator();
     
     

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -340,6 +340,12 @@ void TelemetryCustomScreen::populateTelemetrySourceCB(QComboBox *b, unsigned int
 
   for (unsigned int i = 0; i < (last ? TELEMETRY_SOURCES_STATUS_COUNT : TELEMETRY_SOURCES_DISPLAY_COUNT); i++) {
     b->addItem(RawSource(SOURCE_TYPE_TELEMETRY, i).toString());
+    if (!firmware->isTelemetrySourceAvailable(i)) {
+      //disable item
+      QModelIndex index = b->model()->index(i+1, 0);
+      QVariant v(0);
+      b->model()->setData(index, v, Qt::UserRole - 1);
+    }
     if (!(i>=sizeof(telem_hub)/sizeof(int) || telem_hub[i]==0 || ((telem_hub[i]>=hubproto) && hubproto!=0))) {
       QModelIndex index = b->model()->index(i, 0);
       QVariant v(0);


### PR DESCRIPTION
I followed isTelemetrySourceAvailable() and hided RssiTx and dTE.
