### PR TITLE
Changelog links now open in external browser

### DIFF
--- a/companion/src/contributorsdialog.cpp
+++ b/companion/src/contributorsdialog.cpp
@@ -85,6 +85,7 @@ contributorsDialog::contributorsDialog(QWidget *parent, int contest, QString rnu
         QFile file(":/releasenotes.txt");
         if(file.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
           ui->textEditor->setHtml(file.readAll());
+          ui->textEditor->setOpenExternalLinks(true);
         }
         ui->textEditor->scroll(0,0);
         setWindowTitle(tr("Companion Release Notes"));
@@ -124,6 +125,7 @@ contributorsDialog::~contributorsDialog()
 void contributorsDialog::replyFinished(QNetworkReply * reply)
 {
     ui->textEditor->setHtml(reply->readAll());
+    ui->textEditor->setOpenExternalLinks(true);
 }
 
 void contributorsDialog::forceClose()

--- a/companion/src/contributorsdialog.ui
+++ b/companion/src/contributorsdialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QTextEdit" name="textEditor">
+    <widget class="QTextBrowser" name="textEditor">
      <property name="readOnly">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
I think this is a cool feature when combined with the release notes that contain links to fixed issues.