### PR TITLE
Issue #3024 - Companion 2.1 (windows) - Lua 'execute' fails in non-root directory

### DIFF
--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -697,7 +697,7 @@ FATFS g_FATFS_Obj;
 char *convertSimuPath(const char *path)
 {
   static char result[1024];
-  if (path[0] == '/' && strcmp(simuSdDirectory, "/") != 0)
+  if (((path[0] == '/') || (path[0] == '\\')) && (strcmp(simuSdDirectory, "/") != 0))
     sprintf(result, "%s%s", simuSdDirectory, path);
   else
     strcpy(result, path);
@@ -1006,13 +1006,6 @@ FRESULT f_getcwd (TCHAR *path, UINT sz_path)
 
   // remove simuSdDirectory from the cwd
   strcpy(path, cwd + strlen(simuSdDirectory));
-
-  // convert backslashes to forward - issue #3024
-  for (int i = 0; path[i] != 0; i++) {
-    if (path[i] == '\\') {
-      path[i] = '/';
-    }
-  }
 
   TRACE("f_getcwd() = %s", path);
   return FR_OK;

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -1006,6 +1006,14 @@ FRESULT f_getcwd (TCHAR *path, UINT sz_path)
 
   // remove simuSdDirectory from the cwd
   strcpy(path, cwd + strlen(simuSdDirectory));
+
+  // convert backslashes to forward - issue #3024
+  for (int i = 0; path[i] != 0; i++) {
+    if (path[i] == '\\') {
+      path[i] = '/';
+    }
+  }
+
   TRACE("f_getcwd() = %s", path);
   return FR_OK;
 }


### PR DESCRIPTION
~~Conversion of backward slash to forward slash for companion.~~

Fixes #3025 

Solution was to modify convertSimuPath() to append fully qualified path name for requests starting with both forward and backward slashes.