### PR TITLE
Fix for Issue 2128 Changes to allow foreign characters in sdcard paths for Taranis and sky9...

### DIFF
--- a/companion/src/firmwares/opentx/opentxSky9xsimulator.cpp
+++ b/companion/src/firmwares/opentx/opentxSky9xsimulator.cpp
@@ -155,11 +155,9 @@ using namespace Open9xSky9x;
 Open9xSky9xSimulator::Open9xSky9xSimulator()
 {
     QString path=g.profile[g.id()].sdPath()+"/";
-    int i=0;
-    for (i=0; i< std::min(path.length(),1022); i++) {
-      simuSdDirectory[i]=path.at(i).toAscii();
-    }
-    simuSdDirectory[i]=0;  
+    strncpy (simuSdDirectory, path.toAscii().constData(), sizeof(simuSdDirectory)-1);
+    simuSdDirectory[sizeof(simuSdDirectory)-1] = '\0';
+
 }
 
 bool Open9xSky9xSimulator::timer10ms()

--- a/companion/src/firmwares/opentx/opentxTaranisSimulator.cpp
+++ b/companion/src/firmwares/opentx/opentxTaranisSimulator.cpp
@@ -197,11 +197,8 @@ OpentxTaranisSimulator::OpentxTaranisSimulator()
 {
   taranisSimulatorBoard = GetEepromInterface()->getBoard();
   QString path=g.profile[g.id()].sdPath()+"/";
-  int i=0;
-  for (i=0; i< std::min(path.length(),1022); i++) {
-    simuSdDirectory[i]=path.at(i).toAscii();
-  }
-  simuSdDirectory[i]=0;  
+  strncpy (simuSdDirectory, path.toAscii().constData(), sizeof(simuSdDirectory)-1);
+  simuSdDirectory[sizeof(simuSdDirectory)-1] = '\0';  
 }
 
 bool OpentxTaranisSimulator::timer10ms()


### PR DESCRIPTION
Changes to allow foreign characters in sdcard paths for Taranis and sky9x Companion and simulators. 

Closes Issue #2128.