### PR TITLE
Fixes #1360

### DIFF
--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -95,6 +95,8 @@ int main(int argc, char *argv[])
   app.installTranslator(&qtTranslator);
 
   QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
+  
+  registerOpenTxFirmwares();
 
   if (g.profile[g.id()].fwType().isEmpty()){
     g.profile[g.id()].fwType(default_firmware_variant->getId());
@@ -111,7 +113,6 @@ int main(int argc, char *argv[])
   QSplashScreen *splash = new QSplashScreen(pixmap);
 
   RegisterEepromInterfaces();
-  registerOpenTxFirmwares();
 
   current_firmware_variant = GetFirmware(g.profile[g.id()].fwType());
 


### PR DESCRIPTION
Perhaps RegisterEepromInterfaces should also be lifted to earlier in the file to avoid running code before the initialization is complete? I see no issue now, so I left it where it is.
