### PR TITLE
Fix to #2122

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -355,6 +355,8 @@ SetupPanel::SetupPanel(QWidget *parent, ModelData & model, GeneralSettings & gen
 
   ui->setupUi(this);
 
+  QRegExp rx(CHAR_FOR_NAMES_REGEX);
+  ui->name->setValidator(new QRegExpValidator(rx, this));
   ui->name->setMaxLength(IS_TARANIS(firmware->getBoard()) ? 12 : 10);
 
   if (firmware->getCapability(ModelImage)) {


### PR DESCRIPTION
Limit input characters for model name in companion. Use the same rules as for flight mode names.
Allowed characters " A-Za-z0-9_.-," (space included).