### PR TITLE
Fixes #1909: tab order in Companion dialogs

### DIFF
--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -1049,10 +1049,26 @@ Mode 4:
   </layout>
  </widget>
  <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>profileNameLE</tabstop>
+  <tabstop>removeProfileButton</tabstop>
+  <tabstop>downloadVerCB</tabstop>
+  <tabstop>langCombo</tabstop>
+  <tabstop>voiceCombo</tabstop>
+  <tabstop>SplashFileName</tabstop>
+  <tabstop>SplashSelect</tabstop>
+  <tabstop>clearImageButton</tabstop>
+  <tabstop>sdPath</tabstop>
+  <tabstop>sdPathButton</tabstop>
+  <tabstop>stickmodeCB</tabstop>
+  <tabstop>channelorderCB</tabstop>
+  <tabstop>renameFirmware</tabstop>
+  <tabstop>burnFirmware</tabstop>
   <tabstop>ge_lineedit</tabstop>
   <tabstop>ge_pathButton</tabstop>
   <tabstop>historySize</tabstop>
   <tabstop>showSplash</tabstop>
+  <tabstop>modelWizard_CB</tabstop>
   <tabstop>startupCheck_fw</tabstop>
   <tabstop>startupCheck_companion9x</tabstop>
   <tabstop>backupPath</tabstop>
@@ -1061,7 +1077,6 @@ Mode 4:
   <tabstop>splashincludeCB</tabstop>
   <tabstop>libraryPath</tabstop>
   <tabstop>libraryPathButton</tabstop>
-  <tabstop>buttonBox</tabstop>
   <tabstop>snapshotPath</tabstop>
   <tabstop>snapshotPathButton</tabstop>
   <tabstop>snapshotClipboardCKB</tabstop>
@@ -1070,11 +1085,7 @@ Mode 4:
   <tabstop>joystickCB</tabstop>
   <tabstop>joystickChkB</tabstop>
   <tabstop>joystickcalButton</tabstop>
-  <tabstop>SplashFileName</tabstop>
-  <tabstop>stickmodeCB</tabstop>
-  <tabstop>channelorderCB</tabstop>
-  <tabstop>renameFirmware</tabstop>
-  <tabstop>burnFirmware</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
   <include location="companion.qrc"/>

--- a/companion/src/burnconfigdialog.ui
+++ b/companion/src/burnconfigdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>531</width>
-    <height>335</height>
+    <height>422</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -817,6 +817,14 @@ Please only use this if you know what you are doing.  There are no error checks 
   <tabstop>avrdude_port</tabstop>
   <tabstop>avrArgs</tabstop>
   <tabstop>pushButton_4</tabstop>
+  <tabstop>samba_location</tabstop>
+  <tabstop>sb_browse</tabstop>
+  <tabstop>arm_mcu</tabstop>
+  <tabstop>samba_port</tabstop>
+  <tabstop>dfu_location</tabstop>
+  <tabstop>dfu_browse</tabstop>
+  <tabstop>dfuArgs</tabstop>
+  <tabstop>advCtrChkB</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/burndialog.ui
+++ b/companion/src/burndialog.ui
@@ -357,11 +357,11 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>BurnFlashButton</tabstop>
   <tabstop>FWFileName</tabstop>
   <tabstop>FlashLoadButton</tabstop>
   <tabstop>versionField</tabstop>
   <tabstop>ModField</tabstop>
+  <tabstop>DateField</tabstop>
   <tabstop>useProfileImageCB</tabstop>
   <tabstop>useFwImageCB</tabstop>
   <tabstop>useLibraryImageCB</tabstop>
@@ -371,6 +371,7 @@
   <tabstop>patchhw_CB</tabstop>
   <tabstop>EEpromCB</tabstop>
   <tabstop>cancelButton</tabstop>
+  <tabstop>BurnFlashButton</tabstop>
  </tabstops>
  <resources>
   <include location="companion.qrc"/>

