### PR TITLE
2.1.x implementation of displayLuaScriptError()

### DIFF
--- a/radio/src/lua_api.cpp
+++ b/radio/src/lua_api.cpp
@@ -1784,6 +1784,17 @@ bool luaLoadTelemetryScript(uint8_t index)
   return true;
 }
 
+uint8_t isTelemetryScriptAvailable(uint8_t index)
+{
+  for (int i=0; i<luaScriptsCount; i++) {
+    ScriptInternalData & sid = scriptInternalData[i];
+    if (sid.reference == SCRIPT_TELEMETRY_FIRST+index) {
+      return sid.state;
+    }
+  }
+  return SCRIPT_NOFILE;
+}
+
 void luaLoadPermanentScripts()
 {
   luaScriptsCount = 0;

--- a/radio/src/lua_api.h
+++ b/radio/src/lua_api.h
@@ -98,6 +98,7 @@
   void luaExec(const char *filename);
   int luaGetMemUsed();
   #define luaGetCpuUsed(idx) scriptInternalData[idx].instructions
+  uint8_t isTelemetryScriptAvailable(uint8_t index);
   #define LUA_LOAD_MODEL_SCRIPTS()   luaState |= INTERPRETER_RELOAD_PERMANENT_SCRIPTS
   #define LUA_LOAD_MODEL_SCRIPT(idx) luaState |= INTERPRETER_RELOAD_PERMANENT_SCRIPTS
   #define LUA_STANDALONE_SCRIPT_RUNNING() (luaState == INTERPRETER_RUNNING_STANDALONE_SCRIPT)


### PR DESCRIPTION
This is an initial fix for issue #1914 and implements the 2.0.x changes for lua telemetry screen errors.

Still outstanding is whether or not to attempt to capture and display more meaningful lua error messages.

David

