### PR TITLE
Fixes #2364: use fixed analog value for non-connected pots (ported fr…

### DIFF
--- a/radio/src/targets/taranis/adc_driver.cpp
+++ b/radio/src/targets/taranis/adc_driver.cpp
@@ -165,6 +165,12 @@ void adcStop()
 
 uint16_t getAnalogValue(uint32_t index)
 {
+  if (IS_POT(index) && !IS_POT_AVAILABLE(index)) {
+    // Use fixed analog value for non-existing and/or non-connected pots.
+    // Non-connected analog inputs will slightly follow the adjacent connected analog inputs, 
+    // which produces ghost readings on these inputs.
+    return 0;
+  }
 #if defined(REV9E)
   index = ana_mapping[index];
 #endif


### PR DESCRIPTION
…om master)

Closes #2364 

Again this was **NOT TESTED**