### PR TITLE
Remove __CYGWIN__ from Issue 3012 Windows pathing fix because Cygwin

### DIFF
--- a/companion/src/simulation/simulatorinterface.cpp
+++ b/companion/src/simulation/simulatorinterface.cpp
@@ -53,7 +53,7 @@ void registerSimulators()
   if (!simulatorsFound) {
 #if defined(__APPLE__)
     dir = QLibraryInfo::location(QLibraryInfo::PrefixPath) + "/Resources";
-#elif (!defined __GNUC__) || (defined __CYGWIN__)
+#elif (!defined __GNUC__) 
     char name[MAX_PATH];
     GetModuleFileName(NULL, name, MAX_PATH);
 	QString path(name);


### PR DESCRIPTION
Remove __CYGWIN__ from Issue 3012 Windows pathing fix because Cygwin uses posix pathing and not Windows pathing and does define __GNUC__ as well as __CYGWIN__..