### PR TITLE
Fixes #2154: USB mass storage problem with cards bigger than 4GB

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -17,6 +17,8 @@
 <li>Telemetry bars title fix (<a href=https://github.com/opentx/opentx/issues/2203>#2203</a>)</li> 
 </ul>
 
+[Bootloader]
+<li>Fixed USB access problem with SD cards larger than 4GB (<a href=https://github.com/opentx/opentx/issues/2154>#2154</a>)</li> 
 
 
 <h2>Version 2.0.15 / 2015-01-13</h2>

--- a/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/radio/src/targets/taranis/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -511,7 +511,6 @@ static int8_t SCSI_Read10(uint8_t lun , uint8_t *params)
     }
     
     MSC_BOT_State = BOT_DATA_IN;
-    SCSI_blk_addr *= SCSI_blk_size;
     SCSI_blk_len  *= SCSI_blk_size;
     
     /* cases 4,5 : Hi <> Dn */
@@ -583,7 +582,6 @@ static int8_t SCSI_Write10 (uint8_t lun , uint8_t *params)
       return -1; /* error */      
     }
     
-    SCSI_blk_addr *= SCSI_blk_size;
     SCSI_blk_len  *= SCSI_blk_size;
     
     /* cases 3,11,13 : Hn,Ho <> D0 */
@@ -672,7 +670,7 @@ static int8_t SCSI_ProcessRead (uint8_t lun)
   
   if( USBD_STORAGE_fops->Read(lun ,
                               MSC_BOT_Data, 
-                              SCSI_blk_addr / SCSI_blk_size, 
+                              SCSI_blk_addr, 
                               len / SCSI_blk_size) < 0)
   {
     
@@ -687,7 +685,7 @@ static int8_t SCSI_ProcessRead (uint8_t lun)
              len);
   
   
-  SCSI_blk_addr   += len; 
+  SCSI_blk_addr   += len / SCSI_blk_size; 
   SCSI_blk_len    -= len;  
   
   /* case 6 : Hi = Di */
@@ -715,7 +713,7 @@ static int8_t SCSI_ProcessWrite (uint8_t lun)
   
   if(USBD_STORAGE_fops->Write(lun ,
                               MSC_BOT_Data, 
-                              SCSI_blk_addr / SCSI_blk_size, 
+                              SCSI_blk_addr, 
                               len / SCSI_blk_size) < 0)
   {
     SCSI_SenseCode(lun, HARDWARE_ERROR, WRITE_FAULT);     
@@ -723,7 +721,7 @@ static int8_t SCSI_ProcessWrite (uint8_t lun)
   }
   
   
-  SCSI_blk_addr  += len; 
+  SCSI_blk_addr  += len / SCSI_blk_size; 
   SCSI_blk_len   -= len; 
   
   /* case 12 : Ho = Do */


### PR DESCRIPTION
This attempts to fix large (>4GB) SD card problem without resorting to 64 bit variables and arithmetics.

I have tested this with my radio and 8GB SD card and looks like it is working. I insist that somebody else also tests this, before we merge into `master`!

Closes #2154 