### PR TITLE
Re #2615: ratio telemetry sensor parameter broken into multiplier and…

### DIFF
--- a/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
+++ b/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
@@ -24,6 +24,7 @@
 #define COMPANION
 #define SIMU
 #define SIMU_EXCEPTIONS
+#define SIMU_TELEMETRY
 #define GUI
 #define SPLASH
 #define FRSKY

--- a/radio/src/gui/9X/menu_model_telemetry.cpp
+++ b/radio/src/gui/9X/menu_model_telemetry.cpp
@@ -267,7 +267,7 @@ bool isSensorAvailable(int sensor)
 #define SENSOR_PREC_ROWS       (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PARAM1_ROWS     (sensor->unit >= UNIT_FIRST_VIRTUAL ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM2_ROWS     (sensor->unit == UNIT_RPMS || sensor->unit == UNIT_GPS || sensor->unit == UNIT_DATETIME || sensor->unit == UNIT_CELLS || (sensor->type==TELEM_TYPE_CALCULATED && (sensor->formula==TELEM_FORMULA_CONSUMPTION || sensor->formula==TELEM_FORMULA_TOTALIZE)) ? HIDDEN_ROW : (uint8_t)0)
-#define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW
+#define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CUSTOM || (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY)) ? (uint8_t)0 : HIDDEN_ROW
 #define SENSOR_PARAM4_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW
 #define SENSOR_AUTOOFFSET_ROWS (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_FILTER_ROWS     (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
@@ -397,21 +397,13 @@ void menuModelSensor(uint8_t event)
           }
         }
         else {
-          if (sensor->unit == UNIT_RPMS) {
-            lcd_putsLeft(y, NO_INDENT(STR_BLADES));
-            if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.ratio, 1, 30000);
-            lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr);
-            break;
-          }
-          else {
-            lcd_putsLeft(y, STR_RATIO);
-            if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.ratio, 0, 30000);
-            if (sensor->custom.ratio == 0)
-              lcd_putcAtt(SENSOR_2ND_COLUMN, y, '-', attr);
-            else
-              lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
-            break;
-          }
+          lcd_putsLeft(y, STR_MULTIPLIER);
+          if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.multiplier, 0, 16000);
+          if (sensor->custom.multiplier == 0)
+            lcd_putcAtt(SENSOR_2ND_COLUMN, y, '-', attr);
+          else
+            lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.multiplier, LEFT|attr);
+          break;
         }
         // no break
 
@@ -431,15 +423,20 @@ void menuModelSensor(uint8_t event)
           }
         }
         else {
-          lcd_putsLeft(y, NO_INDENT(STR_OFFSET));
-          if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.offset, -30000, +30000);
-          if (sensor->prec > 0) attr |= (sensor->prec == 2 ? PREC2 : PREC1);
-          lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
+          lcd_putsLeft(y, "Divisor");
+          if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.divisor, 0, 3);
+          lcd_outdezAtt(SENSOR_2ND_COLUMN, y, divisors_div[sensor->custom.divisor], LEFT|attr);
           break;
         }
         // no break
 
       case SENSOR_FIELD_PARAM3:
+        if (sensor->type == TELEM_TYPE_CUSTOM) {
+          lcd_putsLeft(y, NO_INDENT(STR_OFFSET));
+          if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.offset, -30000, +30000);
+          if (sensor->prec > 0) attr |= (sensor->prec == 2 ? PREC2 : PREC1);
+          lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
+        }
         // no break
 
       case SENSOR_FIELD_PARAM4:

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -213,7 +213,7 @@ bool isSensorAvailable(int sensor)
 #define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable() && sensor->unit != UNIT_FAHRENHEIT  ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PARAM1_ROWS     (sensor->unit >= UNIT_FIRST_VIRTUAL ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM2_ROWS     (sensor->unit == UNIT_GPS || sensor->unit == UNIT_DATETIME || sensor->unit == UNIT_CELLS || (sensor->type==TELEM_TYPE_CALCULATED && (sensor->formula==TELEM_FORMULA_CONSUMPTION || sensor->formula==TELEM_FORMULA_TOTALIZE)) ? HIDDEN_ROW : (uint8_t)0)
