### PR TITLE
tmrtmrt/Fixes#2825_MEGA_2560_audio_output_not_working

### DIFF
--- a/radio/src/audio_avr.cpp
+++ b/radio/src/audio_avr.cpp
@@ -62,7 +62,7 @@ void audioQueue::heartbeat()
     else {
 #if defined(CPUM2560)
       if (toneFreq) {
-        OCR0A = (5000 / toneFreq); // sticking with old values approx 20(abs. min) to 90, 60 being the default tone(?).
+        OCR4A = (5000 / toneFreq); // sticking with old values approx 20(abs. min) to 90, 60 being the default tone(?).
         speakerOn();
       }
 #endif
@@ -88,7 +88,7 @@ void audioQueue::heartbeat()
       if (tone2TimeLeft > 0) {
 #if defined(CPUM2560)
         if (tone2Freq) {
-          OCR0A = (5000 / tone2Freq); // sticking with old values approx 20(abs. min) to 90, 60 being the default tone(?).
+          OCR4A = (5000 / tone2Freq); // sticking with old values approx 20(abs. min) to 90, 60 being the default tone(?).
           speakerOn();
         }
 #else

--- a/radio/src/targets/mega2560/board_mega2560.cpp
+++ b/radio/src/targets/mega2560/board_mega2560.cpp
@@ -62,11 +62,10 @@ inline void boardInit()
   OCR2A   = 156;
   TIMSK2 |= (1<<OCIE2A) |  (1<<TOIE2); // Enable Output-Compare and Overflow interrrupts
 
-  // Set up Phase correct Waveform Gen. mode, at clk/64 = 250,000 counts/second
-  // (Higher speed allows for finer control of frequencies in the audio range.)
+  // TIMER4 set into CTC mode, prescaler 16MHz/64=250 kHz 
   // Used for audio tone generation
   TCCR4B  = (1<<WGM42) | (0b011 << CS00);
-  TCCR4A  = (0b01<<WGM40);
+  TCCR4A  = 0x00;
   
   #if defined (VOICE)     // OLD FROM GRUVIN9X, TO REWRITE
   // SOMO set-up


### PR DESCRIPTION
Fixed bugs in referencing a wrong timer register in audio_avr.cpp and correcting the timer 4 configuration for the CTC mode.