### PR TITLE
Fixes a bug for case: telemetry values used in logical switches and they...

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -241,8 +241,10 @@ bool getLogicalSwitch(uint8_t idx)
 #if defined(FRSKY)
       // Telemetry
       if (v1 >= MIXSRC_FIRST_TELEM) {
-        if ((!TELEMETRY_STREAMING() && v1 >= MIXSRC_FIRST_TELEM+TELEM_FIRST_STREAMED_VALUE-1) || IS_FAI_FORBIDDEN(v1-1))
-          return false;
+        if ((!TELEMETRY_STREAMING() && v1 >= MIXSRC_FIRST_TELEM+TELEM_FIRST_STREAMED_VALUE-1) || IS_FAI_FORBIDDEN(v1-1)) {
+          x = 0;  //replace actual value with zero and continue processing (needed for duraton and delay)
+          //we could also return actual stored values (except when FAI FORBIDDEN, then we would return 0)
+        }
 
         y = convertLswTelemValue(ls);
 


### PR DESCRIPTION
... have a duration and/or delay set.

Scenario:

```
L14   RSSIRx > 0   Duration (5s)
```

What happens in the old code:
- when powering up RX for the first time, L14 becomes ON for 5s - this is correct
- when removing power from RX and then powering back nothing happens - L14 stays OFF

This pull fixes that second case. The problem was the `return false` statement when telemetry was not streaming. This `return` resulted in skipped delay/duration processing code.