--- a/companion/src/fwpreferencesdialog.ui
+++ b/companion/src/fwpreferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>416</width>
-    <height>153</height>
+    <height>154</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -177,6 +177,10 @@ May be different from firmware language</string>
   </layout>
  </widget>
  <tabstops>
+  <tabstop>checkFWUpdates</tabstop>
+  <tabstop>fw_dnld</tabstop>
+  <tabstop>voiceCombo</tabstop>
+  <tabstop>voice_dnld</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/generaledit.ui
+++ b/companion/src/generaledit.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>804</width>
+    <width>879</width>
     <height>912</height>
    </rect>
   </property>
@@ -106,7 +106,7 @@
 These will be relevant for all models in the same EEPROM.</string>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabSetup">
       <attribute name="title">
@@ -3348,6 +3348,58 @@ p, li { white-space: pre-wrap; }
   </layout>
  </widget>
  <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>beeperCB</tabstop>
+  <tabstop>beeperlenCB</tabstop>
+  <tabstop>hapticmodeCB</tabstop>
+  <tabstop>hapticLengthCB</tabstop>
+  <tabstop>hapticStrength</tabstop>
+  <tabstop>battwarningDSB</tabstop>
+  <tabstop>contrastSB</tabstop>
+  <tabstop>displayTypeCB</tabstop>
+  <tabstop>inactimerSB</tabstop>
+  <tabstop>splashScreenChkB</tabstop>
+  <tabstop>splashScreenDuration</tabstop>
+  <tabstop>alarmwarnChkB</tabstop>
+  <tabstop>memwarnChkB</tabstop>
+  <tabstop>mavbaud_CB</tabstop>
+  <tabstop>chkSA</tabstop>
+  <tabstop>chkSB</tabstop>
+  <tabstop>chkSC</tabstop>
+  <tabstop>chkSD</tabstop>
+  <tabstop>chkSE</tabstop>
+  <tabstop>chkSF</tabstop>
+  <tabstop>chkSG</tabstop>
+  <tabstop>chkSH</tabstop>
+  <tabstop>stickmodeCB</tabstop>
+  <tabstop>stickReverse1</tabstop>
+  <tabstop>stickReverse2</tabstop>
+  <tabstop>stickReverse3</tabstop>
+  <tabstop>stickReverse4</tabstop>
+  <tabstop>channelorderCB</tabstop>
+  <tabstop>faimode_CB</tabstop>
+  <tabstop>switchesDelay</tabstop>
+  <tabstop>soundModeCB</tabstop>
+  <tabstop>speakerPitchSB</tabstop>
+  <tabstop>volume_SB</tabstop>
+  <tabstop>beepVolume_SL</tabstop>
+  <tabstop>wavVolume_SL</tabstop>
+  <tabstop>varioVolume_SL</tabstop>
+  <tabstop>bgVolume_SL</tabstop>
+  <tabstop>varioP0_SB</tabstop>
+  <tabstop>varioPMax_SB</tabstop>
+  <tabstop>varioR0_SB</tabstop>
+  <tabstop>backlightswCB</tabstop>
+  <tabstop>backlightautoSB</tabstop>
+  <tabstop>blAlarm_ChkB</tabstop>
+  <tabstop>BLBright_SB</tabstop>
+  <tabstop>backlightColor_SL</tabstop>
+  <tabstop>re_CB</tabstop>
+  <tabstop>countrycode_CB</tabstop>
+  <tabstop>units_CB</tabstop>
+  <tabstop>gpsFormatCB</tabstop>
+  <tabstop>timezoneSB</tabstop>
+  <tabstop>voiceLang_CB</tabstop>
   <tabstop>trnMode_1</tabstop>
   <tabstop>trnChn_1</tabstop>
   <tabstop>trnWeight_1</tabstop>
@@ -3372,12 +3424,32 @@ p, li { white-space: pre-wrap; }
   <tabstop>ana4Neg</tabstop>
   <tabstop>ana4Mid</tabstop>
   <tabstop>ana4Pos</tabstop>
