### PR TITLE
Fixes #2623: several fixes:

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -7,6 +7,7 @@
 <li>9XE top LDC fixes: added TX battery blinking on battery warning, fixed display problem when battery voltage lower than batlow value. (<a href=https://github.com/opentx/opentx/issues/2671>#2671</a>)</li>
 <li>Timers range extended (it was limited to around 9 hours before) (<a href=https://github.com/opentx/opentx/issues/2702>#2702</a>)</li>
 <li>Fixed: Playing two background sounds at once causes sound to stop (<a href=https://github.com/opentx/opentx/issues/2704>#2704</a>)</li>
+<li>Several fixes to the SD card manager menu (<a href=https://github.com/opentx/opentx/issues/2623>#2623</a>)</li>
 </ul>
 
 [Sky9x / 9XR-PRO]

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -942,7 +942,7 @@ FRESULT f_unlink (const TCHAR* name)
 
 FRESULT f_rename(const TCHAR *oldname, const TCHAR *newname)
 {
-  if ( rename(oldname, newname) < 0) {
+  if (rename(oldname, newname) < 0) {
     TRACE("f_rename(%s, %s) = error %d (%s)", oldname, newname, errno, strerror(errno));
     return FR_INVALID_NAME;
   }

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -929,14 +929,24 @@ FRESULT f_mkdir (const TCHAR*)
   return FR_OK;
 }
 
-FRESULT f_unlink (const TCHAR*)
+FRESULT f_unlink (const TCHAR* name)
 {
+  char *path = convertSimuPath(name);
+  if (unlink(path)) {
+    TRACE("f_unlink(%s) = error %d (%s)", path, errno, strerror(errno));
+    return FR_INVALID_NAME;
+  }
+  TRACE("f_unlink(%s) = OK", path);
   return FR_OK;
 }
 
 FRESULT f_rename(const TCHAR *oldname, const TCHAR *newname)
 {
-  TRACE("f_rename(%s, %s)", oldname, newname);
+  if ( rename(oldname, newname) < 0) {
+    TRACE("f_rename(%s, %s) = error %d (%s)", oldname, newname, errno, strerror(errno));
+    return FR_INVALID_NAME;
+  }
+  TRACE("f_rename(%s, %s) = OK", oldname, newname);
   return FR_OK;
 }
 
@@ -966,7 +976,12 @@ int f_printf (FIL *fil, const TCHAR * format, ...)
 
 FRESULT f_getcwd (TCHAR *path, UINT sz_path)
 {
-  strcpy(path, ".");
+  // remove simuSdDirectory from the cwd
+  char * cwd = get_current_dir_name();
+  std::string c(cwd + strlen(simuSdDirectory));
+  free(cwd);
+  strcpy(path, c.c_str());
+  TRACE("f_getcwd() = %s", path);
   return FR_OK;
 }
 


### PR DESCRIPTION
Disable menu for [..],
Refresh file list after delete,
Copy destination can be a directory,
Prevent copy/paste into the same directory,
Enabled renaming of directories and files without extension,
Removed delete menu option for directories,
Several simulator filesystem functions improved

Closes #2623 

Please test thoroughly before merging!