### PR TITLE
Added logic in perMain() to suppress killed events.  Fixes #2469

### DIFF
--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -242,6 +242,7 @@ class Key
     bool state()       { return m_vals > 0; }
     void pauseEvents() { m_state = KSTATE_PAUSE; m_cnt = 0; }
     void killEvents()  { m_state = KSTATE_KILLED; }
+    bool isKilled() { return (m_state == KSTATE_KILLED); }
     EnumKeys key() const;
 };
 

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -99,6 +99,15 @@ void checkEeprom()
   }
 }
 
+bool eventIsKilled(uint8_t event)
+{
+  event = EVT_KEY_MASK(event);
+  if (event < (int)DIM(keys)) {
+    return keys[event].isKilled();
+  }
+  return false;
+}
+
 void perMain()
 {
 #if defined(PCBSKY9X) && !defined(REVA)
@@ -182,7 +191,9 @@ void perMain()
       menuEvent = 0;
       AUDIO_MENUS();
     }
-    g_menuStack[g_menuStackPtr]((warn || menu) ? 0 : evt);
+    if (!eventIsKilled(evt)) { // fixes issue #2469
+      g_menuStack[g_menuStackPtr]((warn || menu) ? 0 : evt);
+    }
     if (warn) DISPLAY_WARNING(evt);
     if (menu) {
       const char * result = displayMenu(evt);


### PR DESCRIPTION
Fixes #2469 

The logic to bypass killed events looked pretty straight forward so I took a swing at it.

I'm still testing for unwanted side effects, but I'd like some more feedback on the proposed changes.