+  <tabstop>pot1Type</tabstop>
+  <tabstop>pot2Type</tabstop>
+  <tabstop>pot3Type</tabstop>
+  <tabstop>serialPortMode</tabstop>
   <tabstop>battCalibDSB</tabstop>
+  <tabstop>CurrentCalib_SB</tabstop>
   <tabstop>PPM1</tabstop>
   <tabstop>PPM2</tabstop>
   <tabstop>PPM3</tabstop>
   <tabstop>PPM4</tabstop>
   <tabstop>PPM_MultiplierDSB</tabstop>
+  <tabstop>ana5Neg</tabstop>
+  <tabstop>ana5Mid</tabstop>
+  <tabstop>ana5Pos</tabstop>
+  <tabstop>ana6Neg</tabstop>
+  <tabstop>ana6Mid</tabstop>
+  <tabstop>ana6Pos</tabstop>
+  <tabstop>ana7Neg</tabstop>
+  <tabstop>ana7Mid</tabstop>
+  <tabstop>ana7Pos</tabstop>
+  <tabstop>ana8Neg</tabstop>
+  <tabstop>ana8Mid</tabstop>
+  <tabstop>ana8Pos</tabstop>
+  <tabstop>profile_CB</tabstop>
+  <tabstop>calretrieve_PB</tabstop>
+  <tabstop>calstore_PB</tabstop>
  </tabstops>
  <resources>
   <include location="companion.qrc"/>

--- a/companion/src/imgpreferences.ui
+++ b/companion/src/imgpreferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>685</width>
-    <height>418</height>
+    <height>432</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -441,6 +441,25 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>backLightColor</tabstop>
+  <tabstop>joystickCB</tabstop>
+  <tabstop>joystickChkB</tabstop>
+  <tabstop>joystickcalButton</tabstop>
+  <tabstop>simuSW</tabstop>
+  <tabstop>snapshotPath</tabstop>
+  <tabstop>snapshotPathButton</tabstop>
+  <tabstop>snapshotClipboardCKB</tabstop>
+  <tabstop>libraryPath</tabstop>
+  <tabstop>libraryPathButton</tabstop>
+  <tabstop>splashincludeCB</tabstop>
+  <tabstop>SplashFileName</tabstop>
+  <tabstop>SplashSelect</tabstop>
+  <tabstop>splashLibraryButton</tabstop>
+  <tabstop>clearImageButton</tabstop>
+  <tabstop>InvertPixels</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources>
   <include location="companion.qrc"/>
  </resources>

--- a/companion/src/logsdialog.ui
+++ b/companion/src/logsdialog.ui
@@ -287,6 +287,17 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>FileName_LE</tabstop>
+  <tabstop>fileOpen_BT</tabstop>
+  <tabstop>FieldsTW</tabstop>
+  <tabstop>ZoomX_ChkB</tabstop>
+  <tabstop>ZoomY_ChkB</tabstop>
+  <tabstop>Reset_PB</tabstop>
+  <tabstop>sessions_CB</tabstop>
+  <tabstop>logTable</tabstop>
+  <tabstop>mapsButton</tabstop>
+ </tabstops>
  <resources>
   <include location="companion.qrc"/>
  </resources>

--- a/companion/src/modeledit/curves.ui
+++ b/companion/src/modeledit/curves.ui
@@ -339,6 +339,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>curvePreview</tabstop>
+  <tabstop>curvePoints</tabstop>
+  <tabstop>curveCustom</tabstop>
+  <tabstop>curveSmooth</tabstop>
+  <tabstop>curveName</tabstop>
+  <tabstop>curveType</tabstop>
+  <tabstop>curveCoeff</tabstop>
+  <tabstop>yMin</tabstop>
+  <tabstop>yMid</tabstop>
+  <tabstop>yMax</tabstop>
+  <tabstop>curveSide</tabstop>
+  <tabstop>curveApply</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>381</width>
-    <height>414</height>
+    <width>389</width>
+    <height>488</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -481,6 +481,9 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
   <tabstop>weightGV</tabstop>
   <tabstop>weightSB</tabstop>
   <tabstop>weightCB</tabstop>
