### PR TITLE
Fix #2774 (out of bounds access to trim array when the source of an input is not a stick)

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -530,8 +530,13 @@ int getSourceTrimValue(int source, int value=0)
 {
   if (source >= MIXSRC_Rud && source <= MIXSRC_Ail)
     return getStickTrimValue(source - MIXSRC_Rud, value);
-  else if (source >= MIXSRC_FIRST_INPUT && source <= MIXSRC_LAST_INPUT)
-    return getStickTrimValue(virtualInputsTrims[source - MIXSRC_FIRST_INPUT], value);
+  else if (source >= MIXSRC_FIRST_INPUT && source <= MIXSRC_LAST_INPUT) {
+    int8_t trim = virtualInputsTrims[source - MIXSRC_FIRST_INPUT];
+    if (trim >= 0)
+      return getStickTrimValue(trim, value);
+    else
+      return 0;
+  }
   else
     return 0;
 }


### PR DESCRIPTION
Looks good to me and it didn't fail tests, but I'd still appreciate a review...