-#define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW
+#define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CUSTOM || (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY)) ? (uint8_t)0 : HIDDEN_ROW
 #define SENSOR_PARAM4_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW
 #define SENSOR_AUTOOFFSET_ROWS (sensor->unit != UNIT_RPMS && sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_ONLYPOS_ROWS    (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
@@ -358,21 +358,13 @@ void menuModelSensor(uint8_t event)
           }
         }
         else {
-          if (sensor->unit == UNIT_RPMS) {
-            lcd_putsLeft(y, NO_INDENT(STR_BLADES));
-            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 1, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
-            lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr);
-            break;
-          }
-          else {
-            lcd_putsLeft(y, STR_RATIO);
-            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 0, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
-            if (sensor->custom.ratio == 0)
-              lcd_putcAtt(SENSOR_2ND_COLUMN, y, '-', attr);
-            else
-              lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
-            break;
-          }
+          lcd_putsLeft(y, STR_MULTIPLIER);
+          if (attr) sensor->custom.multiplier = checkIncDec(event, sensor->custom.multiplier, 0, 16000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+          if (sensor->custom.multiplier == 0)
+            lcd_putcAtt(SENSOR_2ND_COLUMN, y, '-', attr);
+          else
+            lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.multiplier, LEFT|attr);
+          break;
         }
         // no break
 
@@ -391,22 +383,22 @@ void menuModelSensor(uint8_t event)
             break;
           }
         }