+  <tabstop>offsetGV</tabstop>
+  <tabstop>offsetSB</tabstop>
+  <tabstop>offsetCB</tabstop>
   <tabstop>curveTypeCB</tabstop>
   <tabstop>curveGVarCB</tabstop>
   <tabstop>curveValueCB</tabstop>

--- a/companion/src/modeledit/flightmode.ui
+++ b/companion/src/modeledit/flightmode.ui
@@ -457,6 +457,24 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>name</tabstop>
+  <tabstop>fadeIn</tabstop>
+  <tabstop>swtch</tabstop>
+  <tabstop>fadeOut</tabstop>
+  <tabstop>trim2Use</tabstop>
+  <tabstop>trim2Value</tabstop>
+  <tabstop>trim1Use</tabstop>
+  <tabstop>trim1Value</tabstop>
+  <tabstop>trim3Use</tabstop>
+  <tabstop>trim3Value</tabstop>
+  <tabstop>trim4Use</tabstop>
+  <tabstop>trim4Value</tabstop>
+  <tabstop>trim2Slider</tabstop>
+  <tabstop>trim3Slider</tabstop>
+  <tabstop>trim1Slider</tabstop>
+  <tabstop>trim4Slider</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/modeledit/mixerdialog.ui
+++ b/companion/src/modeledit/mixerdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>364</width>
-    <height>434</height>
+    <width>412</width>
+    <height>541</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -611,6 +611,39 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>mixerName</tabstop>
+  <tabstop>sourceCB</tabstop>
+  <tabstop>weightGV</tabstop>
+  <tabstop>weightCB</tabstop>
+  <tabstop>weightSB</tabstop>
+  <tabstop>offsetGV</tabstop>
+  <tabstop>offsetCB</tabstop>
+  <tabstop>offsetSB</tabstop>
+  <tabstop>curveTypeCB</tabstop>
+  <tabstop>curveGVarCB</tabstop>
+  <tabstop>curveValueCB</tabstop>
+  <tabstop>curveValueSB</tabstop>
+  <tabstop>trimCB</tabstop>
+  <tabstop>MixDR_CB</tabstop>
+  <tabstop>cb_FP0</tabstop>
+  <tabstop>cb_FP1</tabstop>
+  <tabstop>cb_FP2</tabstop>
+  <tabstop>cb_FP3</tabstop>
+  <tabstop>cb_FP4</tabstop>
+  <tabstop>cb_FP5</tabstop>
+  <tabstop>cb_FP6</tabstop>
+  <tabstop>cb_FP7</tabstop>
+  <tabstop>cb_FP8</tabstop>
+  <tabstop>switchesCB</tabstop>
+  <tabstop>warningCB</tabstop>
+  <tabstop>mltpxCB</tabstop>
+  <tabstop>delayUpSB</tabstop>
+  <tabstop>slowUpSB</tabstop>
+  <tabstop>delayDownSB</tabstop>
+  <tabstop>slowDownSB</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../companion.qrc"/>
  </resources>

