### PR TITLE
Saves RAM on Taranis

### DIFF
--- a/radio/src/pulses/ppm_arm.cpp
+++ b/radio/src/pulses/ppm_arm.cpp
@@ -36,13 +36,6 @@
 
 #include "../opentx.h"
 
-#define PPM_STREAM_INIT  { 2000, 2200, 2400, 2600, 2800, 3000, 3200, 3400, 9000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
-#if defined(PCBTARANIS)
-  uint16_t ppmStream[NUM_MODULES+1][20]  = { PPM_STREAM_INIT, PPM_STREAM_INIT, PPM_STREAM_INIT };
-#else
-  uint16_t ppmStream[NUM_MODULES][20]  = { MODULES_INIT(PPM_STREAM_INIT) };
-#endif
-
 void setupPulsesPPM(unsigned int port)                   // Don't enable interrupts through here
 {
   int16_t PPM_range = g_model.extendedLimits ? (512*LIMIT_EXT_PERCENT/100) * 2 : 512 * 2; //range of 0.7..1.7msec
@@ -65,7 +58,7 @@ void setupPulsesPPM(unsigned int port)                   // Don't enable interru
     pwmptr->PWM_CH_NUM[pwmCh].PWM_CMR |= 0x00000200 ;   // CPOL
 #endif
 
-  uint16_t * ptr = ppmStream[port];
+  uint16_t * ptr = (port == TRAINER_MODULE ? trainerPulsesData.ppm.pulses : modulePulsesData[port].ppm.pulses);
   int32_t rest = 22500u * 2;
   rest += (int32_t(g_model.moduleData[port].ppmFrameLength)) * 1000;
   for (uint32_t i=firstCh; i<lastCh; i++) {

--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -40,7 +40,7 @@ uint8_t s_pulses_paused = 0;
 uint8_t s_current_protocol[NUM_MODULES] = { MODULES_INIT(255) };
 uint16_t failsafeCounter[NUM_MODULES] = { MODULES_INIT(100) };
 uint8_t moduleFlag[NUM_MODULES] = { 0 };
-uint32_t nextMixerTime[NUM_MODULES] = { 0 };
+U64 nextMixerTime[NUM_MODULES] = { 0 };
 #define SCHEDULE_MIXER_START(module, delay) nextMixerTime[module] = (CoGetOSTime() + (delay)/2 - 1/*2ms*/)
 
 ModulePulsesData modulePulsesData[NUM_MODULES];

--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -40,7 +40,7 @@ uint8_t s_pulses_paused = 0;
 uint8_t s_current_protocol[NUM_MODULES] = { MODULES_INIT(255) };
 uint16_t failsafeCounter[NUM_MODULES] = { MODULES_INIT(100) };
 uint8_t moduleFlag[NUM_MODULES] = { 0 };
-U64 nextMixerTime[NUM_MODULES] = { 0 };
+uint64_t nextMixerTime[NUM_MODULES] = { 0 };
 #define SCHEDULE_MIXER_START(module, delay) nextMixerTime[module] = (CoGetOSTime() + (delay)/2 - 1/*2ms*/)
 
 ModulePulsesData modulePulsesData[NUM_MODULES];

--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -40,6 +40,11 @@ uint8_t s_pulses_paused = 0;
 uint8_t s_current_protocol[NUM_MODULES] = { MODULES_INIT(255) };
 uint16_t failsafeCounter[NUM_MODULES] = { MODULES_INIT(100) };
 uint8_t moduleFlag[NUM_MODULES] = { 0 };
+uint32_t nextMixerTime[NUM_MODULES] = { 0 };
+#define SCHEDULE_MIXER_START(module, delay) nextMixerTime[module] = (CoGetOSTime() + (delay)/2 - 1/*2ms*/)
+
+ModulePulsesData modulePulsesData[NUM_MODULES];
+TrainerPulsesData trainerPulsesData;
 
 void setupPulses(unsigned int port)
 {
@@ -144,18 +149,22 @@ void setupPulses(unsigned int port)
   switch (required_protocol) {
     case PROTO_PXX:
       setupPulsesPXX(port);
+      SCHEDULE_MIXER_START(port, 9);
       break;
 #if defined(DSM2)
     case PROTO_DSM2_LP45:
     case PROTO_DSM2_DSM2:
     case PROTO_DSM2_DSMX:
       setupPulsesDSM2(port);
+      SCHEDULE_MIXER_START(port, 11);
       break;
 #endif
     case PROTO_PPM:
       setupPulsesPPM(port);
+      SCHEDULE_MIXER_START(port, (45+g_model.moduleData[port].ppmFrameLength)/2);
       break ;
     default:
+      SCHEDULE_MIXER_START(port, 20);
       break;
   }
 }

--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -40,8 +40,6 @@ uint8_t s_pulses_paused = 0;
 uint8_t s_current_protocol[NUM_MODULES] = { MODULES_INIT(255) };
 uint16_t failsafeCounter[NUM_MODULES] = { MODULES_INIT(100) };
 uint8_t moduleFlag[NUM_MODULES] = { 0 };
-uint64_t nextMixerTime[NUM_MODULES] = { 0 };
-#define SCHEDULE_MIXER_START(module, delay) nextMixerTime[module] = (CoGetOSTime() + (delay)/2 - 1/*2ms*/)
 
 ModulePulsesData modulePulsesData[NUM_MODULES];
 TrainerPulsesData trainerPulsesData;
@@ -149,22 +147,18 @@ void setupPulses(unsigned int port)
   switch (required_protocol) {
     case PROTO_PXX:
       setupPulsesPXX(port);
-      SCHEDULE_MIXER_START(port, 9);
       break;
 #if defined(DSM2)
     case PROTO_DSM2_LP45:
     case PROTO_DSM2_DSM2:
     case PROTO_DSM2_DSMX:
       setupPulsesDSM2(port);
-      SCHEDULE_MIXER_START(port, 11);
       break;
 #endif
     case PROTO_PPM:
       setupPulsesPPM(port);
-      SCHEDULE_MIXER_START(port, (45+g_model.moduleData[port].ppmFrameLength)/2);
       break ;
     default:
-      SCHEDULE_MIXER_START(port, 20);
       break;
   }
 }

--- a/radio/src/pulses/pulses_arm.h
+++ b/radio/src/pulses/pulses_arm.h
@@ -47,6 +47,55 @@ extern uint8_t s_current_protocol[NUM_MODULES];
 extern uint8_t s_pulses_paused;
 extern uint16_t failsafeCounter[NUM_MODULES];
 
+PACK(struct PpmPulsesData {
+  uint16_t pulses[20];
+#if defined(PCBSKY9X)
+  uint32_t index;
+#else
+  uint16_t *ptr;
+#endif
+});
+
+PACK(struct PxxPulsesData {
+#if defined(PCBSKY9X)
+  uint8_t  pulses[64];
+  uint8_t  *ptr;
+#else
+  uint16_t pulses[400];
+  uint16_t *ptr;
+#endif
+  uint16_t pcmValue;
+  uint16_t pcmCrc;
+  uint8_t  pcmOnesCount;
+});
+
+PACK(struct Dsm2PulsesData {
+#if defined(PCBSKY9X)
+  uint8_t  pulses[64];
+  uint8_t *ptr;
+  uint8_t  serialByte ;
+  uint8_t  serialBitCount;
+#else
+  uint16_t pulses[400];
+  uint16_t *ptr;
+  uint16_t value;
+  uint8_t  index;
+#endif
+});
+
+union ModulePulsesData {
+  PxxPulsesData pxx;
+  Dsm2PulsesData dsm2;
+  PpmPulsesData ppm;
+};
+
+union TrainerPulsesData {
+  PpmPulsesData ppm;
+};
+
+extern ModulePulsesData modulePulsesData[NUM_MODULES];
+extern TrainerPulsesData trainerPulsesData;
+
 void setupPulses(unsigned int port);
 void setupPulsesDSM2(unsigned int port);
 void setupPulsesPXX(unsigned int port);
@@ -64,7 +113,7 @@ inline void startPulses()
   setupPulses(INTERNAL_MODULE);
   setupPulses(EXTERNAL_MODULE);
 #else
-  setupPulses(0);
+  setupPulses(EXTERNAL_MODULE);
 #endif
 
 #if defined(HUBSAN)

--- a/radio/src/pulses/pxx_arm.cpp
+++ b/radio/src/pulses/pxx_arm.cpp
@@ -40,18 +40,6 @@
 #define PXX_SEND_FAILSAFE                  (1 << 4)
 #define PXX_SEND_RANGECHECK                (1 << 5)
 
-#if defined(PCBTARANIS)
-uint16_t pxxStream[NUM_MODULES][400];
-uint16_t *pxxStreamPtr[NUM_MODULES];
-#else
-uint8_t  pxxStream[NUM_MODULES][64];
-uint8_t  *pxxStreamPtr[NUM_MODULES];
-#endif
-
-uint16_t PxxValue[NUM_MODULES];
-uint16_t PcmCrc[NUM_MODULES];
-uint8_t  PcmOnesCount[NUM_MODULES];
-
 const uint16_t CRCTable[]=
 {
   0x0000,0x1189,0x2312,0x329b,0x4624,0x57ad,0x6536,0x74bf,
@@ -90,25 +78,25 @@ const uint16_t CRCTable[]=
 
 void crc(uint8_t data, unsigned int port)
 {
-  PcmCrc[port]=(PcmCrc[port]<<8)^(CRCTable[((PcmCrc[port]>>8)^data) & 0xFF]);
+  modulePulsesData[port].pxx.pcmCrc = (modulePulsesData[port].pxx.pcmCrc<<8) ^ (CRCTable[((modulePulsesData[port].pxx.pcmCrc>>8)^data) & 0xFF]);
 }
 
 #if defined(PCBTARANIS)
 
 void putPcmPart(uint8_t value, unsigned int port)
 {
-  PxxValue[port] += 18 ;                                        // Output 1 for this time
-  *pxxStreamPtr[port]++ = PxxValue[port] ;
-  PxxValue[port] += 14 ;
+  modulePulsesData[port].pxx.pcmValue += 18 ;                                        // Output 1 for this time
+  *modulePulsesData[port].pxx.ptr++ = modulePulsesData[port].pxx.pcmValue ;
+  modulePulsesData[port].pxx.pcmValue += 14 ;
   if (value) {
-    PxxValue[port] += 16 ;
+    modulePulsesData[port].pxx.pcmValue += 16 ;
   }
-  *pxxStreamPtr[port]++ = PxxValue[port] ;  // Output 0 for this time
+  *modulePulsesData[port].pxx.ptr++ = modulePulsesData[port].pxx.pcmValue ;  // Output 0 for this time
 }
 
 void putPcmFlush(unsigned int port)
 {
-  *pxxStreamPtr[port]++ = 18010 ;             // Past the 18000 of the ARR
+  *modulePulsesData[port].pxx.ptr++ = 18010 ;             // Past the 18000 of the ARR
 }
 
 #else
@@ -122,7 +110,7 @@ void putPcmSerialBit(uint8_t bit, unsigned int port)
     pcmSerialByte[port] |= 0x80;
   }
   if (++pcmSerialBitCount[port] >= 8) {
-    *pxxStreamPtr[port]++ = pcmSerialByte[port];
+    *modulePulsesData[port].pxx.ptr++ = pcmSerialByte[port];
     pcmSerialBitCount[port] = 0;
   }
 }
