### PR TITLE
Jtaylor2/issue  2762

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -68,128 +68,128 @@ void TelemetrySimulator::generateTelemetryFrame()
   switch(item++) {
     case 0:
       if (ui->Rssi->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, RSSI_ID, LIMIT<uint32_t>(0, ui->Rssi->text().toInt(&ok, 0), 0xFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, RSSI_ID, LIMIT<uint32_t>(0, ui->Rssi->text().toInt(&ok, 0), 0xFF));
       break;
 
     case 1:
 #if defined(XJT_VERSION_ID)
-      generateSportPacket(buffer, 1, DATA_FRAME, XJT_VERSION_ID, 11);
+      generateSportPacket(buffer, INSTANCE, DATA_FRAME, XJT_VERSION_ID, 11);
 #endif
       break;
 
     case 2:
       if (ui->Swr->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, SWR_ID, LIMIT<uint32_t>(0, ui->Swr->text().toInt(&ok, 0), 0xFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, SWR_ID, LIMIT<uint32_t>(0, ui->Swr->text().toInt(&ok, 0), 0xFFFF));
       break;
 
     case 3:
       if (ui->A1->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ADC1_ID, LIMIT<uint32_t>(0, ui->A1->text().toInt(&ok, 0), 0xFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ADC1_ID, LIMIT<uint32_t>(0, ui->A1->text().toInt(&ok, 0), 0xFF));
       break;
 
     case 4:
       if (ui->A2->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ADC2_ID, LIMIT<uint32_t>(0, ui->A2->text().toInt(&ok, 0), 0xFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ADC2_ID, LIMIT<uint32_t>(0, ui->A2->text().toInt(&ok, 0), 0xFF));
       break;
 
     case 5:
       if (ui->A3->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, A3_FIRST_ID, LIMIT<uint32_t>(0, ui->A3->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, A3_FIRST_ID, LIMIT<uint32_t>(0, ui->A3->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 6:
       if (ui->A4->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, A4_FIRST_ID, LIMIT<uint32_t>(0, ui->A4->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, A4_FIRST_ID, LIMIT<uint32_t>(0, ui->A4->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 7:
       if (ui->T1->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, T1_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->T1->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, T1_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->T1->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 8:
       if (ui->T2->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, T2_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->T2->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, T2_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->T2->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 9:
       if (ui->rpm->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, RPM_FIRST_ID, LIMIT<uint32_t>(0, ui->rpm->text().toInt(&ok, 0), 0xFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, RPM_FIRST_ID, LIMIT<uint32_t>(0, ui->rpm->text().toInt(&ok, 0), 0xFFFF));
       break;
 
     case 10:
       if (ui->fuel->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, FUEL_FIRST_ID, LIMIT<uint32_t>(0, ui->fuel->text().toInt(&ok, 0), 0xFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, FUEL_FIRST_ID, LIMIT<uint32_t>(0, ui->fuel->text().toInt(&ok, 0), 0xFFFF));
       break;
 
     case 11:
       if (ui->aspeed->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, AIR_SPEED_FIRST_ID, LIMIT<uint32_t>(0, ui->aspeed->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, AIR_SPEED_FIRST_ID, LIMIT<uint32_t>(0, ui->aspeed->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 12:
       if (ui->vspeed->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, VARIO_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->vspeed->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, VARIO_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->vspeed->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 13:
       if (ui->valt->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ALT_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->valt->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ALT_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->valt->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 14:
       if (ui->accx->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ACCX_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accx->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ACCX_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accx->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 15:
       if (ui->accy->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ACCY_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accy->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ACCY_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accy->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 16:
       if (ui->accz->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, ACCZ_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accz->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, ACCZ_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->accz->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 17:
       if (ui->vfas->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, VFAS_FIRST_ID, LIMIT<uint32_t>(0, ui->vfas->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, VFAS_FIRST_ID, LIMIT<uint32_t>(0, ui->vfas->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 18:
       if (ui->curr->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, CURR_FIRST_ID, LIMIT<uint32_t>(0, ui->curr->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, CURR_FIRST_ID, LIMIT<uint32_t>(0, ui->curr->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 19:
       if (ui->cells->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, CELLS_FIRST_ID, LIMIT<uint32_t>(0, ui->cells->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, CELLS_FIRST_ID, LIMIT<uint32_t>(0, ui->cells->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 20:
       if (ui->gps_alt->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, GPS_ALT_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->gps_alt->text().toInt(&ok, 0), 0x7FFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, GPS_ALT_FIRST_ID, LIMIT<int32_t>(-0x7FFFFFFF, ui->gps_alt->text().toInt(&ok, 0), 0x7FFFFFFF));
       break;
 
     case 21:
       if (ui->gps_speed->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, GPS_SPEED_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_speed->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, GPS_SPEED_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_speed->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 22:
       if (ui->gps_course->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, GPS_COURS_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_course->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, GPS_COURS_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_course->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 23:
       if (ui->gps_time->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, GPS_TIME_DATE_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_time->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, GPS_TIME_DATE_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_time->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     case 24:
       if (ui->gps_latlon->text().length())
-        generateSportPacket(buffer, 1, DATA_FRAME, GPS_LONG_LATI_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_latlon->text().toInt(&ok, 0), 0xFFFFFFFF));
+        generateSportPacket(buffer, INSTANCE, DATA_FRAME, GPS_LONG_LATI_FIRST_ID, LIMIT<uint32_t>(0, ui->gps_latlon->text().toInt(&ok, 0), 0xFFFFFFFF));
       break;
 
     default:

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -7,6 +7,8 @@
 #include <QTimer>
 #include "simulatorinterface.h"
 
+#define INSTANCE (ui->Instance->text().toInt(&ok,0) -1)
+
 namespace Ui {
   class TelemetrySimulator;
 }

--- a/companion/src/simulation/telemetrysimu.ui
+++ b/companion/src/simulation/telemetrysimu.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>278</width>
+    <width>331</width>
     <height>384</height>
    </rect>
   </property>
@@ -323,6 +323,20 @@
        </property>
        <property name="text">
         <string>simulate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_26">
+       <property name="text">
+        <string>Instance</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLineEdit" name="Instance">
+       <property name="text">
+        <string>2</string>
        </property>
       </widget>
      </item>

--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -583,6 +583,37 @@ void telemetryReset()
 #endif
 #endif
 
+/*Add some default sensor values to the simulator*/
+#if defined(CPUARM) && defined(SIMU)
+  for (int i=0; i<MAX_SENSORS; i++) {
+    const TelemetrySensor & sensor = g_model.telemetrySensors[i];
+    printf("Sensor ID %x Instance %i \n", sensor.id, sensor.instance);
+      switch (sensor.id)
+      {
+        case RSSI_ID:
+          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RSSI_ID, sensor.instance , 75, UNIT_RAW, 0);
+          break;
+
+        case ADC1_ID:
+          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC1_ID, sensor.instance, 100, UNIT_RAW, 0);
+          break;
+
+        case ADC2_ID:
+          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC2_ID, sensor.instance, 245, UNIT_RAW, 0);
+          break;
+
+        case SWR_ID:
+          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, SWR_ID, sensor.instance, 30, UNIT_RAW, 0);
+          break;
+
+        case BATT_ID:
+          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, BATT_ID, sensor.instance, 100, UNIT_RAW, 0);
+          break;
+      }
+    }
+#endif
+
+
 #if defined(CPUARM) && defined(SIMU) && !defined(COMPANION)
   setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RSSI_ID, 25, 75, UNIT_RAW, 0);
   setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, SWR_ID, 25, 5, UNIT_RAW, 0);

--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -586,31 +586,26 @@ void telemetryReset()
 /*Add some default sensor values to the simulator*/
 #if defined(CPUARM) && defined(SIMU)
   for (int i=0; i<MAX_SENSORS; i++) {
-    const TelemetrySensor & sensor = g_model.telemetrySensors[i];
-    printf("Sensor ID %x Instance %i \n", sensor.id, sensor.instance);
-      switch (sensor.id)
-      {
-        case RSSI_ID:
-          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RSSI_ID, sensor.instance , 75, UNIT_RAW, 0);
-          break;
-
-        case ADC1_ID:
-          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC1_ID, sensor.instance, 100, UNIT_RAW, 0);
-          break;
-
-        case ADC2_ID:
-          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC2_ID, sensor.instance, 245, UNIT_RAW, 0);
-          break;
-
-        case SWR_ID:
-          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, SWR_ID, sensor.instance, 30, UNIT_RAW, 0);
-          break;
-
-        case BATT_ID:
-          setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, BATT_ID, sensor.instance, 100, UNIT_RAW, 0);
-          break;
-      }
+  const TelemetrySensor & sensor = g_model.telemetrySensors[i];
+    switch (sensor.id)
+    {
+      case RSSI_ID:
+        setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RSSI_ID, sensor.instance , 75, UNIT_RAW, 0);
+        break;
+      case ADC1_ID:
+        setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC1_ID, sensor.instance, 100, UNIT_RAW, 0);
+        break;
+      case ADC2_ID:
+        setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ADC2_ID, sensor.instance, 245, UNIT_RAW, 0);
+        break;
+      case SWR_ID:
+        setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, SWR_ID, sensor.instance, 30, UNIT_RAW, 0);
+        break;
+      case BATT_ID:
+        setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, BATT_ID, sensor.instance, 100, UNIT_RAW, 0);
+        break;
     }
+  }
 #endif
 
 

--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -607,19 +607,6 @@ void telemetryReset()
     }
   }
 #endif
-
-
-#if defined(CPUARM) && defined(SIMU) && !defined(COMPANION)
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RSSI_ID, 25, 75, UNIT_RAW, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, SWR_ID, 25, 5, UNIT_RAW, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, T1_FIRST_ID, 5, 100, UNIT_CELSIUS, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, T1_FIRST_ID+0x10, 5, 200, UNIT_CELSIUS, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, ALT_FIRST_ID, 1, 1000, UNIT_METERS, 2);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, CELLS_FIRST_ID, 2, 0x80280220, UNIT_CELLS, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, CURR_FIRST_ID, 3, 100, UNIT_AMPS, 2);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, RPM_FIRST_ID, 5, 3600, UNIT_RPMS, 0);
-  setTelemetryValue(TELEM_PROTO_FRSKY_SPORT, FUEL_QTY_FIRST_ID, 11, 1000, UNIT_MILLILITERS, 2);
-#endif
 }
 
 void telemetryInit(void)

--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -586,7 +586,7 @@ void telemetryReset()
 /*Add some default sensor values to the simulator*/
 #if defined(CPUARM) && defined(SIMU)
   for (int i=0; i<MAX_SENSORS; i++) {
-  const TelemetrySensor & sensor = g_model.telemetrySensors[i];
+    const TelemetrySensor & sensor = g_model.telemetrySensors[i];
     switch (sensor.id)
     {
       case RSSI_ID:


### PR DESCRIPTION
Add ability to select the sensor instance  to which the  telemetry simulator sends data,
Add default data to detected sensors (RSSI, SWR, A1, A2, rxBAT) in Companion Simulator to prevent alarms programmed with LS/SF from alarming constantly while in the simulator.
Fixes issue 2762.