### PR TITLE
Fixes #1364 - Stack alignment to 8 bytes

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -44,7 +44,8 @@
 #define DEBUG_STACK_SIZE    500
 
 OS_TID menusTaskId;
-OS_STK menusStack[MENUS_STACK_SIZE];
+//stack must be alligned to 8 bytes otherwise printf for %f does not work!
+OS_STK __attribute__((aligned(8))) menusStack[MENUS_STACK_SIZE];
 
 OS_TID mixerTaskId;
 OS_STK mixerStack[MIXER_STACK_SIZE];


### PR DESCRIPTION
This fixes printf() when using floating point format specifiers (ie %f, %g, %e)

Found hint here http://stackoverflow.com/questions/18746570/printf-cannot-print-float-double-correctly-on-the-screen
