### PR TITLE
Fixes #2607: Added support for 0.01V resolution to D series VFAS ID 0x39

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -30,6 +30,7 @@
 <li>Added Timer3 to stats screen (<a href=https://github.com/opentx/opentx/issues/2515>#2515</a>)</li>
 <li>FrSky S.Port Airspeed sensor unit set to kph (<a href=https://github.com/opentx/opentx/issues/2305>#2305</a>)</li>
 <li>Frsky-D Telemetry protocol bug fixed (0x5D followed by 0x3D)</li>
+<li>Added support for 0.01V resolution to D series VFAS ID 0x39 (<a href=https://github.com/opentx/opentx/issues/2607>#2607</a>)</li>
 </ul>
 
 [Boards with narrow LCD (9X, 9XR, etc)]

--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -91,6 +91,9 @@
 #define D_A1_ID                 0xF1
 #define D_A2_ID                 0xF2
 
+#define VFAS_D_HIPREC_OFFSET    2000
+ 
+
 // FrSky new DATA IDs (2 bytes)
 #define ALT_FIRST_ID            0x0100
 #define ALT_LAST_ID             0x010f
@@ -151,6 +154,7 @@
 #define DATA_ID_RPM              0xE4 // 4
 #define DATA_ID_SP2UH            0x45 // 5
 #define DATA_ID_SP2UR            0xC6 // 6
+
 
 // Global Fr-Sky telemetry data variables
 extern uint8_t frskyStreaming; // >0 (true) == data is streaming in. 0 = nodata detected for some time

--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -640,7 +640,14 @@ void processHubPacket(uint8_t id, int16_t value)
     data = data * 60;
   }
   else if (id == VFAS_ID) {
-    data *= 10;
+    if (data >= VFAS_D_HIPREC_OFFSET) {
+      // incoming value has a resolution of 0.01V and added offset of VFAS_D_HIPREC_OFFSET
+      data -= VFAS_D_HIPREC_OFFSET;
+    }
+    else {
+      // incoming value has a resolution of 0.1V
+      data *= 10;
+    }
   }
   
   setTelemetryValue(TELEM_PROTO_FRSKY_D, id, 0, data, unit, precision);


### PR DESCRIPTION
Closes #2607 

Tested in simu with the help of gdb (manually calling function `call processHubPacket(0x39, 14087)`) and it seems to work.
