### PR TITLE
Update flasheepromdialog.ui

### DIFF
--- a/companion/src/flasheepromdialog.ui
+++ b/companion/src/flasheepromdialog.ui
@@ -110,7 +110,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>Allows Companion to write to older version of the firmware</string>
+      <string>Saves a dated copy of your eeprom to the backup folder you specified in the Companion settings before writing the current model to the radio.</string>
      </property>
      <property name="text">
       <string>Backup before Write</string>

--- a/companion/src/flasheepromdialog.ui
+++ b/companion/src/flasheepromdialog.ui
@@ -110,7 +110,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>Saves a dated copy of your eeprom to the backup folder you specified in the Companion settings before writing the current model to the radio.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves a dated copy of your eeprom to the backup folder you specified in the Companion settings before writing the current model to the radio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>Backup before Write</string>


### PR DESCRIPTION
Corrected the tool tip for the backupBeforeWrite checkbox. It incorrectly had the text from Check Firmware Compatibility. I tried to word the tooltip as descriptive as possible.