--- a/companion/src/modeledit/setup.ui
+++ b/companion/src/modeledit/setup.ui
@@ -532,6 +532,19 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>name</tabstop>
+  <tabstop>image</tabstop>
+  <tabstop>throttleSource</tabstop>
+  <tabstop>throttleTrim</tabstop>
+  <tabstop>throttleWarning</tabstop>
+  <tabstop>throttleReverse</tabstop>
+  <tabstop>trimIncrement</tabstop>
+  <tabstop>extendedLimits</tabstop>
+  <tabstop>extendedTrims</tabstop>
+  <tabstop>displayText</tabstop>
+  <tabstop>potWarningMode</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/modeledit/setup_module.ui
+++ b/companion/src/modeledit/setup_module.ui
@@ -541,6 +541,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>trainerMode</tabstop>
+  <tabstop>protocol</tabstop>
+  <tabstop>channelsStart</tabstop>
+  <tabstop>channelsCount</tabstop>
+  <tabstop>ppmFrameLength</tabstop>
+  <tabstop>ppmPolarity</tabstop>
+  <tabstop>ppmDelay</tabstop>
+  <tabstop>failsafeMode</tabstop>
+  <tabstop>rxNumber</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/modeledit/telemetry.ui
+++ b/companion/src/modeledit/telemetry.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>850</width>
-    <height>457</height>
+    <height>521</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1005,6 +1005,28 @@
    <header>qautocombobox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>telemetryProtocol</tabstop>
+  <tabstop>rssiAlarm1CB</tabstop>
+  <tabstop>rssiAlarm1SB</tabstop>
+  <tabstop>rssiAlarm2CB</tabstop>
+  <tabstop>rssiAlarm2SB</tabstop>
+  <tabstop>varioSourceCB</tabstop>
+  <tabstop>varioLimitMin_DSB</tabstop>
+  <tabstop>varioLimitCenterMin_DSB</tabstop>
+  <tabstop>varioLimitCenterMax_DSB</tabstop>
+  <tabstop>varioLimitMax_DSB</tabstop>
+  <tabstop>AltitudeGPS_ChkB</tabstop>
+  <tabstop>AltitudeToolbar_ChkB</tabstop>
+  <tabstop>frskyProtoCB</tabstop>
+  <tabstop>fasOffset_DSB</tabstop>
+  <tabstop>mahCount_SB</tabstop>
+  <tabstop>mahCount_ChkB</tabstop>
+  <tabstop>frskyVoltCB</tabstop>
+  <tabstop>frskyCurrentCB</tabstop>
+  <tabstop>bladesCount</tabstop>
+  <tabstop>customScreens</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/modeledit/telemetry_analog.ui
+++ b/companion/src/modeledit/telemetry_analog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>276</width>
-    <height>118</height>
+    <height>138</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -325,6 +325,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>UnitCB</tabstop>
+  <tabstop>RatioSB</tabstop>
+  <tabstop>CalibSB</tabstop>
+  <tabstop>alarm1LevelCB</tabstop>
+  <tabstop>alarm1GreaterCB</tabstop>
+  <tabstop>alarm1ValueSB</tabstop>
+  <tabstop>alarm2LevelCB</tabstop>
+  <tabstop>alarm2GreaterCB</tabstop>
+  <tabstop>alarm2ValueSB</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/preferencesdialog.ui
+++ b/companion/src/preferencesdialog.ui
@@ -1625,22 +1625,91 @@ May be different from firmware language</string>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>InvertPixels</tabstop>
-  <tabstop>clearImageButton</tabstop>
+  <tabstop>showSplash</tabstop>
+  <tabstop>startupCheck_companion9x</tabstop>
+  <tabstop>startupCheck_fw</tabstop>
+  <tabstop>historySize</tabstop>
+  <tabstop>wizardEnable_ChkB</tabstop>
+  <tabstop>backupPath</tabstop>
+  <tabstop>backupPathButton</tabstop>
+  <tabstop>backupEnable</tabstop>
+  <tabstop>ge_lineedit</tabstop>
+  <tabstop>ge_pathButton</tabstop>
   <tabstop>SplashFileName</tabstop>
   <tabstop>splashLibraryButton</tabstop>
   <tabstop>SplashSelect</tabstop>
+  <tabstop>splashincludeCB</tabstop>
   <tabstop>libraryPath</tabstop>
   <tabstop>libraryPathButton</tabstop>
