### PR TITLE
Fixes #1937: reverse polarity on external CPPM output (Taranis)

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -1,3 +1,11 @@
+<h2>Version 2.0.16 / todo</h2>
+
+[Taranis]
+<ul>
+<li>Fixed reverse polarity on external PPM output. <b>Users with external module in PPM mode should check and update PPM polarity setting.</b></li>
+</ul>
+
+
 <h2>Version 2.0.15 / 2015-01-13</h2>
 
 Nothing new (only Companion fixes)
@@ -14,7 +22,7 @@ Nothing new (only Companion fixes)
 <li>Added switch auto detection in Timer source</li>
 <li>Totally removed splash screen display if duration is set to ---</li>
 <li>Back-light turned on sooner at startup (Taranis +)</li>
-<li>Fixed reverse polarity on external CPPM output</li>
+<li><strike>Fixed reverse polarity on external CPPM output</strike> (update: this was not fixed in 2.0.14)</li>
 <li>Suppressed center beep for non-existing pots</li>
 <li>Fixed THt persistent timer running after model load (with Throttle at -100%)</li>
 <li>Fixed buffer overflow for automatic flight mode change audio announcements (if very long model and flight mode names were used)</li>

--- a/radio/src/Makefile
+++ b/radio/src/Makefile
@@ -307,6 +307,12 @@ TRACE_SD_CARD = NO
 TRACE_FATFS = NO
 TRACE_AUDIO = NO
 
+# Enable internal module PPM mode for Taranis 
+# Notice: enabling this only enable code in the driver, 
+# the menu selection is still not possible.
+# Values = NO, YES
+TARANIS_INTERNAL_PPM = NO
+
 #------- END BUILD OPTIONS ---------------------------
 
 # Define programs and commands.
@@ -712,6 +718,9 @@ ifeq ($(PCB), TARANIS)
   endif
   ifeq ($(DEBUG_TRACE_BUFFER), YES)
     CPPDEFS += -DDEBUG_TRACE_BUFFER 
+  endif
+  ifeq ($(TARANIS_INTERNAL_PPM), YES)
+    CPPDEFS += -DTARANIS_INTERNAL_PPM
   endif
   LDSCRIPT = targets/taranis/stm32_flash_bl.ld
   TRGT = arm-none-eabi-

--- a/radio/src/pulses/ppm_arm.cpp
+++ b/radio/src/pulses/ppm_arm.cpp
@@ -88,5 +88,10 @@ void setupPulsesPPM(unsigned int port)                   // Don't enable interru
   else if (port == EXTERNAL_MODULE) {
     set_external_ppm_parameters(rest, ppmDelay, !g_model.moduleData[EXTERNAL_MODULE].ppmPulsePol);
   }
+#if defined(TARANIS_INTERNAL_PPM)
+  else if (port == INTERNAL_MODULE) {
+    set_internal_ppm_parameters(rest, ppmDelay, !g_model.moduleData[INTERNAL_MODULE].ppmPulsePol);
+  }
+#endif   // #if defined(TARANIS_INTERNAL_PPM)
 #endif
 }

--- a/radio/src/targets/taranis/board_taranis.h
+++ b/radio/src/targets/taranis/board_taranis.h
@@ -150,6 +150,7 @@ void init_no_pulses(uint32_t port);
 void disable_no_pulses(uint32_t port);
 void init_ppm( uint32_t module_index );
 void disable_ppm( uint32_t module_index );
+void set_external_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
 void init_pxx( uint32_t module_index );
 void disable_pxx( uint32_t module_index );
 void init_dsm2( uint32_t module_index );
@@ -158,6 +159,7 @@ void disable_dsm2( uint32_t module_index );
 // Trainer driver
 void init_trainer_ppm(void);
 void stop_trainer_ppm(void);
+void set_trainer_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
 void init_trainer_capture(void);
 void stop_trainer_capture(void);
 

--- a/radio/src/targets/taranis/board_taranis.h
+++ b/radio/src/targets/taranis/board_taranis.h
@@ -151,6 +151,9 @@ void disable_no_pulses(uint32_t port);
 void init_ppm( uint32_t module_index );
 void disable_ppm( uint32_t module_index );
 void set_external_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
+#if defined(TARANIS_INTERNAL_PPM)
+  void set_internal_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
+#endif
 void init_pxx( uint32_t module_index );
 void disable_pxx( uint32_t module_index );
 void init_dsm2( uint32_t module_index );


### PR DESCRIPTION
Removed support for internal module PPM mode (Taranis)
Hw specific code moved to drivers

I have tested this on my Taranis radio and oscilloscope. I measured both external module and trainer port signals before and after this modification. My tests show that it now works correct in every mode. 

**But I won't let this be merged until somebody else also tests this on their radio**.

Another thing: There are already upset/confused users on forums. They are mainly annoyed by the fact that such important thing as PPM polarity has changed in 2.0.15 (fortunately in reality it hasn't changed yet) and they were not aware of that. They say that they were not informed about this at the upgrade time.  We have a note about this in the firmware changelog, but I gues that is not enough for everybody. Do we have any solution for this, because this pull will **really change** PPM polarity?
