### PR TITLE
Issue2780 - getValue() for special telemetry fields

### DIFF
--- a/radio/src/lua_api.cpp
+++ b/radio/src/lua_api.cpp
@@ -182,7 +182,7 @@ static void luaGetValueAndPush(int src)
   if (src >= MIXSRC_FIRST_TELEM && src <= MIXSRC_LAST_TELEM) {
     src = (src-MIXSRC_FIRST_TELEM) / 3;
     // telemetry values
-    if (TELEMETRY_STREAMING() /* && telemetryItems[src].isAvailable() */) {
+    if (TELEMETRY_STREAMING() && telemetryItems[src].isAvailable()) {
       TelemetrySensor & telemetrySensor = g_model.telemetrySensors[src];
       switch (telemetrySensor.unit) {
         case UNIT_GPS:

--- a/radio/src/lua_api.cpp
+++ b/radio/src/lua_api.cpp
@@ -119,7 +119,7 @@ static int luaGetTime(lua_State *L)
 static void luaPushDateTime(lua_State *L, uint32_t year, uint32_t mon, uint32_t day,
                             uint32_t hour, uint32_t min, uint32_t sec)
 {
-  lua_newtable(L);
+  lua_createtable(L, 0, 6);
   lua_pushtableinteger(L, "year", year);
   lua_pushtableinteger(L, "mon", mon);
   lua_pushtableinteger(L, "day", day);
@@ -150,7 +150,7 @@ static void luaPushLatLon(TelemetrySensor & telemetrySensor, TelemetryItem & tel
   lon = gpsLon / 1000000.0;
   if (telemetryItem.gps.longitudeEW == 'W') lon = -lon;
 
-  lua_newtable(L);
+  lua_createtable(L, 0, 2);
   lua_pushtablenumber(L, "lat", lat);
   lua_pushtablenumber(L, "lon", lon);
 }
@@ -166,7 +166,7 @@ static void luaPushCells(TelemetrySensor & telemetrySensor, TelemetryItem & tele
   if (telemetryItem.cells.count == 0)
     lua_pushinteger(L, (int)0); // returns zero if no cells
   else {
-    lua_createtable(L, 0 /*telemetryItem.cells.count*/, 0);
+    lua_createtable(L, telemetryItem.cells.count, 0);
     for (int i = 0; i < telemetryItem.cells.count; i++) {
       lua_pushnumber(L, i + 1);
       lua_pushnumber(L, telemetryItem.cells.values[i].value / 100.0);

--- a/radio/src/lua_api.cpp
+++ b/radio/src/lua_api.cpp
@@ -116,22 +116,28 @@ static int luaGetTime(lua_State *L)
   return 1;
 }
 
+static void luaPushDateTime(lua_State *L, uint32_t year, uint32_t mon, uint32_t day,
+                            uint32_t hour, uint32_t min, uint32_t sec)
+{
+  lua_newtable(L);
+  lua_pushtableinteger(L, "year", year);
+  lua_pushtableinteger(L, "mon", mon);
+  lua_pushtableinteger(L, "day", day);
+  lua_pushtableinteger(L, "hour", hour);
+  lua_pushtableinteger(L, "min", min);
+  lua_pushtableinteger(L, "sec", sec);
+}
+
 static int luaGetDateTime(lua_State *L)
 {
   struct gtm utm;
   gettime(&utm);
-  lua_newtable(L);
-  lua_pushtableinteger(L, "year", utm.tm_year+1900);
-  lua_pushtableinteger(L, "mon", utm.tm_mon+1);
-  lua_pushtableinteger(L, "day", utm.tm_mday);
-  lua_pushtableinteger(L, "hour", utm.tm_hour);
-  lua_pushtableinteger(L, "min", utm.tm_min);
-  lua_pushtableinteger(L, "sec", utm.tm_sec);
+  luaPushDateTime(L, utm.tm_year + 1900, utm.tm_mon + 1, utm.tm_mday, utm.tm_hour, utm.tm_min, utm.tm_sec);
   return 1;
 }
 
 static void luaPushLatLon(TelemetrySensor & telemetrySensor, TelemetryItem & telemetryItem)
-/* result is lua table containing members ["Lat"] and ["Lon"] as lua_Number (doubles) in decimal degrees */
+/* result is lua table containing members ["lat"] and ["lon"] as lua_Number (doubles) in decimal degrees */
 {
   lua_Number lat = 0.0;
   lua_Number lon = 0.0;
@@ -144,31 +150,57 @@ static void luaPushLatLon(TelemetrySensor & telemetrySensor, TelemetryItem & tel
   lon = gpsLon / 1000000.0;
   if (telemetryItem.gps.longitudeEW == 'W') lon = -lon;
 
-  lua_createtable(L, 0, 2); /* push the result table */
-  lua_pushstring(L, "Lat");
-  lua_pushnumber(L, lat);
-  lua_settable(L, -3);
-  lua_pushstring(L, "Lon");
-  lua_pushnumber(L, lon);
-  lua_settable(L, -3);
+  lua_newtable(L);
+  lua_pushtablenumber(L, "lat", lat);
+  lua_pushtablenumber(L, "lon", lon);
+}
 
+static void luaPushTelemetryDateTime(TelemetrySensor & telemetrySensor, TelemetryItem & telemetryItem)
+{
+  luaPushDateTime(L, telemetryItem.datetime.year + 2000, telemetryItem.datetime.month, telemetryItem.datetime.day,
+                  telemetryItem.datetime.hour, telemetryItem.datetime.min, telemetryItem.datetime.sec);
+}
+
+static void luaPushCells(TelemetrySensor & telemetrySensor, TelemetryItem & telemetryItem)
+{
+  if (telemetryItem.cells.count == 0)
+    lua_pushinteger(L, (int)0); // returns zero if no cells
+  else {
+    lua_createtable(L, 0 /*telemetryItem.cells.count*/, 0);
+    for (int i = 0; i < telemetryItem.cells.count; i++) {
+      lua_pushnumber(L, i + 1);
+      lua_pushnumber(L, telemetryItem.cells.values[i].value / 100.0);
+      lua_settable(L, -3);
+    }
+  }
 }
 
 static void luaGetValueAndPush(int src)
 {
-  getvalue_t value = getValue(src);
+  getvalue_t value = getValue(src); // ignored for GPS, DATETIME, and CELLS
 
   if (src >= MIXSRC_FIRST_TELEM && src <= MIXSRC_LAST_TELEM) {
     src = (src-MIXSRC_FIRST_TELEM) / 3;
     // telemetry values
-    if (TELEMETRY_STREAMING() && telemetryItems[src].isAvailable()) {
+    if (TELEMETRY_STREAMING() /* && telemetryItems[src].isAvailable() */) {
       TelemetrySensor & telemetrySensor = g_model.telemetrySensors[src];
-      if (telemetrySensor.unit == UNIT_GPS)
-        luaPushLatLon(telemetrySensor, telemetryItems[src]);
-      else if (telemetrySensor.prec > 0)
-        lua_pushnumber(L, float(value)/(telemetrySensor.prec == 2 ? 100.0 : 10.0));
-      else
-        lua_pushinteger(L, value);
+      switch (telemetrySensor.unit) {
+        case UNIT_GPS:
+          luaPushLatLon(telemetrySensor, telemetryItems[src]);
+          break;
+        case UNIT_DATETIME:
+          luaPushTelemetryDateTime(telemetrySensor, telemetryItems[src]);
+          break;
+        case UNIT_CELLS:
+          luaPushCells(telemetrySensor, telemetryItems[src]);
+          break;
+        default:
+          if (telemetrySensor.prec > 0)
+            lua_pushnumber(L, float(value)/(telemetrySensor.prec == 2 ? 100.0 : 10.0));
+          else
+            lua_pushinteger(L, value);
+          break;
+      }
     }
     else {
       // telemetry not working, return zero for telemetry sources


### PR DESCRIPTION
Changes to address issue #2780.  Tested on Taranis hardware using two different GPS units and 2-cell and 3-cell lipos with FrSky Lipo voltage sensor.

Note: this change also includes modification of getValue for UNIT_GPS to use table members 'lat' and 'lon' (not capitalized) following the convention of the luaGetDateTime() function.

Due to problems related to variable scope, I opted to comment the initial call to getValue(src) indicating that it is ignored for special telemetry values rather than restructure the use of the variable 'value'.

David