### PR TITLE
Fixes #2531: VFAS id 0x39: was 10x to small

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -12,10 +12,10 @@
 <li>New feature: model name played when model is loaded (plays file "SOUNDS/<language>/<model_name>/name.wav") (<a href=https://github.com/opentx/opentx/issues/2404>#2404</a>)</li>
 <li>Faster scrolling when setting custom sensor id (<a href=https://github.com/opentx/opentx/issues/2506>#2506</a>)</li>
 <li>Removed telemetry values from available selection in Global Functions for "Play Value" and "Reset" (<a href=https://github.com/opentx/opentx/issues/2519>#2519</a>)</li>
-<li>Fixed non working VFAS when using D series sensors (<a href=https://github.com/opentx/opentx/issues/2518>#2518</a>)</li>
 <li>D-type RPM sensor was broken (<a href=https://github.com/opentx/opentx/issues/2509>#2509</a>)</li>
 <li>Voltage unit symbol changed from "v" to "V" (<a href=https://github.com/opentx/opentx/issues/2509>#2509</a>)</li>
 <li>Fixed missing option in the sensor setup menu (<a href=https://github.com/opentx/opentx/issues/2533>#2533</a>)</li>
+<li>Fixed several VFAS issues when using D series sensors (<a href=https://github.com/opentx/opentx/issues/2518>#2518</a>, <a href=https://github.com/opentx/opentx/issues/2531>#2531</a>)</li>, <a href=https://github.com/opentx/opentx/issues/2530>#2530</a>)</li>
 </ul>
 
 [Boards with narrow LCD (9X, 9XR, etc)]

--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -601,7 +601,7 @@ void processHubPacket(uint8_t id, int16_t value)
   }
   else if (id == VOLTS_AP_ID) {
     if (lastId == VOLTS_BP_ID) {
-      data += lastValue * 100;
+      data = ((lastValue * 100 + value * 10) * 210) / 110;
       unit = UNIT_VOLTS;
       precision = 2;
     }
@@ -638,6 +638,9 @@ void processHubPacket(uint8_t id, int16_t value)
   }
   if (id == RPM_ID) {
     data = data * 60;
+  }
+  else if (id == VFAS_ID) {
+    data *= 10;
   }
   
   setTelemetryValue(TELEM_PROTO_FRSKY_D, id, 0, data, unit, precision);


### PR DESCRIPTION
Fixes #2530: VFAS id 0x3A and 0x3B: wrong calculation of value

Closes #2530, closes #2531 

I've only tested #2531 on my setup and its is fixed.

The #2530 issue was **not tested** I don't have that sensor. The formula was taken from 2.0 sources and multiplied by 10.