### PR TITLE
Update flasheepromdialog.ui, Fixed backupBeforeWrite toolTip.

### DIFF
--- a/companion/src/flasheepromdialog.ui
+++ b/companion/src/flasheepromdialog.ui
@@ -110,7 +110,7 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>Allows Companion to write to older version of the firmware</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves a dated copy of your eeprom to the backup folder you specified in the Companion settings before writing the current model to the radio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>Backup before Write</string>


### PR DESCRIPTION

![backupbeforewrite_tooltip](https://cloud.githubusercontent.com/assets/7920310/11205946/65b25b2e-8cd1-11e5-8b30-67c4014ab444.png)
Updating the backupBeforeWrite toolTip. It was incorrectly set to the checkFirmwareCompatibility text.