### PR TITLE
No special characters in edit fields for CZ language, but enabled in int...

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -621,7 +621,12 @@ extern uint8_t pxxFlag[NUM_MODULES];
 #define PXX_SEND_RANGECHECK  (1 << 5)
 
 #define LEN_STD_CHARS 40
+
+#if defined(TRANSLATIONS_CZ)
+#define ZCHAR_MAX (LEN_STD_CHARS)
+#else
 #define ZCHAR_MAX (LEN_STD_CHARS + LEN_SPECIAL_CHARS)
+#endif
 
 char idx2char(int8_t idx);
 #if defined(CPUARM) || defined(SIMU)

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -49,7 +49,7 @@ char idx2char(int8_t idx)
   if (idx < 37) return '0' + idx - 27;
   if (idx <= 40) return pgm_read_byte(s_charTab+idx-37);
 #if LEN_SPECIAL_CHARS > 0
-  if (idx <= ZCHAR_MAX) return 'z' + 5 + idx - 40;
+  if (idx <= (LEN_STD_CHARS + LEN_SPECIAL_CHARS)) return 'z' + 5 + idx - 40;
 #endif
   return ' ';
 }

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -54,7 +54,7 @@
 #define LEN_SPECIAL_CHARS 6
 #elif defined(TRANSLATIONS_CZ)
 #include "translations/cz.h"
-#define LEN_SPECIAL_CHARS 0
+#define LEN_SPECIAL_CHARS 17
 #elif defined(TRANSLATIONS_ES)
 #include "translations/es.h"
 #define LEN_SPECIAL_CHARS 0


### PR DESCRIPTION
...ernally defined strings.

It fixes auto generated INPUTS names where CZ special characters were replaced by empty char.