@@ -149,14 +137,14 @@ void putPcmFlush(unsigned int port)
 void putPcmBit(uint8_t bit, unsigned int port)
 {
   if (bit) {
-    PcmOnesCount[port] += 1;
+    modulePulsesData[port].pxx.pcmOnesCount += 1;
     putPcmPart(1, port);
   }
   else {
-    PcmOnesCount[port] = 0;
+    modulePulsesData[port].pxx.pcmOnesCount = 0;
     putPcmPart(0, port);
   }
-  if (PcmOnesCount[port] >= 5) {
+  if (modulePulsesData[port].pxx.pcmOnesCount >= 5) {
     putPcmBit(0, port);                                // Stuff a 0 bit in
   }
 }
@@ -189,10 +177,10 @@ void setupPulsesPXX(unsigned int port)
 {
   uint16_t chan=0, chan_low=0;
 
-  pxxStreamPtr[port] = pxxStream[port];
-  PxxValue[port] = 0 ;
-  PcmCrc[port] = 0;
-  PcmOnesCount[port] = 0;
+  modulePulsesData[port].pxx.ptr = modulePulsesData[port].pxx.pulses;
+  modulePulsesData[port].pxx.pcmValue = 0 ;
+  modulePulsesData[port].pxx.pcmCrc = 0;
+  modulePulsesData[port].pxx.pcmOnesCount = 0;
 
   /* Preamble */
   putPcmPart(0, port);
@@ -271,7 +259,7 @@ void setupPulsesPXX(unsigned int port)
 
   /* CRC16 */
   putPcmByte(0, port);
-  chan = PcmCrc[port];
+  chan = modulePulsesData[port].pxx.pcmCrc;
   putPcmByte(chan>>8, port);
   putPcmByte(chan, port);
 

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -420,6 +420,7 @@ extern OS_MutexID audioMutex;
 #define CoLeaveMutexSection(m) pthread_mutex_unlock(&(m))
 #define CoTickDelay(...)
 #define CoCreateFlag(...) 0
+#define CoGetOSTime(...) 0
 inline void UART3_Configure(uint32_t baudrate, uint32_t masterClock) { }
 #define UART_Stop(...)
 #define UART3_Stop(...)

--- a/radio/src/targets/taranis/board_taranis.h
+++ b/radio/src/targets/taranis/board_taranis.h
@@ -196,8 +196,11 @@ uint32_t isBootloaderStart(const void * buffer);
 void init_no_pulses(uint32_t port);
 void disable_no_pulses(uint32_t port);
 void init_ppm( uint32_t module_index );
-void set_external_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
 void disable_ppm( uint32_t module_index );
+void set_external_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
+#if defined(TARANIS_INTERNAL_PPM)
+  void set_internal_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
+#endif
 void init_pxx( uint32_t module_index );
 void disable_pxx( uint32_t module_index );
 void init_dsm2( uint32_t module_index );
@@ -261,7 +264,7 @@ void pwrOff(void);
 uint32_t pwrPressed(void);
 uint32_t pwrPressedDuration(void);
 #endif
-#define UNEXPECTED_SHUTDOWN() (g_eeGeneral.unexpectedShutdown)
+#define UNEXPECTED_SHUTDOWN()   (g_eeGeneral.unexpectedShutdown)
 
 // Backlight driver
 #if defined(REVPLUS)

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -123,7 +123,7 @@ uint32_t stack_free(uint32_t tid)
 
 #if !defined(SIMU)
 
-extern uint32_t nextMixerTime[NUM_MODULES];
+extern U64 nextMixerTime[NUM_MODULES];
 #define GET_MIXER_DELAY(module) int(nextMixerTime[module] - CoGetOSTime())
 
 void mixerTask(void * pdata)
@@ -153,11 +153,13 @@ void mixerTask(void * pdata)
     }
 
     int delay = 10; // 20ms default
-    if (GET_MIXER_DELAY(0) >= 0)
-      delay = min(delay, GET_MIXER_DELAY(0));
+    int moduleDelay = GET_MIXER_DELAY(0);
+    if (moduleDelay >= 0)
+      delay = min(delay, moduleDelay);
 #if NUM_MODULES >= 2
-    if (GET_MIXER_DELAY(1) >= 0)
-      delay = min(delay, GET_MIXER_DELAY(1));
+    moduleDelay = GET_MIXER_DELAY(1);
+    if (moduleDelay >= 0)
+      delay = min(delay, moduleDelay);
 #endif
     CoTickDelay(delay);
   }

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -123,6 +123,9 @@ uint32_t stack_free(uint32_t tid)
 
 #if !defined(SIMU)
 