-  <tabstop>downloadVerCB</tabstop>
-  <tabstop>fw_dnld</tabstop>
-  <tabstop>optionCheckBox_1</tabstop>
-  <tabstop>optionCheckBox_2</tabstop>
-  <tabstop>checkFWUpdates</tabstop>
-  <tabstop>channelorderCB</tabstop>
+  <tabstop>InvertPixels</tabstop>
+  <tabstop>clearImageButton</tabstop>
+  <tabstop>backLightColor</tabstop>
+  <tabstop>simuSW</tabstop>
   <tabstop>joystickChkB</tabstop>
   <tabstop>joystickCB</tabstop>
   <tabstop>joystickcalButton</tabstop>
+  <tabstop>snapshotClipboardCKB</tabstop>
+  <tabstop>snapshotPath</tabstop>
+  <tabstop>snapshotPathButton</tabstop>
+  <tabstop>downloadVerCB</tabstop>
+  <tabstop>langCombo</tabstop>
+  <tabstop>fw_dnld</tabstop>
+  <tabstop>sdPath</tabstop>
+  <tabstop>sdPathButton</tabstop>
+  <tabstop>voiceCombo</tabstop>
+  <tabstop>voice_dnld</tabstop>
+  <tabstop>optionCheckBox_1</tabstop>
+  <tabstop>optionCheckBox_2</tabstop>
+  <tabstop>optionCheckBox_3</tabstop>
+  <tabstop>optionCheckBox_4</tabstop>
+  <tabstop>optionCheckBox_5</tabstop>
+  <tabstop>optionCheckBox_6</tabstop>
+  <tabstop>optionCheckBox_7</tabstop>
+  <tabstop>optionCheckBox_8</tabstop>
+  <tabstop>optionCheckBox_9</tabstop>
+  <tabstop>optionCheckBox_10</tabstop>
+  <tabstop>optionCheckBox_11</tabstop>
+  <tabstop>optionCheckBox_12</tabstop>
+  <tabstop>optionCheckBox_13</tabstop>
+  <tabstop>optionCheckBox_14</tabstop>
+  <tabstop>optionCheckBox_15</tabstop>
+  <tabstop>optionCheckBox_16</tabstop>
+  <tabstop>optionCheckBox_17</tabstop>
+  <tabstop>optionCheckBox_18</tabstop>
+  <tabstop>optionCheckBox_19</tabstop>
+  <tabstop>optionCheckBox_20</tabstop>
+  <tabstop>optionCheckBox_21</tabstop>
+  <tabstop>optionCheckBox_22</tabstop>
+  <tabstop>optionCheckBox_23</tabstop>
+  <tabstop>optionCheckBox_24</tabstop>
+  <tabstop>optionCheckBox_25</tabstop>
+  <tabstop>optionCheckBox_26</tabstop>
+  <tabstop>optionCheckBox_27</tabstop>
+  <tabstop>optionCheckBox_28</tabstop>
+  <tabstop>optionCheckBox_29</tabstop>
+  <tabstop>optionCheckBox_30</tabstop>
+  <tabstop>optionCheckBox_31</tabstop>
+  <tabstop>optionCheckBox_32</tabstop>
+  <tabstop>optionCheckBox_33</tabstop>
+  <tabstop>optionCheckBox_34</tabstop>
+  <tabstop>optionCheckBox_35</tabstop>
+  <tabstop>optionCheckBox_36</tabstop>
+  <tabstop>optionCheckBox_37</tabstop>
+  <tabstop>optionCheckBox_38</tabstop>
+  <tabstop>optionCheckBox_39</tabstop>
+  <tabstop>optionCheckBox_40</tabstop>
+  <tabstop>optionCheckBox_41</tabstop>
+  <tabstop>optionCheckBox_42</tabstop>
+  <tabstop>checkFWUpdates</tabstop>
+  <tabstop>renameFirmware</tabstop>
+  <tabstop>burnFirmware</tabstop>
+  <tabstop>stickmodeCB</tabstop>
+  <tabstop>channelorderCB</tabstop>
+  <tabstop>ProfSlot_SB</tabstop>
+  <tabstop>ProfName_LE</tabstop>
+  <tabstop>ProfSave_PB</tabstop>
+  <tabstop>import_PB</tabstop>
+  <tabstop>export_PB</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/simulation/joystickdialog.ui
+++ b/companion/src/simulation/joystickdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>301</height>
+    <width>505</width>
+    <height>398</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -908,6 +908,35 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>Ch_1</tabstop>
+  <tabstop>ChInv_1</tabstop>
+  <tabstop>jsmapCB_1</tabstop>
+  <tabstop>Ch_2</tabstop>
+  <tabstop>ChInv_2</tabstop>
+  <tabstop>jsmapCB_2</tabstop>
+  <tabstop>Ch_3</tabstop>
+  <tabstop>ChInv_3</tabstop>
+  <tabstop>jsmapCB_3</tabstop>
+  <tabstop>Ch_4</tabstop>
+  <tabstop>ChInv_4</tabstop>
+  <tabstop>jsmapCB_4</tabstop>
+  <tabstop>Ch_5</tabstop>
+  <tabstop>ChInv_5</tabstop>
+  <tabstop>jsmapCB_5</tabstop>
+  <tabstop>Ch_6</tabstop>
+  <tabstop>ChInv_6</tabstop>
+  <tabstop>jsmapCB_6</tabstop>
+  <tabstop>Ch_7</tabstop>
+  <tabstop>ChInv_7</tabstop>
+  <tabstop>jsmapCB_7</tabstop>
+  <tabstop>Ch_8</tabstop>
+  <tabstop>ChInv_8</tabstop>
+  <tabstop>jsmapCB_8</tabstop>
+  <tabstop>cancelButton</tabstop>
+  <tabstop>nextButton</tabstop>
+  <tabstop>okButton</tabstop>
+ </tabstops>
  <resources>
   <include location="companion.qrc"/>
  </resources>

