### PR TITLE
Projectkk2glider/issue 2260 simulator volume gain

### DIFF
--- a/companion/releasenotes.txt
+++ b/companion/releasenotes.txt
@@ -3,6 +3,7 @@
 <li>Enabled <i>Mixers monitor</i> in Taranis simulator</li>
 <li>Better support for multi-axes in Log Viewer (<a href=https://github.com/opentx/opentx/issues/2267>#2267</a>)</li>
 <li>File path issue in Taranis simulator function <i>findTrueFileName()</i> on Windows (<a href=https://github.com/opentx/opentx/issues/2301>#2301</a>)</li>
+<li>Added simulator volume gain setting (<a href=https://github.com/opentx/opentx/issues/2260>#2260</a>)</li>
 </ul>
 
 

--- a/companion/src/appdata.cpp
+++ b/companion/src/appdata.cpp
@@ -295,6 +295,7 @@ QString Profile::fwName()        const { return _fwName;        }
 QString Profile::fwType()        const { return _fwType;        }
 QString Profile::name()          const { return _name;          }
 QString Profile::sdPath()        const { return _sdPath;        }
+int     Profile::volumeGain()    const { return _volumeGain;    }
 QString Profile::pBackupDir()    const { return _pBackupDir;    }
 QString Profile::splashFile()    const { return _splashFile;    }
 bool    Profile::burnFirmware()  const { return _burnFirmware;  }
@@ -324,6 +325,7 @@ void Profile::name          (const QString x) { store(x, _name,          "Name" 
 void Profile::fwName        (const QString x) { store(x, _fwName,        "fwName"                ,"Profiles", QString("profile%1").arg(index));}
 void Profile::fwType        (const QString x) { store(x, _fwType,        "fwType"                ,"Profiles", QString("profile%1").arg(index));}
 void Profile::sdPath        (const QString x) { store(x, _sdPath,        "sdPath"                ,"Profiles", QString("profile%1").arg(index));}
+void Profile::volumeGain    (const int     x) { store(x, _volumeGain,    "volumeGain"            ,"Profiles", QString("profile%1").arg(index));}
 void Profile::pBackupDir    (const QString x) { store(x, _pBackupDir,    "pBackupDir"            ,"Profiles", QString("profile%1").arg(index));}
 void Profile::splashFile    (const QString x) { store(x, _splashFile,    "SplashFileName"        ,"Profiles", QString("profile%1").arg(index));}
 void Profile::burnFirmware  (const bool    x) { store(x, _burnFirmware,  "burnFirmware"          ,"Profiles", QString("profile%1").arg(index));}
@@ -361,6 +363,7 @@ Profile& Profile::operator=(const Profile& rhs)
     fwName       ( rhs.fwName()        );
     fwType       ( rhs.fwType()        );
     sdPath       ( rhs.sdPath()        );
+    volumeGain   ( rhs.volumeGain()    );
     pBackupDir   ( rhs.pBackupDir()    );
     splashFile   ( rhs.splashFile()    );
     burnFirmware ( rhs.burnFirmware()  );
@@ -438,6 +441,7 @@ void Profile::init(int newIndex)
     _fwType =        "";
     _name =          "";
     _sdPath =        "";
+    _volumeGain =    10;
     _pBackupDir =    "";
     _splashFile =    "";
     _burnFirmware =  false;
@@ -462,6 +466,7 @@ void Profile::flush()
     getset( _fwType,        "fwType"                ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _name,          "Name"                  ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _sdPath,        "sdPath"                ,""     ,"Profiles", QString("profile%1").arg(index));
+    getset( _volumeGain,    "volumeGain"            ,10     ,"Profiles", QString("profile%1").arg(index));
     getset( _pBackupDir,    "pBackupDir"            ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _splashFile,    "SplashFileName"        ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _burnFirmware,  "burnFirmware"          ,false  ,"Profiles", QString("profile%1").arg(index));

--- a/companion/src/appdata.h
+++ b/companion/src/appdata.h
@@ -107,6 +107,7 @@ class Profile: protected CompStoreObj
     QString _fwType;
     QString _name;
     QString _sdPath;
+    int     _volumeGain;
     QString _pBackupDir;
     QString _splashFile;
     bool    _burnFirmware;
@@ -138,6 +139,7 @@ class Profile: protected CompStoreObj
     QString fwType() const;
     QString name() const;
     QString sdPath() const;
+    int     volumeGain() const;
     QString pBackupDir() const;
     QString splashFile() const;
     bool    burnFirmware() const;
@@ -166,6 +168,7 @@ class Profile: protected CompStoreObj
     void name          (const QString);
     void fwName        (const QString);
     void fwType        (const QString);
+    void volumeGain    (const int);
     void sdPath        (const QString);
     void pBackupDir    (const QString);
     void splashFile    (const QString);

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -48,6 +48,7 @@ void AppPreferencesDialog::writeValues()
   g.useWizard(ui->modelWizard_CB->isChecked());
   g.historySize(ui->historySize->value());
   g.backLight(ui->backLightColor->currentIndex());
+  g.profile[g.id()].volumeGain(round(ui->volumeGain->value() * 10.0));
   g.libDir(ui->libraryPath->text());
   g.gePath(ui->ge_lineedit->text());
   g.embedSplashes(ui->splashincludeCB->currentIndex());
@@ -111,6 +112,7 @@ void AppPreferencesDialog::initSettings()
   ui->showSplash->setChecked(g.showSplash());
   ui->historySize->setValue(g.historySize());
   ui->backLightColor->setCurrentIndex(g.backLight());
+  ui->volumeGain->setValue(g.profile[g.id()].volumeGain() / 10.0);
 
   if (IS_TARANIS(GetCurrentFirmware()->getBoard())) {
     ui->backLightColor->setEnabled(false);

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>686</width>
-    <height>550</height>
+    <height>619</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -889,49 +889,10 @@ Mode 4:
        <string>Simulator Settings</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="5" column="4">
+        <widget class="QPushButton" name="joystickcalButton">
          <property name="text">
-          <string>Simulator BackLight</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="2">
-        <widget class="QCheckBox" name="joystickChkB">
-         <property name="text">
-          <string>Enable</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="4">
-        <widget class="QPushButton" name="snapshotPathButton">
-         <property name="text">
-          <string>Open Folder</string>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
+          <string>Calibrate</string>
          </property>
         </widget>
        </item>
@@ -970,6 +931,73 @@ Mode 4:
          </item>
         </widget>
        </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_19">
+         <property name="text">
+          <string>Simulator capture folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1" colspan="4">
+        <widget class="QCheckBox" name="snapshotClipboardCKB">
+         <property name="text">
+          <string>Only capture to clipboard</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="QCheckBox" name="joystickChkB">
+         <property name="text">
+          <string>Enable</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="joystickCB">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QPushButton" name="snapshotPathButton">
+         <property name="text">
+          <string>Open Folder</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
        <item row="5" column="0">
         <widget class="QLabel" name="label_11">
          <property name="sizePolicy">
@@ -983,42 +1011,21 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="joystickCB">
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-        </widget>
-       </item>
-       <item row="5" column="4">
-        <widget class="QPushButton" name="joystickcalButton">
          <property name="text">
-          <string>Calibrate</string>
+          <string>Simulator BackLight</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
         </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_19">
-         <property name="text">
-          <string>Simulator capture folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="0" column="1" colspan="2">
         <widget class="QLineEdit" name="snapshotPath">
@@ -1036,17 +1043,42 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="1" column="1" colspan="4">
-        <widget class="QCheckBox" name="snapshotClipboardCKB">
-         <property name="text">
-          <string>Only capture to clipboard</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="1" colspan="4">
         <widget class="QCheckBox" name="simuSW">
          <property name="text">
           <string>Remember simulator switch values</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_volumeGain">
+         <property name="text">
+          <string>Simulator Volume Gain</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QDoubleSpinBox" name="volumeGain">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+         <property name="minimum">
+          <double>0.500000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>3.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -1058,6 +1090,7 @@ Mode 4:
  </widget>
  <tabstops>
   <tabstop>tabWidget</tabstop>
+  <tabstop>profileNameLE</tabstop>
   <tabstop>removeProfileButton</tabstop>
   <tabstop>downloadVerCB</tabstop>
   <tabstop>langCombo</tabstop>
@@ -1067,6 +1100,9 @@ Mode 4:
   <tabstop>clearImageButton</tabstop>
   <tabstop>sdPath</tabstop>
   <tabstop>sdPathButton</tabstop>
+  <tabstop>profilebackupPath</tabstop>
+  <tabstop>ProfilebackupPathButton</tabstop>
+  <tabstop>pbackupEnable</tabstop>
   <tabstop>stickmodeCB</tabstop>
   <tabstop>channelorderCB</tabstop>
   <tabstop>renameFirmware</tabstop>
@@ -1092,6 +1128,7 @@ Mode 4:
   <tabstop>joystickCB</tabstop>
   <tabstop>joystickChkB</tabstop>
   <tabstop>joystickcalButton</tabstop>
+  <tabstop>volumeGain</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/firmwares/opentx/opentxSky9xsimulator.cpp
+++ b/companion/src/firmwares/opentx/opentxSky9xsimulator.cpp
@@ -183,7 +183,7 @@ void Open9xSky9xSimulator::start(QByteArray & eeprom, bool tests)
   g_rotenc[0] = 0;
   memcpy(Open9xSky9x::eeprom, eeprom.data(), std::min<int>(sizeof(Open9xSky9x::eeprom), eeprom.size()));
   StartEepromThread(NULL);
-  StartAudioThread();
+  StartAudioThread(g.profile[g.id()].volumeGain());
   StartMainThread(tests);
 }
 
@@ -191,7 +191,7 @@ void Open9xSky9xSimulator::start(const char * filename, bool tests)
 {
   g_rotenc[0] = 0;
   StartEepromThread(filename);
-  StartAudioThread();
+  StartAudioThread(g.profile[g.id()].volumeGain());
   StartMainThread(tests);
 }
 

--- a/companion/src/firmwares/opentx/opentxTaranisSimulator.cpp
+++ b/companion/src/firmwares/opentx/opentxTaranisSimulator.cpp
@@ -224,14 +224,14 @@ void OpentxTaranisSimulator::start(QByteArray & eeprom, bool tests)
 {
   memcpy(Open9xX9D::eeprom, eeprom.data(), std::min<int>(sizeof(Open9xX9D::eeprom), eeprom.size()));
   StartEepromThread(NULL);
-  StartAudioThread();
+  StartAudioThread(g.profile[g.id()].volumeGain());
   StartMainThread(tests);
 }
 
 void OpentxTaranisSimulator::start(const char * filename, bool tests)
 {
   StartEepromThread(filename);
-  StartAudioThread();
+  StartAudioThread(g.profile[g.id()].volumeGain());
   StartMainThread(tests);
 }
 

--- a/radio/src/audio_arm.h
+++ b/radio/src/audio_arm.h
@@ -159,7 +159,7 @@ class AudioQueue {
 
   friend void audioTask(void* pdata);
 #if defined(SIMU)
-  friend void *audio_thread(void *);
+  friend void *audioThread(void *);
 #endif
 
   public:

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -396,8 +396,15 @@ void StopMainThread()
 }
 
 #if defined(CPUARM)
-int audio_volumeGain;
-int Volume;
+
+struct SimulatorAudio {
+  int volumeGain;
+  int currentVolume;
+  uint16_t leftoverData[AUDIO_BUFFER_SIZE];
+  int leftoverLen;
+  bool threadRunning;
+  pthread_t threadPid;
+} simuAudio;
 
 bool dacQueue(AudioBuffer *buffer)
 {
@@ -406,34 +413,31 @@ bool dacQueue(AudioBuffer *buffer)
 
 void setVolume(uint8_t volume)
 {
-  Volume = min<int>((volumeScale[min<uint8_t>(volume, VOLUME_LEVEL_MAX)] * audio_volumeGain) / 10, 127);
-  TRACE("setVolume(): in: %u, out: %u", volume, Volume);
+  simuAudio.currentVolume = min<int>((volumeScale[min<uint8_t>(volume, VOLUME_LEVEL_MAX)] * simuAudio.volumeGain) / 10, 127);
+  // TRACE("setVolume(): in: %u, out: %u", volume, simuAudio.currentVolume);
 }
 #endif
 
 #if defined(SIMU_AUDIO) && defined(CPUARM)
 
-int leftover_len = 0;
-uint16_t leftover_data[AUDIO_BUFFER_SIZE];
-
 void copyBuffer(uint8_t * dest, uint16_t * buff, unsigned int samples) 
 {
   for(unsigned int i=0; i<samples; i++) {
     int sample = ((int32_t)(uint32_t)(buff[i]) - 0x8000);  // conversion from uint16_t 
-    *((uint16_t*)dest) = (int16_t)((sample * Volume)/127);
+    *((uint16_t*)dest) = (int16_t)((sample * simuAudio.currentVolume)/127);
     dest += 2;
   }
 }
 
-void fill_audio(void *udata, Uint8 *stream, int len)
+void fillAudioBuffer(void *udata, Uint8 *stream, int len)
 {
   SDL_memset(stream, 0, len);
 
-  if (leftover_len) {
-    copyBuffer(stream, leftover_data, leftover_len);
-    len -= leftover_len*2;
-    stream += leftover_len*2;
-    leftover_len = 0;
+  if (simuAudio.leftoverLen) {
+    copyBuffer(stream, simuAudio.leftoverData, simuAudio.leftoverLen);
+    len -= simuAudio.leftoverLen*2;
+    stream += simuAudio.leftoverLen*2;
+    simuAudio.leftoverLen = 0;
     // putchar('l');
   }
 
@@ -450,8 +454,8 @@ void fill_audio(void *udata, Uint8 *stream, int len)
         else {
           //partial
           copyBuffer(stream, nextBuffer->data, len/2);
-          leftover_len = (nextBuffer->size-len/2);
-          memcpy(leftover_data, &nextBuffer->data[len/2], leftover_len*2);
+          simuAudio.leftoverLen = (nextBuffer->size-len/2);
+          memcpy(simuAudio.leftoverData, &nextBuffer->data[len/2], simuAudio.leftoverLen*2);
           len = 0;
           // putchar('p');
           break;
@@ -470,9 +474,7 @@ void fill_audio(void *udata, Uint8 *stream, int len)
   }
 }
 
-bool audio_thread_running = false;
-
-void *audio_thread(void *)
+void * audioThread(void *)
 {
   /*
     Checking here if SDL audio was initialized is wrong, because
@@ -491,7 +493,7 @@ void *audio_thread(void *)
   wanted.format = AUDIO_S16SYS;
   wanted.channels = 1;    /* 1 = mono, 2 = stereo */
   wanted.samples = AUDIO_BUFFER_SIZE*2;  /* Good low-latency value for callback */
-  wanted.callback = fill_audio;
+  wanted.callback = fillAudioBuffer;
   wanted.userdata = NULL;
 
   /*
@@ -504,7 +506,7 @@ void *audio_thread(void *)
   }
   SDL_PauseAudio(0);
 
-  while (audio_thread_running) {
+  while (simuAudio.threadRunning) {
     audioQueue.wakeup();
     sleep(1);
   }
@@ -512,28 +514,28 @@ void *audio_thread(void *)
   return 0;
 }
 
-pthread_t audio_thread_pid;
-
 void StartAudioThread(int volumeGain)
 { 
-  audio_volumeGain = volumeGain;
+  simuAudio.leftoverLen = 0;
+  simuAudio.threadRunning = true;
+  simuAudio.volumeGain = volumeGain;
   setVolume(VOLUME_LEVEL_DEF);
+
   pthread_attr_t attr;
   pthread_attr_init(&attr);
   struct sched_param sp;
   sp.sched_priority = SCHED_RR;
   pthread_attr_setschedparam(&attr, &sp);
-  pthread_create(&audio_thread_pid, &attr, &audio_thread, NULL);
-  audio_thread_running = true;
+  pthread_create(&simuAudio.threadPid, &attr, &audioThread, NULL);
   return;
 }
 
 void StopAudioThread()
 {
-  audio_thread_running = false;
-  pthread_join(audio_thread_pid, NULL);
+  simuAudio.threadRunning = false;
+  pthread_join(simuAudio.threadPid, NULL);
 }
-#endif // #if defined(CPUARM)
+#endif // #if defined(SIMU_AUDIO) && defined(CPUARM)
 
 pthread_t eeprom_thread_pid;
 

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -396,7 +396,9 @@ void StopMainThread()
 }
 
 #if defined(CPUARM)
-int Volume = volumeScale[VOLUME_LEVEL_DEF];
+int audio_volumeGain;
+int Volume;
+
 bool dacQueue(AudioBuffer *buffer)
 {
   return false;
@@ -404,7 +406,8 @@ bool dacQueue(AudioBuffer *buffer)
 
 void setVolume(uint8_t volume)
 {
-  Volume = volumeScale[min<uint8_t>(volume, VOLUME_LEVEL_MAX)];
+  Volume = min<int>((volumeScale[min<uint8_t>(volume, VOLUME_LEVEL_MAX)] * audio_volumeGain) / 10, 127);
+  TRACE("setVolume(): in: %u, out: %u", volume, Volume);
 }
 #endif
 
@@ -511,8 +514,10 @@ void *audio_thread(void *)
 
 pthread_t audio_thread_pid;
 
-void StartAudioThread()
+void StartAudioThread(int volumeGain)
 { 
+  audio_volumeGain = volumeGain;
+  setVolume(VOLUME_LEVEL_DEF);
   pthread_attr_t attr;
   pthread_attr_init(&attr);
   struct sched_param sp;

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -354,7 +354,7 @@ void StopMainThread();
 void StartEepromThread(const char *filename="eeprom.bin");
 void StopEepromThread();
 #if defined(SIMU_AUDIO) && defined(CPUARM)
-  void StartAudioThread(void);
+  void StartAudioThread(int volumeGain = 10);
   void StopAudioThread(void);
 #else
   #define StartAudioThread()


### PR DESCRIPTION
I've left this in a separate commits to aid the review. I can squash them into one commit after it is approved. 

Closes #2260 

The new setting **Simulator volume gain** in the radio profile is used to multiply the volume set by the radio in the simulator. The multiplier is only applied up to resulting maximum volume to avoid audio clipping.

Standalone simu uses default gain of 1.0. It would require addition of option parsing to be able to set the gain from command-line when starting. I think it is not needed, almost nobody uses it anyway.

The standalone Companion simulator uses gain set in Companion.

I will port this to `next` if accepted.