### PR TITLE
Fixes issue where strings may be truncated unnecessarily.

### DIFF
--- a/radio/src/lcd.cpp
+++ b/radio/src/lcd.cpp
@@ -337,6 +337,7 @@ void lcd_putc(xcoord_t x, uint8_t y, const unsigned char c)
 void lcd_putsnAtt(xcoord_t x, uint8_t y, const pm_char * s, uint8_t len, LcdFlags mode)
 {
   xcoord_t orig_x = x;
+  uint8_t const orig_len = len;
   bool setx = false;
   while (len--) {
     unsigned char c;
@@ -373,6 +374,7 @@ void lcd_putsnAtt(xcoord_t x, uint8_t y, const pm_char * s, uint8_t len, LcdFlag
       setx = true;
     }
     else if (c == 0x1E) {  //NEWLINE
+      len = orig_len;
       x = orig_x;
       y += FH;
 #if defined(CPUARM)      


### PR DESCRIPTION
If the string spans multiple lines (contains character 0x1E), the limit on the line's length should be set back to the original value when moving to a new line in the output function.

There is support for writing strings to the LCD that span multiple lines. The special character 0x36 is used to mark the position where the text should move to the new line. I have noticed that some functions (e.g. displayBox() ) write strings to the display, and pass a maximum line length (e.g. WARNING_LINE_LEN (32)) to lcd_putsnAtt().
If the string to write is longer than this limit, but also contains 0x36 (newline) characters, the string will still be truncated after the specified maximum number of characters has been output, even though the allowed line length should probably be set back to the limit whenever moving to a new line.

Please incorporate this pull request into the main project if you agree that this is an issue, and that this commit fixes the problem.
