### PR TITLE
Fixes #2364: use fixed analog value for non-connected pots

### DIFF
--- a/radio/src/targets/taranis/adc_driver.cpp
+++ b/radio/src/targets/taranis/adc_driver.cpp
@@ -136,6 +136,12 @@ void adcRead()
       Analog_values[i] = 0;
     }
 #endif
+    if (IS_POT(i) && !IS_POT_AVAILABLE(i)) {
+      // Use fixed analog value for non-existing and/or non-connected pots.
+      // Non-connected analog inputs will slightly follow the adjacent connected analog inputs, 
+      // which produces ghost readings on these inputs.
+      Analog_values[i] = 0;  
+    }
   }
 #endif
 }


### PR DESCRIPTION
**WARNING** this is completely untested! I have no radio with S3 pot.

Closes #2364 

If accepted I will port it to the `next`
