### PR TITLE
Receiver number wasn't showing up for DSM (Fix #1641)

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -210,8 +210,8 @@ void ModulePanel::update()
 
   ui->label_protocol->setVisible(mask & MASK_PROTOCOL);
   ui->protocol->setVisible(mask & MASK_PROTOCOL);
-  ui->label_rxNumber->setVisible(mask & MASK_FAILSAFES);
-  ui->rxNumber->setVisible(mask & MASK_FAILSAFES);
+  ui->label_rxNumber->setVisible(mask & MASK_RX_NUMBER);
+  ui->rxNumber->setVisible(mask & MASK_RX_NUMBER);
   ui->rxNumber->setValue(model.modelId);
   ui->label_channelsStart->setVisible(mask & MASK_CHANNELS_RANGE);
   ui->channelsStart->setVisible(mask & MASK_CHANNELS_RANGE);


### PR DESCRIPTION
Opening a pull request as it's a bit of a mess right now, and I don't understand how you want to handle the parallel work on the not-yet-released 2.0.9 and what's already been commited in next for 2.1.
