### PR TITLE
Fixes #2623: several fixes (ported from 2.1):

### DIFF
--- a/radio/src/gui/menu_general.cpp
+++ b/radio/src/gui/menu_general.cpp
@@ -984,12 +984,12 @@ void menuGeneralSdManager(uint8_t _event)
       else
 #endif
       {
-#if defined(CPUARM)
         uint8_t index = m_posVert-1-s_pgOfs;
         char *line = reusableBuffer.sdmanager.lines[index];
         if (!strcmp(line, "..")) {
           break;      // no menu for parent dir
         }
+#if defined(CPUARM)
         // TODO duplicated code for finding extension
         char * ext = line;
         int len = strlen(ext) - 4;
@@ -1059,7 +1059,8 @@ void menuGeneralSdManager(uint8_t _event)
 #else
         fn = fno.fname;
 #endif
-        if (strlen(fn) > SD_SCREEN_FILE_LENGTH) continue;
+        TRACE("strlen(%s) = %d", fn, strlen(fn));
+        if (strlen(fn) > SD_SCREEN_FILE_LENGTH) { TRACE("too long"); continue; }
 
         reusableBuffer.sdmanager.count++;
 

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -921,11 +921,21 @@ int f_printf (FIL *fil, const TCHAR * format, ...)
 
 FRESULT f_getcwd (TCHAR *path, UINT sz_path)
 {
+  char cwd[1024];
+  if (!getcwd(cwd, 1024)) {
+    TRACE("f_getcwd() = getcwd() error %d (%s)", errno, strerror(errno));
+    strcpy(path, ".");
+    return FR_NO_PATH;
+  }
+
+  if (strlen(cwd) < strlen(simuSdDirectory)) {
+    TRACE("f_getcwd() = logic error strlen(cwd) < strlen(simuSdDirectory):  cwd: \"%s\",  simuSdDirectory: \"%s\"", cwd, simuSdDirectory);
+    strcpy(path, ".");
+    return FR_NO_PATH;
+  }
+
   // remove simuSdDirectory from the cwd
-  char * cwd = get_current_dir_name();
-  std::string c(cwd + strlen(simuSdDirectory));
-  free(cwd);
-  strcpy(path, c.c_str());
+  strcpy(path, cwd + strlen(simuSdDirectory));
   TRACE("f_getcwd() = %s", path);
   return FR_OK;
 }

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -884,8 +884,14 @@ FRESULT f_mkdir (const TCHAR*)
   return FR_OK;
 }
 
-FRESULT f_unlink (const TCHAR*)
+FRESULT f_unlink (const TCHAR* name)
 {
+  char *path = convertSimuPath(name);
+  if (unlink(path)) {
+    TRACE("f_unlink(%s) = error %d (%s)", path, errno, strerror(errno));
+    return FR_INVALID_NAME;
+  }
+  TRACE("f_unlink(%s) = OK", path);
   return FR_OK;
 }
 
@@ -915,7 +921,12 @@ int f_printf (FIL *fil, const TCHAR * format, ...)
 
 FRESULT f_getcwd (TCHAR *path, UINT sz_path)
 {
-  strcpy(path, ".");
+  // remove simuSdDirectory from the cwd
+  char * cwd = get_current_dir_name();
+  std::string c(cwd + strlen(simuSdDirectory));
+  free(cwd);
+  strcpy(path, c.c_str());
+  TRACE("f_getcwd() = %s", path);
   return FR_OK;
 }
 


### PR DESCRIPTION
Disable menu for [..],
Refresh file list after delete,
Removed delete menu option for directories,
Several simulator filesystem functions improved

Closes #2623 

This is the the port of #2691 to the 2.0 branch. I urge you to test this thoroughly. There are some changes compared to the 2.1 solution, namely the `REFRESH_FILES()` is different: `m_posVert = 1` where on 2.1 the `m_posVert = 0` is used.  