### PR TITLE
Fixes #2896: draw curves without using temporary disk files

### DIFF
--- a/companion/src/comparedialog.cpp
+++ b/companion/src/comparedialog.cpp
@@ -101,7 +101,7 @@ void CompareDialog::dropEvent(QDropEvent *event)
   if (model1Valid && model2Valid) {
     multimodelprinter.setModel(0, model1);
     multimodelprinter.setModel(1, model2);
-    ui->textEdit->setHtml(multimodelprinter.print());
+    ui->textEdit->setHtml(multimodelprinter.print(ui->textEdit->document()));
   }
 }
 

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -17,9 +17,6 @@ ModelPrinter::ModelPrinter(Firmware * firmware, const GeneralSettings & generalS
 
 ModelPrinter::~ModelPrinter()
 {
-  foreach(QString filename, curvefiles) {
-    qunlink(filename);
-  }
 }
 
 void debugHtml(const QString & html)
@@ -620,29 +617,12 @@ void CurveImage::drawCurve(const CurveData & curve, QColor color)
   }
 }
 
-void CurveImage::save(const QString & filename)
-{
-  image.save(filename, "png", 100);
-}
-
-QString ModelPrinter::createCurveImage(int idx)
+QString ModelPrinter::createCurveImage(int idx, QTextDocument * document)
 {
   CurveImage image;
   image.drawCurve(model.curves[idx], colors[idx]);
-  QString filename = generateProcessUniqueTempFileName(QString("curve-%1-%2.png").arg((uint64_t)this).arg(idx));
-  image.save(filename);
-  curvefiles << filename;
-  return filename;
-}
-
-QString ModelPrinter::createCurvesImage()
-{
-  CurveImage image;
-  for (int idx=0; idx<firmware->getCapability(NumCurves); idx++) {
-    image.drawCurve(model.curves[idx], colors[idx]);
-  }
-  QString filename = generateProcessUniqueTempFileName(QString("curves-%1.png").arg((uint64_t)this));
-  image.save(filename);
-  curvefiles << filename;
-  return filename;
+  QString filename = QString("curve-%1-%2.png").arg((uint64_t)this).arg(idx);
+  if (document) document->addResource(QTextDocument::ImageResource, QUrl(filename), image.get());
+  // qDebug() << "ModelPrinter::createCurveImage()" << idx << filename;
+  return ":" + filename;
 }

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QStringList>
 #include <QPainter>
+#include <QTextDocument>
 #include "eeprominterface.h"
 
 QString changeColor(const QString & input, const QString & to, const QString & from = "grey");
@@ -17,7 +18,7 @@ class CurveImage
   public:
     CurveImage();
     void drawCurve(const CurveData & curve, QColor color);
-    void save(const QString & filename);
+    const QImage & get() const { return image; };
 
   protected:
     int size;
@@ -59,14 +60,12 @@ class ModelPrinter: public QObject
     static QString printChannelName(int idx);
     QString printOutputName(int idx);
     QString printCurve(int idx);
-    QString createCurvesImage();
-    QString createCurveImage(int idx);
+    QString createCurveImage(int idx, QTextDocument * document);
 
   private:
     Firmware * firmware;
     const GeneralSettings & generalSettings;
     const ModelData & model;
-    QStringList curvefiles;
 
 };
 

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -122,8 +122,10 @@ void MultiModelPrinter::setModel(int idx, const ModelData & model)
   modelPrinters[idx] = new ModelPrinter(firmware, defaultSettings, model);
 }
 
-QString MultiModelPrinter::print()
+QString MultiModelPrinter::print(QTextDocument * document)
 {
+  if (document) document->clear();
+
   QString str = "<table border='1' cellspacing='0' cellpadding='3' width='100%' style='font-family: monospace;'>";
   str += printSetup();
   if (firmware->getCapability(FlightModes))
@@ -131,7 +133,7 @@ QString MultiModelPrinter::print()
   str += printInputs();
   str += printMixers();
   str += printLimits();
-  str += printCurves();
+  str += printCurves(document);
   if (firmware->getCapability(Gvars) && !firmware->getCapability(GvarsFlightModes))
     str += printGvars();
   str += printLogicalSwitches();
@@ -366,7 +368,7 @@ QString MultiModelPrinter::printMixers()
   return str;
 }
 
-QString MultiModelPrinter::printCurves()
+QString MultiModelPrinter::printCurves(QTextDocument * document)
 {
   QString str;
   MultiColumns columns(models.size());
@@ -385,7 +387,7 @@ QString MultiModelPrinter::printCurves()
       columns.append("<tr><td width='20%'><b>" + tr("CV%1").arg(i+1) + "</b></td><td>");
       COMPARE(modelPrinter->printCurve(i));
       for (int k=0; k<models.size(); k++)
-        columns.append(k, QString("<br/><img src='%1' border='0' />").arg(modelPrinters[k]->createCurveImage(i)));
+        columns.append(k, QString("<br/><img src='%1' border='0' />").arg(modelPrinters[k]->createCurveImage(i, document)));
       columns.append("</td></tr>");
     }
   }

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -2,6 +2,7 @@
 #define _MULTIMODELPRINTER_H
 
 #include <QObject>
+#include <QTextDocument>
 #include "eeprominterface.h"
 #include "modelprinter.h"
 
@@ -14,7 +15,7 @@ class MultiModelPrinter: public QObject
     virtual ~MultiModelPrinter();
     
     void setModel(int idx, const ModelData & model);
-    QString print();
+    QString print(QTextDocument * document);
 
   protected:
     class MultiColumns {
@@ -46,7 +47,7 @@ class MultiModelPrinter: public QObject
     QString printLimits();
     QString printInputs();
     QString printMixers();
-    QString printCurves();
+    QString printCurves(QTextDocument * document);
     QString printGvars();
     QString printLogicalSwitches();
     QString printCustomFunctions();

--- a/companion/src/printdialog.cpp
+++ b/companion/src/printdialog.cpp
@@ -21,7 +21,7 @@ PrintDialog::PrintDialog(QWidget *parent, Firmware * firmware, GeneralSettings &
   setWindowIcon(CompanionIcon("print.png"));
   setWindowTitle(model.name);
   multimodelprinter.setModel(0, model);
-  ui->textEdit->setHtml(multimodelprinter.print());
+  ui->textEdit->setHtml(multimodelprinter.print(ui->textEdit->document()));
   if (!printfilename.isEmpty()) {
     printToFile();
     QTimer::singleShot(0, this, SLOT(autoClose()));


### PR DESCRIPTION
Closes #2896.

Perhaps this change will fix the original issue. The model curves are no longer created on disk, but embedded directly into the document.