--- a/companion/src/simulation/simulatordialog-taranis.ui
+++ b/companion/src/simulation/simulatordialog-taranis.ui
@@ -1694,6 +1694,43 @@ QPushButton:checked {
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>switchF</tabstop>
+  <tabstop>dialP_3</tabstop>
+  <tabstop>switchE</tabstop>
+  <tabstop>switchA</tabstop>
+  <tabstop>switchB</tabstop>
+  <tabstop>dialP_1</tabstop>
+  <tabstop>dialP_2</tabstop>
+  <tabstop>switchC</tabstop>
+  <tabstop>switchD</tabstop>
+  <tabstop>switchG</tabstop>
+  <tabstop>dialP_4</tabstop>
+  <tabstop>switchH</tabstop>
+  <tabstop>holdLeftY</tabstop>
+  <tabstop>FixLeftY</tabstop>
+  <tabstop>FixLeftX</tabstop>
+  <tabstop>holdLeftX</tabstop>
+  <tabstop>leftStick</tabstop>
+  <tabstop>trimHL_L</tabstop>
+  <tabstop>trimHLeft</tabstop>
+  <tabstop>trimHL_R</tabstop>
+  <tabstop>trimVL_D</tabstop>
+  <tabstop>trimVLeft</tabstop>
+  <tabstop>trimVL_U</tabstop>
+  <tabstop>trimVR_U</tabstop>
+  <tabstop>trimVRight</tabstop>
+  <tabstop>trimVR_D</tabstop>
+  <tabstop>trimHR_L</tabstop>
+  <tabstop>trimHRight</tabstop>
+  <tabstop>trimHR_R</tabstop>
+  <tabstop>rightStick</tabstop>
+  <tabstop>holdRightY</tabstop>
+  <tabstop>FixRightY</tabstop>
+  <tabstop>FixRightX</tabstop>
+  <tabstop>holdRightX</tabstop>
+ </tabstops>
  <resources>
   <include location="../companion.qrc"/>
  </resources>


### PR DESCRIPTION
This unfortunately is not a complete solution. Some controls are created in code (for example timers in model settings) and their tab order is not set.
