### PR TITLE
Issue #1935 - added Mavlink 115200 Baud speed - to test

### DIFF
--- a/radio/src/gui/view_mavlink.cpp
+++ b/radio/src/gui/view_mavlink.cpp
@@ -206,7 +206,11 @@ void mav_title(const pm_char * s, uint8_t index)
   lcd_putsAtt(0, 0, PSTR("MAVLINK"), INVERS);
   lcd_puts(10 * FW, 0, s);
   displayScreenIndex(index, MAX_MAVLINK_MENU, INVERS);
+  #if defined(PCBSKY9X)
   lcd_putc(7 * FW, 0, mav_heartbeat+'0');	/* ok til 9 :-) */
+  #else
+  lcd_putc(7 * FW, 0, (mav_heartbeat > 0) ? '*' : ' ');  
+  #endif
   lcd_putc(8 * FW, 0, telemetry_data.active ? 'A' : 'N');
 }
 
@@ -344,7 +348,7 @@ void menuTelemetryMavlinkBattery(void) {
     
 }
 
-/*!	\brief Navigation dislplay
+/*!	\brief Navigation display
  *	\details Shows Navigation telemetry.
  *	Altitude in this menu is the relative (to the home location) altitude. This
  *	is the same altitude used by the waypoints.

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -243,6 +243,23 @@ static void uart_76800(void) {
 #endif
 }
 
+static void uart_115200(void) {
+#ifndef SIMU
+#undef BAUD  // avoid compiler warning
+//#define USE_2X 1			// not useful
+//#define BAUD 115200		// compiler warning
+#define BAUD 115400			// compiles ok -> TODO check BAUD_TOL
+#include <util/setbaud.h>
+  UBRR0H = UBRRH_VALUE;
+  UBRR0L = UBRRL_VALUE;
+#if USE_2X
+  UCSR0A |= (1 << U2X0);
+#else
+	UCSR0A &= ~(1 << U2X0);
+#endif
+#endif
+}
+
 inline void SERIAL_EnableTXD(void) {
 	//UCSR0B |= (1 << TXEN0); // enable TX
 	UCSR0B |= (1 << TXEN0) | (1 << UDRIE0); // enable TX and TX interrupt
@@ -280,6 +297,12 @@ void SERIAL_Init(void) {
 		break;
 	case BAUD_76800:
 		uart_76800();
+		break;
+	case BAUD_115200:
+		uart_115200();
+		break;
+	default:
+		uart_9600();
 		break;
 	}
 

--- a/radio/src/serial.h
+++ b/radio/src/serial.h
@@ -32,7 +32,8 @@ enum SERIAL_BAUDS {
 	BAUD_19200,
 	BAUD_38400,
 	BAUD_57600,
-	BAUD_76800
+	BAUD_76800,
+	BAUD_115200
 };
 
 //! \brief Definition of baudrate settings item choices.

--- a/radio/src/telemetry/mavlink.h
+++ b/radio/src/telemetry/mavlink.h
@@ -63,8 +63,8 @@ extern void SERIAL_send_uart_bytes(const uint8_t * buf, uint16_t len);
 #include "../GCS_MAVLink/include_v1.0/ardupilotmega/mavlink.h"
 
 //#define MAVLINK_PARAMS
-#define DUMP_RX_TX
-//#undef DUMP_RX_TX
+//#define DUMP_RX_TX
+#undef DUMP_RX_TX
 #define ERROR_NUM_MODES 99
 #define ERROR_MAV_ACTION_NB 99
 
@@ -239,7 +239,8 @@ void MAVLINK_Init(void);
 void telemetryWakeup();
 void telemetryInterrupt10ms(void);
 void menuTelemetryMavlink(uint8_t);
-NOINLINE void processSerialData(uint8_t);
+static void processSerialData(uint8_t c);
+
 uint32_t Index2Baud(uint8_t);
 
 static inline void handleMessage(mavlink_message_t*);


### PR DESCRIPTION
I used a trick to avoid compiler warning about 115200 speed.
Tested on my APM2.5 and openlrsng settled @ 115200 and works.


Note: 115200 to 115400 difference is 1.8% -> should be compatible with RS232C standards.

