### PR TITLE
Bug fix and refactoring of globalTimer

### DIFF
--- a/radio/src/gui/view_statistics.cpp
+++ b/radio/src/gui/view_statistics.cpp
@@ -50,7 +50,7 @@ void menuStatisticsView(uint8_t event)
     case EVT_KEY_LONG(KEY_MENU):
       g_eeGeneral.globalTimer = 0;
       eeDirty(EE_GENERAL);
-      s_timeCumTot = 0;
+      sessionTimer = 0;
       break;
 #endif
     case EVT_KEY_FIRST(KEY_EXIT):
@@ -65,10 +65,10 @@ void menuStatisticsView(uint8_t event)
   putsTimer(    5*FW+5*FWNUM+1, FH*2, s_timeCumThr, 0, 0);
   putsTimer(   12*FW+5*FWNUM+1, FH*2, s_timeCum16ThrP/16, 0, 0);
 
-  putsTimer(   12*FW+5*FWNUM+1, FH*0, s_timeCumTot, 0, 0);
+  putsTimer(   12*FW+5*FWNUM+1, FH*0, sessionTimer, 0, 0);
   
 #if defined(CPUARM)
-  putsTimer(21*FW+5*FWNUM+1, 0*FH, g_eeGeneral.globalTimer + s_timeCumTot, TIMEHOUR, 0);
+  putsTimer(21*FW+5*FWNUM+1, 0*FH, g_eeGeneral.globalTimer + sessionTimer, TIMEHOUR, 0);
 #endif
 
 #if defined(THRTRACE)
@@ -113,7 +113,7 @@ void menuStatisticsDebug(uint8_t event)
 #if defined(PCBSKY9X)
       Current_used = 0;
 #endif
-      s_timeCumTot = 0;
+      sessionTimer = 0;
       killEvents(event);
       AUDIO_KEYPAD_UP();
       break;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1597,7 +1597,7 @@ uint8_t g_vbat100mV = 0;
 uint16_t lightOffCounter;
 uint8_t flashCounter = 0;
 
-uint16_t s_timeCumTot;
+uint16_t sessionTimer;
 uint16_t s_timeCumThr;    // THR in 1/16 sec
 uint16_t s_timeCum16ThrP; // THR% in 1/16 sec
 
@@ -2365,7 +2365,7 @@ void doMixerCalculations()
 
       if (s_cnt_1s >= 10) { // 1sec
         s_cnt_1s -= 10;
-        s_timeCumTot += 1;
+        sessionTimer += 1;
 
         struct t_inactivity *ptrInactivity = &inactivity;
         FORCE_INDIRECT(ptrInactivity) ;
@@ -2374,9 +2374,9 @@ void doMixerCalculations()
           AUDIO_INACTIVITY();
 
 #if defined(AUDIO)
-        if (mixWarning & 1) if ((s_timeCumTot&0x03)==0) AUDIO_MIX_WARNING(1);
-        if (mixWarning & 2) if ((s_timeCumTot&0x03)==1) AUDIO_MIX_WARNING(2);
-        if (mixWarning & 4) if ((s_timeCumTot&0x03)==2) AUDIO_MIX_WARNING(3);
+        if (mixWarning & 1) if ((sessionTimer&0x03)==0) AUDIO_MIX_WARNING(1);
+        if (mixWarning & 2) if ((sessionTimer&0x03)==1) AUDIO_MIX_WARNING(2);
+        if (mixWarning & 4) if ((sessionTimer&0x03)==2) AUDIO_MIX_WARNING(3);
 #endif
 
 #if defined(ACCURAT_THROTTLE_TIMER)
@@ -3238,10 +3238,10 @@ void saveTimers()
   }
 
 #if defined(CPUARM) && !defined(REVA)
-  if (s_timeCumTot > 0) {
-    g_eeGeneral.globalTimer += s_timeCumTot;
+  if (sessionTimer > 0) {
+    g_eeGeneral.globalTimer += sessionTimer;
     eeDirty(EE_GENERAL);
-    s_timeCumTot = 0;
+    sessionTimer = 0;
   }
 #endif
 }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -828,7 +828,7 @@ void setTrimValue(uint8_t phase, uint8_t idx, int trim);
   #define GV_RANGELARGE_OFFSET_NEG  GV_RANGELARGE_NEG
 #endif
 
-extern uint16_t s_timeCumTot;
+extern uint16_t sessionTimer;
 extern uint16_t s_timeCumThr;
 extern uint16_t s_timeCum16ThrP;
 


### PR DESCRIPTION
After reading this post http://www.rcgroups.com/forums/showpost.php?p=28810543&postcount=2197 Ilooked at the code and spotted:
- g_eeGeneral.globalTimer was not saved to EEPROM after reset, session timer reset was also missing
- noticed duplication of session timer: `s_timeCumTot` and `sessionTimer` both did the same thing, so I removed one.

Please review and merge if ok.
