### PR TITLE
Re #1937: reverse polarity on external CPPM output (Taranis all)

### DIFF
--- a/radio/src/targets/taranis/pulses_driver.cpp
+++ b/radio/src/targets/taranis/pulses_driver.cpp
@@ -546,7 +546,7 @@ static void init_pa7_ppm()
   TIM8->CCER = TIM_CCER_CC1E ;
 #else
   TIM8->CCER = TIM_CCER_CC1NE;
-  if(!g_model.moduleData[EXTERNAL_MODULE].ppmPulsePol)
+  if(g_model.moduleData[EXTERNAL_MODULE].ppmPulsePol)
     TIM8->CCER |= TIM_CCER_CC1NP;
 #endif
   TIM8->CCMR1 = TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC2PE ;                   // PWM mode 1


### PR DESCRIPTION
Closes #1937 

I did not verify this, but since we are using complementary output the polarity has to use reversed logic also.
