### PR TITLE
Fixes #2533: menu was wrong if all items on the end were hidden

### DIFF
--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -235,8 +235,11 @@ void menuModelSensor(uint8_t event)
     int k = i + s_pgOfs;
 
     for (int j=0; j<k; j++) {
-      if (mstate_tab[j+1] == HIDDEN_ROW)
-        k++;
+      if (mstate_tab[j+1] == HIDDEN_ROW) {
+        if (++k >= (int)DIM(mstate_tab)) {
+          return;
+        }
+      }
     }
 
     LcdFlags attr = (sub==k ? (s_editMode>0 ? BLINK|INVERS : INVERS) : 0);


### PR DESCRIPTION
This fixes problem on the sensor menu.  Closes #2533.

**But other menus** uses the same kind of code and could have the same issue. 