### PR TITLE
Fixes #2728: edge switch could trigger right after the logicalSwitche…

### DIFF
--- a/radio/releasenotes.txt
+++ b/radio/releasenotes.txt
@@ -9,6 +9,7 @@
 <li>Fixed: Playing two background sounds at once causes sound to stop (<a href=https://github.com/opentx/opentx/issues/2704>#2704</a>)</li>
 <li>Several fixes to the SD card manager menu (<a href=https://github.com/opentx/opentx/issues/2623>#2623</a>)</li>
 <li>Fixed the difference between top and main LCD TX battery bars on 9Xe (<a href=https://github.com/opentx/opentx/issues/2671>#2671</a>)</li>
+<li>Fixed: Edge Logical Switch could trigger right after the model was loaded or the radio turned on (<a href=https://github.com/opentx/opentx/issues/2728>#2728</a>)</li>
 </ul>
 
 [Sky9x / 9XR-PRO]

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -835,6 +835,13 @@ void logicalSwitchesTimerTick()
 #if defined(CPUARM)
       else if (ls->func == LS_FUNC_EDGE) {
         ls_stay_struct & lastValue = (ls_stay_struct &)LS_LAST_VALUE(fm, i);
+        // if this ls was reset by the logicalSwitchesReset() the lastValue will be set to CS_LAST_VALUE_INIT(0x8000)
+        // when it is unpacked into ls_stay_struct the lastValue.duration will have a value of 0x4000
+        // this will produce an instant true for edge logical switch if the second parameter is big enough.
+        // So we reset it here.
+        if (LS_LAST_VALUE(fm, i) == CS_LAST_VALUE_INIT) {
+          lastValue.duration = 0;
+        }
         lastValue.state = false;
         bool state = getSwitch(ls->v1);
         if (state) {


### PR DESCRIPTION
…sReset() was called

Re #2728

Please test this fix. If this is accepted solution, I will also port it back to the 2.0 branch.