### PR TITLE
Proper SDL library initialization for Audio and Joystick subsystems

### DIFF
--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -48,6 +48,9 @@
 #include <QSplashScreen>
 #include <QThread>
 #include <iostream>
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  #include <SDL.h>
+#endif
 #include "mainwindow.h"
 #include "eeprominterface.h"
 #include "appdata.h"
@@ -95,9 +98,20 @@ int main(int argc, char *argv[])
   app.installTranslator(&qtTranslator);
 
   QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
-  
-    RegisterEepromInterfaces();
-    registerOpenTxFirmwares();
+
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  uint32_t sdlFlags = 0;
+  #ifdef JOYSTICKS
+    sdlFlags |= SDL_INIT_JOYSTICK;
+  #endif
+  #ifdef SIMU_AUDIO
+    sdlFlags |= SDL_INIT_AUDIO;
+  #endif
+  SDL_Init(sdlFlags);
+#endif
+
+  RegisterEepromInterfaces();
+  registerOpenTxFirmwares();
 
   if (g.profile[g.id()].fwType().isEmpty()){
     g.profile[g.id()].fwType(default_firmware_variant->getId());
@@ -132,6 +146,10 @@ int main(int argc, char *argv[])
 
   UnregisterFirmwares();
   UnregisterEepromInterfaces();
+
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  SDL_Quit();
+#endif
 
   return result;
 }

--- a/companion/src/simulation/joystick.cpp
+++ b/companion/src/simulation/joystick.cpp
@@ -3,13 +3,13 @@
 Joystick::Joystick(QObject *parent, int joystickEventTimeout, bool doAutoRepeat, int repeatDelay)
   : QObject(parent)
 {
-  if ( SDL_Init(SDL_INIT_JOYSTICK) == 0 ) {
+  if ( SDL_WasInit(SDL_INIT_JOYSTICK) ) {
     int i;
     for (i = 0; i < SDL_NumJoysticks(); i++)
       joystickNames.append(SDL_JoystickName(i));
     connect(&joystickTimer, SIGNAL(timeout()), this, SLOT(processEvents()));
   } else {
-    fprintf(stderr, "ERROR: couldn't initialize SDL joystick support");
+    fprintf(stderr, "ERROR: couldn't initialize SDL joystick support\n");
   }
 
   joystick = NULL;
@@ -23,8 +23,6 @@ Joystick::~Joystick()
 {
   if ( isOpen() )
     close();
-
-  SDL_Quit();
 }
 
 bool Joystick::open(int stick)

--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -48,6 +48,9 @@
 #include <QSplashScreen>
 #include <QThread>
 #include <iostream>
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  #include <SDL.h>
+#endif
 #include "simulatordialog.h"
 #include "eeprominterface.h"
 
@@ -97,6 +100,17 @@ int main(int argc, char *argv[])
 */
 
   QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
+
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  uint32_t sdlFlags = 0;
+  #ifdef JOYSTICKS
+    sdlFlags |= SDL_INIT_JOYSTICK;
+  #endif
+  #ifdef SIMU_AUDIO
+    sdlFlags |= SDL_INIT_AUDIO;
+  #endif
+  SDL_Init(sdlFlags);
+#endif
 
   RegisterEepromInterfaces();
   registerOpenTxFirmwares();
@@ -171,6 +185,10 @@ int main(int argc, char *argv[])
   int result = app.exec();
 
   delete dialog;
+
+#if defined(JOYSTICKS) || defined(SIMU_AUDIO)
+  SDL_Quit();
+#endif
 
   return result;
 }

--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -42,6 +42,9 @@
 #include "opentx.h"
 #include <time.h>
 #include <ctype.h>
+#if defined(SIMU_AUDIO)
+  #include <SDL.h>
+#endif
 
 #define LCD_ZOOM 2
 
@@ -89,6 +92,10 @@ Open9xSim::Open9xSim(FXApp* a):
   firstTime = true;
   for(int i=0; i<(LCD_W*LCD_H/8); i++) displayBuf[i]=0;//rand();
   bmp = new FXPPMImage(getApp(),NULL,IMAGE_OWNED|IMAGE_KEEP|IMAGE_SHMI|IMAGE_SHMP, W2, H2);
+
+#if defined(SIMU_AUDIO)
+  SDL_Init(SDL_INIT_AUDIO);
+#endif
 
   FXHorizontalFrame *hf11=new FXHorizontalFrame(this,LAYOUT_CENTER_X);
   FXHorizontalFrame *hf1=new FXHorizontalFrame(this,LAYOUT_FILL_X);
@@ -147,6 +154,10 @@ Open9xSim::~Open9xSim()
   }
 
   delete bmf;
+
+#if defined(SIMU_AUDIO)
+  SDL_Quit();
+#endif
 }
 
 void Open9xSim::makeSnapshot(const FXDrawable* drawable)

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -471,6 +471,11 @@ bool audio_thread_running = false;
 
 void *audio_thread(void *)
 {
+  if ( !SDL_WasInit(SDL_INIT_AUDIO) ) {
+    fprintf(stderr, "ERROR: couldn't initialize SDL audio support\n");
+    return 0;
+  }
+
   SDL_AudioSpec wanted, have;
 
   /* Set the audio format */


### PR DESCRIPTION
Now that we use two SDL subsystems (joystick and audio) the SDL initialization has to be corrected. 

This pull might also affect and/or fix https://github.com/opentx/opentx/issues/1732#issuecomment-87364197

If accepted I will prepare a PR for `next` branch.