-        else if (sensor->unit == UNIT_RPMS) {
-          lcd_putsLeft(y, STR_MULTIPLIER);
-          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, 1, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
-          lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
+        else {
+          lcd_putsLeft(y, "Divisor");
+          if (attr) sensor->custom.divisor = checkIncDec(event, sensor->custom.divisor, 0, 3, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+          lcd_outdezAtt(SENSOR_2ND_COLUMN, y, divisors_div[sensor->custom.divisor], LEFT|attr);
           break;
         }
-        else {
+        // no break
+
+      case SENSOR_FIELD_PARAM3:
+        if (sensor->type == TELEM_TYPE_CUSTOM) {
           lcd_putsLeft(y, NO_INDENT(STR_OFFSET));
           if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, -30000, +30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
           if (sensor->prec > 0) attr |= (sensor->prec == 2 ? PREC2 : PREC1);
           lcd_outdezAtt(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
           break;
         }
-        // no break
-
-      case SENSOR_FIELD_PARAM3:
         // no break
 
       case SENSOR_FIELD_PARAM4:

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -1270,6 +1270,8 @@ enum TelemetrySensorFormula
   TELEM_FORMULA_LAST = TELEM_FORMULA_DIST
 };
 
+extern uint16_t divisors_div[];
+
 PACK(typedef struct {
   union {
     uint16_t id;                   // data identifier, for FrSky we can reuse existing ones. Source unit is derived from type.
@@ -1291,7 +1293,9 @@ PACK(typedef struct {
   uint8_t  spare:3;
   union {
     PACK(struct {
-      uint16_t ratio;
+      // uint16_t ratio;
+      uint16_t multiplier:14;  // range 1-16384, 0 - not used
+      uint16_t divisor:2;   // actual divisor value is 10^divisor, possble values: 1, 10, 100, 1000, 
       int16_t  offset;
     }) custom;
     PACK(struct {

--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -486,7 +486,7 @@ void telemetryInterrupt10ms()
     frskyStreaming--;
   }
   else {
-#if !defined(SIMU)
+#if !defined(SIMU) || defined(SIMU_TELEMETRY)
 #if defined(CPUARM)
     frskyData.rssi.reset();
 #else

--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -509,8 +509,8 @@ struct FrSkyDSensor {
 
 const FrSkyDSensor frskyDSensors[] = {
   { D_RSSI_ID, ZSTR_RSSI, UNIT_RAW, 0 },
-  { D_A1_ID, ZSTR_A1, UNIT_VOLTS, 1 },
-  { D_A2_ID, ZSTR_A2, UNIT_VOLTS, 1 },
+  { D_A1_ID, ZSTR_A1, UNIT_VOLTS, 2 },
+  { D_A2_ID, ZSTR_A2, UNIT_VOLTS, 2 },
   { RPM_ID, ZSTR_RPM, UNIT_RPMS, 0 },
   { FUEL_ID, ZSTR_FUEL, UNIT_PERCENT, 0 },
   { TEMP1_ID, ZSTR_TEMP, UNIT_CELSIUS, 0 },
@@ -674,8 +674,8 @@ void frskyDSetDefault(int index, uint16_t id)
       telemetrySensor.logs = true;
     }
     else if (id >= D_A1_ID && id <= D_A2_ID) {
-      telemetrySensor.custom.ratio = 132;
-      telemetrySensor.filter = 1;
+      telemetrySensor.custom.multiplier = 5176;
+      telemetrySensor.custom.divisor = 3;
     }
     else if (id == CURRENT_ID) {
       telemetrySensor.onlyPositive = 1;
@@ -684,8 +684,8 @@ void frskyDSetDefault(int index, uint16_t id)
       telemetrySensor.autoOffset = 1;
     }
     if (unit == UNIT_RPMS) {
-      telemetrySensor.custom.ratio = 1;
-      telemetrySensor.custom.offset = 1;
+      telemetrySensor.custom.multiplier = 5;    // default blades = 5/10^1 = 0.5 = two blades
+      telemetrySensor.custom.divisor = 1;
     }
     else if (unit == UNIT_METERS) {
       if (IS_IMPERIAL_ENABLE()) {

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -59,8 +59,8 @@ struct FrSkySportSensor {
 const FrSkySportSensor sportSensors[] = {
   { RSSI_ID, RSSI_ID, ZSTR_RSSI, UNIT_DB, 0 },
   { SWR_ID, SWR_ID, ZSTR_SWR, UNIT_RAW, 0 },
-  { ADC1_ID, ADC1_ID, ZSTR_A1, UNIT_VOLTS, 1 },
-  { ADC2_ID, ADC2_ID, ZSTR_A2, UNIT_VOLTS, 1 },
+  { ADC1_ID, ADC1_ID, ZSTR_A1, UNIT_VOLTS, 2 },
+  { ADC2_ID, ADC2_ID, ZSTR_A2, UNIT_VOLTS, 2 },
   { A3_FIRST_ID, A3_LAST_ID, ZSTR_A3, UNIT_VOLTS, 2 },
   { A4_FIRST_ID, A4_LAST_ID, ZSTR_A4, UNIT_VOLTS, 2 },  
   { BATT_ID, BATT_ID, ZSTR_BATT, UNIT_VOLTS, 1 },
@@ -270,7 +270,8 @@ void frskySportSetDefault(int index, uint16_t id, uint8_t instance)
       telemetrySensor.logs = true;
     }
     else if (id >= ADC1_ID && id <= BATT_ID) {
-      telemetrySensor.custom.ratio = 132;
+      telemetrySensor.custom.multiplier = 5176;
+      telemetrySensor.custom.divisor = 3;
       telemetrySensor.filter = 1;
     }
     else if (id >= CURR_FIRST_ID && id <= CURR_LAST_ID) {
@@ -280,8 +281,8 @@ void frskySportSetDefault(int index, uint16_t id, uint8_t instance)
       telemetrySensor.autoOffset = 1;
     }
     if (unit == UNIT_RPMS) {
-      telemetrySensor.custom.ratio = 1;
-      telemetrySensor.custom.offset = 1;
+      telemetrySensor.custom.multiplier = 5;    // default blades = 5/10^1 = 0.5 = two blades
+      telemetrySensor.custom.divisor = 1;
     }
     else if (unit == UNIT_METERS) {
       if (IS_IMPERIAL_ENABLE()) {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -178,11 +178,6 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
     datetime.timestate = 1;
     newVal = 0;
   }
-  else if (unit == UNIT_RPMS) {
-    if (sensor.custom.ratio != 0) {
-      newVal = (newVal * sensor.custom.offset) / sensor.custom.ratio;
-    }
-  }
   else {
     newVal = sensor.getValue(newVal, unit, prec);
     if (sensor.autoOffset) {
@@ -590,26 +585,34 @@ int32_t convertTelemetryValue(int32_t value, uint8_t unit, uint8_t prec, uint8_t
     }
   }
   
-  for (int i=destPrec; i<prec; i++)
+  for (int i=destPrec; i<prec; i++) {
+    value += (value >= 0) ? 5 : -5;
     value /= 10;
+  }
 
   return value;
 }
 
+uint16_t divisors_add[] = {0, 5, 50, 500};
+uint16_t divisors_div[] = {1,10,100,1000};
+
 int32_t TelemetrySensor::getValue(int32_t value, uint8_t unit, uint8_t prec) const
 {
-  if (type == TELEM_TYPE_CUSTOM && custom.ratio) {
-    if (this->prec == 2) {
-      value *= 10;
-      prec = 2;
-    }
-    else {
-      prec = 1;
-    }
-    value = (custom.ratio * value + 122) / 255;
-  }
-
   value = convertTelemetryValue(value, unit, prec, this->unit, this->prec);
+
+  if (type == TELEM_TYPE_CUSTOM ) {
+    if (custom.multiplier) {
+      value *= custom.multiplier;
+    }
+    if (custom.divisor) {
+      // for (uint n=custom.divisor; n>0; n--) {
+      //   value += (value >= 0) ? 5 : -5;
+      //   value /= 10;
+      // }
+      value += (value >= 0) ? divisors_add[custom.divisor] : -divisors_add[custom.divisor];
+      value /= divisors_div[custom.divisor];
+    }
+  }
 
   if (type == TELEM_TYPE_CUSTOM) {
     value += custom.offset;

--- a/radio/src/tests/frsky.cpp
+++ b/radio/src/tests/frsky.cpp
@@ -395,9 +395,9 @@ TEST(FrSkySPORT, frskySetCellVoltageTwoSensors)
 
   telemetryWakeup();
 
-  EXPECT_EQ(telemetryItems[2].value, 287);
-  EXPECT_EQ(telemetryItems[2].valueMin, 287);
-  EXPECT_EQ(telemetryItems[2].valueMax, 287);
+  EXPECT_EQ(telemetryItems[2].value, 289);  //12.5 + 16.4 =  28.9
+  EXPECT_EQ(telemetryItems[2].valueMin, 289);
+  EXPECT_EQ(telemetryItems[2].valueMax, 289);
 
   //now change some voltages
   generateSportCellPacket(packet, 3, 2, _V(415), _V(  0)); processSportPacket(packet);
@@ -407,9 +407,9 @@ TEST(FrSkySPORT, frskySetCellVoltageTwoSensors)
 
   telemetryWakeup();
 
-  EXPECT_EQ(telemetryItems[2].value, 283);
-  EXPECT_EQ(telemetryItems[2].valueMin, 283);
-  EXPECT_EQ(telemetryItems[2].valueMax, 287);
+  EXPECT_EQ(telemetryItems[2].value, 284);
+  EXPECT_EQ(telemetryItems[2].valueMin, 284);
+  EXPECT_EQ(telemetryItems[2].valueMax, 289);
 
   //display test
   lcd_clear();


### PR DESCRIPTION
… divisor, added rounding for divisions Re #2615.

Here is my take on the ratio subject.

The `ratio` parameter is now replaced by two values: 
- multiplier
- divisor

The `multiplier` is just that a number with a range of 1-16000. The `divisor` is a power of 10 divisor. Possible values are 1, 10, 100 and 1000. 

The new values are used as:

```
       out_value = in_value * multiplier / 10^divisor
```

Together both new parameters give following resulting multipliers:
- 1 - 16000 in steps of 1
- 0.1 - 1600 in steps of 0.1
- 0.01 - 160 in steps of 0.01
- 0.001 - 16 in steps of 0.001

I think this is big enough range and also precise enough. 

This new parameters are used also for A1 and A2 values, they give ample adjustment resolution if divisor 1000 is used. The default value for them is again set to accommodate the  1:4 divider in FrSky receivers.

Tell me if you like the way this is going or perhaps we should take some other route. Code is not yet cleaned up, this is just a proof of concept. Do not merge yet!