+extern uint32_t nextMixerTime[NUM_MODULES];
+#define GET_MIXER_DELAY(module) int(nextMixerTime[module] - CoGetOSTime())
+
 void mixerTask(void * pdata)
 {
   s_pulses_paused = true;
@@ -149,7 +152,14 @@ void mixerTask(void * pdata)
       if (t0 > maxMixerDuration) maxMixerDuration = t0 ;
     }
 
-    CoTickDelay(1);  // 2ms for now
+    int delay = 10; // 20ms default
+    if (GET_MIXER_DELAY(0) >= 0)
+      delay = min(delay, GET_MIXER_DELAY(0));
+#if NUM_MODULES >= 2
+    if (GET_MIXER_DELAY(1) >= 0)
+      delay = min(delay, GET_MIXER_DELAY(1));
+#endif
+    CoTickDelay(delay);
   }
 }
 

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -123,7 +123,7 @@ uint32_t stack_free(uint32_t tid)
 
 #if !defined(SIMU)
 
-extern U64 nextMixerTime[NUM_MODULES];
+extern uint64_t nextMixerTime[NUM_MODULES];
 #define GET_MIXER_DELAY(module) int(nextMixerTime[module] - CoGetOSTime())
 
 void mixerTask(void * pdata)

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -123,9 +123,6 @@ uint32_t stack_free(uint32_t tid)
 
 #if !defined(SIMU)
 
-extern uint64_t nextMixerTime[NUM_MODULES];
-#define GET_MIXER_DELAY(module) int(nextMixerTime[module] - CoGetOSTime())
-
 void mixerTask(void * pdata)
 {
   s_pulses_paused = true;
@@ -152,16 +149,7 @@ void mixerTask(void * pdata)
       if (t0 > maxMixerDuration) maxMixerDuration = t0 ;
     }
 
-    int delay = 10; // 20ms default
-    int moduleDelay = GET_MIXER_DELAY(0);
-    if (moduleDelay >= 0)
-      delay = min(delay, moduleDelay);
-#if NUM_MODULES >= 2
-    moduleDelay = GET_MIXER_DELAY(1);
-    if (moduleDelay >= 0)
-      delay = min(delay, moduleDelay);
-#endif
-    CoTickDelay(delay);
+    CoTickDelay(1);  // 2ms for now
   }
 }
 


### PR DESCRIPTION
Saves CPU (mixes calculated only when needed) and RAM (pulses arrays for PXX/DSM2/PPM shared) - Still not tested, needs a code review first!