### PR TITLE
Correction to "compilation error on 9XR with MAVLINK extension"

### DIFF
--- a/radio/src/telemetry/mavlink.cpp
+++ b/radio/src/telemetry/mavlink.cpp
@@ -73,6 +73,10 @@ uint8_t mav_dump_rx = 0;
 #if defined(CPUARM)
 #else
 #include "serial.cpp"
+void MAVLINK_rxhandler(uint8_t byte) {
+	processSerialData(byte);
+}
+
 SerialFuncP RXHandler = MAVLINK_rxhandler;
 #endif
 


### PR DESCRIPTION
It compiles ok, but I have't tested on a 9XR radio.
Modifications are minimal and it should work
