### PR TITLE
Fixes #2469: Allow usage of PLUS, MINUS, MENU and ENT keys in telemet…

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -323,13 +323,13 @@ void evalFunctions()
             newActiveFunctions |= (1 << FUNCTION_INSTANT_TRIM);
             if (!isFunctionActive(FUNCTION_INSTANT_TRIM)) {
 #if defined(GUI)
-              if (g_menuStack[0] == menuMainView
+              if (menuHandlers[0] == menuMainView
 #if defined(FRSKY)
-                || g_menuStack[0] == menuTelemetryFrsky
+                || menuHandlers[0] == menuTelemetryFrsky
 #endif
 #if defined(PCBTARANIS)
-                || g_menuStack[0] == menuMainViewChannelsMonitor
-                || g_menuStack[0] == menuChannelsView
+                || menuHandlers[0] == menuMainViewChannelsMonitor
+                || menuHandlers[0] == menuChannelsView
 #endif
               )
 #endif

--- a/radio/src/gui/9X/helpers.cpp
+++ b/radio/src/gui/9X/helpers.cpp
@@ -184,7 +184,7 @@ bool isSwitchAvailableInLogicalSwitches(int swtch)
 
 bool isSwitchAvailableInCustomFunctions(int swtch)
 {
-  if (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions)
+  if (menuHandlers[menuLevel] == menuModelCustomFunctions)
     return isSwitchAvailable(swtch, ModelCustomFunctionsContext);
   else
     return isSwitchAvailable(swtch, GeneralCustomFunctionsContext);
@@ -220,7 +220,7 @@ bool isLogicalSwitchFunctionAvailable(int function)
 
 bool isAssignableFunctionAvailable(int function)
 {
-  bool modelFunctions = (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions);
+  bool modelFunctions = (menuHandlers[menuLevel] == menuModelCustomFunctions);
 
   switch (function) {
     case FUNC_OVERRIDE_CHANNEL:

--- a/radio/src/gui/9X/menu_general_diaganas.cpp
+++ b/radio/src/gui/9X/menu_general_diaganas.cpp
@@ -79,24 +79,24 @@ void menuGeneralDiagAna(uint8_t event)
   adcBatt = ((adcBatt * 7) + anaIn(TX_VOLTAGE)) / 8;
   uint32_t batCalV = (adcBatt + adcBatt*(g_eeGeneral.txVoltageCalibration)/128) * 4191;
   batCalV /= 55296;
-  putsVolts(LEN_CALIB_FIELDS*FW+4*FW, MENU_HEADER_HEIGHT+1+4*FH, batCalV, (m_posVert==1 ? INVERS : 0));
+  putsVolts(LEN_CALIB_FIELDS*FW+4*FW, MENU_HEADER_HEIGHT+1+4*FH, batCalV, (menuVerticalPosition==1 ? INVERS : 0));
 #elif defined(PCBGRUVIN9X)
   lcd_putsLeft(6*FH-2, STR_BATT_CALIB);
   // Gruvin wants 2 decimal places and instant update of volts calib field when button pressed
   static uint16_t adcBatt;
   adcBatt = ((adcBatt * 7) + anaIn(TX_VOLTAGE)) / 8; // running average, sourced directly (to avoid unending debate :P)
   uint32_t batCalV = ((uint32_t)adcBatt*1390 + (10*(int32_t)adcBatt*g_eeGeneral.txVoltageCalibration)/8) / BandGap;
-  lcd_outdezNAtt(LEN_CALIB_FIELDS*FW+4*FW, 6*FH-2, batCalV, PREC2|(m_posVert==1 ? INVERS : 0));
+  lcd_outdezNAtt(LEN_CALIB_FIELDS*FW+4*FW, 6*FH-2, batCalV, PREC2|(menuVerticalPosition==1 ? INVERS : 0));
 #else
   lcd_putsLeft(6*FH-2, STR_BATT_CALIB);
-  putsVolts(LEN_CALIB_FIELDS*FW+4*FW, 6*FH-2, g_vbat100mV, (m_posVert==1 ? INVERS : 0));
+  putsVolts(LEN_CALIB_FIELDS*FW+4*FW, 6*FH-2, g_vbat100mV, (menuVerticalPosition==1 ? INVERS : 0));
 #endif
-  if (m_posVert==1) CHECK_INCDEC_GENVAR(event, g_eeGeneral.txVoltageCalibration, -127, 127);
+  if (menuVerticalPosition==1) CHECK_INCDEC_GENVAR(event, g_eeGeneral.txVoltageCalibration, -127, 127);
 
 #if defined(TX_CAPACITY_MEASUREMENT)
   lcd_putsLeft(6*FH+1, STR_CURRENT_CALIB);
-  putsValueWithUnit(LEN_CALIB_FIELDS*FW+4*FW, 6*FH+1, getCurrent(), UNIT_MILLIAMPS, (m_posVert==2 ? INVERS : 0)) ;
-  if (m_posVert==2) CHECK_INCDEC_GENVAR(event, g_eeGeneral.txCurrentCalibration, -49, 49);
+  putsValueWithUnit(LEN_CALIB_FIELDS*FW+4*FW, 6*FH+1, getCurrent(), UNIT_MILLIAMPS, (menuVerticalPosition==2 ? INVERS : 0)) ;
+  if (menuVerticalPosition==2) CHECK_INCDEC_GENVAR(event, g_eeGeneral.txCurrentCalibration, -49, 49);
 #endif
 
 #if defined(PCBSKY9X)
@@ -109,7 +109,7 @@ void menuGeneralDiagAna(uint8_t event)
   #endif
 
   lcd_putsLeft(TEMP_CALIB_POS, STR_TEMP_CALIB);
-  putsValueWithUnit(LEN_CALIB_FIELDS*FW+4*FW, TEMP_CALIB_POS, getTemperature(), UNIT_TEMPERATURE, (m_posVert==TEMP_CALIB_MENU_POS ? INVERS : 0)) ;
-  if (m_posVert==TEMP_CALIB_MENU_POS) CHECK_INCDEC_GENVAR(event, g_eeGeneral.temperatureCalib, -100, 100);
+  putsValueWithUnit(LEN_CALIB_FIELDS*FW+4*FW, TEMP_CALIB_POS, getTemperature(), UNIT_TEMPERATURE, (menuVerticalPosition==TEMP_CALIB_MENU_POS ? INVERS : 0)) ;
+  if (menuVerticalPosition==TEMP_CALIB_MENU_POS) CHECK_INCDEC_GENVAR(event, g_eeGeneral.temperatureCalib, -100, 100);
 #endif
 }

--- a/radio/src/gui/9X/menu_general_hardware.cpp
+++ b/radio/src/gui/9X/menu_general_hardware.cpp
@@ -53,7 +53,7 @@ void menuGeneralHardware(uint8_t event)
 {
   MENU(STR_HARDWARE, menuTabGeneral, e_Hardware, ITEM_SETUP_HW_MAX+1, {0, 0, (uint8_t)-1, 0, 0, 0, IF_ROTARY_ENCODERS(0) CASE_BLUETOOTH(0)});
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/9X/menu_general_hardware.cpp
+++ b/radio/src/gui/9X/menu_general_hardware.cpp
@@ -57,7 +57,7 @@ void menuGeneralHardware(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
     uint8_t blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
     uint8_t attr = (sub == k ? blink : 0);
 

--- a/radio/src/gui/9X/menu_general_sdmanager.cpp
+++ b/radio/src/gui/9X/menu_general_sdmanager.cpp
@@ -76,7 +76,7 @@ void onSdManagerMenu(const char *result)
 {
   TCHAR lfn[_MAX_LFN+1];
 
-  uint8_t index = m_posVert-1-s_pgOfs;
+  uint8_t index = menuVerticalPosition-1-s_pgOfs;
   if (result == STR_SD_INFO) {
     pushMenu(menuGeneralSdManagerInfo);
   }
@@ -91,7 +91,7 @@ void onSdManagerMenu(const char *result)
     strncpy(statusLineMsg, reusableBuffer.sdmanager.lines[index], 13);
     strcpy_P(statusLineMsg+min((uint8_t)strlen(statusLineMsg), (uint8_t)13), STR_REMOVED);
     showStatusLine();
-    if ((uint16_t)m_posVert == reusableBuffer.sdmanager.count) m_posVert--;
+    if ((uint16_t)menuVerticalPosition == reusableBuffer.sdmanager.count) menuVerticalPosition--;
     reusableBuffer.sdmanager.offset = s_pgOfs-1;
   }
 #if defined(CPUARM)
@@ -157,32 +157,32 @@ void menuGeneralSdManager(uint8_t _event)
     case EVT_KEY_FIRST(KEY_RIGHT):
     case EVT_KEY_FIRST(KEY_ENTER):
     {
-      if (m_posVert > 0) {
-        vertpos_t index = m_posVert-1-s_pgOfs;
+      if (menuVerticalPosition > 0) {
+        vertpos_t index = menuVerticalPosition-1-s_pgOfs;
         if (!reusableBuffer.sdmanager.lines[index][SD_SCREEN_FILE_LENGTH+1]) {
           f_chdir(reusableBuffer.sdmanager.lines[index]);
           s_pgOfs = 0;
-          m_posVert = 1;
+          menuVerticalPosition = 1;
           reusableBuffer.sdmanager.offset = 65535;
           killEvents(_event);
           break;
         }
       }
-      if (!IS_ROTARY_BREAK(_event) || m_posVert==0)
+      if (!IS_ROTARY_BREAK(_event) || menuVerticalPosition==0)
         break;
       // no break;
     }
 
     case EVT_KEY_LONG(KEY_ENTER):
       killEvents(_event);
-      if (m_posVert == 0) {
+      if (menuVerticalPosition == 0) {
         POPUP_MENU_ADD_ITEM(STR_SD_INFO);
         POPUP_MENU_ADD_ITEM(STR_SD_FORMAT);
       }
       else
       {
 #if defined(CPUARM)
-        uint8_t index = m_posVert-1-s_pgOfs;
+        uint8_t index = menuVerticalPosition-1-s_pgOfs;
         // TODO duplicated code for finding extension
         char * ext = reusableBuffer.sdmanager.lines[index];
         int len = strlen(ext) - 4;
@@ -289,7 +289,7 @@ void menuGeneralSdManager(uint8_t _event)
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
     lcdNextPos = 0;
-    uint8_t attr = (m_posVert-1-s_pgOfs == i ? BSS|INVERS : BSS);
+    uint8_t attr = (menuVerticalPosition-1-s_pgOfs == i ? BSS|INVERS : BSS);
     if (reusableBuffer.sdmanager.lines[i][0]) {
       if (!reusableBuffer.sdmanager.lines[i][SD_SCREEN_FILE_LENGTH+1]) { lcd_putcAtt(0, y, '[', attr); }
       lcd_putsAtt(lcdNextPos, y, reusableBuffer.sdmanager.lines[i], attr);

--- a/radio/src/gui/9X/menu_general_sdmanager.cpp
+++ b/radio/src/gui/9X/menu_general_sdmanager.cpp
@@ -176,8 +176,8 @@ void menuGeneralSdManager(uint8_t _event)
     case EVT_KEY_LONG(KEY_ENTER):
       killEvents(_event);
       if (m_posVert == 0) {
-        MENU_ADD_ITEM(STR_SD_INFO);
-        MENU_ADD_ITEM(STR_SD_FORMAT);
+        POPUP_MENU_ADD_ITEM(STR_SD_INFO);
+        POPUP_MENU_ADD_ITEM(STR_SD_FORMAT);
       }
       else
       {
@@ -188,19 +188,19 @@ void menuGeneralSdManager(uint8_t _event)
         int len = strlen(ext) - 4;
         ext += len;
         /* TODO if (!strcasecmp(ext, MODELS_EXT)) {
-          s_menu[s_menu_count++] = STR_LOAD_FILE;
+          popupMenuItems[popupMenuNoItems++] = STR_LOAD_FILE;
         }
         else */ if (!strcasecmp(ext, SOUNDS_EXT)) {
-          MENU_ADD_ITEM(STR_PLAY_FILE);
+          POPUP_MENU_ADD_ITEM(STR_PLAY_FILE);
         }
 #endif
         if (!READ_ONLY()) {
-          MENU_ADD_ITEM(STR_DELETE_FILE);
-          // MENU_ADD_ITEM(STR_RENAME_FILE);  TODO: Implement
-          // MENU_ADD_ITEM(STR_COPY_FILE);    TODO: Implement
+          POPUP_MENU_ADD_ITEM(STR_DELETE_FILE);
+          // POPUP_MENU_ADD_ITEM(STR_RENAME_FILE);  TODO: Implement
+          // POPUP_MENU_ADD_ITEM(STR_COPY_FILE);    TODO: Implement
         }
       }
-      menuHandler = onSdManagerMenu;
+      popupMenuHandler = onSdManagerMenu;
       break;
   }
 

--- a/radio/src/gui/9X/menu_general_sdmanager.cpp
+++ b/radio/src/gui/9X/menu_general_sdmanager.cpp
@@ -121,8 +121,8 @@ void menuGeneralSdManager(uint8_t _event)
   fno.lfsize = sizeof(lfn);
 
 #if defined(SDCARD)
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     displayPopup(STR_FORMATTING);
     closeLogs();
 #if defined(PCBSKY9X)

--- a/radio/src/gui/9X/menu_general_sdmanager.cpp
+++ b/radio/src/gui/9X/menu_general_sdmanager.cpp
@@ -76,7 +76,7 @@ void onSdManagerMenu(const char *result)
 {
   TCHAR lfn[_MAX_LFN+1];
 
-  uint8_t index = menuVerticalPosition-1-s_pgOfs;
+  uint8_t index = menuVerticalPosition-1-menuVerticalOffset;
   if (result == STR_SD_INFO) {
     pushMenu(menuGeneralSdManagerInfo);
   }
@@ -92,7 +92,7 @@ void onSdManagerMenu(const char *result)
     strcpy_P(statusLineMsg+min((uint8_t)strlen(statusLineMsg), (uint8_t)13), STR_REMOVED);
     showStatusLine();
     if ((uint16_t)menuVerticalPosition == reusableBuffer.sdmanager.count) menuVerticalPosition--;
-    reusableBuffer.sdmanager.offset = s_pgOfs-1;
+    reusableBuffer.sdmanager.offset = menuVerticalOffset-1;
   }
 #if defined(CPUARM)
   /* TODO else if (result == STR_LOAD_FILE) {
@@ -158,10 +158,10 @@ void menuGeneralSdManager(uint8_t _event)
     case EVT_KEY_FIRST(KEY_ENTER):
     {
       if (menuVerticalPosition > 0) {
-        vertpos_t index = menuVerticalPosition-1-s_pgOfs;
+        vertpos_t index = menuVerticalPosition-1-menuVerticalOffset;
         if (!reusableBuffer.sdmanager.lines[index][SD_SCREEN_FILE_LENGTH+1]) {
           f_chdir(reusableBuffer.sdmanager.lines[index]);
-          s_pgOfs = 0;
+          menuVerticalOffset = 0;
           menuVerticalPosition = 1;
           reusableBuffer.sdmanager.offset = 65535;
           killEvents(_event);
@@ -182,7 +182,7 @@ void menuGeneralSdManager(uint8_t _event)
       else
       {
 #if defined(CPUARM)
-        uint8_t index = menuVerticalPosition-1-s_pgOfs;
+        uint8_t index = menuVerticalPosition-1-menuVerticalOffset;
         // TODO duplicated code for finding extension
         char * ext = reusableBuffer.sdmanager.lines[index];
         int len = strlen(ext) - 4;
@@ -204,16 +204,16 @@ void menuGeneralSdManager(uint8_t _event)
       break;
   }
 
-  if (reusableBuffer.sdmanager.offset != s_pgOfs) {
-    if (s_pgOfs == 0) {
+  if (reusableBuffer.sdmanager.offset != menuVerticalOffset) {
+    if (menuVerticalOffset == 0) {
       reusableBuffer.sdmanager.offset = 0;
       memset(reusableBuffer.sdmanager.lines, 0, sizeof(reusableBuffer.sdmanager.lines));
     }
-    else if (s_pgOfs == reusableBuffer.sdmanager.count-7) {
-      reusableBuffer.sdmanager.offset = s_pgOfs;
+    else if (menuVerticalOffset == reusableBuffer.sdmanager.count-7) {
+      reusableBuffer.sdmanager.offset = menuVerticalOffset;
       memset(reusableBuffer.sdmanager.lines, 0, sizeof(reusableBuffer.sdmanager.lines));
     }
-    else if (s_pgOfs > reusableBuffer.sdmanager.offset) {
+    else if (menuVerticalOffset > reusableBuffer.sdmanager.offset) {
       memmove(reusableBuffer.sdmanager.lines[0], reusableBuffer.sdmanager.lines[1], 6*sizeof(reusableBuffer.sdmanager.lines[0]));
       memset(reusableBuffer.sdmanager.lines[6], 0xff, SD_SCREEN_FILE_LENGTH);
       reusableBuffer.sdmanager.lines[6][SD_SCREEN_FILE_LENGTH+1] = 1;
@@ -242,7 +242,7 @@ void menuGeneralSdManager(uint8_t _event)
 
         bool isfile = !(fno.fattrib & AM_DIR);
 
-        if (s_pgOfs == 0) {
+        if (menuVerticalOffset == 0) {
           for (uint8_t i=0; i<LCD_LINES-1; i++) {
             char *line = reusableBuffer.sdmanager.lines[i];
             if (line[0] == '\0' || isFilenameLower(isfile, fn, line)) {
@@ -254,7 +254,7 @@ void menuGeneralSdManager(uint8_t _event)
             }
           }
         }
-        else if (reusableBuffer.sdmanager.offset == s_pgOfs) {
+        else if (reusableBuffer.sdmanager.offset == menuVerticalOffset) {
           for (int8_t i=6; i>=0; i--) {
             char *line = reusableBuffer.sdmanager.lines[i];
             if (line[0] == '\0' || isFilenameGreater(isfile, fn, line)) {
@@ -266,7 +266,7 @@ void menuGeneralSdManager(uint8_t _event)
             }
           }
         }
-        else if (s_pgOfs > reusableBuffer.sdmanager.offset) {
+        else if (menuVerticalOffset > reusableBuffer.sdmanager.offset) {
           if (isFilenameGreater(isfile, fn, reusableBuffer.sdmanager.lines[5]) && isFilenameLower(isfile, fn, reusableBuffer.sdmanager.lines[6])) {
             memset(reusableBuffer.sdmanager.lines[6], 0, sizeof(reusableBuffer.sdmanager.lines[0]));
             strcpy(reusableBuffer.sdmanager.lines[6], fn);
@@ -284,12 +284,12 @@ void menuGeneralSdManager(uint8_t _event)
     }
   }
 
-  reusableBuffer.sdmanager.offset = s_pgOfs;
+  reusableBuffer.sdmanager.offset = menuVerticalOffset;
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
     lcdNextPos = 0;
-    uint8_t attr = (menuVerticalPosition-1-s_pgOfs == i ? BSS|INVERS : BSS);
+    uint8_t attr = (menuVerticalPosition-1-menuVerticalOffset == i ? BSS|INVERS : BSS);
     if (reusableBuffer.sdmanager.lines[i][0]) {
       if (!reusableBuffer.sdmanager.lines[i][SD_SCREEN_FILE_LENGTH+1]) { lcd_putcAtt(0, y, '[', attr); }
       lcd_putsAtt(lcdNextPos, y, reusableBuffer.sdmanager.lines[i], attr);

--- a/radio/src/gui/9X/menu_general_setup.cpp
+++ b/radio/src/gui/9X/menu_general_setup.cpp
@@ -159,7 +159,7 @@ void menuGeneralSetup(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
     uint8_t blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
     uint8_t attr = (sub == k ? blink : 0);
 

--- a/radio/src/gui/9X/menu_general_setup.cpp
+++ b/radio/src/gui/9X/menu_general_setup.cpp
@@ -146,8 +146,8 @@ void menuGeneralSetup(uint8_t event)
 #endif
 
 #if defined(FAI_CHOICE)
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     g_eeGeneral.fai = true;
     eeDirty(EE_GENERAL);
   }

--- a/radio/src/gui/9X/menu_general_setup.cpp
+++ b/radio/src/gui/9X/menu_general_setup.cpp
@@ -137,7 +137,7 @@ void menuGeneralSetup(uint8_t event)
   struct gtm t;
   gettime(&t);
 
-  if ((m_posVert==ITEM_SETUP_DATE+1 || m_posVert==ITEM_SETUP_TIME+1) &&
+  if ((menuVerticalPosition==ITEM_SETUP_DATE+1 || menuVerticalPosition==ITEM_SETUP_TIME+1) &&
       (s_editMode>0) &&
       (event==EVT_KEY_FIRST(KEY_ENTER) || event==EVT_KEY_FIRST(KEY_EXIT) || IS_ROTARY_BREAK(event) || IS_ROTARY_LONG(event))) {
     // set the date and time into RTC chip
@@ -155,7 +155,7 @@ void menuGeneralSetup(uint8_t event)
 
   MENU(STR_MENURADIOSETUP, menuTabGeneral, e_Setup, ITEM_SETUP_MAX+1, {0, CASE_RTCLOCK(2) CASE_RTCLOCK(2) CASE_BATTGRAPH(1) LABEL(SOUND), CASE_AUDIO(0) CASE_BUZZER(0) CASE_VOICE(0) CASE_CPUARM(0) CASE_CPUARM(0) CASE_CPUARM(0) 0, CASE_AUDIO(0) CASE_VARIO_CPUARM(LABEL(VARIO)) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_HAPTIC(LABEL(HAPTIC)) CASE_HAPTIC(0) CASE_HAPTIC(0) CASE_HAPTIC(0) 0, LABEL(ALARMS), 0, CASE_CAPACITY(0) CASE_PCBSKY9X(0) 0, 0, 0, IF_ROTARY_ENCODERS(0) LABEL(BACKLIGHT), 0, 0, CASE_CPUARM(0) CASE_PWM_BACKLIGHT(0) CASE_PWM_BACKLIGHT(0) 0, CASE_SPLASH_PARAM(0) CASE_GPS(0) CASE_GPS(0) CASE_PXX(0) CASE_CPUARM(0) CASE_CPUARM(0) IF_FAI_CHOICE(0) CASE_MAVLINK(0) CASE_CPUARM(0) 0, COL_TX_MODE, 1/*to force edit mode*/});
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -169,7 +169,7 @@ void menuGeneralSetup(uint8_t event)
         lcd_putsLeft(y, STR_DATE);
         lcd_putc(RADIO_SETUP_DATE_COLUMN, y, '-'); lcd_putc(RADIO_SETUP_DATE_COLUMN+3*FW-2, y, '-');
         for (uint8_t j=0; j<3; j++) {
-          uint8_t rowattr = (m_posHorz==j ? attr : 0);
+          uint8_t rowattr = (menuHorizontalPosition==j ? attr : 0);
           switch (j) {
             case 0:
               lcd_outdezAtt(RADIO_SETUP_DATE_COLUMN, y, t.tm_year+1900, rowattr);
@@ -200,7 +200,7 @@ void menuGeneralSetup(uint8_t event)
         lcd_putsLeft(y, STR_TIME);
         lcd_putc(RADIO_SETUP_TIME_COLUMN+1, y, ':'); lcd_putc(RADIO_SETUP_TIME_COLUMN+3*FW-2, y, ':');
         for (uint8_t j=0; j<3; j++) {
-          uint8_t rowattr = (m_posHorz==j ? attr : 0);
+          uint8_t rowattr = (menuHorizontalPosition==j ? attr : 0);
           switch (j) {
             case 0:
               lcd_outdezNAtt(RADIO_SETUP_TIME_COLUMN, y, t.tm_hour, rowattr|LEADING0, 2);
@@ -224,11 +224,11 @@ void menuGeneralSetup(uint8_t event)
 #if defined(BATTGRAPH)
       case ITEM_SETUP_BATT_RANGE:
         lcd_putsLeft(y, STR_BATTERY_RANGE);
-        putsVolts(RADIO_SETUP_2ND_COLUMN, y,  90+g_eeGeneral.vBatMin, (m_posHorz==0 ? attr : 0)|LEFT|NO_UNIT);
+        putsVolts(RADIO_SETUP_2ND_COLUMN, y,  90+g_eeGeneral.vBatMin, (menuHorizontalPosition==0 ? attr : 0)|LEFT|NO_UNIT);
         lcd_putc(lcdLastPos, y, '-');
-        putsVolts(lcdLastPos+FW, y, 120+g_eeGeneral.vBatMax, (m_posHorz>0 ? attr : 0)|LEFT|NO_UNIT);
+        putsVolts(lcdLastPos+FW, y, 120+g_eeGeneral.vBatMax, (menuHorizontalPosition>0 ? attr : 0)|LEFT|NO_UNIT);
         if (attr && s_editMode>0) {
-          if (m_posHorz==0)
+          if (menuHorizontalPosition==0)
             CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatMin, -50, g_eeGeneral.vBatMax+29); // min=4.0V
           else
             CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatMax, g_eeGeneral.vBatMin-29, +40); // max=16.0V

--- a/radio/src/gui/9X/menu_general_trainer.cpp
+++ b/radio/src/gui/9X/menu_general_trainer.cpp
@@ -60,11 +60,11 @@ void menuGeneralTrainer(uint8_t event)
       uint8_t chan = channel_order(i);
       volatile TrainerMix *td = &g_eeGeneral.trainer.mix[chan-1];
 
-      putsMixerSource(0, y, MIXSRC_Rud-1+chan, (m_posVert==i && CURSOR_ON_LINE()) ? INVERS : 0);
+      putsMixerSource(0, y, MIXSRC_Rud-1+chan, (menuVerticalPosition==i && CURSOR_ON_LINE()) ? INVERS : 0);
 
       for (uint8_t j=0; j<3; j++) {
 
-        attr = ((m_posVert==i && m_posHorz==j) ? blink : 0);
+        attr = ((menuVerticalPosition==i && menuHorizontalPosition==j) ? blink : 0);
 
         switch(j) {
           case 0:
@@ -86,12 +86,12 @@ void menuGeneralTrainer(uint8_t event)
       y += FH;
     }
 
-    attr = (m_posVert==5) ? blink : 0;
+    attr = (menuVerticalPosition==5) ? blink : 0;
     lcd_putsLeft(MENU_HEADER_HEIGHT+1+5*FH, STR_MULTIPLIER);
     lcd_outdezAtt(LEN_MULTIPLIER*FW+3*FW, MENU_HEADER_HEIGHT+1+5*FH, g_eeGeneral.PPM_Multiplier+10, attr|PREC1);
     if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.PPM_Multiplier, -10, 40);
 
-    attr = (m_posVert==6) ? INVERS : 0;
+    attr = (menuVerticalPosition==6) ? INVERS : 0;
     if (attr) s_editMode = 0;
     lcd_putsAtt(0*FW, MENU_HEADER_HEIGHT+1+6*FH, STR_CAL, attr);
     for (uint8_t i=0; i<4; i++) {

--- a/radio/src/gui/9X/menu_model.cpp
+++ b/radio/src/gui/9X/menu_model.cpp
@@ -122,7 +122,7 @@ static int8_t s_copySrcRow;
 static int8_t s_copyTgtOfs;
 
 #if defined(CPUM64)
-  #define editNameCursorPos m_posHorz
+  #define editNameCursorPos menuHorizontalPosition
 #else
   static uint8_t editNameCursorPos = 0;
 #endif

--- a/radio/src/gui/9X/menu_model_curves.cpp
+++ b/radio/src/gui/9X/menu_model_curves.cpp
@@ -249,7 +249,7 @@ void menuModelCurvesAll(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i + s_pgOfs;
+    uint8_t k = i + menuVerticalOffset;
     uint8_t attr = (sub == k ? INVERS : 0);
 #if defined(GVARS) && defined(PCBSTD)
     if (k >= MAX_CURVES) {

--- a/radio/src/gui/9X/menu_model_curves.cpp
+++ b/radio/src/gui/9X/menu_model_curves.cpp
@@ -117,7 +117,7 @@ void menuModelCurveOne(uint8_t event)
     CASE_EVT_ROTARY_BREAK
     case EVT_KEY_BREAK(KEY_ENTER):
       if (s_editMode <= 0)
-        m_posHorz = 0;
+        menuHorizontalPosition = 0;
       if (s_editMode == 1 && crv.custom)
         s_editMode = 2;
       else
@@ -125,10 +125,10 @@ void menuModelCurveOne(uint8_t event)
       break;
     case EVT_KEY_LONG(KEY_ENTER):
       if (s_editMode <= 0) {
-        if (int8_t(++m_posHorz) > 4)
-          m_posHorz = -4;
+        if (int8_t(++menuHorizontalPosition) > 4)
+          menuHorizontalPosition = -4;
         for (uint8_t i=0; i<crv.points; i++)
-          crv.crv[i] = (i-(crv.points/2)) * int8_t(m_posHorz) * 50 / (crv.points-1);
+          crv.crv[i] = (i-(crv.points/2)) * int8_t(menuHorizontalPosition) * 50 / (crv.points-1);
         eeDirty(EE_MODEL);
         killEvents(event);
       }
@@ -136,7 +136,7 @@ void menuModelCurveOne(uint8_t event)
     case EVT_KEY_BREAK(KEY_EXIT):
       if (s_editMode > 0) {
         if (--s_editMode == 0)
-          m_posHorz = 0;
+          menuHorizontalPosition = 0;
       }
       else {
         popMenu();
@@ -146,7 +146,7 @@ void menuModelCurveOne(uint8_t event)
     /* CASE_EVT_ROTARY_LEFT */
     case EVT_KEY_REPT(KEY_LEFT):
     case EVT_KEY_FIRST(KEY_LEFT):
-      if (s_editMode==1 && m_posHorz>0) m_posHorz--;
+      if (s_editMode==1 && menuHorizontalPosition>0) menuHorizontalPosition--;
       if (s_editMode <= 0) {
         if (crv.custom) {
           moveCurve(s_curveChan, -crv.points+2);
@@ -164,7 +164,7 @@ void menuModelCurveOne(uint8_t event)
     /* CASE_EVT_ROTARY_RIGHT */
     case EVT_KEY_REPT(KEY_RIGHT):
     case EVT_KEY_FIRST(KEY_RIGHT):
-      if (s_editMode==1 && m_posHorz<(crv.points-1)) m_posHorz++;
+      if (s_editMode==1 && menuHorizontalPosition<(crv.points-1)) menuHorizontalPosition++;
       if (s_editMode <= 0) {
         if (!crv.custom) {
           moveCurve(s_curveChan, crv.points-2, crv.points);
@@ -194,7 +194,7 @@ void menuModelCurveOne(uint8_t event)
   DrawCurve();
 
   if (s_editMode>0) {
-    uint8_t i = m_posHorz;
+    uint8_t i = menuHorizontalPosition;
     point_t point = getPoint(i);
 
     if (s_editMode==1 || !BLINK_ON_PHASE) {
@@ -232,7 +232,7 @@ void menuModelCurvesAll(uint8_t event)
   SIMPLE_MENU(STR_MENUCURVES, menuTabModel, e_CurvesAll, 1+MAX_CURVES);
 #endif
 
-  int8_t  sub = m_posVert - 1;
+  int8_t  sub = menuVerticalPosition - 1;
 
   switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)

--- a/radio/src/gui/9X/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9X/menu_model_custom_functions.cpp
@@ -74,6 +74,7 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
     }
     if (!listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), NULL)) {
       POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
+      s_menu_flags = 0;
     }
   }
   else {
@@ -248,6 +249,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
               }
               else {
                 POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
+                s_menu_flags = 0;
               }
             }
             break;

--- a/radio/src/gui/9X/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9X/menu_model_custom_functions.cpp
@@ -48,11 +48,11 @@
 #if defined(CPUARM) && defined(SDCARD)
 void onCustomFunctionsFileSelectionMenu(const char *result)
 {
-  int  sub = m_posVert - 1;
+  int  sub = menuVerticalPosition - 1;
   CustomFunctionData * cfn;
   uint8_t eeFlags;
 
-  if (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions) {
+  if (menuHandlers[menuLevel] == menuModelCustomFunctions) {
     cfn = &g_model.customFn[sub];
     eeFlags = EE_MODEL;
   }
@@ -86,7 +86,7 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
 
 void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFunctionsContext * functionsContext)
 {
-  int8_t sub = m_posVert - 1;
+  int8_t sub = menuVerticalPosition - 1;
 
 #if defined(CPUARM)
   uint8_t eeFlags = (functions == g_model.customFn) ? EE_MODEL : EE_GENERAL;
@@ -101,7 +101,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
     CustomFunctionData *cfn = &functions[k];
     uint8_t func = CFN_FUNC(cfn);
     for (uint8_t j=0; j<5; j++) {
-      uint8_t attr = ((sub==k && m_posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
+      uint8_t attr = ((sub==k && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
       uint8_t active = (attr && (s_editMode>0 || p1valdiff));
       switch (j) {
         case 0:
@@ -128,7 +128,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
           }
           else {
             j = 4; // skip other fields
-            if (sub==k && m_posHorz > 0) {
+            if (sub==k && menuHorizontalPosition > 0) {
               REPEAT_LAST_CURSOR_MOVE();
             }
           }

--- a/radio/src/gui/9X/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9X/menu_model_custom_functions.cpp
@@ -96,7 +96,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     CustomFunctionData *cfn = &functions[k];
     uint8_t func = CFN_FUNC(cfn);

--- a/radio/src/gui/9X/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9X/menu_model_custom_functions.cpp
@@ -74,7 +74,6 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
     }
     if (!listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), NULL)) {
       POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else {
@@ -245,11 +244,10 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
                 strncpy(directory+SOUNDS_PATH_LNG_OFS, currentLanguagePack->id, 2);
               }
               if (listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), cfn->play.name)) {
-                menuHandler = onCustomFunctionsFileSelectionMenu;
+                popupMenuHandler = onCustomFunctionsFileSelectionMenu;
               }
               else {
                 POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-                s_menu_flags = 0;
               }
             }
             break;

--- a/radio/src/gui/9X/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9X/menu_model_custom_functions.cpp
@@ -74,7 +74,7 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
     }
     if (!listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), NULL)) {
       POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-      s_menu_flags = 0;
+      popupMenuFlags = 0;
     }
   }
   else {
@@ -249,7 +249,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
               }
               else {
                 POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-                s_menu_flags = 0;
+                popupMenuFlags = 0;
               }
             }
             break;

--- a/radio/src/gui/9X/menu_model_flightmodes.cpp
+++ b/radio/src/gui/9X/menu_model_flightmodes.cpp
@@ -90,7 +90,7 @@ void menuModelPhaseOne(uint8_t event)
   #define PHASE_ONE_FIRST_LINE (1+1*FH)
 #endif
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
   int8_t editMode = s_editMode;
 
 #if defined(GVARS) && !defined(PCBSTD)
@@ -116,8 +116,8 @@ void menuModelPhaseOne(uint8_t event)
       case ITEM_MODEL_PHASE_TRIMS:
         lcd_putsLeft(y, STR_TRIMS);
         for (uint8_t t=0; t<NUM_STICKS; t++) {
-          putsTrimMode(MIXES_2ND_COLUMN+(t*FW), y, s_currIdx, t, m_posHorz==t ? attr : 0);
-          if (attr && m_posHorz==t && ((editMode>0) || p1valdiff)) {
+          putsTrimMode(MIXES_2ND_COLUMN+(t*FW), y, s_currIdx, t, menuHorizontalPosition==t ? attr : 0);
+          if (attr && menuHorizontalPosition==t && ((editMode>0) || p1valdiff)) {
             int16_t v = getRawTrimValue(s_currIdx, t);
             if (v < TRIM_EXTENDED_MAX) v = TRIM_EXTENDED_MAX;
             v = checkIncDec(event, v, TRIM_EXTENDED_MAX, TRIM_EXTENDED_MAX+MAX_FLIGHT_MODES-1, EE_MODEL);
@@ -133,8 +133,8 @@ void menuModelPhaseOne(uint8_t event)
       case ITEM_MODEL_PHASE_ROTARY_ENCODERS:
         lcd_putsLeft(y, STR_ROTARY_ENCODER);
         for (uint8_t t=0; t<NUM_ROTARY_ENCODERS; t++) {
-          putsRotaryEncoderMode(MIXES_2ND_COLUMN+(t*FW), y, s_currIdx, t, m_posHorz==t ? attr : 0);
-          if (attr && m_posHorz==t && ((editMode>0) || p1valdiff)) {
+          putsRotaryEncoderMode(MIXES_2ND_COLUMN+(t*FW), y, s_currIdx, t, menuHorizontalPosition==t ? attr : 0);
+          if (attr && menuHorizontalPosition==t && ((editMode>0) || p1valdiff)) {
             int16_t v = flightModeAddress(s_currIdx)->rotaryEncoders[t];
             if (v < ROTARY_ENCODER_MAX) v = ROTARY_ENCODER_MAX;
             v = checkIncDec(event, v, ROTARY_ENCODER_MAX, ROTARY_ENCODER_MAX+MAX_FLIGHT_MODES-1, EE_MODEL);
@@ -163,7 +163,7 @@ void menuModelPhaseOne(uint8_t event)
       default:
       {
         uint8_t idx = i-ITEM_MODEL_PHASE_GV1;
-        uint8_t posHorz = m_posHorz;
+        uint8_t posHorz = menuHorizontalPosition;
         if (attr && posHorz > 0 && s_currIdx==0) posHorz++;
 
         putsStrIdx(INDENT_WIDTH, y, STR_GV, idx+1);
@@ -223,7 +223,7 @@ void menuModelFlightModesAll(uint8_t event)
 {
   SIMPLE_MENU(STR_MENUFLIGHTPHASES, menuTabModel, e_FlightModesAll, 1+MAX_FLIGHT_MODES+1);
 
-  int8_t sub = m_posVert - 1;
+  int8_t sub = menuVerticalPosition - 1;
 
   switch (event) {
     CASE_EVT_ROTARY_BREAK

--- a/radio/src/gui/9X/menu_model_flightmodes.cpp
+++ b/radio/src/gui/9X/menu_model_flightmodes.cpp
@@ -98,7 +98,7 @@ void menuModelPhaseOne(uint8_t event)
 
   for (uint8_t k=0; k<LCD_LINES-1; k++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
-    int8_t i = k + s_pgOfs;
+    int8_t i = k + menuVerticalOffset;
     if (s_currIdx == 0 && i>=ITEM_MODEL_PHASE_SWITCH) i += ITEM_MODEL_PHASE_FADE_IN-ITEM_MODEL_PHASE_SWITCH;
     uint8_t attr = (sub==i ? (editMode>0 ? BLINK|INVERS : INVERS) : 0);
 #else
@@ -244,7 +244,7 @@ void menuModelFlightModesAll(uint8_t event)
   uint8_t att;
   for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
 #if defined(CPUARM)
-    int8_t y = 1 + (1+i-s_pgOfs)*FH;
+    int8_t y = 1 + (1+i-menuVerticalOffset)*FH;
     if (y<1*FH+1 || y>(LCD_LINES-1)*FH+1) continue;
 #else
     uint8_t y = 1 + (i+1)*FH;
@@ -275,7 +275,7 @@ void menuModelFlightModesAll(uint8_t event)
   }
 
 #if defined(CPUARM)
-  if (s_pgOfs != MAX_FLIGHT_MODES-(LCD_LINES-2)) return;
+  if (menuVerticalOffset != MAX_FLIGHT_MODES-(LCD_LINES-2)) return;
 #endif
 
   lcd_putsLeft((LCD_LINES-1)*FH+1, STR_CHECKTRIMS);

--- a/radio/src/gui/9X/menu_model_heli.cpp
+++ b/radio/src/gui/9X/menu_model_heli.cpp
@@ -50,7 +50,7 @@ void menuModelHeli(uint8_t event)
 {
   SIMPLE_MENU(STR_MENUHELISETUP, menuTabModel, e_Heli, 7);
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   for (uint8_t i=0; i<6; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/9X/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/9X/menu_model_inputs_mixes.cpp
@@ -44,7 +44,7 @@ FlightModesType editFlightModes(coord_t x, coord_t y, uint8_t event, FlightModes
 {
   lcd_putsColumnLeft(x, y, STR_FLMODE);
 
-  uint8_t posHorz = m_posHorz;
+  uint8_t posHorz = menuHorizontalPosition;
 
 #if defined(CPUARM)
   bool expoMenu = (x==EXPO_ONE_2ND_COLUMN-5*FW);
@@ -301,7 +301,7 @@ void menuModelExpoOne(uint8_t event)
 
   SET_SCROLLBAR_X(EXPO_ONE_2ND_COLUMN+10*FW);
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   coord_t y = MENU_HEADER_HEIGHT + 1;
 
@@ -470,9 +470,9 @@ void menuModelMixOne(uint8_t event)
 
 #if defined(ROTARY_ENCODERS)
 #if defined(CURVES)
-  if ((m_posVert == MIX_FIELD_TRIM && md2->srcRaw > NUM_STICKS) || (m_posVert == MIX_FIELD_CURVE && md2->curveMode == MODE_CURVE))
+  if ((menuVerticalPosition == MIX_FIELD_TRIM && md2->srcRaw > NUM_STICKS) || (menuVerticalPosition == MIX_FIELD_CURVE && md2->curveMode == MODE_CURVE))
 #else
-  if (m_posVert == MIX_FIELD_TRIM && md2->srcRaw > NUM_STICKS)
+  if (menuVerticalPosition == MIX_FIELD_TRIM && md2->srcRaw > NUM_STICKS)
 #endif
     SUBMENU_NOTITLE(MIX_FIELD_COUNT, {CASE_CPUARM(0) 0, 0, 0, 0, CASE_CURVES(0) CASE_FLIGHT_MODES((MAX_FLIGHT_MODES-1) | NAVIGATION_LINE_BY_LINE) 0, 0 /*, ...*/})
   else
@@ -485,7 +485,7 @@ void menuModelMixOne(uint8_t event)
   lcd_vline(MENU_COLUMN2_X-4, FH+1, LCD_H-FH-1);
 #endif
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
   int8_t editMode = s_editMode;
 
   for (uint8_t k=0; k<MENU_COLUMNS*(LCD_LINES-1); k++) {
@@ -541,12 +541,12 @@ void menuModelMixOne(uint8_t event)
         uint8_t not_stick = (md2->srcRaw > NUM_STICKS);
         int8_t carryTrim = -md2->carryTrim;
         lcd_putsColumnLeft(COLUMN_X, y, STR_TRIM);
-        lcd_putsiAtt((not_stick ? COLUMN_X+MIXES_2ND_COLUMN : COLUMN_X+6*FW-3), y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, m_posHorz==0 ? attr : 0);
-        if (attr && m_posHorz==0 && (not_stick || editMode>0)) md2->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_AIL);
+        lcd_putsiAtt((not_stick ? COLUMN_X+MIXES_2ND_COLUMN : COLUMN_X+6*FW-3), y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, menuHorizontalPosition==0 ? attr : 0);
+        if (attr && menuHorizontalPosition==0 && (not_stick || editMode>0)) md2->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_AIL);
         if (!not_stick) {
           lcd_puts(COLUMN_X+MIXES_2ND_COLUMN, y, STR_DREX);
-          menu_lcd_onoff(COLUMN_X+MIXES_2ND_COLUMN+DREX_CHBOX_OFFSET, y, !md2->noExpo, m_posHorz==1 ? attr : 0);
-          if (attr && m_posHorz==1 && editMode>0) md2->noExpo = !checkIncDecModel(event, !md2->noExpo, 0, 1);
+          menu_lcd_onoff(COLUMN_X+MIXES_2ND_COLUMN+DREX_CHBOX_OFFSET, y, !md2->noExpo, menuHorizontalPosition==1 ? attr : 0);
+          if (attr && menuHorizontalPosition==1 && editMode>0) md2->noExpo = !checkIncDecModel(event, !md2->noExpo, 0, 1);
         }
         else if (attr) {
           REPEAT_LAST_CURSOR_MOVE();
@@ -574,9 +574,9 @@ void menuModelMixOne(uint8_t event)
           }
         }
         else {
-          lcd_putsAtt(COLUMN_X+MIXES_2ND_COLUMN, y, PSTR("Diff"), m_posHorz==0 ? attr : 0);
-          md2->curveParam = GVAR_MENU_ITEM(COLUMN_X+MIXES_2ND_COLUMN+5*FW, y, curveParam, -100, 100, LEFT|(m_posHorz==1 ? attr : 0), 0, editMode>0 ? event : 0);
-          if (attr && editMode>0 && m_posHorz==0) {
+          lcd_putsAtt(COLUMN_X+MIXES_2ND_COLUMN, y, PSTR("Diff"), menuHorizontalPosition==0 ? attr : 0);
+          md2->curveParam = GVAR_MENU_ITEM(COLUMN_X+MIXES_2ND_COLUMN+5*FW, y, curveParam, -100, 100, LEFT|(menuHorizontalPosition==1 ? attr : 0), 0, editMode>0 ? event : 0);
+          if (attr && editMode>0 && menuHorizontalPosition==0) {
             int8_t tmp = 0;
             CHECK_INCDEC_MODELVAR(event, tmp, -1, 1);
             if (tmp != 0) {
@@ -664,7 +664,7 @@ static uint8_t s_copySrcCh;
 #if defined(NAVIGATION_MENUS)
 void onExpoMixMenu(const char *result)
 {
-  bool expo = (g_menuStack[g_menuStackPtr] == menuModelExposAll);
+  bool expo = (menuHandlers[menuLevel] == menuModelExposAll);
   uint8_t chn = (expo ? expoAddress(s_currIdx)->chn+1 : mixAddress(s_currIdx)->destCh+1);
 
   if (result == STR_EDIT) {
@@ -673,7 +673,7 @@ void onExpoMixMenu(const char *result)
   else if (result == STR_INSERT_BEFORE || result == STR_INSERT_AFTER) {
     if (!reachExpoMixCountLimit(expo)) {
       s_currCh = chn;
-      if (result == STR_INSERT_AFTER) { s_currIdx++; m_posVert++; }
+      if (result == STR_INSERT_AFTER) { s_currIdx++; menuVerticalPosition++; }
       insertExpoMix(expo, s_currIdx);
       pushMenu(expo ? menuModelExpoOne : menuModelMixOne);
     }
@@ -682,7 +682,7 @@ void onExpoMixMenu(const char *result)
     s_copyMode = (result == STR_COPY ? COPY_MODE : MOVE_MODE);
     s_copySrcIdx = s_currIdx;
     s_copySrcCh = chn;
-    s_copySrcRow = m_posVert;
+    s_copySrcRow = menuVerticalPosition;
   }
   else if (result == STR_DELETE) {
     deleteExpoMix(expo, s_currIdx);
@@ -745,7 +745,7 @@ void displayExpoLine(coord_t y, ExpoData *ed)
 
 void menuModelExpoMix(uint8_t expo, uint8_t event)
 {
-  uint8_t sub = m_posVert;
+  uint8_t sub = menuVerticalPosition;
 
   if (s_editMode > 0)
     s_editMode = 0;
@@ -786,7 +786,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
             } while (s_copyTgtOfs != 0);
             eeDirty(EE_MODEL);
           }
-          m_posVert = s_copySrcRow;
+          menuVerticalPosition = s_copySrcRow;
           s_copyTgtOfs = 0;
         }
         s_copyMode = 0;
@@ -855,7 +855,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
       if (s_copyMode && !s_copyTgtOfs) {
         if (reachExpoMixCountLimit(expo)) break;
         s_currCh = chn;
-        if (event == EVT_KEY_LONG(KEY_RIGHT)) { s_currIdx++; m_posVert++; }
+        if (event == EVT_KEY_LONG(KEY_RIGHT)) { s_currIdx++; menuVerticalPosition++; }
         insertExpoMix(expo, s_currIdx);
         pushMenu(expo ? menuModelExpoOne : menuModelMixOne);
         s_copyMode = 0;
@@ -903,7 +903,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
 
   SIMPLE_MENU(expo ? STR_MENUINPUTS : STR_MIXER, menuTabModel, expo ? e_InputsAll : e_MixAll, s_maxLines);
 
-  sub = m_posVert;
+  sub = menuVerticalPosition;
   s_currCh = 0;
   uint8_t cur = 1;
   uint8_t i = 0;
@@ -928,7 +928,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
             cur++; y+=FH;
           }
           if (s_currIdx == i) {
-            sub = m_posVert = cur;
+            sub = menuVerticalPosition = cur;
             s_currCh = ch;
           }
         }
@@ -1002,7 +1002,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
     }
   }
   s_maxLines = cur;
-  if (sub >= s_maxLines-1) m_posVert = s_maxLines-1;
+  if (sub >= s_maxLines-1) menuVerticalPosition = s_maxLines-1;
 }
 
 void menuModelExposAll(uint8_t event)

--- a/radio/src/gui/9X/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/9X/menu_model_inputs_mixes.cpp
@@ -830,13 +830,13 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           else {
             event = 0;
             s_copyMode = 0;
-            MENU_ADD_ITEM(STR_EDIT);
-            MENU_ADD_ITEM(STR_INSERT_BEFORE);
-            MENU_ADD_ITEM(STR_INSERT_AFTER);
-            MENU_ADD_ITEM(STR_COPY);
-            MENU_ADD_ITEM(STR_MOVE);
-            MENU_ADD_ITEM(STR_DELETE);
-            menuHandler = onExpoMixMenu;
+            POPUP_MENU_ADD_ITEM(STR_EDIT);
+            POPUP_MENU_ADD_ITEM(STR_INSERT_BEFORE);
+            POPUP_MENU_ADD_ITEM(STR_INSERT_AFTER);
+            POPUP_MENU_ADD_ITEM(STR_COPY);
+            POPUP_MENU_ADD_ITEM(STR_MOVE);
+            POPUP_MENU_ADD_ITEM(STR_DELETE);
+            popupMenuHandler = onExpoMixMenu;
           }
 #else
           if (s_currCh) {

--- a/radio/src/gui/9X/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/9X/menu_model_inputs_mixes.cpp
@@ -504,7 +504,7 @@ void menuModelMixOne(uint8_t event)
     int8_t i = k;
 #else
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
-    int8_t i = k + s_pgOfs;
+    int8_t i = k + menuVerticalOffset;
 #endif
 
     uint8_t attr = (sub==i ? (editMode>0 ? BLINK|INVERS : INVERS) : 0);
@@ -880,7 +880,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           if (reachExpoMixCountLimit(expo)) break;
           copyExpoMix(expo, s_currIdx);
           if (IS_ROTARY_DOWN(event) || key==KEY_MOVE_DOWN) s_currIdx++;
-          else if (sub-s_pgOfs >= 6) s_pgOfs++;
+          else if (sub-menuVerticalOffset >= 6) menuVerticalOffset++;
         }
         else if (next_ofs==0 && s_copyMode==COPY_MODE) {
           // delete the mix
@@ -910,9 +910,9 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
 
   for (uint8_t ch=1; ch<=(expo ? NUM_INPUTS : NUM_CHNOUT); ch++) {
     void *pointer = NULL; MixData * &md = (MixData * &)pointer; ExpoData * &ed = (ExpoData * &)pointer;
-    coord_t y = MENU_HEADER_HEIGHT-FH+1+(cur-s_pgOfs)*FH;
+    coord_t y = MENU_HEADER_HEIGHT-FH+1+(cur-menuVerticalOffset)*FH;
     if (expo ? (i<MAX_EXPOS && (ed=expoAddress(i))->chn+1 == ch && EXPO_VALID(ed)) : (i<MAX_MIXERS && (md=mixAddress(i))->srcRaw && md->destCh+1 == ch)) {
-      if (s_pgOfs < cur && cur-s_pgOfs < LCD_LINES) {
+      if (menuVerticalOffset < cur && cur-menuVerticalOffset < LCD_LINES) {
         if (expo) {
           putsMixerSource(0, y, MIXSRC_Rud+ch-1, 0);
         }
@@ -923,7 +923,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
       uint8_t mixCnt = 0;
       do {
         if (s_copyMode) {
-          if (s_copyMode == MOVE_MODE && s_pgOfs < cur && cur-s_pgOfs < 8 && s_copySrcCh == ch && s_copyTgtOfs != 0 && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
+          if (s_copyMode == MOVE_MODE && menuVerticalOffset < cur && cur-menuVerticalOffset < 8 && s_copySrcCh == ch && s_copyTgtOfs != 0 && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
             lcd_rect(expo ? 18 : 22, y-1, expo ? LCD_W-18 : LCD_W-22, 9, DOTTED);
             cur++; y+=FH;
           }
@@ -935,7 +935,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
         else if (sub == cur) {
           s_currIdx = i;
         }
-        if (s_pgOfs < cur && cur-s_pgOfs < 8) {
+        if (menuVerticalOffset < cur && cur-menuVerticalOffset < 8) {
           uint8_t attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
           if (expo) {
             ed->weight = GVAR_MENU_ITEM(EXPO_LINE_WEIGHT_POS, y, ed->weight, MIN_EXPO_WEIGHT, 100, attr | (isExpoActive(i) ? BOLD : 0), 0, event);
@@ -973,7 +973,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
         }
         cur++; y+=FH; mixCnt++; i++; if (expo) ed++; else md++;
       } while (expo ? (i<MAX_EXPOS && ed->chn+1 == ch && EXPO_VALID(ed)) : (i<MAX_MIXERS && md->srcRaw && md->destCh+1 == ch));
-      if (s_copyMode == MOVE_MODE && s_pgOfs < cur && cur-s_pgOfs < LCD_LINES && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
+      if (s_copyMode == MOVE_MODE && menuVerticalOffset < cur && cur-menuVerticalOffset < LCD_LINES && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
         lcd_rect(expo ? EXPO_LINE_SELECT_POS : 22, y-1, expo ? LCD_W-EXPO_LINE_SELECT_POS : LCD_W-22, 9, DOTTED);
         cur++; y+=FH;
       }
@@ -987,7 +987,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           attr = INVERS;
         }
       }
-      if (s_pgOfs < cur && cur-s_pgOfs < LCD_LINES) {
+      if (menuVerticalOffset < cur && cur-menuVerticalOffset < LCD_LINES) {
         if (expo) {
           putsMixerSource(0, y, MIXSRC_Rud+ch-1, attr);
         }

--- a/radio/src/gui/9X/menu_model_limits.cpp
+++ b/radio/src/gui/9X/menu_model_limits.cpp
@@ -121,8 +121,8 @@ void menuModelLimits(uint8_t event)
   MENU(STR_MENULIMITS, menuTabModel, e_Limits, 1+NUM_CHNOUT+1, {0, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, ITEM_LIMITS_MAXROW, 0});
 #endif
 
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     LimitData *ld = limitAddress(sub);
     ld->revert = !ld->revert;
     eeDirty(EE_MODEL);

--- a/radio/src/gui/9X/menu_model_limits.cpp
+++ b/radio/src/gui/9X/menu_model_limits.cpp
@@ -130,7 +130,7 @@ void menuModelLimits(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     if (k==NUM_CHNOUT) {
       // last line available - add the "copy trim menu" line

--- a/radio/src/gui/9X/menu_model_limits.cpp
+++ b/radio/src/gui/9X/menu_model_limits.cpp
@@ -135,11 +135,11 @@ void menuModelLimits(uint8_t event)
     if (k==NUM_CHNOUT) {
       // last line available - add the "copy trim menu" line
       uint8_t attr = (sub==NUM_CHNOUT) ? INVERS : 0;
-      lcd_putsAtt(CENTER_OFS, y, STR_TRIMS2OFFSETS, s_noHi ? 0 : attr);
+      lcd_putsAtt(CENTER_OFS, y, STR_TRIMS2OFFSETS, NO_HIGHLIGHT() ? 0 : attr);
       if (attr) {
         s_editMode = 0;
         if (event==EVT_KEY_LONG(KEY_ENTER)) {
-          s_noHi = NO_HI_LEN;
+          START_NO_HIGHLIGHT();
           killEvents(event);
           moveTrimsToOffsets(); // if highlighted and menu pressed - move trims to offsets
         }

--- a/radio/src/gui/9X/menu_model_limits.cpp
+++ b/radio/src/gui/9X/menu_model_limits.cpp
@@ -104,7 +104,7 @@ enum LimitsItems {
 
 void menuModelLimits(uint8_t event)
 {
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   if (sub < NUM_CHNOUT) {
 #if defined(PPM_CENTER_ADJUSTABLE) || defined(PPM_UNIT_US)
@@ -163,7 +163,7 @@ void menuModelLimits(uint8_t event)
     putsChn(0, y, k+1, 0);
 
     for (uint8_t j=0; j<ITEM_LIMITS_COUNT; j++) {
-      uint8_t attr = ((sub==k && m_posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
+      uint8_t attr = ((sub==k && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
       uint8_t active = (attr && (s_editMode>0 || p1valdiff)) ;
       if (active) STICK_SCROLL_DISABLE();
       switch(j)

--- a/radio/src/gui/9X/menu_model_logical_switches.cpp
+++ b/radio/src/gui/9X/menu_model_logical_switches.cpp
@@ -100,7 +100,7 @@ void menuModelLogicalSwitchOne(uint8_t event)
 
   SUBMENU_NOTITLE(LS_FIELD_COUNT, {0, 0, 1, 0 /*, 0...*/});
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   INCDEC_DECLARE_VARS(EE_MODEL);
 
@@ -169,9 +169,9 @@ void menuModelLogicalSwitchOne(uint8_t event)
           v2_max = 122;
         }
         else if (cstate == LS_FAMILY_EDGE) {
-          putsEdgeDelayParam(CSWONE_2ND_COLUMN, y, cs, m_posHorz==0 ? attr : 0, m_posHorz==1 ? attr : 0);
+          putsEdgeDelayParam(CSWONE_2ND_COLUMN, y, cs, menuHorizontalPosition==0 ? attr : 0, menuHorizontalPosition==1 ? attr : 0);
           if (s_editMode <= 0) continue;
-          if (attr && m_posHorz==1) {
+          if (attr && menuHorizontalPosition==1) {
             CHECK_INCDEC_MODELVAR(event, cs->v3, -1, 222 - cs->v2);
             break;
           }
@@ -247,7 +247,7 @@ void menuModelLogicalSwitches(uint8_t event)
 
   coord_t y = 0;
   uint8_t k = 0;
-  int8_t sub = m_posVert - 1;
+  int8_t sub = menuVerticalPosition - 1;
 
   switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)
@@ -325,8 +325,8 @@ void menuModelLogicalSwitches(uint8_t event)
   MENU(STR_MENULOGICALSWITCHES, menuTabModel, e_LogicalSwitches, NUM_LOGICAL_SWITCH+1, {0, NAVIGATION_LINE_BY_LINE|LS_FIELD_LAST/*repeated...*/});
 
   uint8_t   k = 0;
-  int8_t    sub = m_posVert - 1;
-  horzpos_t horz = m_posHorz;
+  int8_t    sub = menuVerticalPosition - 1;
+  horzpos_t horz = menuHorizontalPosition;
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/9X/menu_model_logical_switches.cpp
+++ b/radio/src/gui/9X/menu_model_logical_switches.cpp
@@ -108,7 +108,7 @@ void menuModelLogicalSwitchOne(uint8_t event)
 
   for (uint8_t k=0; k<LCD_LINES-1; k++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
-    uint8_t i = k + s_pgOfs;
+    uint8_t i = k + menuVerticalOffset;
     uint8_t attr = (sub==i ? (s_editMode>0 ? BLINK|INVERS : INVERS) : 0);
     uint8_t cstate = lswFamily(cs->func);
     switch(i) {
@@ -264,7 +264,7 @@ void menuModelLogicalSwitches(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     y = 1 + (i+1)*FH;
-    k = i+s_pgOfs;
+    k = i+menuVerticalOffset;
     LogicalSwitchData * cs = lswAddress(k);
 
     // CSW name
@@ -330,7 +330,7 @@ void menuModelLogicalSwitches(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    k = i+s_pgOfs;
+    k = i+menuVerticalOffset;
     uint8_t attr = (sub==k ? ((s_editMode>0) ? BLINK|INVERS : INVERS)  : 0);
     uint8_t attr1 = (horz==1 ? attr : 0);
     uint8_t attr2 = (horz==2 ? attr : 0);

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -128,7 +128,7 @@ void menuModelSelect(uint8_t event)
   {
       case EVT_ENTRY:
         menuVerticalPosition = sub = g_eeGeneral.currModel;
-        if (sub >= LCD_LINES-1) s_pgOfs = sub-LCD_LINES+2;
+        if (sub >= LCD_LINES-1) menuVerticalOffset = sub-LCD_LINES+2;
         s_copyMode = 0;
         s_editMode = EDIT_MODE_INIT;
         eeCheck(true);
@@ -332,7 +332,7 @@ void menuModelSelect(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     lcd_outdezNAtt(3*FW+2, y, k+1, LEADING0+((!s_copyMode && sub==k) ? INVERS : 0), 2);
 
@@ -363,11 +363,11 @@ void menuModelSelect(uint8_t event)
       putsModelName(4*FW, y, name, k, 0);
       lcd_outdezAtt(20*FW, y, eeModelSize(k), 0);
 #endif
-      if (k==g_eeGeneral.currModel && (s_copyMode!=COPY_MODE || s_copySrcRow<0 || i+s_pgOfs!=(vertpos_t)sub))
+      if (k==g_eeGeneral.currModel && (s_copyMode!=COPY_MODE || s_copySrcRow<0 || i+menuVerticalOffset!=(vertpos_t)sub))
         lcd_putc(1, y, '*');
     }
 
-    if (s_copyMode && (vertpos_t)sub==i+s_pgOfs) {
+    if (s_copyMode && (vertpos_t)sub==i+menuVerticalOffset) {
       drawFilledRect(9, y, MODELSEL_W-1-9, 7);
       lcd_rect(8, y-1, MODELSEL_W-1-7, 9, s_copyMode == COPY_MODE ? SOLID : DOTTED);
     }

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -64,7 +64,6 @@ void onModelSelectMenu(const char *result)
   else if (result == STR_RESTORE_MODEL || result == STR_UPDATE_LIST) {
     if (!listSdFiles(MODELS_PATH, MODELS_EXT, MENU_LINE_LENGTH-1, NULL)) {
       POPUP_WARNING(STR_NO_MODELS_ON_SD);
-      s_menu_flags = 0;
     }
   }
 #endif
@@ -235,27 +234,27 @@ void menuModelSelect(uint8_t event)
 #if defined(NAVIGATION_MENUS)
           if (g_eeGeneral.currModel != sub) {
             if (eeModelExists(sub)) {
-              MENU_ADD_ITEM(STR_SELECT_MODEL);
-              MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
-              MENU_ADD_ITEM(STR_COPY_MODEL);
-              MENU_ADD_ITEM(STR_MOVE_MODEL);
-              MENU_ADD_ITEM(STR_DELETE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_SELECT_MODEL);
+              POPUP_MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_COPY_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_MOVE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_DELETE_MODEL);
             }
             else {
 #if defined(SDCARD)
-              MENU_ADD_ITEM(STR_CREATE_MODEL);
-              MENU_ADD_ITEM(STR_RESTORE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_CREATE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_RESTORE_MODEL);
 #else
               selectModel(sub);
 #endif
             }
           }
           else {
-            MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
-            MENU_ADD_ITEM(STR_COPY_MODEL);
-            MENU_ADD_ITEM(STR_MOVE_MODEL);
+            POPUP_MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
+            POPUP_MENU_ADD_ITEM(STR_COPY_MODEL);
+            POPUP_MENU_ADD_ITEM(STR_MOVE_MODEL);
           }
-          menuHandler = onModelSelectMenu;
+          popupMenuHandler = onModelSelectMenu;
 #else
           if (g_eeGeneral.currModel != sub) {
             selectModel(sub);

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -64,7 +64,7 @@ void onModelSelectMenu(const char *result)
   else if (result == STR_RESTORE_MODEL || result == STR_UPDATE_LIST) {
     if (!listSdFiles(MODELS_PATH, MODELS_EXT, MENU_LINE_LENGTH-1, NULL)) {
       POPUP_WARNING(STR_NO_MODELS_ON_SD);
-      s_menu_flags = 0;
+      popupMenuFlags = 0;
     }
   }
 #endif

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -64,6 +64,7 @@ void onModelSelectMenu(const char *result)
   else if (result == STR_RESTORE_MODEL || result == STR_UPDATE_LIST) {
     if (!listSdFiles(MODELS_PATH, MODELS_EXT, MENU_LINE_LENGTH-1, NULL)) {
       POPUP_WARNING(STR_NO_MODELS_ON_SD);
+      s_menu_flags = 0;
     }
   }
 #endif

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -41,7 +41,7 @@
 #if defined(NAVIGATION_MENUS)
 void onModelSelectMenu(const char *result)
 {
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
     selectModel(sub);
@@ -93,7 +93,7 @@ void menuModelSelect(uint8_t event)
 {
   if (s_warning_result) {
     s_warning_result = 0;
-    eeDeleteModel(m_posVert); // delete file
+    eeDeleteModel(menuVerticalPosition); // delete file
     s_copyMode = 0;
     event = EVT_ENTRY_UP;
   }
@@ -104,7 +104,7 @@ void menuModelSelect(uint8_t event)
     _event_ -= KEY_EXIT;
   }
 
-  int8_t oldSub = m_posVert;
+  int8_t oldSub = menuVerticalPosition;
 
   check_submenu_simple(_event_, MAX_MODELS-1);
 
@@ -122,12 +122,12 @@ void menuModelSelect(uint8_t event)
   }
 #endif
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   switch (event)
   {
       case EVT_ENTRY:
-        m_posVert = sub = g_eeGeneral.currModel;
+        menuVerticalPosition = sub = g_eeGeneral.currModel;
         if (sub >= LCD_LINES-1) s_pgOfs = sub-LCD_LINES+2;
         s_copyMode = 0;
         s_editMode = EDIT_MODE_INIT;
@@ -148,7 +148,7 @@ void menuModelSelect(uint8_t event)
         }
         else {
           s_copyMode = 0;
-          m_posVert = g_eeGeneral.currModel;
+          menuVerticalPosition = g_eeGeneral.currModel;
         }
         break;
 
@@ -160,7 +160,7 @@ void menuModelSelect(uint8_t event)
           break;
         }
         else if (!s_copyMode) {
-          m_posVert = sub = g_eeGeneral.currModel;
+          menuVerticalPosition = sub = g_eeGeneral.currModel;
           s_copyMode = 0;
           s_editMode = EDIT_MODE_INIT;
         }
@@ -169,11 +169,11 @@ void menuModelSelect(uint8_t event)
 
       case EVT_KEY_BREAK(KEY_EXIT):
         if (s_copyMode) {
-          sub = m_posVert = (s_copyMode == MOVE_MODE || s_copySrcRow<0) ? (MAX_MODELS+sub+s_copyTgtOfs) % MAX_MODELS : s_copySrcRow;
+          sub = menuVerticalPosition = (s_copyMode == MOVE_MODE || s_copySrcRow<0) ? (MAX_MODELS+sub+s_copyTgtOfs) % MAX_MODELS : s_copySrcRow;
           s_copyMode = 0;
         }
-        else if (m_posVert != g_eeGeneral.currModel) {
-          m_posVert = g_eeGeneral.currModel;
+        else if (menuVerticalPosition != g_eeGeneral.currModel) {
+          menuVerticalPosition = g_eeGeneral.currModel;
         }
         else {
           popMenu();
@@ -294,7 +294,7 @@ void menuModelSelect(uint8_t event)
       case EVT_KEY_FIRST(KEY_MOVE_DOWN):
       case EVT_KEY_REPT(KEY_MOVE_DOWN):
         if (s_copyMode) {
-          int8_t next_ofs = s_copyTgtOfs + oldSub - m_posVert;
+          int8_t next_ofs = s_copyTgtOfs + oldSub - menuVerticalPosition;
           if (next_ofs == MAX_MODELS || next_ofs == -MAX_MODELS)
             next_ofs = 0;
 
@@ -309,7 +309,7 @@ void menuModelSelect(uint8_t event)
               s_copyMode = 0;
             }
             next_ofs = 0;
-            m_posVert = sub;
+            menuVerticalPosition = sub;
           }
           s_copyTgtOfs = next_ofs;
         }

--- a/radio/src/gui/9X/menu_model_select.cpp
+++ b/radio/src/gui/9X/menu_model_select.cpp
@@ -81,7 +81,7 @@ void onModelSelectMenu(const char *result)
   else {
     // The user choosed a file on SD to restore
     POPUP_WARNING(eeRestoreModel(sub, (char *)result));
-    if (!s_warning && g_eeGeneral.currModel == sub) {
+    if (!warningText && g_eeGeneral.currModel == sub) {
       eeLoadModel(sub);
     }
   }
@@ -91,8 +91,8 @@ void onModelSelectMenu(const char *result)
 
 void menuModelSelect(uint8_t event)
 {
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     eeDeleteModel(menuVerticalPosition); // delete file
     s_copyMode = 0;
     event = EVT_ENTRY_UP;

--- a/radio/src/gui/9X/menu_model_setup.cpp
+++ b/radio/src/gui/9X/menu_model_setup.cpp
@@ -160,7 +160,7 @@ void menuModelSetup(uint8_t event)
 
   TITLE(STR_MENUSETUP);
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
   int8_t editMode = s_editMode;
 
   for (uint8_t i=0; i<NUM_BODY_LINES; ++i) {
@@ -195,11 +195,11 @@ void menuModelSetup(uint8_t event)
         unsigned int timerIdx = (k>=ITEM_MODEL_TIMER3 ? 2 : (k>=ITEM_MODEL_TIMER2 ? 1 : 0));
         TimerData * timer = &g_model.timers[timerIdx];
         putsStrIdx(0*FW, y, STR_TIMER, timerIdx+1);
-        putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, m_posHorz==0 ? attr : 0);
-        putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, m_posHorz==1 ? attr : 0, m_posHorz==2 ? attr : 0);
+        putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
+        putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr : 0, menuHorizontalPosition==2 ? attr : 0);
         if (attr && (editMode>0 || p1valdiff)) {
           div_t qr = div(timer->start, 60);
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
             {
               int8_t timerMode = timer->mode;
@@ -285,11 +285,11 @@ void menuModelSetup(uint8_t event)
         }
         else {
           putsStrIdx(0*FW, y, STR_TIMER, k>=ITEM_MODEL_TIMER2 ? 2 : 1);
-          putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, m_posHorz==0 ? attr : 0);
-          putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, m_posHorz==1 ? attr : 0, m_posHorz==2 ? attr : 0);
+          putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
+          putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr : 0, menuHorizontalPosition==2 ? attr : 0);
           if (attr && (editMode>0 || p1valdiff)) {
             div_t qr = div(timer->start, 60);
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR_CHECK(event, timer->mode, SWSRC_FIRST, TMRMODE_COUNT+SWSRC_LAST-1/*SWSRC_None removed*/, isSwitchAvailableInTimers);
                 break;
@@ -326,9 +326,9 @@ void menuModelSetup(uint8_t event)
 #if defined(CPUM64)
         ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, attr, event);
 #else
-        ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, m_posHorz<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
-        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, m_posHorz>0  && !s_noHi ? attr : 0);
-        if (attr && m_posHorz>0) {
+        ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, menuHorizontalPosition<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
+        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, menuHorizontalPosition>0  && !s_noHi ? attr : 0);
+        if (attr && menuHorizontalPosition>0) {
           s_editMode = 0;
           if (event==EVT_KEY_LONG(KEY_ENTER)) {
             s_noHi = NO_HI_LEN;
@@ -399,11 +399,11 @@ void menuModelSetup(uint8_t event)
               CASE_EVT_ROTARY_BREAK
               case EVT_KEY_BREAK(KEY_ENTER):
 #if defined(CPUM64)
-                g_model.switchWarningEnable ^= (1 << m_posHorz);
+                g_model.switchWarningEnable ^= (1 << menuHorizontalPosition);
                 eeDirty(EE_MODEL);
 #else
-                if (m_posHorz < NUM_SWITCHES-1) {
-                  g_model.switchWarningEnable ^= (1 << m_posHorz);
+                if (menuHorizontalPosition < NUM_SWITCHES-1) {
+                  g_model.switchWarningEnable ^= (1 << menuHorizontalPosition);
                   eeDirty(EE_MODEL);
                 }
 #endif
@@ -416,7 +416,7 @@ void menuModelSetup(uint8_t event)
                 AUDIO_WARNING1();
                 eeDirty(EE_MODEL);
 #else
-                if (m_posHorz == NUM_SWITCHES-1) {
+                if (menuHorizontalPosition == NUM_SWITCHES-1) {
                   s_noHi = NO_HI_LEN;
                   getMovedSwitch();
                   g_model.switchWarningState = switches_states;
@@ -446,14 +446,14 @@ void menuModelSetup(uint8_t event)
             c = pgm_read_byte(STR_VSWITCHES - 2 + 9 + (3*(i+1)));
             states >>= 1;
           }
-          if (line && (m_posHorz == i)) {
+          if (line && (menuHorizontalPosition == i)) {
             attr = BLINK;
             if (swactive)
               attr |= INVERS;
           }
           lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive || (attr & BLINK)) ? c : '-', attr);
 #if !defined(CPUM64)
-          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (m_posHorz == NUM_SWITCHES-1 && !s_noHi) ? line : 0);
+          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (menuHorizontalPosition == NUM_SWITCHES-1 && !s_noHi) ? line : 0);
 #endif
         }
         break;
@@ -464,13 +464,13 @@ void menuModelSetup(uint8_t event)
         for (uint8_t i=0; i<NUM_STICKS+NUM_POTS+NUM_ROTARY_ENCODERS; i++) {
           // TODO flash saving, \001 not needed in STR_RETA123
           coord_t x = MODEL_SETUP_2ND_COLUMN+i*FW;
-          lcd_putsiAtt(x, y, STR_RETA123, i, ((m_posHorz==i) && attr) ? BLINK|INVERS : (((g_model.beepANACenter & ((BeepANACenter)1<<i)) || (attr && CURSOR_ON_LINE())) ? INVERS : 0 ) );
+          lcd_putsiAtt(x, y, STR_RETA123, i, ((menuHorizontalPosition==i) && attr) ? BLINK|INVERS : (((g_model.beepANACenter & ((BeepANACenter)1<<i)) || (attr && CURSOR_ON_LINE())) ? INVERS : 0 ) );
         }
         if (attr && CURSOR_ON_CELL) {
           if (event==EVT_KEY_BREAK(KEY_ENTER) || p1valdiff) {
             if (READ_ONLY_UNLOCKED()) {
               s_editMode = 0;
-              g_model.beepANACenter ^= ((BeepANACenter)1<<m_posHorz);
+              g_model.beepANACenter ^= ((BeepANACenter)1<<menuHorizontalPosition);
               eeDirty(EE_MODEL);
             }
           }
@@ -498,13 +498,13 @@ void menuModelSetup(uint8_t event)
 
       case ITEM_MODEL_EXTERNAL_MODULE_MODE:
         lcd_putsLeft(y, STR_MODE);
-        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].type, m_posHorz==0 ? attr : 0);
+        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
         if (IS_MODULE_XJT(EXTERNAL_MODULE))
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].rfProtocol, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].rfProtocol, menuHorizontalPosition==1 ? attr : 0);
         else if (IS_MODULE_DSM2(EXTERNAL_MODULE))
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].rfProtocol, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].rfProtocol, menuHorizontalPosition==1 ? attr : 0);
         if (attr && (editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               g_model.moduleData[EXTERNAL_MODULE].type = checkIncDec(event, g_model.moduleData[EXTERNAL_MODULE].type, MODULE_TYPE_NONE, MODULE_TYPE_COUNT-1, EE_MODEL, isModuleAvailable);
               if (checkIncDec_Ret) {
@@ -540,12 +540,12 @@ void menuModelSetup(uint8_t event)
         ModuleData & moduleData = g_model.moduleData[moduleIdx];
         lcd_putsLeft(y, STR_CHANNELRANGE);
         if ((int8_t)PORT_CHANNELS_ROWS(moduleIdx) >= 0) {
-          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN, y, STR_CH, m_posHorz==0 ? attr : 0);
-          lcd_outdezAtt(lcdLastPos, y, moduleData.channelsStart+1, LEFT | (m_posHorz==0 ? attr : 0));
+          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN, y, STR_CH, menuHorizontalPosition==0 ? attr : 0);
+          lcd_outdezAtt(lcdLastPos, y, moduleData.channelsStart+1, LEFT | (menuHorizontalPosition==0 ? attr : 0));
           lcd_putc(lcdLastPos, y, '-');
-          lcd_outdezAtt(lcdLastPos + FW+1, y, moduleData.channelsStart+NUM_CHANNELS(moduleIdx), LEFT | (m_posHorz==1 ? attr : 0));
+          lcd_outdezAtt(lcdLastPos + FW+1, y, moduleData.channelsStart+NUM_CHANNELS(moduleIdx), LEFT | (menuHorizontalPosition==1 ? attr : 0));
           if (attr && (editMode>0 || p1valdiff)) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.channelsStart, 32-8-moduleData.channelsCount);
                 break;
@@ -573,13 +573,13 @@ void menuModelSetup(uint8_t event)
         if (IS_MODULE_PPM(moduleIdx)) {
           lcd_putsLeft(y, STR_PPMFRAME);
           lcd_puts(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_MS);
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)moduleData.ppmFrameLength*5 + 225, (m_posHorz<=0 ? attr : 0) | PREC1|LEFT);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)moduleData.ppmFrameLength*5 + 225, (menuHorizontalPosition<=0 ? attr : 0) | PREC1|LEFT);
           lcd_putc(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, 'u');
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (moduleData.ppmDelay*50)+300, (CURSOR_ON_LINE() || m_posHorz==1) ? attr : 0);
-          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, moduleData.ppmPulsePol ? '+' : '-', (CURSOR_ON_LINE() || m_posHorz==2) ? attr : 0);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (moduleData.ppmDelay*50)+300, (CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0);
+          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, moduleData.ppmPulsePol ? '+' : '-', (CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0);
 
           if (attr && (editMode>0 || p1valdiff)) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR(event, moduleData.ppmFrameLength, -20, 35);
                 break;
@@ -593,7 +593,7 @@ void menuModelSetup(uint8_t event)
           }
         }
         else {
-          horzpos_t l_posHorz = m_posHorz;
+          horzpos_t l_posHorz = menuHorizontalPosition;
           coord_t xOffsetBind = MODEL_SETUP_BIND_OFS;
           if (IS_MODULE_XJT(moduleIdx) && IS_D8_RX(moduleIdx)) {
             xOffsetBind = 0;
@@ -650,18 +650,18 @@ void menuModelSetup(uint8_t event)
         ModuleData & moduleData = g_model.moduleData[moduleIdx];
         lcd_putsLeft(y, TR_FAILSAFE);
         if (IS_MODULE_XJT(moduleIdx)) {
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VFAILSAFE, moduleData.failsafeMode, m_posHorz==0 ? attr : 0);
-          if (moduleData.failsafeMode == FAILSAFE_CUSTOM) lcd_putsAtt(MODEL_SETUP_2ND_COLUMN + MODEL_SETUP_SET_FAILSAFE_OFS, y, STR_SET, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VFAILSAFE, moduleData.failsafeMode, menuHorizontalPosition==0 ? attr : 0);
+          if (moduleData.failsafeMode == FAILSAFE_CUSTOM) lcd_putsAtt(MODEL_SETUP_2ND_COLUMN + MODEL_SETUP_SET_FAILSAFE_OFS, y, STR_SET, menuHorizontalPosition==1 ? attr : 0);
           if (attr) {
             if (moduleData.failsafeMode != FAILSAFE_CUSTOM)
-              m_posHorz = 0;
-            if (m_posHorz==0) {
+              menuHorizontalPosition = 0;
+            if (menuHorizontalPosition==0) {
               if (editMode>0 || p1valdiff) {
                 CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.failsafeMode, FAILSAFE_LAST);
                 if (checkIncDec_Ret) SEND_FAILSAFE_NOW(moduleIdx);
               }
             }
-            else if (m_posHorz==1) {
+            else if (menuHorizontalPosition==1) {
               s_editMode = 0;
               if (moduleData.failsafeMode==FAILSAFE_CUSTOM && event==EVT_KEY_FIRST(KEY_ENTER)) {
                 g_moduleIdx = moduleIdx;
@@ -680,15 +680,15 @@ void menuModelSetup(uint8_t event)
 #if !defined(CPUARM)
       case ITEM_MODEL_PPM1_PROTOCOL:
         lcd_putsLeft(y, NO_INDENT(STR_PROTO));
-        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VPROTOS, protocol, m_posHorz<=0 ? attr : 0);
+        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VPROTOS, protocol, menuHorizontalPosition<=0 ? attr : 0);
         if (IS_PPM_PROTOCOL(protocol)) {
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+7*FW, y, STR_NCHANNELS, g_model.ppmNCH+2, m_posHorz!=0 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+7*FW, y, STR_NCHANNELS, g_model.ppmNCH+2, menuHorizontalPosition!=0 ? attr : 0);
         }
-        else if (m_posHorz>0 && attr) {
+        else if (menuHorizontalPosition>0 && attr) {
           MOVE_CURSOR_FROM_HERE();
         }
         if (attr && (editMode>0 || p1valdiff || (!IS_PPM_PROTOCOL(protocol) && !IS_DSM2_PROTOCOL(protocol)))) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR_ZERO(event, g_model.protocol, PROTO_MAX-1);
               break;
@@ -705,12 +705,12 @@ void menuModelSetup(uint8_t event)
       case ITEM_MODEL_PPM2_PROTOCOL:
         lcd_putsLeft(y, PSTR("Port2"));
         lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VPROTOS, 0, 0);
-        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW+3, y, STR_CH, m_posHorz<=0 ? attr : 0);
-        lcd_outdezAtt(lcdLastPos, y, g_model.moduleData[1].channelsStart+1, LEFT | (m_posHorz<=0 ? attr : 0));
+        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW+3, y, STR_CH, menuHorizontalPosition<=0 ? attr : 0);
+        lcd_outdezAtt(lcdLastPos, y, g_model.moduleData[1].channelsStart+1, LEFT | (menuHorizontalPosition<=0 ? attr : 0));
         lcd_putc(lcdLastPos, y, '-');
-        lcd_outdezAtt(lcdLastPos + FW+1, y, g_model.moduleData[1].channelsStart+8+g_model.moduleData[1].channelsCount, LEFT | (m_posHorz!=0 ? attr : 0));
+        lcd_outdezAtt(lcdLastPos + FW+1, y, g_model.moduleData[1].channelsStart+8+g_model.moduleData[1].channelsCount, LEFT | (menuHorizontalPosition!=0 ? attr : 0));
         if (attr && (editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR_ZERO(event, g_model.moduleData[1].channelsStart, 32-8-g_model.moduleData[1].channelsCount);
               SET_DEFAULT_PPM_FRAME_LENGTH(1);
@@ -726,12 +726,12 @@ void menuModelSetup(uint8_t event)
       case ITEM_MODEL_PPM2_PARAMS:
         lcd_putsLeft(y, STR_PPMFRAME);
         lcd_puts(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_MS);
-        lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)g_model.moduleData[1].ppmFrameLength*5 + 225, (m_posHorz<=0 ? attr : 0) | PREC1|LEFT);
+        lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)g_model.moduleData[1].ppmFrameLength*5 + 225, (menuHorizontalPosition<=0 ? attr : 0) | PREC1|LEFT);
         lcd_putc(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, 'u');
-        lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (g_model.moduleData[1].ppmDelay*50)+300, (m_posHorz < 0 || m_posHorz==1) ? attr : 0);
-        lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, g_model.moduleData[1].ppmPulsePol ? '+' : '-', (m_posHorz < 0 || m_posHorz==2) ? attr : 0);
+        lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (g_model.moduleData[1].ppmDelay*50)+300, (menuHorizontalPosition < 0 || menuHorizontalPosition==1) ? attr : 0);
+        lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, g_model.moduleData[1].ppmPulsePol ? '+' : '-', (menuHorizontalPosition < 0 || menuHorizontalPosition==2) ? attr : 0);
         if (attr && (editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.moduleData[1].ppmFrameLength, -20, 35);
               break;
@@ -751,12 +751,12 @@ void menuModelSetup(uint8_t event)
         if (IS_PPM_PROTOCOL(protocol)) {
           lcd_putsLeft(y, STR_PPMFRAME);
           lcd_puts(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_MS);
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)g_model.ppmFrameLength*5 + 225, (m_posHorz<=0 ? attr : 0) | PREC1|LEFT);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)g_model.ppmFrameLength*5 + 225, (menuHorizontalPosition<=0 ? attr : 0) | PREC1|LEFT);
           lcd_putc(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, 'u');
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (g_model.ppmDelay*50)+300, (CURSOR_ON_LINE() || m_posHorz==1) ? attr : 0);
-          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, g_model.pulsePol ? '+' : '-', (CURSOR_ON_LINE() || m_posHorz==2) ? attr : 0);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (g_model.ppmDelay*50)+300, (CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0);
+          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, g_model.pulsePol ? '+' : '-', (CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0);
           if (attr && (editMode>0 || p1valdiff)) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR(event, g_model.ppmFrameLength, -20, 35);
                 break;
@@ -771,19 +771,19 @@ void menuModelSetup(uint8_t event)
         }
 #if defined(DSM2) || defined(PXX)
         else if (IS_DSM2_PROTOCOL(protocol) || IS_PXX_PROTOCOL(protocol)) {
-          if (attr && m_posHorz > 1) {
+          if (attr && menuHorizontalPosition > 1) {
             REPEAT_LAST_CURSOR_MOVE(); // limit 3 column row to 2 colums (Rx_Num and RANGE fields)
           }
           lcd_putsLeft(y, STR_RXNUM);
-          lcd_outdezNAtt(MODEL_SETUP_2ND_COLUMN, y, g_model.header.modelId[0], (m_posHorz<=0 ? attr : 0) | LEADING0|LEFT, 2);
-          if (attr && (m_posHorz==0 && (editMode>0 || p1valdiff))) {
+          lcd_outdezNAtt(MODEL_SETUP_2ND_COLUMN, y, g_model.header.modelId[0], (menuHorizontalPosition<=0 ? attr : 0) | LEADING0|LEFT, 2);
+          if (attr && (menuHorizontalPosition==0 && (editMode>0 || p1valdiff))) {
             CHECK_INCDEC_MODELVAR_ZERO(event, g_model.header.modelId[0], 99);
           }
 #if defined(PXX)
           if (protocol == PROTO_PXX) {
-            lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW, y, STR_SYNCMENU, m_posHorz!=0 ? attr : 0);
+            lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW, y, STR_SYNCMENU, menuHorizontalPosition!=0 ? attr : 0);
             uint8_t newFlag = 0;
-            if (attr && m_posHorz>0 && editMode>0) {
+            if (attr && menuHorizontalPosition>0 && editMode>0) {
               // send reset code
               newFlag = MODULE_BIND;
             }
@@ -792,8 +792,8 @@ void menuModelSetup(uint8_t event)
 #endif
 #if defined(DSM2)
           if (IS_DSM2_PROTOCOL(protocol)) {
-            lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW, y, STR_MODULE_RANGE, m_posHorz!=0 ? attr : 0);
-            moduleFlag[0] = (attr && m_posHorz>0 && editMode>0) ? MODULE_RANGECHECK : 0; // [MENU] key toggles range check mode
+            lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+4*FW, y, STR_MODULE_RANGE, menuHorizontalPosition!=0 ? attr : 0);
+            moduleFlag[0] = (attr && menuHorizontalPosition>0 && editMode>0) ? MODULE_RANGECHECK : 0; // [MENU] key toggles range check mode
           }
 #endif
         }
@@ -820,7 +820,7 @@ void menuModelFailsafe(uint8_t event)
 
   if (event == EVT_KEY_LONG(KEY_ENTER) && s_editMode) {
     s_noHi = NO_HI_LEN;
-    g_model.moduleData[g_moduleIdx].failsafeChannels[m_posVert] = channelOutputs[m_posVert];
+    g_model.moduleData[g_moduleIdx].failsafeChannels[menuVerticalPosition] = channelOutputs[menuVerticalPosition];
     eeDirty(EE_MODEL);
     AUDIO_WARNING1();
     SEND_FAILSAFE_NOW(g_moduleIdx);
@@ -832,7 +832,7 @@ void menuModelFailsafe(uint8_t event)
 
   #define COL_W   (LCD_W)
   const uint8_t SLIDER_W = 90;
-  ch = 8 * (m_posVert / 8);
+  ch = 8 * (menuVerticalPosition / 8);
 
   lcd_putsCenter(0*FH, FAILSAFESET);
   lcd_invert_line(0);
@@ -850,7 +850,7 @@ void menuModelFailsafe(uint8_t event)
 
       if (ch < g_model.moduleData[g_moduleIdx].channelsStart || ch >= NUM_CHANNELS(g_moduleIdx) + g_model.moduleData[g_moduleIdx].channelsStart)
         val = 0;
-      else if (s_editMode && m_posVert == ch)
+      else if (s_editMode && menuVerticalPosition == ch)
         val = channelOutputs[ch];
       else
         val = g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line];
@@ -859,7 +859,7 @@ void menuModelFailsafe(uint8_t event)
 
       // Value
       LcdFlags flags = TINSIZE;
-      if (m_posVert == ch && !s_noHi) {
+      if (menuVerticalPosition == ch && !s_noHi) {
         flags |= INVERS;
         if (s_editMode)
           flags |= BLINK;

--- a/radio/src/gui/9X/menu_model_setup.cpp
+++ b/radio/src/gui/9X/menu_model_setup.cpp
@@ -165,7 +165,7 @@ void menuModelSetup(uint8_t event)
 
   for (uint8_t i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 #if defined(CPUARM)
     for (int j=0; j<=k; j++) {
       if (mstate_tab[j+1] == HIDDEN_ROW) {

--- a/radio/src/gui/9X/menu_model_setup.cpp
+++ b/radio/src/gui/9X/menu_model_setup.cpp
@@ -327,11 +327,11 @@ void menuModelSetup(uint8_t event)
         ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, attr, event);
 #else
         ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, menuHorizontalPosition<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
-        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, menuHorizontalPosition>0  && !s_noHi ? attr : 0);
+        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, (menuHorizontalPosition>0  && !NO_HIGHLIGHT()) ? attr : 0);
         if (attr && menuHorizontalPosition>0) {
           s_editMode = 0;
           if (event==EVT_KEY_LONG(KEY_ENTER)) {
-            s_noHi = NO_HI_LEN;
+            START_NO_HIGHLIGHT();
             for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
               memclear(&g_model.flightModeData[i], TRIMS_ARRAY_SIZE);
             }
@@ -417,7 +417,7 @@ void menuModelSetup(uint8_t event)
                 eeDirty(EE_MODEL);
 #else
                 if (menuHorizontalPosition == NUM_SWITCHES-1) {
-                  s_noHi = NO_HI_LEN;
+                  START_NO_HIGHLIGHT();
                   getMovedSwitch();
                   g_model.switchWarningState = switches_states;
                   AUDIO_WARNING1();
@@ -453,7 +453,7 @@ void menuModelSetup(uint8_t event)
           }
           lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive || (attr & BLINK)) ? c : '-', attr);
 #if !defined(CPUM64)
-          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (menuHorizontalPosition == NUM_SWITCHES-1 && !s_noHi) ? line : 0);
+          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (menuHorizontalPosition == NUM_SWITCHES-1 && !NO_HIGHLIGHT()) ? line : 0);
 #endif
         }
         break;
@@ -819,7 +819,7 @@ void menuModelFailsafe(uint8_t event)
   uint8_t ch = 0;
 
   if (event == EVT_KEY_LONG(KEY_ENTER) && s_editMode) {
-    s_noHi = NO_HI_LEN;
+    START_NO_HIGHLIGHT();
     g_model.moduleData[g_moduleIdx].failsafeChannels[menuVerticalPosition] = channelOutputs[menuVerticalPosition];
     eeDirty(EE_MODEL);
     AUDIO_WARNING1();
@@ -859,7 +859,7 @@ void menuModelFailsafe(uint8_t event)
 
       // Value
       LcdFlags flags = TINSIZE;
-      if (menuVerticalPosition == ch && !s_noHi) {
+      if (menuVerticalPosition == ch && !NO_HIGHLIGHT()) {
         flags |= INVERS;
         if (s_editMode)
           flags |= BLINK;

--- a/radio/src/gui/9X/menu_model_telemetry.cpp
+++ b/radio/src/gui/9X/menu_model_telemetry.cpp
@@ -524,8 +524,8 @@ void onSensorMenu(const char *result)
 void menuModelTelemetry(uint8_t event)
 {
 #if defined(CPUARM)
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     for (int i=0; i<MAX_SENSORS; i++) {
       delTelemetryIndex(i);
     }

--- a/radio/src/gui/9X/menu_model_telemetry.cpp
+++ b/radio/src/gui/9X/menu_model_telemetry.cpp
@@ -288,7 +288,7 @@ void menuModelSensor(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i + s_pgOfs;
+    uint8_t k = i + menuVerticalOffset;
 
     for (int j=0; j<k; j++) {
       if (mstate_tab[j+1] == HIDDEN_ROW)
@@ -548,7 +548,7 @@ void menuModelTelemetry(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i + s_pgOfs;
+    uint8_t k = i + menuVerticalOffset;
 #if defined(CPUARM)
     for (int j=0; j<=k; j++) {
       if (mstate_tab[j+1] == HIDDEN_ROW)

--- a/radio/src/gui/9X/menu_model_telemetry.cpp
+++ b/radio/src/gui/9X/menu_model_telemetry.cpp
@@ -284,7 +284,7 @@ void menuModelSensor(uint8_t event)
 
   putsTelemetryChannelValue(SENSOR_2ND_COLUMN, 0, s_currIdx, getValue(MIXSRC_FIRST_TELEM+3*s_currIdx), LEFT);
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -318,10 +318,10 @@ void menuModelSensor(uint8_t event)
       case SENSOR_FIELD_ID:
         if (sensor->type == TELEM_TYPE_CUSTOM) {
           lcd_putsLeft(y, STR_ID);
-          lcd_outhex4(SENSOR_2ND_COLUMN, y, sensor->id, LEFT|(m_posHorz==0 ? attr : 0));
-          lcd_outdezAtt(SENSOR_3RD_COLUMN, y, sensor->instance, LEFT|(m_posHorz==1 ? attr : 0));
+          lcd_outhex4(SENSOR_2ND_COLUMN, y, sensor->id, LEFT|(menuHorizontalPosition==0 ? attr : 0));
+          lcd_outdezAtt(SENSOR_3RD_COLUMN, y, sensor->instance, LEFT|(menuHorizontalPosition==1 ? attr : 0));
           if (attr) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR_ZERO(event, sensor->id, 0xffff);
                 break;
@@ -487,7 +487,7 @@ void menuModelSensor(uint8_t event)
 
 void onSensorMenu(const char *result)
 {
-  uint8_t index = m_posVert - 1 - ITEM_TELEMETRY_SENSOR1;
+  uint8_t index = menuVerticalPosition - 1 - ITEM_TELEMETRY_SENSOR1;
 
   if (index < MAX_SENSORS) {
     if (result == STR_EDIT) {
@@ -497,9 +497,9 @@ void onSensorMenu(const char *result)
       delTelemetryIndex(index);
       index += 1;
       if (index<MAX_SENSORS && isTelemetryFieldAvailable(index))
-        m_posVert += 1;
+        menuVerticalPosition += 1;
       else
-        m_posVert = 1+ITEM_TELEMETRY_NEW_SENSOR;
+        menuVerticalPosition = 1+ITEM_TELEMETRY_NEW_SENSOR;
     }
     else if (result == STR_COPY) {
       int newIndex = availableTelemetryIndex();
@@ -534,7 +534,7 @@ void menuModelTelemetry(uint8_t event)
 
   MENU(STR_MENUTELEMETRY, menuTabModel, e_Telemetry, ITEM_TELEMETRY_MAX+1, {0, TELEMETRY_TYPE_ROWS CHANNELS_ROWS RSSI_ROWS SENSORS_ROWS USRDATA_ROWS CASE_VARIO(LABEL(Vario)) CASE_VARIO(0) CASE_VARIO(VARIO_RANGE_ROWS) TELEMETRY_SCREEN_ROWS(0), TELEMETRY_SCREEN_ROWS(1), CASE_CPUARM(TELEMETRY_SCREEN_ROWS(2)) CASE_CPUARM(TELEMETRY_SCREEN_ROWS(3))});
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   switch (event) {
     case EVT_KEY_BREAK(KEY_DOWN):
@@ -663,10 +663,10 @@ void menuModelTelemetry(uint8_t event)
       case ITEM_TELEMETRY_A1_RANGE:
       case ITEM_TELEMETRY_A2_RANGE:
         lcd_putsLeft(y, STR_RANGE);
-        putsTelemetryChannelValue(TELEM_COL2, y, dest, 255-channel.offset, (m_posHorz<=0 ? attr : 0)|NO_UNIT|LEFT);
-        lcd_putsiAtt(lcdLastPos, y, STR_VTELEMUNIT, channel.type, m_posHorz!=0 ? attr : 0);
+        putsTelemetryChannelValue(TELEM_COL2, y, dest, 255-channel.offset, (menuHorizontalPosition<=0 ? attr : 0)|NO_UNIT|LEFT);
+        lcd_putsiAtt(lcdLastPos, y, STR_VTELEMUNIT, channel.type, menuHorizontalPosition!=0 ? attr : 0);
         if (attr && (s_editMode>0 || p1valdiff)) {
-          if (m_posHorz == 0) {
+          if (menuHorizontalPosition == 0) {
             uint16_t ratio = checkIncDec(event, channel.ratio, 0, 256, EE_MODEL);
             if (checkIncDec_Ret) {
               if (ratio == 127 && channel.multiplier > 0) {
@@ -700,13 +700,13 @@ void menuModelTelemetry(uint8_t event)
       {
         uint8_t alarm = ((k==ITEM_TELEMETRY_A1_ALARM1 || k==ITEM_TELEMETRY_A2_ALARM1) ? 0 : 1);
         lcd_putsLeft(y, STR_ALARM);
-        lcd_putsiAtt(TELEM_COL2, y, STR_VALARM, ALARM_LEVEL(ch, alarm), m_posHorz<=0 ? attr : 0);
-        lcd_putsiAtt(TELEM_COL2+4*FW, y, STR_VALARMFN, ALARM_GREATER(ch, alarm), (CURSOR_ON_LINE() || m_posHorz==1) ? attr : 0);
-        putsTelemetryChannelValue(TELEM_COL2+6*FW, y, dest, channel.alarms_value[alarm], ((CURSOR_ON_LINE() || m_posHorz==2) ? attr : 0) | LEFT);
+        lcd_putsiAtt(TELEM_COL2, y, STR_VALARM, ALARM_LEVEL(ch, alarm), menuHorizontalPosition<=0 ? attr : 0);
+        lcd_putsiAtt(TELEM_COL2+4*FW, y, STR_VALARMFN, ALARM_GREATER(ch, alarm), (CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0);
+        putsTelemetryChannelValue(TELEM_COL2+6*FW, y, dest, channel.alarms_value[alarm], ((CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0) | LEFT);
 
         if (attr && (s_editMode>0 || p1valdiff)) {
           uint8_t t;
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
            case 0:
              t = ALARM_LEVEL(ch, alarm);
              channel.alarms_level = (channel.alarms_level & ~(3<<(2*alarm))) + (checkIncDecModel(event, t, 0, 3) << (2*alarm));
@@ -735,12 +735,12 @@ void menuModelTelemetry(uint8_t event)
       case ITEM_TELEMETRY_RSSI_ALARM2: {
         uint8_t alarm = k-ITEM_TELEMETRY_RSSI_ALARM1;
         lcd_putsLeft(y, STR_ALARM);
-        lcd_putsiAtt(TELEM_COL2, y, STR_VALARM, ((2+alarm+g_model.frsky.rssiAlarms[alarm].level)%4), m_posHorz<=0 ? attr : 0);
+        lcd_putsiAtt(TELEM_COL2, y, STR_VALARM, ((2+alarm+g_model.frsky.rssiAlarms[alarm].level)%4), menuHorizontalPosition<=0 ? attr : 0);
         lcd_putc(TELEM_COL2+4*FW, y, '<');
-        lcd_outdezNAtt(TELEM_COL2+6*FW, y, getRssiAlarmValue(alarm), LEFT|(m_posHorz!=0 ? attr : 0), 3);
+        lcd_outdezNAtt(TELEM_COL2+6*FW, y, getRssiAlarmValue(alarm), LEFT|(menuHorizontalPosition!=0 ? attr : 0), 3);
 
         if (attr && (s_editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.rssiAlarms[alarm].level, -3, 2); // circular (saves flash)
               break;
@@ -815,10 +815,10 @@ void menuModelTelemetry(uint8_t event)
       case ITEM_TELEMETRY_VARIO_RANGE:
         lcd_putsLeft(y, STR_LIMIT);
 #if defined(PCBSTD)
-        lcd_outdezAtt(TELEM_COL2, y, 5+g_model.frsky.varioCenterMax, (m_posHorz==0 ? attr : 0)|PREC1|LEFT);
-        lcd_outdezAtt(TELEM_COL2+8*FW, y, 10+g_model.frsky.varioMax, (m_posHorz==1 ? attr : 0));
+        lcd_outdezAtt(TELEM_COL2, y, 5+g_model.frsky.varioCenterMax, (menuHorizontalPosition==0 ? attr : 0)|PREC1|LEFT);
+        lcd_outdezAtt(TELEM_COL2+8*FW, y, 10+g_model.frsky.varioMax, (menuHorizontalPosition==1 ? attr : 0));
         if (attr && (s_editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioCenterMax, -15, +15);
               break;
@@ -828,12 +828,12 @@ void menuModelTelemetry(uint8_t event)
           }
         }
 #else
-        lcd_outdezAtt(TELEM_COL2, y, -10+g_model.frsky.varioMin, (m_posHorz<=0 ? attr : 0)|LEFT);
-        lcd_outdezAtt(TELEM_COL2+7*FW-2, y, -5+g_model.frsky.varioCenterMin, ((CURSOR_ON_LINE() || m_posHorz==1) ? attr : 0)|PREC1);
-        lcd_outdezAtt(TELEM_COL2+10*FW, y, 5+g_model.frsky.varioCenterMax, ((CURSOR_ON_LINE() || m_posHorz==2) ? attr : 0)|PREC1);
-        lcd_outdezAtt(TELEM_COL2+13*FW+2, y, 10+g_model.frsky.varioMax, ((CURSOR_ON_LINE() || m_posHorz==3) ? attr : 0));
+        lcd_outdezAtt(TELEM_COL2, y, -10+g_model.frsky.varioMin, (menuHorizontalPosition<=0 ? attr : 0)|LEFT);
+        lcd_outdezAtt(TELEM_COL2+7*FW-2, y, -5+g_model.frsky.varioCenterMin, ((CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0)|PREC1);
+        lcd_outdezAtt(TELEM_COL2+10*FW, y, 5+g_model.frsky.varioCenterMax, ((CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0)|PREC1);
+        lcd_outdezAtt(TELEM_COL2+13*FW+2, y, 10+g_model.frsky.varioMax, ((CURSOR_ON_LINE() || menuHorizontalPosition==3) ? attr : 0));
         if (attr && (s_editMode>0 || p1valdiff)) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioMin, -7, 7);
               break;
@@ -861,7 +861,7 @@ void menuModelTelemetry(uint8_t event)
         uint8_t screenIndex = TELEMETRY_CURRENT_SCREEN(k);
         putsStrIdx(0*FW, y, STR_SCREEN, screenIndex+1);
         TelemetryScreenType oldScreenType = TELEMETRY_SCREEN_TYPE(screenIndex);
-        TelemetryScreenType newScreenType = (TelemetryScreenType)selectMenuItem(TELEM_SCRTYPE_COL, y, PSTR(""), STR_VTELEMSCREENTYPE, oldScreenType, 0, TELEMETRY_SCREEN_TYPE_MAX, (m_posHorz==0 ? attr : 0), event);
+        TelemetryScreenType newScreenType = (TelemetryScreenType)selectMenuItem(TELEM_SCRTYPE_COL, y, PSTR(""), STR_VTELEMSCREENTYPE, oldScreenType, 0, TELEMETRY_SCREEN_TYPE_MAX, (menuHorizontalPosition==0 ? attr : 0), event);
         if (newScreenType != oldScreenType) {
           g_model.frsky.screensType = (g_model.frsky.screensType & (~(0x03 << (2*screenIndex)))) | (newScreenType << (2*screenIndex));
           memset(&g_model.frsky.screens[screenIndex], 0, sizeof(g_model.frsky.screens[screenIndex]));
@@ -926,29 +926,29 @@ void menuModelTelemetry(uint8_t event)
           FrSkyBarData & bar = g_model.frsky.screens[screenIndex].bars[lineIndex];
           source_t barSource = bar.source;
 #if defined(CPUARM)
-          putsMixerSource(TELEM_COL1, y, barSource, m_posHorz==0 ? attr : 0);
+          putsMixerSource(TELEM_COL1, y, barSource, menuHorizontalPosition==0 ? attr : 0);
           if (barSource) {
             if (barSource <= MIXSRC_LAST_CH) {
-              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, calc100toRESX(bar.barMin), (m_posHorz==1 ? attr : 0) | LEFT);
-              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, calc100toRESX(bar.barMax), (m_posHorz==2 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | LEFT);
             }
             else {
-              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, bar.barMin, (m_posHorz==1 ? attr : 0) | LEFT);
-              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, bar.barMax, (m_posHorz==2 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | LEFT);
             }
           }
 #else
-          lcd_putsiAtt(TELEM_COL1, y, STR_VTELEMCHNS, barSource, m_posHorz==0 ? attr : 0);
+          lcd_putsiAtt(TELEM_COL1, y, STR_VTELEMCHNS, barSource, menuHorizontalPosition==0 ? attr : 0);
           if (barSource) {
-            putsTelemetryChannelValue(TELEM_BARS_COLMIN, y, barSource-1, convertBarTelemValue(barSource, bar.barMin), (m_posHorz==1 ? attr : 0) | LEFT);
-            putsTelemetryChannelValue(TELEM_BARS_COLMAX, y, barSource-1, convertBarTelemValue(barSource, 255-bar.barMax), (m_posHorz==2 ? attr : 0) | LEFT);
+            putsTelemetryChannelValue(TELEM_BARS_COLMIN, y, barSource-1, convertBarTelemValue(barSource, bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | LEFT);
+            putsTelemetryChannelValue(TELEM_BARS_COLMAX, y, barSource-1, convertBarTelemValue(barSource, 255-bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | LEFT);
           }
 #endif
-          else if (attr && m_posHorz>0) {
-            m_posHorz = 0;
+          else if (attr && menuHorizontalPosition>0) {
+            menuHorizontalPosition = 0;
           }
           if (attr && (s_editMode>0 || p1valdiff)) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
 #if defined(CPUARM)
                 bar.source = CHECK_INCDEC_MODELVAR_ZERO_CHECK(event, barSource, MIXSRC_LAST_TELEM, isSourceAvailable);
@@ -985,7 +985,7 @@ void menuModelTelemetry(uint8_t event)
 #endif
         {
           for (uint8_t c=0; c<NUM_LINE_ITEMS; c++) {
-            uint8_t cellAttr = (m_posHorz==c ? attr : 0);
+            uint8_t cellAttr = (menuHorizontalPosition==c ? attr : 0);
             source_t & value = g_model.frsky.screens[screenIndex].lines[lineIndex].sources[c];
             uint8_t pos[] = {INDENT_WIDTH, TELEM_COL2};
 #if defined(CPUARM)
@@ -1000,7 +1000,7 @@ void menuModelTelemetry(uint8_t event)
             }
 #endif
           }
-          if (attr && m_posHorz == NUM_LINE_ITEMS) {
+          if (attr && menuHorizontalPosition == NUM_LINE_ITEMS) {
             REPEAT_LAST_CURSOR_MOVE();
           }
         }

--- a/radio/src/gui/9X/menu_model_telemetry.cpp
+++ b/radio/src/gui/9X/menu_model_telemetry.cpp
@@ -590,10 +590,10 @@ void menuModelTelemetry(uint8_t event)
         s_currIdx = index;
         if (event == EVT_KEY_LONG(KEY_ENTER)) {
           killEvents(event);
-          MENU_ADD_ITEM(STR_EDIT);
-          MENU_ADD_ITEM(STR_COPY);
-          MENU_ADD_ITEM(STR_DELETE);
-          menuHandler = onSensorMenu;
+          POPUP_MENU_ADD_ITEM(STR_EDIT);
+          POPUP_MENU_ADD_ITEM(STR_COPY);
+          POPUP_MENU_ADD_ITEM(STR_DELETE);
+          popupMenuHandler = onSensorMenu;
         }
         else if (event == EVT_KEY_BREAK(KEY_ENTER)) {
           pushMenu(menuModelSensor);

--- a/radio/src/gui/9X/menu_model_templates.cpp
+++ b/radio/src/gui/9X/menu_model_templates.cpp
@@ -43,8 +43,8 @@ void menuModelTemplates(uint8_t event)
   uint8_t sub = menuVerticalPosition - 1;
 
   if (sub < TMPL_COUNT) {
-    if (s_warning_result) {
-      s_warning_result = 0;
+    if (warningResult) {
+      warningResult = 0;
       applyTemplate(sub);
       AUDIO_WARNING2();
     }

--- a/radio/src/gui/9X/menu_model_templates.cpp
+++ b/radio/src/gui/9X/menu_model_templates.cpp
@@ -57,7 +57,7 @@ void menuModelTemplates(uint8_t event)
   coord_t y = MENU_HEADER_HEIGHT + 1;
   uint8_t k = 0;
   for (uint8_t i=0; i<LCD_LINES-1 && k<TMPL_COUNT; i++) {
-    k = i+s_pgOfs;
+    k = i+menuVerticalOffset;
     lcd_outdezNAtt(3*FW, y, k, (sub==k ? INVERS : 0)|LEADING0, 2);
     lcd_putsiAtt(4*FW, y, STR_VTEMPLATES, k, (sub==k ? INVERS  : 0));
     y+=FH;

--- a/radio/src/gui/9X/menu_model_templates.cpp
+++ b/radio/src/gui/9X/menu_model_templates.cpp
@@ -40,7 +40,7 @@ void menuModelTemplates(uint8_t event)
 {
   SIMPLE_MENU(STR_MENUTEMPLATES, menuTabModel, e_Templates, 1+TMPL_COUNT);
 
-  uint8_t sub = m_posVert - 1;
+  uint8_t sub = menuVerticalPosition - 1;
 
   if (sub < TMPL_COUNT) {
     if (s_warning_result) {

--- a/radio/src/gui/9X/menus.cpp
+++ b/radio/src/gui/9X/menus.cpp
@@ -36,43 +36,43 @@
 
 #include "../../opentx.h"
 
-MenuFuncP g_menuStack[5];
+menuHandlerFunc menuHandlers[5];
 uint8_t menuEvent = 0;
-uint8_t g_menuPos[4];
-uint8_t g_menuStackPtr = 0;
+uint8_t menuVerticalPositions[4];
+uint8_t menuLevel = 0;
 
 void popMenu()
 {
-  assert(g_menuStackPtr>0);
-  g_menuStackPtr = g_menuStackPtr-1;
+  assert(menuLevel>0);
+  menuLevel = menuLevel-1;
   menuEvent = EVT_ENTRY_UP;
 }
 
-void chainMenu(MenuFuncP newMenu)
+void chainMenu(menuHandlerFunc newMenu)
 {
-  g_menuStack[g_menuStackPtr] = newMenu;
+  menuHandlers[menuLevel] = newMenu;
   menuEvent = EVT_ENTRY;
 }
 
-void pushMenu(MenuFuncP newMenu)
+void pushMenu(menuHandlerFunc newMenu)
 {
   killEvents(KEY_ENTER);
 
-  if (g_menuStackPtr == 0) {
+  if (menuLevel == 0) {
     if (newMenu == menuGeneralSetup)
-      g_menuPos[0] = 1;
+      menuVerticalPositions[0] = 1;
     if (newMenu == menuModelSelect)
-      g_menuPos[0] = 0;
+      menuVerticalPositions[0] = 0;
   }
   else {
-    g_menuPos[g_menuStackPtr] = m_posVert;
+    menuVerticalPositions[menuLevel] = menuVerticalPosition;
   }
 
-  g_menuStackPtr++;
+  menuLevel++;
 
-  assert(g_menuStackPtr < DIM(g_menuStack));
+  assert(menuLevel < DIM(menuHandlers));
 
-  g_menuStack[g_menuStackPtr] = newMenu;
+  menuHandlers[menuLevel] = newMenu;
   menuEvent = EVT_ENTRY;
 }
 

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -422,7 +422,7 @@ void displayWarning(uint8_t event);
   #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+1)
   extern const char *popupMenuItems[POPUP_MENU_MAX_LINES];
   extern uint16_t popupMenuNoItems;
-  extern uint8_t s_menu_flags;
+  extern uint8_t popupMenuFlags;
   extern uint16_t popupMenuOffset;
   const char * displayPopupMenu(uint8_t event);
   extern void (*popupMenuHandler)(const char *result);

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -58,36 +58,36 @@ typedef uint8_t check_event_t;
   extern tmr10ms_t menuEntryTime;
 #endif
 
-extern vertpos_t m_posVert;
-extern horzpos_t m_posHorz;
+extern vertpos_t menuVerticalPosition;
+extern horzpos_t menuHorizontalPosition;
 extern vertpos_t s_pgOfs;
 extern uint8_t s_noHi;
 extern uint8_t calibrationState;
 
 void menu_lcd_onoff(coord_t x, coord_t y, uint8_t value, LcdFlags attr);
 
-typedef void (*MenuFuncP)(uint8_t event);
+typedef void (*menuHandlerFunc)(uint8_t event);
 typedef void (*MenuFuncP_PROGMEM)(uint8_t event);
 extern const MenuFuncP_PROGMEM menuTabModel[];
 extern const MenuFuncP_PROGMEM menuTabGeneral[];
 extern const MenuFuncP_PROGMEM menuTabFPV[];
 extern const MenuFuncP_PROGMEM menuTabTelemetry[];
 
-extern MenuFuncP g_menuStack[5];
-extern uint8_t g_menuPos[4];
-extern uint8_t g_menuStackPtr;
+extern menuHandlerFunc menuHandlers[5];
+extern uint8_t menuVerticalPositions[4];
+extern uint8_t menuLevel;
 extern uint8_t menuEvent;
 
 /// goto given Menu, but substitute current menu in menuStack
-void chainMenu(MenuFuncP newMenu);
+void chainMenu(menuHandlerFunc newMenu);
 /// goto given Menu, store current menu in menuStack
-void pushMenu(MenuFuncP newMenu);
+void pushMenu(menuHandlerFunc newMenu);
 /// return to last menu in menustack
 void popMenu();
 ///deliver address of last menu which was popped from
-inline MenuFuncP lastPopMenu()
+inline menuHandlerFunc lastPopMenu()
 {
-  return g_menuStack[g_menuStackPtr+1];
+  return menuHandlers[menuLevel+1];
 }
 
 void drawPotsBars();
@@ -271,8 +271,8 @@ int8_t checkIncDecMovedSwitch(int8_t val);
 #define NAVIGATION_LINE_BY_LINE  0
 #define CURSOR_ON_LINE()         (0)
 
-void check(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow);
-void check_simple(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, vertpos_t maxrow);
+void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow);
+void check_simple(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, vertpos_t maxrow);
 void check_submenu_simple(check_event_t event, uint8_t maxrow);
 
 void title(const pm_char * s);
@@ -459,7 +459,7 @@ void displayWarning(uint8_t event);
 #if defined(ROTARY_ENCODER_NAVIGATION)
   void repeatLastCursorMove(uint8_t event);
   #define REPEAT_LAST_CURSOR_MOVE()    { if (EVT_KEY_MASK(event) >= 0x0e) putEvent(event); else repeatLastCursorMove(event); }
-  #define MOVE_CURSOR_FROM_HERE()      if (m_posHorz > 0) REPEAT_LAST_CURSOR_MOVE()
+  #define MOVE_CURSOR_FROM_HERE()      if (menuHorizontalPosition > 0) REPEAT_LAST_CURSOR_MOVE()
 #else
   void repeatLastCursorMove(uint8_t event);
   #define REPEAT_LAST_CURSOR_MOVE()    repeatLastCursorMove(event)

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -422,6 +422,7 @@ void displayWarning(uint8_t event);
   #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+1)
   extern const char *popupMenuItems[POPUP_MENU_MAX_LINES];
   extern uint16_t popupMenuNoItems;
+  extern uint8_t s_menu_flags;
   extern uint16_t popupMenuOffset;
   const char * displayPopupMenu(uint8_t event);
   extern void (*popupMenuHandler)(const char *result);

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -60,7 +60,7 @@ typedef uint8_t check_event_t;
 
 extern vertpos_t menuVerticalPosition;
 extern horzpos_t menuHorizontalPosition;
-extern vertpos_t s_pgOfs;
+extern vertpos_t menuVerticalOffset;
 extern uint8_t s_noHi;
 extern uint8_t calibrationState;
 

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -409,23 +409,22 @@ void displayWarning(uint8_t event);
 
 #if defined(SDCARD) || (defined(ROTARY_ENCODER_NAVIGATION) && !defined(CPUM64))
   #define NAVIGATION_MENUS
-  #define MENU_ADD_ITEM(s) s_menu[s_menu_count++] = s
-  #define MENU_MAX_LINES               6
-  #define MENU_MAX_DISPLAY_LINES       MENU_MAX_LINES
+  #define POPUP_MENU_ADD_ITEM(s) popupMenuItems[popupMenuNoItems++] = s
+  #define POPUP_MENU_MAX_LINES               6
+  #define MENU_MAX_DISPLAY_LINES       POPUP_MENU_MAX_LINES
   #if defined(SDCARD)
-    #define MENU_ADD_SD_ITEM(s)        MENU_ADD_ITEM(s)
+    #define POPUP_MENU_ADD_SD_ITEM(s)        POPUP_MENU_ADD_ITEM(s)
   #else
-    #define MENU_ADD_SD_ITEM(s)
+    #define POPUP_MENU_ADD_SD_ITEM(s)
   #endif
   #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+1)
-  extern const char *s_menu[MENU_MAX_LINES];
-  extern uint16_t s_menu_count;
-  extern uint8_t s_menu_flags;
-  extern uint16_t s_menu_offset;
-  const char * displayMenu(uint8_t event);
-  extern void (*menuHandler)(const char *result);
+  extern const char *popupMenuItems[POPUP_MENU_MAX_LINES];
+  extern uint16_t popupMenuNoItems;
+  extern uint16_t popupMenuOffset;
+  const char * displayPopupMenu(uint8_t event);
+  extern void (*popupMenuHandler)(const char *result);
 #else
-  #define s_menu_count 0
+  #define popupMenuNoItems 0
 #endif
 
 #if defined(SDCARD)

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -364,7 +364,7 @@ void editName(coord_t x, coord_t y, char *name, uint8_t size, uint8_t event, uin
 
 extern const pm_char * warningText;
 extern const pm_char * warningInfoText;
-extern uint8_t         s_warning_info_len;
+extern uint8_t         warningInfoLength;
 extern uint8_t         warningResult;
 extern uint8_t         warningType;
 
@@ -400,13 +400,13 @@ void displayWarning(uint8_t event);
   #define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
   #define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
   #define WARNING_INFO_FLAGS    warningInfoFlags
-  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, warningInfoFlags = flags)
+  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, warningInfoLength = len, warningInfoFlags = flags)
 #else
   #define DISPLAY_WARNING              displayWarning
   #define POPUP_WARNING(s)             warningText = s
   #define POPUP_CONFIRMATION(s)        (warningText = s, warningType = WARNING_TYPE_CONFIRM)
   #define WARNING_INFO_FLAGS           ZCHAR
-  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len)
+  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, warningInfoLength = len)
 #endif
 
 #if defined(SDCARD) || (defined(ROTARY_ENCODER_NAVIGATION) && !defined(CPUM64))

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -360,11 +360,11 @@ void editName(coord_t x, coord_t y, char *name, uint8_t size, uint8_t event, uin
 #define WARNING_TYPE_CONFIRM   1
 #define WARNING_TYPE_INPUT     2
 
-extern const pm_char * s_warning;
-extern const pm_char * s_warning_info;
+extern const pm_char * warningText;
+extern const pm_char * warningInfoText;
 extern uint8_t         s_warning_info_len;
-extern uint8_t         s_warning_result;
-extern uint8_t         s_warning_type;
+extern uint8_t         warningResult;
+extern uint8_t         warningType;
 
 #define MENU_X   10
 #define MENU_Y   16
@@ -379,9 +379,9 @@ void displayWarning(uint8_t event);
 
 #if defined(CPUARM)
   extern void (*popupFunc)(uint8_t event);
-  extern int16_t s_warning_input_value;
-  extern int16_t s_warning_input_min;
-  extern int16_t s_warning_input_max;
+  extern int16_t warningInputValue;
+  extern int16_t warningInputValueMin;
+  extern int16_t warningInputValueMax;
   extern uint8_t s_warning_info_flags;
 #endif
 
@@ -394,17 +394,17 @@ void displayWarning(uint8_t event);
   #define SET_WARNING_INFO(...)
 #elif defined(CPUARM)
   #define DISPLAY_WARNING       (*popupFunc)
-  #define POPUP_WARNING(s)      (s_warning = s, s_warning_info = 0, popupFunc = displayWarning)
-  #define POPUP_CONFIRMATION(s) (s_warning = s, s_warning_type = WARNING_TYPE_CONFIRM, s_warning_info = 0, popupFunc = displayWarning)
-  #define POPUP_INPUT(s, func, start, min, max) (s_warning = s, s_warning_type = WARNING_TYPE_INPUT, popupFunc = func, s_warning_input_value = start, s_warning_input_min = min, s_warning_input_max = max)
+  #define POPUP_WARNING(s)      (warningText = s, warningInfoText = 0, popupFunc = displayWarning)
+  #define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
+  #define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
   #define WARNING_INFO_FLAGS    s_warning_info_flags
-  #define SET_WARNING_INFO(info, len, flags) (s_warning_info = info, s_warning_info_len = len, s_warning_info_flags = flags)
+  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, s_warning_info_flags = flags)
 #else
   #define DISPLAY_WARNING              displayWarning
-  #define POPUP_WARNING(s)             s_warning = s
-  #define POPUP_CONFIRMATION(s)        (s_warning = s, s_warning_type = WARNING_TYPE_CONFIRM)
+  #define POPUP_WARNING(s)             warningText = s
+  #define POPUP_CONFIRMATION(s)        (warningText = s, warningType = WARNING_TYPE_CONFIRM)
   #define WARNING_INFO_FLAGS           ZCHAR
-  #define SET_WARNING_INFO(info, len, flags) (s_warning_info = info, s_warning_info_len = len)
+  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len)
 #endif
 
 #if defined(SDCARD) || (defined(ROTARY_ENCODER_NAVIGATION) && !defined(CPUM64))

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -384,7 +384,7 @@ void displayWarning(uint8_t event);
   extern int16_t warningInputValue;
   extern int16_t warningInputValueMin;
   extern int16_t warningInputValueMax;
-  extern uint8_t s_warning_info_flags;
+  extern uint8_t warningInfoFlags;
 #endif
 
 #if !defined(GUI)
@@ -399,8 +399,8 @@ void displayWarning(uint8_t event);
   #define POPUP_WARNING(s)      (warningText = s, warningInfoText = 0, popupFunc = displayWarning)
   #define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
   #define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
-  #define WARNING_INFO_FLAGS    s_warning_info_flags
-  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, s_warning_info_flags = flags)
+  #define WARNING_INFO_FLAGS    warningInfoFlags
+  #define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, warningInfoFlags = flags)
 #else
   #define DISPLAY_WARNING              displayWarning
   #define POPUP_WARNING(s)             warningText = s

--- a/radio/src/gui/9X/menus.h
+++ b/radio/src/gui/9X/menus.h
@@ -37,8 +37,6 @@
 #ifndef _MENUS_H_
 #define _MENUS_H_
 
-#define NO_HI_LEN  25
-
 #define MENUS_SCROLLBAR_WIDTH  0
 #define MENU_COLUMNS           1
 #define COLUMN_X               0
@@ -61,8 +59,12 @@ typedef uint8_t check_event_t;
 extern vertpos_t menuVerticalPosition;
 extern horzpos_t menuHorizontalPosition;
 extern vertpos_t menuVerticalOffset;
-extern uint8_t s_noHi;
 extern uint8_t calibrationState;
+
+// Temporary no highlight
+extern uint8_t noHighlightCounter;
+#define NO_HIGHLIGHT()        (noHighlightCounter > 0)
+#define START_NO_HIGHLIGHT()  do { noHighlightCounter = 25; } while(0)
 
 void menu_lcd_onoff(coord_t x, coord_t y, uint8_t value, LcdFlags attr);
 

--- a/radio/src/gui/9X/navigation.cpp
+++ b/radio/src/gui/9X/navigation.cpp
@@ -40,8 +40,8 @@ vertpos_t s_pgOfs;
 int8_t s_editMode;
 uint8_t s_noHi;
 uint8_t calibrationState;
-vertpos_t m_posVert;
-horzpos_t m_posHorz;
+vertpos_t menuVerticalPosition;
+horzpos_t menuHorizontalPosition;
 
 #if defined(NAVIGATION_POT1)
 int16_t p1valdiff;
@@ -350,10 +350,10 @@ int8_t checkIncDecGen(uint8_t event, int8_t i_val, int8_t i_min, int8_t i_max)
 tmr10ms_t menuEntryTime;
 #endif
 
-void check(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow)
+void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow)
 {
-  vertpos_t l_posVert = m_posVert;
-  horzpos_t l_posHorz = m_posHorz;
+  vertpos_t l_posVert = menuVerticalPosition;
+  horzpos_t l_posHorz = menuHorizontalPosition;
 
   uint8_t maxcol = MAXCOL(l_posVert);
 
@@ -441,7 +441,7 @@ void check(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t 
       }
 
       if (cc != curr) {
-        chainMenu((MenuFuncP)pgm_read_adr(&menuTab[cc]));
+        chainMenu((menuHandlerFunc)pgm_read_adr(&menuTab[cc]));
       }
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
@@ -692,8 +692,8 @@ void check(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t 
     }
   }
 
-  m_posVert = l_posVert;
-  m_posHorz = l_posHorz;
+  menuVerticalPosition = l_posVert;
+  menuHorizontalPosition = l_posHorz;
 #if !defined(CPUM64)
   // cosmetics on 9x
   if (s_pgOfs > 0) {
@@ -705,7 +705,7 @@ void check(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t 
 #endif
 }
 
-void check_simple(check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, vertpos_t maxrow)
+void check_simple(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, vertpos_t maxrow)
 {
   check(event, curr, menuTab, menuTabSize, 0, 0, maxrow);
 }
@@ -721,6 +721,6 @@ void repeatLastCursorMove(uint8_t event)
     putEvent(event);
   }
   else {
-    m_posHorz = 0;
+    menuHorizontalPosition = 0;
   }
 }

--- a/radio/src/gui/9X/navigation.cpp
+++ b/radio/src/gui/9X/navigation.cpp
@@ -38,7 +38,7 @@
 
 vertpos_t menuVerticalOffset;
 int8_t s_editMode;
-uint8_t s_noHi;
+uint8_t noHighlightCounter;
 uint8_t calibrationState;
 vertpos_t menuVerticalPosition;
 horzpos_t menuHorizontalPosition;

--- a/radio/src/gui/9X/navigation.cpp
+++ b/radio/src/gui/9X/navigation.cpp
@@ -36,7 +36,7 @@
 
 #include "../../opentx.h"
 
-vertpos_t s_pgOfs;
+vertpos_t menuVerticalOffset;
 int8_t s_editMode;
 uint8_t s_noHi;
 uint8_t calibrationState;
@@ -633,7 +633,7 @@ void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, ui
 #if defined(CPUARM)
   int linesCount = maxrow;
   if (l_posVert == 0 || (l_posVert==1 && MAXCOL(vertpos_t(0)) >= HIDDEN_ROW) || (l_posVert==2 && MAXCOL(vertpos_t(0)) >= HIDDEN_ROW && MAXCOL(vertpos_t(1)) >= HIDDEN_ROW)) {
-    s_pgOfs = 0;
+    menuVerticalOffset = 0;
     if (horTab) {
       linesCount = 0;
       for (int i=0; i<maxrow; i++) {
@@ -647,13 +647,13 @@ void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, ui
     if (maxrow > maxLines) {
       while (1) {
         vertpos_t firstLine = 0;
-        for (int numLines=0; firstLine<maxrow && numLines<s_pgOfs; firstLine++) {
+        for (int numLines=0; firstLine<maxrow && numLines<menuVerticalOffset; firstLine++) {
           if (firstLine>=horTabMax || horTab[firstLine+1] != HIDDEN_ROW) {
             numLines++;
           }
         }
         if (l_posVert <= firstLine) {
-          s_pgOfs--;
+          menuVerticalOffset--;
         }
         else {
           vertpos_t lastLine = firstLine;
@@ -663,10 +663,10 @@ void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, ui
             }
           }
           if (l_posVert > lastLine) {
-            s_pgOfs++;
+            menuVerticalOffset++;
           }
           else {
-            linesCount = s_pgOfs + maxLines;
+            linesCount = menuVerticalOffset + maxLines;
             for (int i=lastLine; i<maxrow; i++) {
               if (i>=horTabMax || horTab[i] != HIDDEN_ROW) {
                 linesCount++;
@@ -680,15 +680,15 @@ void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, ui
   }
 #else
   if (l_posVert<1) {
-    s_pgOfs=0;
+    menuVerticalOffset=0;
   }
 #endif
   else {
-    if (l_posVert>maxLines+s_pgOfs) {
-      s_pgOfs = l_posVert-maxLines;
+    if (l_posVert>maxLines+menuVerticalOffset) {
+      menuVerticalOffset = l_posVert-maxLines;
     }
-    else if (l_posVert<=s_pgOfs) {
-      s_pgOfs = l_posVert-1;
+    else if (l_posVert<=menuVerticalOffset) {
+      menuVerticalOffset = l_posVert-1;
     }
   }
 
@@ -696,10 +696,10 @@ void check(check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, ui
   menuHorizontalPosition = l_posHorz;
 #if !defined(CPUM64)
   // cosmetics on 9x
-  if (s_pgOfs > 0) {
+  if (menuVerticalOffset > 0) {
     l_posVert--;
-    if (l_posVert == s_pgOfs && CURSOR_NOT_ALLOWED_IN_ROW(l_posVert)) {
-      s_pgOfs = l_posVert-1;
+    if (l_posVert == menuVerticalOffset && CURSOR_NOT_ALLOWED_IN_ROW(l_posVert)) {
+      menuVerticalOffset = l_posVert-1;
     }
   }
 #endif

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -142,6 +142,7 @@ void (*popupFunc)(uint8_t event) = NULL;
 const char *popupMenuItems[POPUP_MENU_MAX_LINES];
 uint8_t s_menu_item = 0;
 uint16_t popupMenuNoItems = 0;
+uint8_t s_menu_flags = 0;
 uint16_t popupMenuOffset = 0;
 void (*popupMenuHandler)(const char *result);
 const char * displayPopupMenu(uint8_t event)
@@ -154,7 +155,7 @@ const char * displayPopupMenu(uint8_t event)
   lcd_rect(MENU_X, y, MENU_W, display_count * (FH+1) + 2);
 
   for (uint8_t i=0; i<display_count; i++) {
-    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i], 0);
+    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i], s_menu_flags);
     if (i == s_menu_item) drawFilledRect(MENU_X+1, i*(FH+1) + y + 1, MENU_W-2, 9);
   }
 
@@ -223,6 +224,7 @@ const char * displayPopupMenu(uint8_t event)
     case EVT_KEY_BREAK(KEY_EXIT):
       popupMenuNoItems = 0;
       s_menu_item = 0;
+      s_menu_flags = 0;
       popupMenuOffset = 0;
       break;
   }

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -36,17 +36,17 @@
 
 #include "../../opentx.h"
 
-const pm_char * s_warning = NULL;
-const pm_char * s_warning_info;
+const pm_char * warningText = NULL;
+const pm_char * warningInfoText;
 uint8_t         s_warning_info_len;
-uint8_t         s_warning_type;
-uint8_t         s_warning_result = 0;
+uint8_t         warningType;
+uint8_t         warningResult = 0;
 
 #if defined(CPUARM)
 uint8_t         s_warning_info_flags = ZCHAR;
-int16_t         s_warning_input_value;
-int16_t         s_warning_input_min;
-int16_t         s_warning_input_max;
+int16_t         warningInputValue;
+int16_t         warningInputValueMin;
+int16_t         warningInputValueMax;
 #endif
 
 void displayBox()
@@ -54,18 +54,18 @@ void displayBox()
   drawFilledRect(10, 16, LCD_W-20, 40, SOLID, ERASE);
   lcd_rect(10, 16, LCD_W-20, 40);
 #if defined(CPUARM)
-  lcd_putsn(WARNING_LINE_X, WARNING_LINE_Y, s_warning, WARNING_LINE_LEN);
+  lcd_putsn(WARNING_LINE_X, WARNING_LINE_Y, warningText, WARNING_LINE_LEN);
 #else
-  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y, s_warning);
+  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y, warningText);
 #endif
-  // could be a place for a s_warning_info
+  // could be a place for a warningInfoText
 }
 
 void displayPopup(const pm_char * pstr)
 {
-  s_warning = pstr;
+  warningText = pstr;
   displayBox();
-  s_warning = NULL;
+  warningText = NULL;
   lcdRefresh();
 }
 
@@ -100,34 +100,34 @@ void message(const pm_char *title, const pm_char *t, const char *last MESSAGE_SO
 
 void displayWarning(uint8_t event)
 {
-  s_warning_result = false;
+  warningResult = false;
   displayBox();
-  if (s_warning_info) {
-    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, s_warning_info, s_warning_info_len, WARNING_INFO_FLAGS);
+  if (warningInfoText) {
+    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, s_warning_info_len, WARNING_INFO_FLAGS);
   }
-  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, s_warning_type == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
+  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, warningType == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
   switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)
     case EVT_ROTARY_BREAK:
 #endif
     case EVT_KEY_BREAK(KEY_ENTER):
-      if (s_warning_type == WARNING_TYPE_ASTERISK)
+      if (warningType == WARNING_TYPE_ASTERISK)
         break;
-      s_warning_result = true;
+      warningResult = true;
       // no break
 #if defined(ROTARY_ENCODER_NAVIGATION)
     case EVT_ROTARY_LONG:
       killEvents(event);
 #endif
     case EVT_KEY_BREAK(KEY_EXIT):
-      s_warning = NULL;
-      s_warning_type = WARNING_TYPE_ASTERISK;
+      warningText = NULL;
+      warningType = WARNING_TYPE_ASTERISK;
       break;
 #if defined(CPUARM)
     default:
-      if (s_warning_type != WARNING_TYPE_INPUT) break;
+      if (warningType != WARNING_TYPE_INPUT) break;
       s_editMode = EDIT_MODIFY_FIELD;
-      s_warning_input_value = checkIncDec(event, s_warning_input_value, s_warning_input_min, s_warning_input_max);
+      warningInputValue = checkIncDec(event, warningInputValue, warningInputValueMin, warningInputValueMax);
       s_editMode = EDIT_SELECT_FIELD;
       break;
 #endif

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -142,7 +142,7 @@ void (*popupFunc)(uint8_t event) = NULL;
 const char *popupMenuItems[POPUP_MENU_MAX_LINES];
 uint8_t s_menu_item = 0;
 uint16_t popupMenuNoItems = 0;
-uint8_t s_menu_flags = 0;
+uint8_t popupMenuFlags = 0;
 uint16_t popupMenuOffset = 0;
 void (*popupMenuHandler)(const char *result);
 const char * displayPopupMenu(uint8_t event)
@@ -155,7 +155,7 @@ const char * displayPopupMenu(uint8_t event)
   lcd_rect(MENU_X, y, MENU_W, display_count * (FH+1) + 2);
 
   for (uint8_t i=0; i<display_count; i++) {
-    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i], s_menu_flags);
+    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i], popupMenuFlags);
     if (i == s_menu_item) drawFilledRect(MENU_X+1, i*(FH+1) + y + 1, MENU_W-2, 9);
   }
 
@@ -224,7 +224,7 @@ const char * displayPopupMenu(uint8_t event)
     case EVT_KEY_BREAK(KEY_EXIT):
       popupMenuNoItems = 0;
       s_menu_item = 0;
-      s_menu_flags = 0;
+      popupMenuFlags = 0;
       popupMenuOffset = 0;
       break;
   }

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -38,7 +38,7 @@
 
 const pm_char * warningText = NULL;
 const pm_char * warningInfoText;
-uint8_t         s_warning_info_len;
+uint8_t         warningInfoLength;
 uint8_t         warningType;
 uint8_t         warningResult = 0;
 
@@ -103,7 +103,7 @@ void displayWarning(uint8_t event)
   warningResult = false;
   displayBox();
   if (warningInfoText) {
-    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, s_warning_info_len, WARNING_INFO_FLAGS);
+    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, warningInfoLength, WARNING_INFO_FLAGS);
   }
   lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, warningType == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
   switch (event) {

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -139,28 +139,27 @@ void (*popupFunc)(uint8_t event) = NULL;
 #endif
 
 #if defined(NAVIGATION_MENUS)
-const char *s_menu[MENU_MAX_LINES];
+const char *popupMenuItems[POPUP_MENU_MAX_LINES];
 uint8_t s_menu_item = 0;
-uint16_t s_menu_count = 0;
-uint8_t s_menu_flags = 0;
-uint16_t s_menu_offset = 0;
-void (*menuHandler)(const char *result);
-const char * displayMenu(uint8_t event)
+uint16_t popupMenuNoItems = 0;
+uint16_t popupMenuOffset = 0;
+void (*popupMenuHandler)(const char *result);
+const char * displayPopupMenu(uint8_t event)
 {
   const char * result = NULL;
 
-  uint8_t display_count = min<uint8_t>(s_menu_count, MENU_MAX_LINES);
+  uint8_t display_count = min<uint8_t>(popupMenuNoItems, POPUP_MENU_MAX_LINES);
   uint8_t y = (display_count >= 5 ? MENU_Y - FH - 1 : MENU_Y);
   drawFilledRect(MENU_X, y, MENU_W, display_count * (FH+1) + 2, SOLID, ERASE);
   lcd_rect(MENU_X, y, MENU_W, display_count * (FH+1) + 2);
 
   for (uint8_t i=0; i<display_count; i++) {
-    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, s_menu[i], s_menu_flags);
+    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i], 0);
     if (i == s_menu_item) drawFilledRect(MENU_X+1, i*(FH+1) + y + 1, MENU_W-2, 9);
   }
 
-  if (s_menu_count > display_count) {
-    displayScrollbar(MENU_X+MENU_W-1, y+1, MENU_MAX_LINES * (FH+1), s_menu_offset, s_menu_count, MENU_MAX_LINES);
+  if (popupMenuNoItems > display_count) {
+    displayScrollbar(MENU_X+MENU_W-1, y+1, POPUP_MENU_MAX_LINES * (FH+1), popupMenuOffset, popupMenuNoItems, POPUP_MENU_MAX_LINES);
   }
 
   switch(event) {
@@ -173,16 +172,16 @@ const char * displayMenu(uint8_t event)
         s_menu_item--;
       }
 #if defined(SDCARD)
-      else if (s_menu_offset > 0) {
-        s_menu_offset--;
+      else if (popupMenuOffset > 0) {
+        popupMenuOffset--;
         result = STR_UPDATE_LIST;
       }
 #endif
       else {
         s_menu_item = display_count - 1;
 #if defined(SDCARD)
-        if (s_menu_count > MENU_MAX_LINES) {
-          s_menu_offset = s_menu_count - display_count;
+        if (popupMenuNoItems > POPUP_MENU_MAX_LINES) {
+          popupMenuOffset = popupMenuNoItems - display_count;
           result = STR_UPDATE_LIST;
         }
 #endif
@@ -194,20 +193,20 @@ const char * displayMenu(uint8_t event)
 #endif
     case EVT_KEY_FIRST(KEY_MOVE_DOWN):
     case EVT_KEY_REPT(KEY_MOVE_DOWN):
-      if (s_menu_item < display_count - 1 && s_menu_offset + s_menu_item + 1 < s_menu_count) {
+      if (s_menu_item < display_count - 1 && popupMenuOffset + s_menu_item + 1 < popupMenuNoItems) {
         s_menu_item++;
       }
 #if defined(SDCARD)
-      else if (s_menu_count > s_menu_offset + display_count) {
-        s_menu_offset++;
+      else if (popupMenuNoItems > popupMenuOffset + display_count) {
+        popupMenuOffset++;
         result = STR_UPDATE_LIST;
       }
 #endif
       else {
         s_menu_item = 0;
 #if defined(SDCARD)
-        if (s_menu_offset) {
-          s_menu_offset = 0;
+        if (popupMenuOffset) {
+          popupMenuOffset = 0;
           result = STR_UPDATE_LIST;
         }
 #endif
@@ -215,17 +214,16 @@ const char * displayMenu(uint8_t event)
       break;
     CASE_EVT_ROTARY_BREAK
     case EVT_KEY_BREAK(KEY_ENTER):
-      result = s_menu[s_menu_item];
+      result = popupMenuItems[s_menu_item];
       // no break
 #if defined(ROTARY_ENCODER_NAVIGATION)
     CASE_EVT_ROTARY_LONG
       killEvents(event);
 #endif
     case EVT_KEY_BREAK(KEY_EXIT):
-      s_menu_count = 0;
+      popupMenuNoItems = 0;
       s_menu_item = 0;
-      s_menu_flags = 0;
-      s_menu_offset = 0;
+      popupMenuOffset = 0;
       break;
   }
 

--- a/radio/src/gui/9X/popups.cpp
+++ b/radio/src/gui/9X/popups.cpp
@@ -43,7 +43,7 @@ uint8_t         warningType;
 uint8_t         warningResult = 0;
 
 #if defined(CPUARM)
-uint8_t         s_warning_info_flags = ZCHAR;
+uint8_t         warningInfoFlags = ZCHAR;
 int16_t         warningInputValue;
 int16_t         warningInputValueMin;
 int16_t         warningInputValueMax;

--- a/radio/src/gui/9X/view_main.cpp
+++ b/radio/src/gui/9X/view_main.cpp
@@ -573,12 +573,12 @@ void menuMainView(uint8_t event)
 #if defined(GVARS) && !defined(PCBSTD)
   if (s_gvar_timer > 0) {
     s_gvar_timer--;
-    s_warning = STR_GLOBAL_VAR;
+    warningText = STR_GLOBAL_VAR;
     displayBox();
     lcd_putsnAtt(16, 5*FH, g_model.gvars[s_gvar_last].name, LEN_GVAR_NAME, ZCHAR);
     lcd_putsAtt(16+7*FW, 5*FH, PSTR("[\010]"), BOLD);
     lcd_outdezAtt(16+7*FW+4*FW+FW/2, 5*FH, GVAR_VALUE(s_gvar_last, getGVarFlightPhase(mixerCurrentFlightMode, s_gvar_last)), BOLD);
-    s_warning = NULL;
+    warningText = NULL;
   }
 #endif
 

--- a/radio/src/gui/9X/view_main.cpp
+++ b/radio/src/gui/9X/view_main.cpp
@@ -262,12 +262,12 @@ void onMainViewMenu(const char *result)
     pushModelNotes();
   }
   else if (result == STR_RESET_SUBMENU) {
-    MENU_ADD_ITEM(STR_RESET_FLIGHT);
-    MENU_ADD_ITEM(STR_RESET_TIMER1);
-    MENU_ADD_ITEM(STR_RESET_TIMER2);
-    MENU_ADD_ITEM(STR_RESET_TIMER3);
+    POPUP_MENU_ADD_ITEM(STR_RESET_FLIGHT);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER1);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER2);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER3);
 #if defined(FRSKY)
-    MENU_ADD_ITEM(STR_RESET_TELEMETRY);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TELEMETRY);
 #endif
   }
 #endif
@@ -336,26 +336,26 @@ void menuMainView(uint8_t event)
 
 #if defined(CPUARM)
       if (modelHasNotes()) {
-        MENU_ADD_ITEM(STR_VIEW_NOTES);
+        POPUP_MENU_ADD_ITEM(STR_VIEW_NOTES);
       }
 #endif
 
 #if defined(CPUARM)
-      MENU_ADD_ITEM(STR_RESET_SUBMENU);
+      POPUP_MENU_ADD_ITEM(STR_RESET_SUBMENU);
 #else
-      MENU_ADD_ITEM(STR_RESET_TIMER1);
-      MENU_ADD_ITEM(STR_RESET_TIMER2);
+      POPUP_MENU_ADD_ITEM(STR_RESET_TIMER1);
+      POPUP_MENU_ADD_ITEM(STR_RESET_TIMER2);
 #if defined(FRSKY)
-      MENU_ADD_ITEM(STR_RESET_TELEMETRY);
+      POPUP_MENU_ADD_ITEM(STR_RESET_TELEMETRY);
 #endif
-      MENU_ADD_ITEM(STR_RESET_FLIGHT);
+      POPUP_MENU_ADD_ITEM(STR_RESET_FLIGHT);
 #endif
 
-      MENU_ADD_ITEM(STR_STATISTICS);
+      POPUP_MENU_ADD_ITEM(STR_STATISTICS);
 #if defined(CPUARM)
-      MENU_ADD_ITEM(STR_ABOUT_US);
+      POPUP_MENU_ADD_ITEM(STR_ABOUT_US);
 #endif
-      menuHandler = onMainViewMenu;
+      popupMenuHandler = onMainViewMenu;
       break;
 #endif
 

--- a/radio/src/gui/9X/view_mavlink.cpp
+++ b/radio/src/gui/9X/view_mavlink.cpp
@@ -506,7 +506,7 @@ void menuTelemetryMavlinkSetup(uint8_t event) {
 
 	for (uint8_t i=0; i<LCD_LINES-1; i++) {
 		uint8_t y = 1 + 1*FH + i*FH;
-		uint8_t k = i+s_pgOfs;
+		uint8_t k = i+menuVerticalOffset;
 		uint8_t blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
 		uint8_t attr = (sub == k ? blink : 0);
 		switch(k) {	

--- a/radio/src/gui/9X/view_mavlink.cpp
+++ b/radio/src/gui/9X/view_mavlink.cpp
@@ -502,7 +502,7 @@ void menuTelemetryMavlinkSetup(uint8_t event) {
 	
 	MENU(STR_MAVMENUSETUP_TITLE, menuTabModel, e_MavSetup, ITEM_MAVLINK_MAX + 1, {0, 0, 1/*to force edit mode*/});
 	
-	uint8_t sub = m_posVert - 1;
+	uint8_t sub = menuVerticalPosition - 1;
 
 	for (uint8_t i=0; i<LCD_LINES-1; i++) {
 		uint8_t y = 1 + 1*FH + i*FH;

--- a/radio/src/gui/9X/view_text.cpp
+++ b/radio/src/gui/9X/view_text.cpp
@@ -57,13 +57,13 @@ void readTextFile(int & lines_count)
 
   result = f_open(&file, s_text_file, FA_OPEN_EXISTING | FA_READ);
   if (result == FR_OK) {
-    for (int i=0; i<TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz)==FR_OK && sz==1 && (lines_count==0 || current_line-s_pgOfs<LCD_LINES-1); i++) {
+    for (int i=0; i<TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz)==FR_OK && sz==1 && (lines_count==0 || current_line-menuVerticalOffset<LCD_LINES-1); i++) {
       if (c == '\n') {
         ++current_line;
         line_length = 0;
         escape = 0;
       }
-      else if (c!='\r' && current_line>=s_pgOfs && current_line-s_pgOfs<LCD_LINES-1 && line_length<LCD_COLS) {
+      else if (c!='\r' && current_line>=menuVerticalOffset && current_line-menuVerticalOffset<LCD_LINES-1 && line_length<LCD_COLS) {
         if (c=='\\' && escape==0) {
           escape = 1;
           continue;
@@ -90,7 +90,7 @@ void readTextFile(int & lines_count)
           c = 0x1D; //tab
         }
         escape = 0;
-        s_text_screen[current_line-s_pgOfs][line_length++] = c;
+        s_text_screen[current_line-menuVerticalOffset][line_length++] = c;
       }
     }
     if (c != '\n') {
@@ -110,24 +110,24 @@ void menuTextView(uint8_t event)
 
   switch (event) {
     case EVT_ENTRY:
-      s_pgOfs = 0;
+      menuVerticalOffset = 0;
       lines_count = 0;
       readTextFile(lines_count);
       break;
 
     case EVT_KEY_FIRST(KEY_UP):
-      if (s_pgOfs == 0)
+      if (menuVerticalOffset == 0)
         break;
       else
-        s_pgOfs--;
+        menuVerticalOffset--;
         // no break;
 
     case EVT_KEY_FIRST(KEY_DOWN):
       // if (event == EVT_KEY_BREAK(KEY_DOWN)) {
-        if (s_pgOfs+LCD_LINES-1 >= lines_count)
+        if (menuVerticalOffset+LCD_LINES-1 >= lines_count)
           break;
         else
-          ++s_pgOfs;
+          ++menuVerticalOffset;
       // }
       readTextFile(lines_count);
       break;
@@ -151,7 +151,7 @@ void menuTextView(uint8_t event)
   lcd_invert_line(0);
 
   if (lines_count > LCD_LINES-1) {
-    displayScrollbar(LCD_W-1, FH, LCD_H-FH, s_pgOfs, lines_count, LCD_LINES-1);
+    displayScrollbar(LCD_W-1, FH, LCD_H-FH, menuVerticalOffset, lines_count, LCD_LINES-1);
   }
 }
 

--- a/radio/src/gui/9X/widgets.cpp
+++ b/radio/src/gui/9X/widgets.cpp
@@ -92,7 +92,7 @@ select_menu_value_t selectMenuItem(coord_t x, coord_t y, const pm_char *label, c
 {
   lcd_putsColumnLeft(x, y, label);
   if (values) lcd_putsiAtt(x, y, values, value-min, attr);
-  if (attr) value = checkIncDec(event, value, min, max, (g_menuPos[0] == 0) ? EE_MODEL : EE_GENERAL);
+  if (attr) value = checkIncDec(event, value, min, max, (menuVerticalPositions[0] == 0) ? EE_MODEL : EE_GENERAL);
   return value;
 }
 

--- a/radio/src/gui/Taranis/gui.h
+++ b/radio/src/gui/Taranis/gui.h
@@ -43,7 +43,7 @@
 
 struct MenuItem {
   const char *name;
-  const MenuFuncP action;
+  const menuHandlerFunc action;
 };
 
 int circularIncDec(int current, int inc, int min, int max, IsValueAvailable isValueAvailable=NULL);

--- a/radio/src/gui/Taranis/helpers.cpp
+++ b/radio/src/gui/Taranis/helpers.cpp
@@ -273,7 +273,7 @@ bool isSwitchAvailableInLogicalSwitches(int swtch)
 
 bool isSwitchAvailableInCustomFunctions(int swtch)
 {
-  if (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions)
+  if (menuHandlers[menuLevel] == menuModelCustomFunctions)
     return isSwitchAvailable(swtch, ModelCustomFunctionsContext);
   else
     return isSwitchAvailable(swtch, GeneralCustomFunctionsContext);
@@ -318,7 +318,7 @@ bool isLogicalSwitchFunctionAvailable(int function)
 bool isAssignableFunctionAvailable(int function)
 {
 #if defined(OVERRIDE_CHANNEL_FUNCTION) || defined(GVARS)
-  bool modelFunctions = (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions);
+  bool modelFunctions = (menuHandlers[menuLevel] == menuModelCustomFunctions);
 #endif
 
   switch (function) {

--- a/radio/src/gui/Taranis/lcd.cpp
+++ b/radio/src/gui/Taranis/lcd.cpp
@@ -225,20 +225,11 @@ void lcd_putsnAtt(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdFlags
   uint32_t fontsize = FONTSIZE(flags);
   bool setx = false;
   while (len--) {
-    unsigned char c;
-    switch (flags & (BSS+ZCHAR)) {
-      case BSS:
-        c = *s;
-        break;
-#if !defined(BOOT)
-      case ZCHAR:
-        c = idx2char(*s);
-        break;
+#if defined(BOOT)
+    unsigned char c = *s;
+#else
+    unsigned char c = (flags & ZCHAR) ? idx2char(*s) : *s;
 #endif
-      default:
-        c = pgm_read_byte(s);
-        break;
-    }
 
     if (setx) {
       x = c;
@@ -305,7 +296,7 @@ void lcd_putsLeft(coord_t y, const pm_char * s)
 void lcd_putsiAtt(coord_t x, coord_t y, const pm_char * s,uint8_t idx, LcdFlags flags)
 {
   uint8_t length = pgm_read_byte(s++);
-  lcd_putsnAtt(x, y, s+length*idx, length, flags & ~(BSS|ZCHAR));
+  lcd_putsnAtt(x, y, s+length*idx, length, flags & ~ZCHAR);
 }
 
 void lcd_outhex4(coord_t x, coord_t y, uint32_t val, LcdFlags flags)

--- a/radio/src/gui/Taranis/lcd.h
+++ b/radio/src/gui/Taranis/lcd.h
@@ -74,11 +74,6 @@
 /* lcd puts flags */
 /* no 0x80 here because of "GV"1 which is aligned LEFT */
 /* no 0x10 here because of "MODEL"01 which uses LEADING0 */
-#if defined(CPUARM)
-  #define BSS           0x00
-#else
-  #define BSS           0x20
-#endif
 #define ZCHAR           0x80
 
 /* lcd outdez flags */

--- a/radio/src/gui/Taranis/menu_general_hardware.cpp
+++ b/radio/src/gui/Taranis/menu_general_hardware.cpp
@@ -100,7 +100,7 @@ void menuGeneralHardware(uint8_t event)
 {
   MENU(STR_HARDWARE, menuTabGeneral, e_Hardware, ITEM_SETUP_HW_MAX, { LABEL(Sticks), 0, 0, 0, 0, LABEL(Pots), POTS_ROWS, LABEL(Switches), SWITCHES_ROWS, BLUETOOTH_ROWS 0 });
 
-  uint8_t sub = m_posVert;
+  uint8_t sub = menuVerticalPosition;
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -135,13 +135,13 @@ void menuGeneralHardware(uint8_t event)
       {
         int idx = k - ITEM_SETUP_HW_LS2;
         uint8_t mask = (0x01 << idx);
-        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+NUM_XPOTS+2+idx+1, m_posHorz < 0 ? attr : 0);
-        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx]) || (attr && m_posHorz == 0))
-          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx], LEN_ANA_NAME, event, attr && m_posHorz == 0);
+        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+NUM_XPOTS+2+idx+1, menuHorizontalPosition < 0 ? attr : 0);
+        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx]) || (attr && menuHorizontalPosition == 0))
+          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx], LEN_ANA_NAME, event, attr && menuHorizontalPosition == 0);
         else
           lcd_putsiAtt(HW_SETTINGS_COLUMN, y, STR_MMMINV, 0, 0);
         uint8_t potType = (g_eeGeneral.slidersConfig & mask) >> idx;
-        potType = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_SLIDERTYPES, potType, SLIDER_NONE, SLIDER_WITH_DETENT, m_posHorz == 1 ? attr : 0, event);
+        potType = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_SLIDERTYPES, potType, SLIDER_NONE, SLIDER_WITH_DETENT, menuHorizontalPosition == 1 ? attr : 0, event);
         g_eeGeneral.slidersConfig &= ~mask;
         g_eeGeneral.slidersConfig |= (potType << idx);
         break;
@@ -162,13 +162,13 @@ void menuGeneralHardware(uint8_t event)
         int idx = k - ITEM_SETUP_HW_POT1;
         uint8_t shift = (2*idx);
         uint8_t mask = (0x03 << shift);
-        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+idx+1, m_posHorz < 0 ? attr : 0);
-        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+idx]) || (attr && m_posHorz == 0))
-          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+idx], LEN_ANA_NAME, event, attr && m_posHorz == 0);
+        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+idx+1, menuHorizontalPosition < 0 ? attr : 0);
+        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+idx]) || (attr && menuHorizontalPosition == 0))
+          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+idx], LEN_ANA_NAME, event, attr && menuHorizontalPosition == 0);
         else
           lcd_putsiAtt(HW_SETTINGS_COLUMN, y, STR_MMMINV, 0, 0);
         uint8_t potType = (g_eeGeneral.potsConfig & mask) >> shift;
-        potType = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_POTTYPES, potType, POT_NONE, POT_WITHOUT_DETENT, m_posHorz == 1 ? attr : 0, event);
+        potType = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_POTTYPES, potType, POT_NONE, POT_WITHOUT_DETENT, menuHorizontalPosition == 1 ? attr : 0, event);
         g_eeGeneral.potsConfig &= ~mask;
         g_eeGeneral.potsConfig |= (potType << shift);
         break;
@@ -199,12 +199,12 @@ void menuGeneralHardware(uint8_t event)
       {
         int index = k-ITEM_SETUP_HW_SA;
         int config = SWITCH_CONFIG(index);
-        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, MIXSRC_FIRST_SWITCH-MIXSRC_Rud+index+1, m_posHorz < 0 ? attr : 0);
-        if (ZEXIST(g_eeGeneral.switchNames[index]) || (attr && m_posHorz == 0))
-          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.switchNames[index], LEN_SWITCH_NAME, event, m_posHorz == 0 ? attr : 0);
+        lcd_putsiAtt(INDENT_WIDTH, y, STR_VSRCRAW, MIXSRC_FIRST_SWITCH-MIXSRC_Rud+index+1, menuHorizontalPosition < 0 ? attr : 0);
+        if (ZEXIST(g_eeGeneral.switchNames[index]) || (attr && menuHorizontalPosition == 0))
+          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.switchNames[index], LEN_SWITCH_NAME, event, menuHorizontalPosition == 0 ? attr : 0);
         else
           lcd_putsiAtt(HW_SETTINGS_COLUMN, y, STR_MMMINV, 0, 0);
-        config = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_SWTYPES, config, SWITCH_NONE, SWITCH_TYPE_MAX(index), m_posHorz == 1 ? attr : 0, event);
+        config = selectMenuItem(HW_SETTINGS_COLUMN+5*FW, y, "", STR_SWTYPES, config, SWITCH_NONE, SWITCH_TYPE_MAX(index), menuHorizontalPosition == 1 ? attr : 0, event);
         if (attr && checkIncDec_Ret) {
           swconfig_t mask = (swconfig_t)0x03 << (2*index);
           g_eeGeneral.switchConfig = (g_eeGeneral.switchConfig & ~mask) | ((swconfig_t(config) & 0x03) << (2*index));
@@ -214,11 +214,11 @@ void menuGeneralHardware(uint8_t event)
 #if defined(REV9E)
       case ITEM_SETUP_HW_BLUETOOTH:
         lcd_putsLeft(y, "Bluetooth");
-        menu_lcd_onoff(HW_SETTINGS_COLUMN, y, g_eeGeneral.bluetoothEnable, m_posHorz == 0 ? attr : 0);
-        if (attr && m_posHorz == 0) {
+        menu_lcd_onoff(HW_SETTINGS_COLUMN, y, g_eeGeneral.bluetoothEnable, menuHorizontalPosition == 0 ? attr : 0);
+        if (attr && menuHorizontalPosition == 0) {
           g_eeGeneral.bluetoothEnable = checkIncDecGen(event, g_eeGeneral.bluetoothEnable, 0, 1);
         }
-        editName(HW_SETTINGS_COLUMN+5*FW, y, g_eeGeneral.bluetoothName, LEN_BLUETOOTH_NAME, event, m_posHorz == 1 ? attr : 0);
+        editName(HW_SETTINGS_COLUMN+5*FW, y, g_eeGeneral.bluetoothName, LEN_BLUETOOTH_NAME, event, menuHorizontalPosition == 1 ? attr : 0);
         break;
 #endif
       case ITEM_SETUP_HW_UART3_MODE:

--- a/radio/src/gui/Taranis/menu_general_hardware.cpp
+++ b/radio/src/gui/Taranis/menu_general_hardware.cpp
@@ -104,7 +104,7 @@ void menuGeneralHardware(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i + s_pgOfs;
+    int k = i + menuVerticalOffset;
     for (int j=0; j<=k; j++) {
       if (mstate_tab[j] == HIDDEN_ROW)
         k++;

--- a/radio/src/gui/Taranis/menu_general_sdmanager.cpp
+++ b/radio/src/gui/Taranis/menu_general_sdmanager.cpp
@@ -276,9 +276,9 @@ void menuGeneralSdManager(uint8_t _event)
     case EVT_KEY_LONG(KEY_MENU):
       if (!READ_ONLY() && s_editMode == 0) {
         killEvents(_event);
-        MENU_ADD_ITEM(STR_SD_INFO);
-        MENU_ADD_ITEM(STR_SD_FORMAT);
-        menuHandler = onSdManagerMenu;
+        POPUP_MENU_ADD_ITEM(STR_SD_INFO);
+        POPUP_MENU_ADD_ITEM(STR_SD_FORMAT);
+        popupMenuHandler = onSdManagerMenu;
       }
       break;
 
@@ -313,43 +313,43 @@ void menuGeneralSdManager(uint8_t _event)
         }
         if (ext) {
           if (!strcasecmp(ext, SOUNDS_EXT)) {
-            MENU_ADD_ITEM(STR_PLAY_FILE);
+            POPUP_MENU_ADD_ITEM(STR_PLAY_FILE);
           }
           else if (!strcasecmp(ext, BITMAPS_EXT)) {
             if (!READ_ONLY() && (ext-line) <= (int)sizeof(g_model.header.bitmap)) {
-              MENU_ADD_ITEM(STR_ASSIGN_BITMAP);
+              POPUP_MENU_ADD_ITEM(STR_ASSIGN_BITMAP);
             }
           }
           else if (!strcasecmp(ext, TEXT_EXT)) {
-            MENU_ADD_ITEM(STR_VIEW_TEXT);
+            POPUP_MENU_ADD_ITEM(STR_VIEW_TEXT);
           }
 #if defined(LUA)
           else if (!strcasecmp(ext, SCRIPTS_EXT)) {
-            MENU_ADD_ITEM(STR_EXECUTE_FILE);
+            POPUP_MENU_ADD_ITEM(STR_EXECUTE_FILE);
           }
 #endif
           else if (!READ_ONLY() && !strcasecmp(ext, FIRMWARE_EXT)) {
             TCHAR lfn[_MAX_LFN + 1];
             getSelectionFullPath(lfn);
             if (isBootloader(lfn)) {
-              MENU_ADD_ITEM(STR_FLASH_BOOTLOADER);
+              POPUP_MENU_ADD_ITEM(STR_FLASH_BOOTLOADER);
             }
           }
           else if (!READ_ONLY() && !strcasecmp(ext, SPORT_FIRMWARE_EXT)) {
-            MENU_ADD_ITEM(STR_FLASH_EXTERNAL_DEVICE);
-            MENU_ADD_ITEM(STR_FLASH_INTERNAL_MODULE);
+            POPUP_MENU_ADD_ITEM(STR_FLASH_EXTERNAL_DEVICE);
+            POPUP_MENU_ADD_ITEM(STR_FLASH_INTERNAL_MODULE);
           }
         }
         if (!READ_ONLY()) {
           if (IS_FILE(line)) // it's a file
-            MENU_ADD_ITEM(STR_COPY_FILE);
+            POPUP_MENU_ADD_ITEM(STR_COPY_FILE);
           if (clipboard.type == CLIPBOARD_TYPE_SD_FILE)
-            MENU_ADD_ITEM(STR_PASTE);
-          MENU_ADD_ITEM(STR_RENAME_FILE);
+            POPUP_MENU_ADD_ITEM(STR_PASTE);
+          POPUP_MENU_ADD_ITEM(STR_RENAME_FILE);
           if (IS_FILE(line))
-            MENU_ADD_ITEM(STR_DELETE_FILE);
+            POPUP_MENU_ADD_ITEM(STR_DELETE_FILE);
         }
-        menuHandler = onSdManagerMenu;
+        popupMenuHandler = onSdManagerMenu;
       }
       break;
   }

--- a/radio/src/gui/Taranis/menu_general_sdmanager.cpp
+++ b/radio/src/gui/Taranis/menu_general_sdmanager.cpp
@@ -36,7 +36,7 @@
 
 #include "../../opentx.h"
 
-#define REFRESH_FILES()        do { reusableBuffer.sdmanager.offset = 65535; m_posVert = 0; } while(0)
+#define REFRESH_FILES()        do { reusableBuffer.sdmanager.offset = 65535; menuVerticalPosition = 0; } while(0)
 #define NODE_TYPE(fname)       fname[SD_SCREEN_FILE_LENGTH+1]
 #define IS_DIRECTORY(fname)    ((bool)(!NODE_TYPE(fname)))
 #define IS_FILE(fname)         ((bool)(NODE_TYPE(fname)))
@@ -150,7 +150,7 @@ void getSelectionFullPath(char *lfn)
 {
   f_getcwd(lfn, _MAX_LFN);
   strcat(lfn, PSTR("/"));
-  strcat(lfn, reusableBuffer.sdmanager.lines[m_posVert - s_pgOfs]);
+  strcat(lfn, reusableBuffer.sdmanager.lines[menuVerticalPosition - s_pgOfs]);
 }
 
 void onSdManagerMenu(const char *result)
@@ -159,7 +159,7 @@ void onSdManagerMenu(const char *result)
 
   // TODO possible buffer overflows here!
 
-  uint8_t index = m_posVert-s_pgOfs;
+  uint8_t index = menuVerticalPosition-s_pgOfs;
   char *line = reusableBuffer.sdmanager.lines[index];
 
   if (result == STR_SD_INFO) {
@@ -259,12 +259,12 @@ void menuGeneralSdManager(uint8_t _event)
     }
   }
 
-  int lastPos = m_posVert;
+  int lastPos = menuVerticalPosition;
 
   uint8_t event = (EVT_KEY_MASK(_event) == KEY_ENTER ? 0 : _event);
   SIMPLE_MENU(SD_IS_HC() ? STR_SDHC_CARD : STR_SD_CARD, menuTabGeneral, e_Sd, reusableBuffer.sdmanager.count);
 
-  int index = m_posVert-s_pgOfs;
+  int index = menuVerticalPosition-s_pgOfs;
 
   switch(_event) {
     case EVT_ENTRY:
@@ -294,7 +294,7 @@ void menuGeneralSdManager(uint8_t _event)
         if (IS_DIRECTORY(reusableBuffer.sdmanager.lines[index])) {
           f_chdir(reusableBuffer.sdmanager.lines[index]);
           s_pgOfs = 0;
-          m_posVert = 1;
+          menuVerticalPosition = 1;
           index = 1;
           REFRESH_FILES();
           killEvents(_event);
@@ -473,7 +473,7 @@ void menuGeneralSdManager(uint8_t _event)
 
   char *ext = getFileExtension(reusableBuffer.sdmanager.lines[index], SD_SCREEN_FILE_LENGTH+1);
   if (ext && !strcasecmp(ext, BITMAPS_EXT)) {
-    if (lastPos != m_posVert) {
+    if (lastPos != menuVerticalPosition) {
       if (bmpLoad(modelBitmap, reusableBuffer.sdmanager.lines[index], MODEL_BITMAP_WIDTH, MODEL_BITMAP_HEIGHT)) {
         memcpy(modelBitmap, logo_taranis, MODEL_BITMAP_SIZE);
       }

--- a/radio/src/gui/Taranis/menu_general_sdmanager.cpp
+++ b/radio/src/gui/Taranis/menu_general_sdmanager.cpp
@@ -446,7 +446,7 @@ void menuGeneralSdManager(uint8_t _event)
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
     lcdNextPos = 0;
-    LcdFlags attr = (index == i ? BSS|INVERS : BSS);
+    LcdFlags attr = (index == i ? INVERS : 0);
     if (reusableBuffer.sdmanager.lines[i][0]) {
       if (IS_DIRECTORY(reusableBuffer.sdmanager.lines[i])) { lcd_putcAtt(0, y, '[', s_editMode == EDIT_MODIFY_STRING ? 0 : attr); }
       if (s_editMode == EDIT_MODIFY_STRING && attr) {

--- a/radio/src/gui/Taranis/menu_general_sdmanager.cpp
+++ b/radio/src/gui/Taranis/menu_general_sdmanager.cpp
@@ -150,7 +150,7 @@ void getSelectionFullPath(char *lfn)
 {
   f_getcwd(lfn, _MAX_LFN);
   strcat(lfn, PSTR("/"));
-  strcat(lfn, reusableBuffer.sdmanager.lines[menuVerticalPosition - s_pgOfs]);
+  strcat(lfn, reusableBuffer.sdmanager.lines[menuVerticalPosition - menuVerticalOffset]);
 }
 
 void onSdManagerMenu(const char *result)
@@ -159,7 +159,7 @@ void onSdManagerMenu(const char *result)
 
   // TODO possible buffer overflows here!
 
-  uint8_t index = menuVerticalPosition-s_pgOfs;
+  uint8_t index = menuVerticalPosition-menuVerticalOffset;
   char *line = reusableBuffer.sdmanager.lines[index];
 
   if (result == STR_SD_INFO) {
@@ -264,7 +264,7 @@ void menuGeneralSdManager(uint8_t _event)
   uint8_t event = (EVT_KEY_MASK(_event) == KEY_ENTER ? 0 : _event);
   SIMPLE_MENU(SD_IS_HC() ? STR_SDHC_CARD : STR_SD_CARD, menuTabGeneral, e_Sd, reusableBuffer.sdmanager.count);
 
-  int index = menuVerticalPosition-s_pgOfs;
+  int index = menuVerticalPosition-menuVerticalOffset;
 
   switch(_event) {
     case EVT_ENTRY:
@@ -293,7 +293,7 @@ void menuGeneralSdManager(uint8_t _event)
       else {
         if (IS_DIRECTORY(reusableBuffer.sdmanager.lines[index])) {
           f_chdir(reusableBuffer.sdmanager.lines[index]);
-          s_pgOfs = 0;
+          menuVerticalOffset = 0;
           menuVerticalPosition = 1;
           index = 1;
           REFRESH_FILES();
@@ -354,7 +354,7 @@ void menuGeneralSdManager(uint8_t _event)
       break;
   }
 
-  if (reusableBuffer.sdmanager.offset != s_pgOfs) {
+  if (reusableBuffer.sdmanager.offset != menuVerticalOffset) {
     FILINFO fno;
     DIR dir;
     char *fn;   /* This function is assuming non-Unicode cfg. */
@@ -362,15 +362,15 @@ void menuGeneralSdManager(uint8_t _event)
     fno.lfname = lfn;
     fno.lfsize = sizeof(lfn);
     
-    if (s_pgOfs == 0) {
+    if (menuVerticalOffset == 0) {
       reusableBuffer.sdmanager.offset = 0;
       memset(reusableBuffer.sdmanager.lines, 0, sizeof(reusableBuffer.sdmanager.lines));
     }
-    else if (s_pgOfs == reusableBuffer.sdmanager.count-7) {
-      reusableBuffer.sdmanager.offset = s_pgOfs;
+    else if (menuVerticalOffset == reusableBuffer.sdmanager.count-7) {
+      reusableBuffer.sdmanager.offset = menuVerticalOffset;
       memset(reusableBuffer.sdmanager.lines, 0, sizeof(reusableBuffer.sdmanager.lines));
     }
-    else if (s_pgOfs > reusableBuffer.sdmanager.offset) {
+    else if (menuVerticalOffset > reusableBuffer.sdmanager.offset) {
       memmove(reusableBuffer.sdmanager.lines[0], reusableBuffer.sdmanager.lines[1], 6*sizeof(reusableBuffer.sdmanager.lines[0]));
       memset(reusableBuffer.sdmanager.lines[6], 0xff, SD_SCREEN_FILE_LENGTH);
       NODE_TYPE(reusableBuffer.sdmanager.lines[6]) = 1;
@@ -399,7 +399,7 @@ void menuGeneralSdManager(uint8_t _event)
 
         bool isfile = !(fno.fattrib & AM_DIR);
 
-        if (s_pgOfs == 0) {
+        if (menuVerticalOffset == 0) {
           for (int i=0; i<NUM_BODY_LINES; i++) {
             char *line = reusableBuffer.sdmanager.lines[i];
             if (line[0] == '\0' || isFilenameLower(isfile, fn, line)) {
@@ -411,7 +411,7 @@ void menuGeneralSdManager(uint8_t _event)
             }
           }
         }
-        else if (reusableBuffer.sdmanager.offset == s_pgOfs) {
+        else if (reusableBuffer.sdmanager.offset == menuVerticalOffset) {
           for (int8_t i=6; i>=0; i--) {
             char *line = reusableBuffer.sdmanager.lines[i];
             if (line[0] == '\0' || isFilenameGreater(isfile, fn, line)) {
@@ -423,7 +423,7 @@ void menuGeneralSdManager(uint8_t _event)
             }
           }
         }
-        else if (s_pgOfs > reusableBuffer.sdmanager.offset) {
+        else if (menuVerticalOffset > reusableBuffer.sdmanager.offset) {
           if (isFilenameGreater(isfile, fn, reusableBuffer.sdmanager.lines[5]) && isFilenameLower(isfile, fn, reusableBuffer.sdmanager.lines[6])) {
             memset(reusableBuffer.sdmanager.lines[6], 0, sizeof(reusableBuffer.sdmanager.lines[0]));
             strcpy(reusableBuffer.sdmanager.lines[6], fn);
@@ -441,7 +441,7 @@ void menuGeneralSdManager(uint8_t _event)
     }
   }
 
-  reusableBuffer.sdmanager.offset = s_pgOfs;
+  reusableBuffer.sdmanager.offset = menuVerticalOffset;
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/Taranis/menu_general_sdmanager.cpp
+++ b/radio/src/gui/Taranis/menu_general_sdmanager.cpp
@@ -245,8 +245,8 @@ void onSdManagerMenu(const char *result)
 
 void menuGeneralSdManager(uint8_t _event)
 {
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     displayPopup(STR_FORMATTING);
     closeLogs();
     audioQueue.stopSD();

--- a/radio/src/gui/Taranis/menu_general_setup.cpp
+++ b/radio/src/gui/Taranis/menu_general_setup.cpp
@@ -134,7 +134,7 @@ void menuGeneralSetup(uint8_t event)
 
   for (unsigned int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
     uint8_t blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
     uint8_t attr = (sub == k ? blink : 0);
 

--- a/radio/src/gui/Taranis/menu_general_setup.cpp
+++ b/radio/src/gui/Taranis/menu_general_setup.cpp
@@ -112,7 +112,7 @@ void menuGeneralSetup(uint8_t event)
   struct gtm t;
   gettime(&t);
 
-  if ((m_posVert==ITEM_SETUP_DATE || m_posVert==ITEM_SETUP_TIME) &&
+  if ((menuVerticalPosition==ITEM_SETUP_DATE || menuVerticalPosition==ITEM_SETUP_TIME) &&
       (s_editMode>0) &&
       (event==EVT_KEY_FIRST(KEY_ENTER) || event==EVT_KEY_FIRST(KEY_EXIT) || IS_ROTARY_BREAK(event) || IS_ROTARY_LONG(event))) {
     // set the date and time into RTC chip
@@ -130,7 +130,7 @@ void menuGeneralSetup(uint8_t event)
 
   MENU(STR_MENURADIOSETUP, menuTabGeneral, e_Setup, ITEM_SETUP_MAX, { 2, 2, 1, LABEL(SOUND), 0, 0, 0, 0, 0, 0, 0, CASE_VARIO_CPUARM(LABEL(VARIO)) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_VARIO_CPUARM(0) CASE_HAPTIC(LABEL(HAPTIC)) CASE_HAPTIC(0) CASE_HAPTIC(0) CASE_HAPTIC(0) 0, LABEL(ALARMS), 0, 0, 0, 0, IF_ROTARY_ENCODERS(0) LABEL(BACKLIGHT), 0, 0, 0, CASE_REVPLUS(0) CASE_PWM_BACKLIGHT(0) CASE_PWM_BACKLIGHT(0) 0, CASE_SPLASH_PARAM(0) CASE_GPS(LABEL(GPS)) CASE_GPS(0) CASE_GPS(0) CASE_GPS(0) CASE_PXX(0) 0, 0, IF_FAI_CHOICE(0) CASE_MAVLINK(0) 0, 0, LABEL(TX_MODE), 0, 1/*to force edit mode*/ });
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (unsigned int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -143,7 +143,7 @@ void menuGeneralSetup(uint8_t event)
         lcd_putsLeft(y, STR_DATE);
         lcd_putc(RADIO_SETUP_DATE_COLUMN, y, '-'); lcd_putc(RADIO_SETUP_DATE_COLUMN+3*FW-2, y, '-');
         for (uint8_t j=0; j<3; j++) {
-          uint8_t rowattr = (m_posHorz==j ? attr : 0);
+          uint8_t rowattr = (menuHorizontalPosition==j ? attr : 0);
           switch (j) {
             case 0:
               lcd_outdezAtt(RADIO_SETUP_DATE_COLUMN, y, t.tm_year+1900, rowattr);
@@ -165,7 +165,7 @@ void menuGeneralSetup(uint8_t event)
             }
           }
         }
-        if (attr && m_posHorz < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
+        if (attr && menuHorizontalPosition < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
         if (attr && checkIncDec_Ret) {
           g_rtcTime = gmktime(&t); // update local timestamp and get wday calculated
         }
@@ -175,7 +175,7 @@ void menuGeneralSetup(uint8_t event)
         lcd_putsLeft(y, STR_TIME);
         lcd_putc(RADIO_SETUP_TIME_COLUMN+1, y, ':'); lcd_putc(RADIO_SETUP_TIME_COLUMN+3*FW-2, y, ':');
         for (uint8_t j=0; j<3; j++) {
-          uint8_t rowattr = (m_posHorz==j ? attr : 0);
+          uint8_t rowattr = (menuHorizontalPosition==j ? attr : 0);
           switch (j) {
             case 0:
               lcd_outdezNAtt(RADIO_SETUP_TIME_COLUMN, y, t.tm_hour, rowattr|LEADING0, 2);
@@ -191,19 +191,19 @@ void menuGeneralSetup(uint8_t event)
               break;
           }
         }
-        if (attr && m_posHorz < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
+        if (attr && menuHorizontalPosition < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
         if (attr && checkIncDec_Ret)
           g_rtcTime = gmktime(&t); // update local timestamp and get wday calculated
         break;
 
       case ITEM_SETUP_BATT_RANGE:
         lcd_putsLeft(y, STR_BATTERY_RANGE);
-        putsVolts(RADIO_SETUP_2ND_COLUMN, y,  90+g_eeGeneral.vBatMin, (m_posHorz==0 ? attr : 0)|LEFT|NO_UNIT);
+        putsVolts(RADIO_SETUP_2ND_COLUMN, y,  90+g_eeGeneral.vBatMin, (menuHorizontalPosition==0 ? attr : 0)|LEFT|NO_UNIT);
         lcd_putc(lcdLastPos, y, '-');
-        putsVolts(lcdLastPos+FW, y, 120+g_eeGeneral.vBatMax, (m_posHorz>0 ? attr : 0)|LEFT|NO_UNIT);
-        if (attr && m_posHorz < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
+        putsVolts(lcdLastPos+FW, y, 120+g_eeGeneral.vBatMax, (menuHorizontalPosition>0 ? attr : 0)|LEFT|NO_UNIT);
+        if (attr && menuHorizontalPosition < 0) drawFilledRect(RADIO_SETUP_2ND_COLUMN, y, LCD_W-RADIO_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH, 8);
         if (attr && s_editMode>0) {
-          if (m_posHorz==0)
+          if (menuHorizontalPosition==0)
             CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatMin, -50, g_eeGeneral.vBatMax+29); // min=4.0V
           else
             CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatMax, g_eeGeneral.vBatMin-29, +40); // max=16.0V

--- a/radio/src/gui/Taranis/menu_general_setup.cpp
+++ b/radio/src/gui/Taranis/menu_general_setup.cpp
@@ -121,8 +121,8 @@ void menuGeneralSetup(uint8_t event)
 #endif
 
 #if defined(FAI_CHOICE)
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     g_eeGeneral.fai = true;
     eeDirty(EE_GENERAL);
   }

--- a/radio/src/gui/Taranis/menu_general_trainer.cpp
+++ b/radio/src/gui/Taranis/menu_general_trainer.cpp
@@ -56,7 +56,7 @@ void menuGeneralTrainer(uint8_t event)
   lcd_puts(3*FW, MENU_HEADER_HEIGHT+1, STR_MODESRC);
 
   y = MENU_HEADER_HEIGHT + 1 + FH;
-  int sub = m_posVert + 1;
+  int sub = menuVerticalPosition + 1;
 
   for (int i=1; i<=NUM_STICKS; i++) {
     uint8_t chan = channel_order(i);
@@ -66,7 +66,7 @@ void menuGeneralTrainer(uint8_t event)
 
     for (int j=0; j<3; j++) {
 
-      attr = ((sub==i && m_posHorz==j) ? blink : 0);
+      attr = ((sub==i && menuHorizontalPosition==j) ? blink : 0);
 
       switch(j) {
         case 0:

--- a/radio/src/gui/Taranis/menu_general_version.cpp
+++ b/radio/src/gui/Taranis/menu_general_version.cpp
@@ -88,8 +88,8 @@ void backupEeprom()
 
 void menuGeneralVersion(uint8_t event)
 {
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     displayPopup(STR_EEPROMFORMATTING);
     eeErase(false);
 #if !defined(SIMU)

--- a/radio/src/gui/Taranis/menu_model.cpp
+++ b/radio/src/gui/Taranis/menu_model.cpp
@@ -209,7 +209,7 @@ void editName(coord_t x, coord_t y, char *name, uint8_t size, uint8_t event, uin
 
       if (c != v) {
         name[cur] = v;
-        eeDirty(g_menuPos[0] == 0 ? EE_MODEL : EE_GENERAL);
+        eeDirty(menuVerticalPositions[0] == 0 ? EE_MODEL : EE_GENERAL);
       }
 
       if (attr == ZCHAR) {

--- a/radio/src/gui/Taranis/menu_model_curves.cpp
+++ b/radio/src/gui/Taranis/menu_model_curves.cpp
@@ -150,9 +150,9 @@ void menuModelCurveOne(uint8_t event)
   lcd_outdezAtt(PSIZE(TR_MENUCURVE)*FW+1, 0, s_curveChan+1, INVERS|LEFT);
 
   lcd_putsLeft(FH+1, STR_NAME);
-  editName(INDENT_WIDTH, 2*FH+1, g_model.curveNames[s_curveChan], sizeof(g_model.curveNames[s_curveChan]), event, m_posVert==0);
+  editName(INDENT_WIDTH, 2*FH+1, g_model.curveNames[s_curveChan], sizeof(g_model.curveNames[s_curveChan]), event, menuVerticalPosition==0);
 
-  uint8_t attr = (m_posVert==1 ? (s_editMode>0 ? INVERS|BLINK : INVERS) : 0);
+  uint8_t attr = (menuVerticalPosition==1 ? (s_editMode>0 ? INVERS|BLINK : INVERS) : 0);
   lcd_putsLeft(3*FH+1, STR_TYPE);
   lcd_putsiAtt(INDENT_WIDTH, 4*FH+1, STR_CURVE_TYPES, crv.type, attr);
   if (attr) {
@@ -169,7 +169,7 @@ void menuModelCurveOne(uint8_t event)
     }
   }
 
-  attr = (m_posVert==2 ? (s_editMode>0 ? INVERS|BLINK : INVERS) : 0);
+  attr = (menuVerticalPosition==2 ? (s_editMode>0 ? INVERS|BLINK : INVERS) : 0);
   lcd_putsLeft(5*FH+1, STR_COUNT);
   lcd_outdezAtt(INDENT_WIDTH, 6*FH+1, 5+crv.points, LEFT|attr);
   lcd_putsAtt(lcdLastPos, 6*FH+1, STR_PTS, attr);
@@ -192,8 +192,8 @@ void menuModelCurveOne(uint8_t event)
   }
 
   lcd_putsLeft(7*FH+1, STR_SMOOTH);
-  menu_lcd_onoff(7*FW, 7*FH+1, crv.smooth, m_posVert==3 ? INVERS : 0);
-  if (m_posVert==3) crv.smooth = checkIncDecModel(event, crv.smooth, 0, 1);
+  menu_lcd_onoff(7*FW, 7*FH+1, crv.smooth, menuVerticalPosition==3 ? INVERS : 0);
+  if (menuVerticalPosition==3) crv.smooth = checkIncDecModel(event, crv.smooth, 0, 1);
 
   switch(event) {
     case EVT_ENTRY:
@@ -201,7 +201,7 @@ void menuModelCurveOne(uint8_t event)
       SET_SCROLLBAR_X(0);
       break;
     case EVT_KEY_LONG(KEY_ENTER):
-      if (m_posVert > 1) {
+      if (menuVerticalPosition > 1) {
         killEvents(event);
         POPUP_MENU_ADD_ITEM(STR_CURVE_PRESET);
         POPUP_MENU_ADD_ITEM(STR_MIRROR);
@@ -222,12 +222,12 @@ void menuModelCurveOne(uint8_t event)
     point_t point = getPoint(i);
     uint8_t selectionMode = 0;
     if (crv.type==CURVE_TYPE_CUSTOM) {
-      if (m_posVert==4+2*i || (i==5+crv.points-1 && m_posVert==4+5+crv.points+5+crv.points-2-1))
+      if (menuVerticalPosition==4+2*i || (i==5+crv.points-1 && menuVerticalPosition==4+5+crv.points+5+crv.points-2-1))
         selectionMode = 2;
-      else if (i>0 && m_posVert==3+2*i)
+      else if (i>0 && menuVerticalPosition==3+2*i)
         selectionMode = 1;
     }
-    else if (m_posVert == 4+i) {
+    else if (menuVerticalPosition == 4+i) {
       selectionMode = 2;
     }
 
@@ -260,23 +260,23 @@ void menuModelCurveOne(uint8_t event)
 
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, uint8_t event, uint8_t attr)
 {
-  lcd_putsiAtt(x, y, "\004DiffExpoFuncCstm", curve.type, m_posHorz==0 ? attr : 0);
-  if (attr && m_posHorz==0) {
+  lcd_putsiAtt(x, y, "\004DiffExpoFuncCstm", curve.type, menuHorizontalPosition==0 ? attr : 0);
+  if (attr && menuHorizontalPosition==0) {
     CHECK_INCDEC_MODELVAR_ZERO(event, curve.type, CURVE_REF_CUSTOM);
     if (checkIncDec_Ret) curve.value = 0;
   }
   switch (curve.type) {
     case CURVE_REF_DIFF:
     case CURVE_REF_EXPO:
-      curve.value = GVAR_MENU_ITEM(x+5*FW, y, curve.value, -100, 100, m_posHorz==1 ? LEFT|attr : LEFT, 0, event);
+      curve.value = GVAR_MENU_ITEM(x+5*FW, y, curve.value, -100, 100, menuHorizontalPosition==1 ? LEFT|attr : LEFT, 0, event);
       break;
     case CURVE_REF_FUNC:
-      lcd_putsiAtt(x+5*FW, y, STR_VCURVEFUNC, curve.value, m_posHorz==1 ? attr : 0);
-      if (attr && m_posHorz==1) CHECK_INCDEC_MODELVAR_ZERO(event, curve.value, CURVE_BASE-1);
+      lcd_putsiAtt(x+5*FW, y, STR_VCURVEFUNC, curve.value, menuHorizontalPosition==1 ? attr : 0);
+      if (attr && menuHorizontalPosition==1) CHECK_INCDEC_MODELVAR_ZERO(event, curve.value, CURVE_BASE-1);
       break;
     case CURVE_REF_CUSTOM:
-      putsCurve(x+5*FW+2, y, curve.value, m_posHorz==1 ? attr : 0);
-      if (attr && m_posHorz==1) {
+      putsCurve(x+5*FW+2, y, curve.value, menuHorizontalPosition==1 ? attr : 0);
+      if (attr && menuHorizontalPosition==1) {
         if (event==EVT_KEY_LONG(KEY_ENTER) && curve.value!=0) {
           s_curveChan = (curve.value<0 ? -curve.value-1 : curve.value-1);
           pushMenu(menuModelCurveOne);
@@ -293,7 +293,7 @@ void menuModelCurvesAll(uint8_t event)
 {
   SIMPLE_MENU(STR_MENUCURVES, menuTabModel, e_CurvesAll, MAX_CURVES);
 
-  int  sub = m_posVert;
+  int  sub = menuVerticalPosition;
 
   switch (event) {
     case EVT_KEY_BREAK(KEY_ENTER):

--- a/radio/src/gui/Taranis/menu_model_curves.cpp
+++ b/radio/src/gui/Taranis/menu_model_curves.cpp
@@ -306,7 +306,7 @@ void menuModelCurvesAll(uint8_t event)
 
   for (int i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i + s_pgOfs;
+    int k = i + menuVerticalOffset;
     LcdFlags attr = (sub == k ? INVERS : 0);
     {
       putsStrIdx(0, y, STR_CV, k+1, attr);

--- a/radio/src/gui/Taranis/menu_model_curves.cpp
+++ b/radio/src/gui/Taranis/menu_model_curves.cpp
@@ -203,10 +203,10 @@ void menuModelCurveOne(uint8_t event)
     case EVT_KEY_LONG(KEY_ENTER):
       if (m_posVert > 1) {
         killEvents(event);
-        MENU_ADD_ITEM(STR_CURVE_PRESET);
-        MENU_ADD_ITEM(STR_MIRROR);
-        MENU_ADD_ITEM(STR_CLEAR);
-        menuHandler = onCurveOneMenu;
+        POPUP_MENU_ADD_ITEM(STR_CURVE_PRESET);
+        POPUP_MENU_ADD_ITEM(STR_MIRROR);
+        POPUP_MENU_ADD_ITEM(STR_CLEAR);
+        popupMenuHandler = onCurveOneMenu;
       }
       break;
     case EVT_KEY_LONG(KEY_MENU):

--- a/radio/src/gui/Taranis/menu_model_curves.cpp
+++ b/radio/src/gui/Taranis/menu_model_curves.cpp
@@ -98,15 +98,15 @@ bool moveCurve(uint8_t index, int8_t shift)
 void displayPresetChoice(uint8_t event)
 {
   displayWarning(event);
-  lcd_outdezAtt(WARNING_LINE_X+FW*7, WARNING_LINE_Y, 45*s_warning_input_value/4, LEFT|INVERS);
+  lcd_outdezAtt(WARNING_LINE_X+FW*7, WARNING_LINE_Y, 45*warningInputValue/4, LEFT|INVERS);
   lcd_putcAtt(lcdLastPos, WARNING_LINE_Y, '@', INVERS);
 
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     CurveInfo & crv = g_model.curves[s_curveChan];
     int8_t * points = curveAddress(s_curveChan);
     for (uint8_t i=0; i<5+crv.points; i++)
-      points[i] = (i-((5+crv.points)/2)) * s_warning_input_value * 50 / (4+crv.points);
+      points[i] = (i-((5+crv.points)/2)) * warningInputValue * 50 / (4+crv.points);
     if (crv.type == CURVE_TYPE_CUSTOM) {
       for (int i=0; i<3+crv.points; i++)
         points[crv.points+i] = -100 + ((i+1)*200) / (4+crv.points);

--- a/radio/src/gui/Taranis/menu_model_custom_functions.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_functions.cpp
@@ -43,11 +43,11 @@
 
 void onCustomFunctionsFileSelectionMenu(const char *result)
 {
-  int  sub = m_posVert;
+  int  sub = menuVerticalPosition;
   CustomFunctionData * cfn;
   uint8_t eeFlags;
 
-  if (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions) {
+  if (menuHandlers[menuLevel] == menuModelCustomFunctions) {
     cfn = &g_model.customFn[sub];
     eeFlags = EE_MODEL;
   }
@@ -83,11 +83,11 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
 
 void onCustomFunctionsMenu(const char *result)
 {
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
   CustomFunctionData * cfn;
   uint8_t eeFlags;
 
-  if (g_menuStack[g_menuStackPtr] == menuModelCustomFunctions) {
+  if (menuHandlers[menuLevel] == menuModelCustomFunctions) {
     cfn = &g_model.customFn[sub];
     eeFlags = EE_MODEL;
   }
@@ -122,7 +122,7 @@ void onCustomFunctionsMenu(const char *result)
 
 void onAdjustGvarSourceLongEnterPress(const char * result)
 {
-  CustomFunctionData * cfn = &g_model.customFn[m_posVert];
+  CustomFunctionData * cfn = &g_model.customFn[menuVerticalPosition];
 
   if (result == STR_CONSTANT) {
     CFN_GVAR_MODE(cfn) = FUNC_ADJUST_GVAR_CONSTANT;
@@ -151,9 +151,9 @@ void onAdjustGvarSourceLongEnterPress(const char * result)
 
 void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFunctionsContext * functionsContext)
 {
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
   uint8_t eeFlags = (functions == g_model.customFn) ? EE_MODEL : EE_GENERAL;
-  if (m_posHorz<0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
+  if (menuHorizontalPosition<0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
     killEvents(event);
     CustomFunctionData *cfn = &functions[sub];
     if (!CFN_EMPTY(cfn))
@@ -177,12 +177,12 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
     int k = i+s_pgOfs;
 
-    putsStrIdx(0, y, functions == g_model.customFn ? STR_SF : STR_GF, k+1, (sub==k && m_posHorz<0) ? INVERS : 0);
+    putsStrIdx(0, y, functions == g_model.customFn ? STR_SF : STR_GF, k+1, (sub==k && menuHorizontalPosition<0) ? INVERS : 0);
 
     CustomFunctionData *cfn = &functions[k];
     uint8_t func = CFN_FUNC(cfn);
     for (uint8_t j=0; j<5; j++) {
-      uint8_t attr = ((sub==k && m_posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
+      uint8_t attr = ((sub==k && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
       uint8_t active = (attr && s_editMode>0);
       switch (j) {
         case 0:
@@ -203,7 +203,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
           }
           else {
             j = 4; // skip other fields
-            if (sub==k && m_posHorz > 0) {
+            if (sub==k && menuHorizontalPosition > 0) {
               REPEAT_LAST_CURSOR_MOVE();
             }
           }

--- a/radio/src/gui/Taranis/menu_model_custom_functions.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_functions.cpp
@@ -175,7 +175,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i+s_pgOfs;
+    int k = i+menuVerticalOffset;
 
     putsStrIdx(0, y, functions == g_model.customFn ? STR_SF : STR_GF, k+1, (sub==k && menuHorizontalPosition<0) ? INVERS : 0);
 

--- a/radio/src/gui/Taranis/menu_model_custom_functions.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_functions.cpp
@@ -69,7 +69,6 @@ void onCustomFunctionsFileSelectionMenu(const char *result)
     }
     if (!listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), NULL)) {
       POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else {
@@ -158,20 +157,20 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
     killEvents(event);
     CustomFunctionData *cfn = &functions[sub];
     if (!CFN_EMPTY(cfn))
-      MENU_ADD_ITEM(STR_COPY);
+      POPUP_MENU_ADD_ITEM(STR_COPY);
     if (clipboard.type == CLIPBOARD_TYPE_CUSTOM_FUNCTION)
-      MENU_ADD_ITEM(STR_PASTE);
+      POPUP_MENU_ADD_ITEM(STR_PASTE);
     if (!CFN_EMPTY(cfn) && CFN_EMPTY(&functions[NUM_CFN-1]))
-      MENU_ADD_ITEM(STR_INSERT);
+      POPUP_MENU_ADD_ITEM(STR_INSERT);
     if (!CFN_EMPTY(cfn))
-      MENU_ADD_ITEM(STR_CLEAR);
+      POPUP_MENU_ADD_ITEM(STR_CLEAR);
     for (int i=sub+1; i<NUM_CFN; i++) {
       if (!CFN_EMPTY(&functions[i])) {
-        MENU_ADD_ITEM(STR_DELETE);
+        POPUP_MENU_ADD_ITEM(STR_DELETE);
         break;
       }
     }
-    menuHandler = onCustomFunctionsMenu;
+    popupMenuHandler = onCustomFunctionsMenu;
   }
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
@@ -304,11 +303,10 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
                 strncpy(directory+SOUNDS_PATH_LNG_OFS, currentLanguagePack->id, 2);
               }
               if (listSdFiles(directory, func==FUNC_PLAY_SCRIPT ? SCRIPTS_EXT : SOUNDS_EXT, sizeof(cfn->play.name), cfn->play.name)) {
-                menuHandler = onCustomFunctionsFileSelectionMenu;
+                popupMenuHandler = onCustomFunctionsFileSelectionMenu;
               }
               else {
                 POPUP_WARNING(func==FUNC_PLAY_SCRIPT ? STR_NO_SCRIPTS_ON_SD : STR_NO_SOUNDS_ON_SD);
-                s_menu_flags = 0;
               }
             }
             break;
@@ -391,14 +389,14 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
             if (func == FUNC_ADJUST_GVAR && attr && event==EVT_KEY_LONG(KEY_ENTER)) {
               killEvents(event);
               if (CFN_GVAR_MODE(cfn) != FUNC_ADJUST_GVAR_CONSTANT)
-                MENU_ADD_ITEM(STR_CONSTANT);
+                POPUP_MENU_ADD_ITEM(STR_CONSTANT);
               if (CFN_GVAR_MODE(cfn) != FUNC_ADJUST_GVAR_SOURCE)
-                MENU_ADD_ITEM(STR_MIXSOURCE);
+                POPUP_MENU_ADD_ITEM(STR_MIXSOURCE);
               if (CFN_GVAR_MODE(cfn) != FUNC_ADJUST_GVAR_GVAR)
-                MENU_ADD_ITEM(STR_GLOBALVAR);
+                POPUP_MENU_ADD_ITEM(STR_GLOBALVAR);
               if (CFN_GVAR_MODE(cfn) != FUNC_ADJUST_GVAR_INC)
-                MENU_ADD_ITEM(STR_INCDEC);
-              menuHandler = onAdjustGvarSourceLongEnterPress;
+                POPUP_MENU_ADD_ITEM(STR_INCDEC);
+              popupMenuHandler = onAdjustGvarSourceLongEnterPress;
               s_editMode = EDIT_MODIFY_FIELD;
             }
           }

--- a/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
@@ -42,7 +42,6 @@ void onModelCustomScriptMenu(const char *result)
   if (result == STR_UPDATE_LIST) {
     if (!listSdFiles(SCRIPTS_MIXES_PATH, SCRIPTS_EXT, sizeof(sd.file), NULL)) {
       POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else {
@@ -89,11 +88,10 @@ void menuModelCustomScriptOne(uint8_t event)
       if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && !READ_ONLY()) {
         s_editMode = 0;
         if (listSdFiles(SCRIPTS_MIXES_PATH, SCRIPTS_EXT, sizeof(sd.file), sd.file, LIST_NONE_SD_FILE)) {
-          menuHandler = onModelCustomScriptMenu;
+          popupMenuHandler = onModelCustomScriptMenu;
         }
         else {
           POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
-          s_menu_flags = 0;
         }
       }
     }

--- a/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
@@ -72,7 +72,7 @@ void menuModelCustomScriptOne(uint8_t event)
 
   SUBMENU_NOTITLE(3+scriptInputsOutputs[s_currIdx].inputsCount, { 0, 0, LABEL(inputs), 0/*repeated*/ });
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   for (int k=0; k<LCD_LINES-1; k++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
@@ -140,7 +140,7 @@ void menuModelCustomScripts(uint8_t event)
   MENU(STR_MENUCUSTOMSCRIPTS, menuTabModel, e_CustomScripts, MAX_SCRIPTS, { NAVIGATION_LINE_BY_LINE|3/*repeated*/ });
 
   coord_t y;
-  int8_t  sub = m_posVert;
+  int8_t  sub = menuVerticalPosition;
 
   if (event == EVT_KEY_FIRST(KEY_ENTER)) {
     s_currIdx = sub;

--- a/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
+++ b/radio/src/gui/Taranis/menu_model_custom_scripts.cpp
@@ -76,7 +76,7 @@ void menuModelCustomScriptOne(uint8_t event)
 
   for (int k=0; k<LCD_LINES-1; k++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
-    int i = k + s_pgOfs;
+    int i = k + menuVerticalOffset;
     LcdFlags attr = (sub==i ? (s_editMode>0 ? BLINK|INVERS : INVERS) : 0);
 
     if (i == ITEM_MODEL_CUSTOMSCRIPT_FILE) {

--- a/radio/src/gui/Taranis/menu_model_flightmodes.cpp
+++ b/radio/src/gui/Taranis/menu_model_flightmodes.cpp
@@ -60,16 +60,16 @@ enum FlightModesItems {
 
 bool isTrimModeAvailable(int mode)
 {
-  return (mode < 0 || (mode%2) == 0 || (mode/2) != m_posVert);
+  return (mode < 0 || (mode%2) == 0 || (mode/2) != menuVerticalPosition);
 }
 
 void menuModelFlightModesAll(uint8_t event)
 {
   MENU(STR_MENUFLIGHTPHASES, menuTabModel, e_FlightModesAll, MAX_FLIGHT_MODES+1, { NAVIGATION_LINE_BY_LINE|(ITEM_FLIGHT_MODES_LAST-1), NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, NAVIGATION_LINE_BY_LINE|ITEM_FLIGHT_MODES_LAST, 0 });
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
-  horzpos_t posHorz = m_posHorz;
+  horzpos_t posHorz = menuHorizontalPosition;
   if (sub==0 && posHorz > 0) { posHorz += 1; }
 
   if (sub<MAX_FLIGHT_MODES && posHorz>=0) {
@@ -109,7 +109,7 @@ void menuModelFlightModesAll(uint8_t event)
 
     FlightModeData *p = flightModeAddress(k);
 
-    putsFlightMode(0, y, k+1, (getFlightMode()==k ? BOLD : 0) | ((sub==k && m_posHorz<0) ? INVERS : 0));
+    putsFlightMode(0, y, k+1, (getFlightMode()==k ? BOLD : 0) | ((sub==k && menuHorizontalPosition<0) ? INVERS : 0));
 
     for (uint8_t j=0; j<ITEM_FLIGHT_MODES_COUNT; j++) {
       uint8_t attr = ((sub==k && posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);

--- a/radio/src/gui/Taranis/menu_model_flightmodes.cpp
+++ b/radio/src/gui/Taranis/menu_model_flightmodes.cpp
@@ -78,7 +78,7 @@ void menuModelFlightModesAll(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-1; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     if (k==MAX_FLIGHT_MODES) {
       // last line available - add the "check trims" line

--- a/radio/src/gui/Taranis/menu_model_gvars.cpp
+++ b/radio/src/gui/Taranis/menu_model_gvars.cpp
@@ -130,10 +130,10 @@ void menuModelGVars(uint8_t event)
   if (m_posHorz < 0 && event==EVT_KEY_LONG(KEY_ENTER)) {
     killEvents(event);
     if (g_model.gvars[sub].popup)
-      MENU_ADD_ITEM(STR_DISABLE_POPUP);
+      POPUP_MENU_ADD_ITEM(STR_DISABLE_POPUP);
     else
-      MENU_ADD_ITEM(STR_ENABLE_POPUP);
-    MENU_ADD_ITEM(STR_CLEAR);
-    menuHandler = onGVARSMenu;
+      POPUP_MENU_ADD_ITEM(STR_ENABLE_POPUP);
+    POPUP_MENU_ADD_ITEM(STR_CLEAR);
+    popupMenuHandler = onGVARSMenu;
   }
 }

--- a/radio/src/gui/Taranis/menu_model_gvars.cpp
+++ b/radio/src/gui/Taranis/menu_model_gvars.cpp
@@ -37,7 +37,7 @@
 
 void onGVARSMenu(const char *result)
 {
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   if (result == STR_ENABLE_POPUP) {
     g_model.gvars[sub].popup = true;
@@ -75,17 +75,17 @@ void menuModelGVars(uint8_t event)
 
   MENU_FLAGS(menuTitle, menuTabModel, e_GVars, first2seconds ? CHECK_FLAG_NO_SCREEN_INDEX : 0, MAX_GVARS, { NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES, NAVIGATION_LINE_BY_LINE|MAX_FLIGHT_MODES });
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (int l=0; l<LCD_LINES-1; l++) {
     int i = l+s_pgOfs;
     coord_t y = MENU_HEADER_HEIGHT + 1 + l*FH;
 
     if (g_model.gvars[i].popup) lcd_putc(3*FW, y, '!');
-    putsStrIdx(0, y, STR_GV, i+1, (sub==i && m_posHorz<0) ? INVERS : 0);
+    putsStrIdx(0, y, STR_GV, i+1, (sub==i && menuHorizontalPosition<0) ? INVERS : 0);
 
     for (int j=0; j<1+MAX_FLIGHT_MODES; j++) {
-      LcdFlags attr = ((sub==i && m_posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
+      LcdFlags attr = ((sub==i && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
       coord_t x = GVARS_FM_COLUMN(j-1);
 
       switch(j)
@@ -127,7 +127,7 @@ void menuModelGVars(uint8_t event)
     }
   }
 
-  if (m_posHorz < 0 && event==EVT_KEY_LONG(KEY_ENTER)) {
+  if (menuHorizontalPosition < 0 && event==EVT_KEY_LONG(KEY_ENTER)) {
     killEvents(event);
     if (g_model.gvars[sub].popup)
       POPUP_MENU_ADD_ITEM(STR_DISABLE_POPUP);

--- a/radio/src/gui/Taranis/menu_model_gvars.cpp
+++ b/radio/src/gui/Taranis/menu_model_gvars.cpp
@@ -78,7 +78,7 @@ void menuModelGVars(uint8_t event)
   int sub = menuVerticalPosition;
 
   for (int l=0; l<LCD_LINES-1; l++) {
-    int i = l+s_pgOfs;
+    int i = l+menuVerticalOffset;
     coord_t y = MENU_HEADER_HEIGHT + 1 + l*FH;
 
     if (g_model.gvars[i].popup) lcd_putc(3*FW, y, '!');

--- a/radio/src/gui/Taranis/menu_model_heli.cpp
+++ b/radio/src/gui/Taranis/menu_model_heli.cpp
@@ -53,7 +53,7 @@ void menuModelHeli(uint8_t event)
 {
   SIMPLE_MENU(STR_MENUHELISETUP, menuTabModel, e_Heli, ITEM_HELI_MAX);
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (unsigned int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/Taranis/menu_model_heli.cpp
+++ b/radio/src/gui/Taranis/menu_model_heli.cpp
@@ -57,7 +57,7 @@ void menuModelHeli(uint8_t event)
 
   for (unsigned int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i+s_pgOfs;
+    int k = i+menuVerticalOffset;
     LcdFlags blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
     LcdFlags attr = (sub == k ? blink : 0);
 

--- a/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
@@ -325,7 +325,7 @@ void menuModelExpoOne(uint8_t event)
   coord_t y = MENU_HEADER_HEIGHT + 1;
 
   for (unsigned int k=0; k<NUM_BODY_LINES; k++) {
-    int i = k + s_pgOfs;
+    int i = k + menuVerticalOffset;
     for (int j=0; j<=i; ++j) {
       if (j<(int)DIM(mstate_tab) && mstate_tab[j] == HIDDEN_ROW) {
         ++i;
@@ -521,7 +521,7 @@ void menuModelMixOne(uint8_t event)
     int8_t i = k;
     
 #if MENU_COLUMNS < 2
-    i = i + s_pgOfs;
+    i = i + menuVerticalOffset;
 #endif
 
     LcdFlags attr = (sub==i ? (editMode>0 ? BLINK|INVERS : INVERS) : 0);
@@ -812,7 +812,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           if (reachExpoMixCountLimit(expo)) break;
           copyExpoMix(expo, s_currIdx);
           if (key==KEY_MOVE_DOWN) s_currIdx++;
-          else if (sub-s_pgOfs >= 6) s_pgOfs++;
+          else if (sub-menuVerticalOffset >= 6) menuVerticalOffset++;
         }
         else if (next_ofs==0 && s_copyMode==COPY_MODE) {
           // delete the mix
@@ -873,9 +873,9 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
 
   for (int ch=1; ch<=(expo ? NUM_INPUTS : NUM_CHNOUT); ch++) {
     void *pointer = NULL; MixData * &md = (MixData * &)pointer; ExpoData * &ed = (ExpoData * &)pointer;
-    coord_t y = MENU_HEADER_HEIGHT+1+(cur-s_pgOfs)*FH;
+    coord_t y = MENU_HEADER_HEIGHT+1+(cur-menuVerticalOffset)*FH;
     if (expo ? (i<MAX_EXPOS && (ed=expoAddress(i))->chn+1 == ch && EXPO_VALID(ed)) : (i<MAX_MIXERS && (md=mixAddress(i))->srcRaw && md->destCh+1 == ch)) {
-      if (cur-s_pgOfs >= 0 && cur-s_pgOfs < NUM_BODY_LINES) {
+      if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
         if (expo) {
           putsMixerSource(0, y, ch, 0);
         }
@@ -886,7 +886,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
       uint8_t mixCnt = 0;
       do {
         if (s_copyMode) {
-          if (s_copyMode == MOVE_MODE && cur-s_pgOfs >= 0 && cur-s_pgOfs < NUM_BODY_LINES && s_copySrcCh == ch && s_copyTgtOfs != 0 && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
+          if (s_copyMode == MOVE_MODE && cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES && s_copySrcCh == ch && s_copyTgtOfs != 0 && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
             lcd_rect(expo ? 18 : 22, y-1, expo ? LCD_W-18 : LCD_W-22, 9, DOTTED);
             cur++; y+=FH;
           }
@@ -898,7 +898,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
         else if (sub == cur) {
           s_currIdx = i;
         }
-        if (cur-s_pgOfs >= 0 && cur-s_pgOfs < NUM_BODY_LINES) {
+        if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           uint8_t attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
           if (expo) {
             GVAR_MENU_ITEM(EXPO_LINE_WEIGHT_POS, y, ed->weight, MIN_EXPO_WEIGHT, 100, attr | (isExpoActive(i) ? BOLD : 0), 0, 0);
@@ -936,7 +936,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
         }
         cur++; y+=FH; mixCnt++; i++; if (expo) ed++; else md++;
       } while (expo ? (i<MAX_EXPOS && ed->chn+1 == ch && EXPO_VALID(ed)) : (i<MAX_MIXERS && md->srcRaw && md->destCh+1 == ch));
-      if (s_copyMode == MOVE_MODE && cur-s_pgOfs >= 0 && cur-s_pgOfs < NUM_BODY_LINES && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
+      if (s_copyMode == MOVE_MODE && cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
         lcd_rect(expo ? EXPO_LINE_SELECT_POS : 22, y-1, expo ? LCD_W-EXPO_LINE_SELECT_POS : LCD_W-22, 9, DOTTED);
         cur++; y+=FH;
       }
@@ -950,7 +950,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           attr = INVERS;
         }
       }
-      if (cur-s_pgOfs >= 0 && cur-s_pgOfs < NUM_BODY_LINES) {
+      if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
         if (expo) {
           putsMixerSource(0, y, ch, attr);
         }

--- a/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
@@ -776,13 +776,13 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
           else {
             event = 0;
             s_copyMode = 0;
-            MENU_ADD_ITEM(STR_EDIT);
-            MENU_ADD_ITEM(STR_INSERT_BEFORE);
-            MENU_ADD_ITEM(STR_INSERT_AFTER);
-            MENU_ADD_ITEM(STR_COPY);
-            MENU_ADD_ITEM(STR_MOVE);
-            MENU_ADD_ITEM(STR_DELETE);
-            menuHandler = onExpoMixMenu;
+            POPUP_MENU_ADD_ITEM(STR_EDIT);
+            POPUP_MENU_ADD_ITEM(STR_INSERT_BEFORE);
+            POPUP_MENU_ADD_ITEM(STR_INSERT_AFTER);
+            POPUP_MENU_ADD_ITEM(STR_COPY);
+            POPUP_MENU_ADD_ITEM(STR_MOVE);
+            POPUP_MENU_ADD_ITEM(STR_DELETE);
+            popupMenuHandler = onExpoMixMenu;
           }
         }
       }

--- a/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
+++ b/radio/src/gui/Taranis/menu_model_inputs_mixes.cpp
@@ -44,7 +44,7 @@ FlightModesType editFlightModes(coord_t x, coord_t y, uint8_t event, FlightModes
 {
   lcd_putsColumnLeft(x, y, STR_FLMODE);
 
-  int posHorz = m_posHorz;
+  int posHorz = menuHorizontalPosition;
 
   for (int p=0; p<MAX_FLIGHT_MODES; p++) {
     LcdFlags flags = 0;
@@ -320,7 +320,7 @@ void menuModelExpoOne(uint8_t event)
 
   SET_SCROLLBAR_X(EXPO_ONE_2ND_COLUMN+10*FW);
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   coord_t y = MENU_HEADER_HEIGHT + 1;
 
@@ -389,7 +389,7 @@ void menuModelExpoOne(uint8_t event)
         uint8_t not_stick = (ed->srcRaw > MIXSRC_Ail);
         int8_t carryTrim = -ed->carryTrim;
         lcd_putsLeft(y, STR_TRIM);
-        lcd_putsiAtt(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, m_posHorz==0 ? attr : 0);
+        lcd_putsiAtt(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, menuHorizontalPosition==0 ? attr : 0);
         if (attr) ed->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_AIL);
         break;
     }
@@ -504,7 +504,7 @@ void menuModelMixOne(uint8_t event)
   SET_SCROLLBAR_X(0);
 #endif
 
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
   int8_t editMode = s_editMode;
 
   for (int k=0; k<MENU_COLUMNS*(LCD_LINES-1); k++) {
@@ -623,7 +623,7 @@ static uint8_t s_copySrcCh;
 
 void onExpoMixMenu(const char *result)
 {
-  bool expo = (g_menuStack[g_menuStackPtr] == menuModelExposAll);
+  bool expo = (menuHandlers[menuLevel] == menuModelExposAll);
   uint8_t chn = (expo ? expoAddress(s_currIdx)->chn+1 : mixAddress(s_currIdx)->destCh+1);
 
   if (result == STR_EDIT) {
@@ -632,7 +632,7 @@ void onExpoMixMenu(const char *result)
   else if (result == STR_INSERT_BEFORE || result == STR_INSERT_AFTER) {
     if (!reachExpoMixCountLimit(expo)) {
       s_currCh = chn;
-      if (result == STR_INSERT_AFTER) { s_currIdx++; m_posVert++; }
+      if (result == STR_INSERT_AFTER) { s_currIdx++; menuVerticalPosition++; }
       insertExpoMix(expo, s_currIdx);
       pushMenu(expo ? menuModelExpoOne : menuModelMixOne);
     }
@@ -641,7 +641,7 @@ void onExpoMixMenu(const char *result)
     s_copyMode = (result == STR_COPY ? COPY_MODE : MOVE_MODE);
     s_copySrcIdx = s_currIdx;
     s_copySrcCh = chn;
-    s_copySrcRow = m_posVert;
+    s_copySrcRow = menuVerticalPosition;
   }
   else if (result == STR_DELETE) {
     deleteExpoMix(expo, s_currIdx);
@@ -701,7 +701,7 @@ void displayExpoLine(coord_t y, ExpoData *ed)
 
 void menuModelExpoMix(uint8_t expo, uint8_t event)
 {
-  uint8_t sub = m_posVert;
+  uint8_t sub = menuVerticalPosition;
 
   if (s_editMode > 0)
     s_editMode = 0;
@@ -736,7 +736,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
             } while (s_copyTgtOfs != 0);
             eeDirty(EE_MODEL);
           }
-          m_posVert = s_copySrcRow;
+          menuVerticalPosition = s_copySrcRow;
           s_copyTgtOfs = 0;
         }
         s_copyMode = 0;
@@ -792,7 +792,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
       if (s_copyMode && !s_copyTgtOfs) {
         if (reachExpoMixCountLimit(expo)) break;
         s_currCh = chn;
-        if (event == EVT_KEY_LONG(KEY_RIGHT)) { s_currIdx++; m_posVert++; }
+        if (event == EVT_KEY_LONG(KEY_RIGHT)) { s_currIdx++; menuVerticalPosition++; }
         insertExpoMix(expo, s_currIdx);
         pushMenu(expo ? menuModelExpoOne : menuModelMixOne);
         s_copyMode = 0;
@@ -866,7 +866,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
     }
   }
 
-  sub = m_posVert;
+  sub = menuVerticalPosition;
   s_currCh = 0;
   int cur = 0;
   int i = 0;
@@ -891,7 +891,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
             cur++; y+=FH;
           }
           if (s_currIdx == i) {
-            sub = m_posVert = cur;
+            sub = menuVerticalPosition = cur;
             s_currCh = ch;
           }
         }
@@ -965,7 +965,7 @@ void menuModelExpoMix(uint8_t expo, uint8_t event)
     }
   }
   s_maxLines = cur;
-  if (sub >= s_maxLines-1) m_posVert = s_maxLines-1;
+  if (sub >= s_maxLines-1) menuVerticalPosition = s_maxLines-1;
 }
 
 void menuModelExposAll(uint8_t event)

--- a/radio/src/gui/Taranis/menu_model_limits.cpp
+++ b/radio/src/gui/Taranis/menu_model_limits.cpp
@@ -171,10 +171,10 @@ void menuModelLimits(uint8_t event)
     putsChn(0, y, k+1, (sub==k && m_posHorz < 0) ? INVERS : 0);
     if (sub==k && m_posHorz < 0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
       killEvents(event);
-      MENU_ADD_ITEM(STR_RESET);
-      MENU_ADD_ITEM(STR_COPY_TRIMS_TO_OFS);
-      MENU_ADD_ITEM(STR_COPY_STICKS_TO_OFS);
-      menuHandler = onLimitsMenu;
+      POPUP_MENU_ADD_ITEM(STR_RESET);
+      POPUP_MENU_ADD_ITEM(STR_COPY_TRIMS_TO_OFS);
+      POPUP_MENU_ADD_ITEM(STR_COPY_STICKS_TO_OFS);
+      popupMenuHandler = onLimitsMenu;
     }
 
     for (int j=0; j<ITEM_LIMITS_COUNT; j++) {

--- a/radio/src/gui/Taranis/menu_model_limits.cpp
+++ b/radio/src/gui/Taranis/menu_model_limits.cpp
@@ -141,7 +141,7 @@ void menuModelLimits(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     if (k==NUM_CHNOUT) {
       // last line available - add the "copy trim menu" line

--- a/radio/src/gui/Taranis/menu_model_limits.cpp
+++ b/radio/src/gui/Taranis/menu_model_limits.cpp
@@ -94,7 +94,7 @@ enum LimitsItems {
 
 void onLimitsMenu(const char *result)
 {
-  int ch = m_posVert;
+  int ch = menuVerticalPosition;
 
   if (result == STR_RESET) {
     LimitData *ld = limitAddress(ch);
@@ -115,7 +115,7 @@ void onLimitsMenu(const char *result)
 
 void menuModelLimits(uint8_t event)
 {
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   if (sub < NUM_CHNOUT) {
 #if defined(PPM_CENTER_ADJUSTABLE) || defined(PPM_UNIT_US)
@@ -128,8 +128,8 @@ void menuModelLimits(uint8_t event)
 
   MENU(STR_MENULIMITS, menuTabModel, e_Limits, NUM_CHNOUT+1, { NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, NAVIGATION_LINE_BY_LINE|ITEM_LIMITS_MAXROW, 0 });
 
-  if (sub<NUM_CHNOUT && m_posHorz>=0) {
-    displayColumnHeader(STR_LIMITS_HEADERS, m_posHorz);
+  if (sub<NUM_CHNOUT && menuHorizontalPosition>=0) {
+    displayColumnHeader(STR_LIMITS_HEADERS, menuHorizontalPosition);
   }
 
   if (s_warning_result) {
@@ -168,8 +168,8 @@ void menuModelLimits(uint8_t event)
 
     int limit = (g_model.extendedLimits ? LIMIT_EXT_MAX : 1000);
 
-    putsChn(0, y, k+1, (sub==k && m_posHorz < 0) ? INVERS : 0);
-    if (sub==k && m_posHorz < 0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
+    putsChn(0, y, k+1, (sub==k && menuHorizontalPosition < 0) ? INVERS : 0);
+    if (sub==k && menuHorizontalPosition < 0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
       killEvents(event);
       POPUP_MENU_ADD_ITEM(STR_RESET);
       POPUP_MENU_ADD_ITEM(STR_COPY_TRIMS_TO_OFS);
@@ -178,7 +178,7 @@ void menuModelLimits(uint8_t event)
     }
 
     for (int j=0; j<ITEM_LIMITS_COUNT; j++) {
-      LcdFlags attr = ((sub==k && m_posHorz==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
+      LcdFlags attr = ((sub==k && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
       uint8_t active = (attr && s_editMode>0) ;
       if (active) STICK_SCROLL_DISABLE();
       switch(j)

--- a/radio/src/gui/Taranis/menu_model_limits.cpp
+++ b/radio/src/gui/Taranis/menu_model_limits.cpp
@@ -132,8 +132,8 @@ void menuModelLimits(uint8_t event)
     displayColumnHeader(STR_LIMITS_HEADERS, menuHorizontalPosition);
   }
 
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     LimitData *ld = limitAddress(sub);
     ld->revert = !ld->revert;
     eeDirty(EE_MODEL);

--- a/radio/src/gui/Taranis/menu_model_limits.cpp
+++ b/radio/src/gui/Taranis/menu_model_limits.cpp
@@ -146,11 +146,11 @@ void menuModelLimits(uint8_t event)
     if (k==NUM_CHNOUT) {
       // last line available - add the "copy trim menu" line
       uint8_t attr = (sub==NUM_CHNOUT) ? INVERS : 0;
-      lcd_putsAtt(CENTER_OFS, y, STR_TRIMS2OFFSETS, s_noHi ? 0 : attr);
+      lcd_putsAtt(CENTER_OFS, y, STR_TRIMS2OFFSETS, NO_HIGHLIGHT() ? 0 : attr);
       if (attr) {
         s_editMode = 0;
         if (event==EVT_KEY_LONG(KEY_ENTER)) {
-          s_noHi = NO_HI_LEN;
+          START_NO_HIGHLIGHT();
           killEvents(event);
           moveTrimsToOffsets(); // if highlighted and menu pressed - move trims to offsets
         }

--- a/radio/src/gui/Taranis/menu_model_logical_switches.cpp
+++ b/radio/src/gui/Taranis/menu_model_logical_switches.cpp
@@ -110,12 +110,12 @@ void menuModelLogicalSwitches(uint8_t event)
     killEvents(event);
     LogicalSwitchData * cs = lswAddress(sub);
     if (cs->func)
-      MENU_ADD_ITEM(STR_COPY);
+      POPUP_MENU_ADD_ITEM(STR_COPY);
     if (clipboard.type == CLIPBOARD_TYPE_CUSTOM_SWITCH)
-      MENU_ADD_ITEM(STR_PASTE);
+      POPUP_MENU_ADD_ITEM(STR_PASTE);
     if (cs->func || cs->v1 || cs->v2 || cs->delay || cs->duration || cs->andsw)
-      MENU_ADD_ITEM(STR_CLEAR);
-    menuHandler = onLogicalSwitchesMenu;
+      POPUP_MENU_ADD_ITEM(STR_CLEAR);
+    popupMenuHandler = onLogicalSwitchesMenu;
   }
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {

--- a/radio/src/gui/Taranis/menu_model_logical_switches.cpp
+++ b/radio/src/gui/Taranis/menu_model_logical_switches.cpp
@@ -120,7 +120,7 @@ void menuModelLogicalSwitches(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    k = i+s_pgOfs;
+    k = i+menuVerticalOffset;
     LcdFlags attr = (sub==k ? ((s_editMode>0) ? BLINK|INVERS : INVERS)  : 0);
     LcdFlags attr1 = (horz==1 ? attr : 0);
     LcdFlags attr2 = (horz==2 ? attr : 0);

--- a/radio/src/gui/Taranis/menu_model_logical_switches.cpp
+++ b/radio/src/gui/Taranis/menu_model_logical_switches.cpp
@@ -75,7 +75,7 @@ void putsEdgeDelayParam(coord_t x, coord_t y, LogicalSwitchData *cs, uint8_t lat
 
 void onLogicalSwitchesMenu(const char *result)
 {
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
   LogicalSwitchData * cs = lswAddress(sub);
 
   if (result == STR_COPY) {
@@ -99,8 +99,8 @@ void menuModelLogicalSwitches(uint8_t event)
   MENU(STR_MENULOGICALSWITCHES, menuTabModel, e_LogicalSwitches, NUM_LOGICAL_SWITCH, { NAVIGATION_LINE_BY_LINE|LS_FIELD_LAST/*repeated...*/ });
 
   int k = 0;
-  int sub = m_posVert;
-  horzpos_t horz = m_posHorz;
+  int sub = menuVerticalPosition;
+  horzpos_t horz = menuHorizontalPosition;
 
   if (horz>=0) {
     displayColumnHeader(STR_CSW_HEADERS, horz);

--- a/radio/src/gui/Taranis/menu_model_select.cpp
+++ b/radio/src/gui/Taranis/menu_model_select.cpp
@@ -62,7 +62,6 @@ void onModelSelectMenu(const char *result)
   else if (result == STR_RESTORE_MODEL || result == STR_UPDATE_LIST) {
     if (!listSdFiles(MODELS_PATH, MODELS_EXT, MENU_LINE_LENGTH-1, NULL)) {
       POPUP_WARNING(STR_NO_MODELS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else if (result == STR_DELETE_MODEL) {
@@ -178,23 +177,23 @@ void menuModelSelect(uint8_t event)
           killEvents(event);
           if (g_eeGeneral.currModel != sub) {
             if (eeModelExists(sub)) {
-              MENU_ADD_ITEM(STR_SELECT_MODEL);
-              MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
-              MENU_ADD_ITEM(STR_COPY_MODEL);
-              MENU_ADD_ITEM(STR_MOVE_MODEL);
-              MENU_ADD_ITEM(STR_DELETE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_SELECT_MODEL);
+              POPUP_MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_COPY_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_MOVE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_DELETE_MODEL);
             }
             else {
-              MENU_ADD_ITEM(STR_CREATE_MODEL);
-              MENU_ADD_ITEM(STR_RESTORE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_CREATE_MODEL);
+              POPUP_MENU_ADD_ITEM(STR_RESTORE_MODEL);
             }
           }
           else {
-            MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
-            MENU_ADD_ITEM(STR_COPY_MODEL);
-            MENU_ADD_ITEM(STR_MOVE_MODEL);
+            POPUP_MENU_ADD_SD_ITEM(STR_BACKUP_MODEL);
+            POPUP_MENU_ADD_ITEM(STR_COPY_MODEL);
+            POPUP_MENU_ADD_ITEM(STR_MOVE_MODEL);
           }
-          menuHandler = onModelSelectMenu;
+          popupMenuHandler = onModelSelectMenu;
         }
         else if (eeModelExists(sub)) {
           s_copyMode = (s_copyMode == COPY_MODE ? MOVE_MODE : COPY_MODE);

--- a/radio/src/gui/Taranis/menu_model_select.cpp
+++ b/radio/src/gui/Taranis/menu_model_select.cpp
@@ -72,7 +72,7 @@ void onModelSelectMenu(const char *result)
     // The user choosed a file on SD to restore
     eeCheck(true);
     POPUP_WARNING(eeRestoreModel(sub, (char *)result));
-    if (!s_warning && g_eeGeneral.currModel == sub) {
+    if (!warningText && g_eeGeneral.currModel == sub) {
       eeLoadModel(sub);
     }
   }
@@ -80,8 +80,8 @@ void onModelSelectMenu(const char *result)
 
 void menuModelSelect(uint8_t event)
 {
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     eeCheck(true);
     eeDeleteModel(menuVerticalPosition); // delete file
     s_copyMode = 0;

--- a/radio/src/gui/Taranis/menu_model_select.cpp
+++ b/radio/src/gui/Taranis/menu_model_select.cpp
@@ -106,7 +106,7 @@ void menuModelSelect(uint8_t event)
   {
       case EVT_ENTRY:
         menuVerticalPosition = sub = g_eeGeneral.currModel;
-        if (sub >= NUM_BODY_LINES) s_pgOfs = sub-(NUM_BODY_LINES-1);
+        if (sub >= NUM_BODY_LINES) menuVerticalOffset = sub-(NUM_BODY_LINES-1);
         s_copyMode = 0;
         s_editMode = EDIT_MODE_INIT;
         break;
@@ -127,7 +127,7 @@ void menuModelSelect(uint8_t event)
         else {
           if (menuVerticalPosition != g_eeGeneral.currModel) {
             sub = menuVerticalPosition = g_eeGeneral.currModel;
-            s_pgOfs = 0;
+            menuVerticalOffset = 0;
           }
           else if (event != EVT_KEY_LONG(KEY_EXIT)) {
             popMenu();
@@ -246,7 +246,7 @@ void menuModelSelect(uint8_t event)
 
   for (uint8_t i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
 
     lcd_outdezNAtt(3*FW+2, y, k+1, LEADING0+((!s_copyMode && sub==k) ? INVERS : 0), 2);
 
@@ -271,11 +271,11 @@ void menuModelSelect(uint8_t event)
     if (eeModelExists(k)) {
       putsModelName(4*FW, y, modelHeaders[k].name, k, 0);
       lcd_outdezAtt(20*FW, y, eeModelSize(k), 0);
-      if (k==g_eeGeneral.currModel && (s_copyMode!=COPY_MODE || s_copySrcRow<0 || i+s_pgOfs!=(vertpos_t)sub))
+      if (k==g_eeGeneral.currModel && (s_copyMode!=COPY_MODE || s_copySrcRow<0 || i+menuVerticalOffset!=(vertpos_t)sub))
         lcd_putc(1, y, '*');
     }
 
-    if (s_copyMode && (vertpos_t)sub==i+s_pgOfs) {
+    if (s_copyMode && (vertpos_t)sub==i+menuVerticalOffset) {
       drawFilledRect(9, y, MODELSEL_W-1-9, 7);
       lcd_rect(8, y-1, MODELSEL_W-1-7, 9, s_copyMode == COPY_MODE ? SOLID : DOTTED);
     }

--- a/radio/src/gui/Taranis/menu_model_select.cpp
+++ b/radio/src/gui/Taranis/menu_model_select.cpp
@@ -40,7 +40,7 @@
 
 void onModelSelectMenu(const char *result)
 {
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
     selectModel(sub);
@@ -83,7 +83,7 @@ void menuModelSelect(uint8_t event)
   if (s_warning_result) {
     s_warning_result = 0;
     eeCheck(true);
-    eeDeleteModel(m_posVert); // delete file
+    eeDeleteModel(menuVerticalPosition); // delete file
     s_copyMode = 0;
     event = EVT_ENTRY_UP;
   }
@@ -94,18 +94,18 @@ void menuModelSelect(uint8_t event)
     _event_ -= KEY_EXIT;
   }
 
-  int8_t oldSub = m_posVert;
+  int8_t oldSub = menuVerticalPosition;
 
   check_submenu_simple(NULL, _event_, MAX_MODELS);
 
   if (s_editMode > 0) s_editMode = 0;
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   switch (event)
   {
       case EVT_ENTRY:
-        m_posVert = sub = g_eeGeneral.currModel;
+        menuVerticalPosition = sub = g_eeGeneral.currModel;
         if (sub >= NUM_BODY_LINES) s_pgOfs = sub-(NUM_BODY_LINES-1);
         s_copyMode = 0;
         s_editMode = EDIT_MODE_INIT;
@@ -121,12 +121,12 @@ void menuModelSelect(uint8_t event)
         // no break
       case EVT_KEY_BREAK(KEY_EXIT):
         if (s_copyMode) {
-          sub = m_posVert = (s_copyMode == MOVE_MODE || s_copySrcRow<0) ? (MAX_MODELS+sub+s_copyTgtOfs) % MAX_MODELS : s_copySrcRow;
+          sub = menuVerticalPosition = (s_copyMode == MOVE_MODE || s_copySrcRow<0) ? (MAX_MODELS+sub+s_copyTgtOfs) % MAX_MODELS : s_copySrcRow;
           s_copyMode = 0;
         }
         else {
-          if (m_posVert != g_eeGeneral.currModel) {
-            sub = m_posVert = g_eeGeneral.currModel;
+          if (menuVerticalPosition != g_eeGeneral.currModel) {
+            sub = menuVerticalPosition = g_eeGeneral.currModel;
             s_pgOfs = 0;
           }
           else if (event != EVT_KEY_LONG(KEY_EXIT)) {
@@ -213,7 +213,7 @@ void menuModelSelect(uint8_t event)
       case EVT_KEY_FIRST(KEY_MOVE_DOWN):
       case EVT_KEY_REPT(KEY_MOVE_DOWN):
         if (s_copyMode) {
-          int8_t next_ofs = s_copyTgtOfs + oldSub - m_posVert;
+          int8_t next_ofs = s_copyTgtOfs + oldSub - menuVerticalPosition;
           if (next_ofs == MAX_MODELS || next_ofs == -MAX_MODELS)
             next_ofs = 0;
 
@@ -228,7 +228,7 @@ void menuModelSelect(uint8_t event)
               s_copyMode = 0;
             }
             next_ofs = 0;
-            m_posVert = sub;
+            menuVerticalPosition = sub;
           }
           s_copyTgtOfs = next_ofs;
         }

--- a/radio/src/gui/Taranis/menu_model_setup.cpp
+++ b/radio/src/gui/Taranis/menu_model_setup.cpp
@@ -279,7 +279,7 @@ void menuModelSetup(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    uint8_t k = i+s_pgOfs;
+    uint8_t k = i+menuVerticalOffset;
     for (int j=0; j<=k; j++) {
       if (mstate_tab[j] == HIDDEN_ROW)
         k++;
@@ -456,9 +456,9 @@ void menuModelSetup(uint8_t event)
       case ITEM_MODEL_POTS_WARNING2:
         if (i==0) {
           if (CURSOR_MOVED_LEFT(event))
-            s_pgOfs--;
+            menuVerticalOffset--;
           else
-            s_pgOfs++;
+            menuVerticalOffset++;
         }
         break;
 #endif
@@ -468,9 +468,9 @@ void menuModelSetup(uint8_t event)
 #if defined(REV9E)
         if (i>=NUM_BODY_LINES-2 && getSwitchWarningsCount() > 8*(NUM_BODY_LINES-i)) {
           if (CURSOR_MOVED_LEFT(event))
-            s_pgOfs--;
+            menuVerticalOffset--;
           else
-            s_pgOfs++;
+            menuVerticalOffset++;
           break;
         }
 #endif
@@ -531,9 +531,9 @@ void menuModelSetup(uint8_t event)
 #if defined(REV9E)
         if (i==NUM_BODY_LINES-1 && g_model.potsWarnMode) {
           if (CURSOR_MOVED_LEFT(event))
-            s_pgOfs--;
+            menuVerticalOffset--;
           else
-            s_pgOfs++;
+            menuVerticalOffset++;
           break;
         }
 #endif

--- a/radio/src/gui/Taranis/menu_model_setup.cpp
+++ b/radio/src/gui/Taranis/menu_model_setup.cpp
@@ -122,7 +122,6 @@ void onModelSetupBitmapMenu(const char *result)
   if (result == STR_UPDATE_LIST) {
     if (!listSdFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap), NULL)) {
       POPUP_WARNING(STR_NO_BITMAPS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else {
@@ -304,11 +303,10 @@ void menuModelSetup(uint8_t event)
         if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
           s_editMode = 0;
           if (listSdFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap), g_model.header.bitmap, LIST_NONE_SD_FILE)) {
-            menuHandler = onModelSetupBitmapMenu;
+            popupMenuHandler = onModelSetupBitmapMenu;
           }
           else {
             POPUP_WARNING(STR_NO_BITMAPS_ON_SD);
-            s_menu_flags = 0;
           }
         }
         break;

--- a/radio/src/gui/Taranis/menu_model_setup.cpp
+++ b/radio/src/gui/Taranis/menu_model_setup.cpp
@@ -136,12 +136,12 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, uint8_t event)
 {
   TimerData * timer = &g_model.timers[timerIdx];
   putsStrIdx(0*FW, y, STR_TIMER, timerIdx+1);
-  putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, m_posHorz==0 ? attr : 0);
-  putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, m_posHorz==1 ? attr : 0, m_posHorz==2 ? attr : 0);
-  if (attr && m_posHorz < 0) drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, LCD_W-MODEL_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH+1, FH+1);
+  putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
+  putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr : 0, menuHorizontalPosition==2 ? attr : 0);
+  if (attr && menuHorizontalPosition < 0) drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, LCD_W-MODEL_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH+1, FH+1);
   if (attr && s_editMode>0) {
     div_t qr = div(timer->start, 60);
-    switch (m_posHorz) {
+    switch (menuHorizontalPosition) {
       case 0:
       {
         swsrc_t timerMode = timer->mode;
@@ -235,8 +235,8 @@ int getSwitchWarningsCount()
 
 void menuModelSetup(uint8_t event)
 {
-  horzpos_t l_posHorz = m_posHorz;
-  bool CURSOR_ON_CELL = (m_posHorz >= 0);
+  horzpos_t l_posHorz = menuHorizontalPosition;
+  bool CURSOR_ON_CELL = (menuHorizontalPosition >= 0);
 #if defined(TARANIS_INTERNAL_PPM)
   MENU_TAB({ 0, 0, TIMERS_ROWS, TOPLCD_ROWS 0, 1, 0, 0, LABEL(Throttle), 0, 0, 0, LABEL(PreflightCheck), 0, 0, SW_WARN_ITEMS(), POT_WARN_ITEMS(),
     NAVIGATION_LINE_BY_LINE|(NUM_STICKS+NUM_POTS+NUM_ROTARY_ENCODERS-1), 0, 
@@ -275,7 +275,7 @@ void menuModelSetup(uint8_t event)
   }
 #endif
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (int i=0; i<NUM_BODY_LINES; ++i) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -390,9 +390,9 @@ void menuModelSetup(uint8_t event)
         break;
 
       case ITEM_MODEL_EXTENDED_TRIMS:
-        ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, m_posHorz<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
-        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, m_posHorz>0  && !s_noHi ? attr : 0);
-        if (attr && m_posHorz>0) {
+        ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, menuHorizontalPosition<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
+        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, menuHorizontalPosition>0  && !s_noHi ? attr : 0);
+        if (attr && menuHorizontalPosition>0) {
           s_editMode = 0;
           if (event==EVT_KEY_LONG(KEY_ENTER)) {
             s_noHi = NO_HI_LEN;
@@ -486,7 +486,7 @@ void menuModelSetup(uint8_t event)
                 break;
 
               case EVT_KEY_LONG(KEY_ENTER):
-                if (m_posHorz < 0) {
+                if (menuHorizontalPosition < 0) {
                   s_noHi = NO_HI_LEN;
                   getMovedSwitch();
                   g_model.switchWarningState = switches_states;
@@ -511,13 +511,13 @@ void menuModelSetup(uint8_t event)
             }
             uint8_t swactive = !(g_model.switchWarningEnable & (1<<i));
             c = "\300-\301"[states & 0x03];
-            lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+qr.rem*(2*FW+1), y+FH*qr.quot, 'A'+i, line && (m_posHorz==current) ? INVERS : 0);
+            lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+qr.rem*(2*FW+1), y+FH*qr.quot, 'A'+i, line && (menuHorizontalPosition==current) ? INVERS : 0);
             if (swactive) lcd_putc(lcdNextPos, y+FH*qr.quot, c);
             ++current;
           }
           states >>= 2;
         }
-        if (attr && m_posHorz < 0) {
+        if (attr && menuHorizontalPosition < 0) {
 #if defined(REV9E)
           drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, 8*(2*FW+1), 1+FH*((current+7)/8));
 #else
@@ -539,26 +539,26 @@ void menuModelSetup(uint8_t event)
 #endif
 
         lcd_putsLeft(y, STR_POTWARNING);
-        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, PSTR("\004""OFF\0""Man\0""Auto"), g_model.potsWarnMode, (m_posHorz == 0) ? attr : 0);
-        if (attr && (m_posHorz == 0)) {
+        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, PSTR("\004""OFF\0""Man\0""Auto"), g_model.potsWarnMode, (menuHorizontalPosition == 0) ? attr : 0);
+        if (attr && (menuHorizontalPosition == 0)) {
           CHECK_INCDEC_MODELVAR(event, g_model.potsWarnMode, POTS_WARN_OFF, POTS_WARN_AUTO);
           eeDirty(EE_MODEL);
         }
 
         if (attr) {
-          if (m_posHorz > 0) s_editMode = 0;
-          if (!READ_ONLY() && m_posHorz > 0) {
+          if (menuHorizontalPosition > 0) s_editMode = 0;
+          if (!READ_ONLY() && menuHorizontalPosition > 0) {
             switch (event) {
               case EVT_KEY_LONG(KEY_ENTER):
                 killEvents(event);
                 if (g_model.potsWarnMode == POTS_WARN_MANUAL) {
-                  SAVE_POT_POSITION(m_posHorz-1);
+                  SAVE_POT_POSITION(menuHorizontalPosition-1);
                   AUDIO_WARNING1();
                   eeDirty(EE_MODEL);
                 }
                 break;
               case EVT_KEY_BREAK(KEY_ENTER):
-                g_model.potsWarnEnabled ^= (1 << (m_posHorz-1));
+                g_model.potsWarnEnabled ^= (1 << (menuHorizontalPosition-1));
                 eeDirty(EE_MODEL);
                 break;
             }
@@ -568,7 +568,7 @@ void menuModelSetup(uint8_t event)
           coord_t x = MODEL_SETUP_2ND_COLUMN+28;
           for (int i=0; i<NUM_POTS; ++i) {
             if (i<NUM_XPOTS && !IS_POT_AVAILABLE(POT1+i)) {
-              if (attr && (m_posHorz==i+1)) REPEAT_LAST_CURSOR_MOVE();
+              if (attr && (menuHorizontalPosition==i+1)) REPEAT_LAST_CURSOR_MOVE();
             }
             else {
 #if defined(REV9E)
@@ -577,8 +577,8 @@ void menuModelSetup(uint8_t event)
                 x = MODEL_SETUP_2ND_COLUMN;
               }
 #endif
-              LcdFlags flags = ((m_posHorz==i+1) && attr) ? BLINK : 0;
-              if ((!attr || m_posHorz >= 0) && !(g_model.potsWarnEnabled & (1 << i))) {
+              LcdFlags flags = ((menuHorizontalPosition==i+1) && attr) ? BLINK : 0;
+              if ((!attr || menuHorizontalPosition >= 0) && !(g_model.potsWarnEnabled & (1 << i))) {
                 flags |= INVERS;
               }
 
@@ -588,7 +588,7 @@ void menuModelSetup(uint8_t event)
             }
           }
         }
-        if (attr && m_posHorz < 0) {
+        if (attr && menuHorizontalPosition < 0) {
 #if defined(REV9E)
           drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-FH-1, LCD_W-MODEL_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH+1, 2*FH+1);
 #else
@@ -603,17 +603,17 @@ void menuModelSetup(uint8_t event)
         coord_t x = MODEL_SETUP_2ND_COLUMN;
         for (int i=0; i<NUM_STICKS+NUM_POTS+NUM_ROTARY_ENCODERS; i++) {
           if (i>=POT1 && i<POT1+NUM_XPOTS && !IS_POT_AVAILABLE(i)) {
-            if (attr && m_posHorz == i) REPEAT_LAST_CURSOR_MOVE();
+            if (attr && menuHorizontalPosition == i) REPEAT_LAST_CURSOR_MOVE();
             continue;
           }
-          lcd_putsiAtt(x, y, STR_RETA123, i, ((m_posHorz==i) && attr) ? BLINK|INVERS : (((g_model.beepANACenter & ((BeepANACenter)1<<i)) || (attr && CURSOR_ON_LINE())) ? INVERS : 0 ) );
+          lcd_putsiAtt(x, y, STR_RETA123, i, ((menuHorizontalPosition==i) && attr) ? BLINK|INVERS : (((g_model.beepANACenter & ((BeepANACenter)1<<i)) || (attr && CURSOR_ON_LINE())) ? INVERS : 0 ) );
           x += FW;
         }
         if (attr && CURSOR_ON_CELL) {
           if (event==EVT_KEY_BREAK(KEY_ENTER)) {
             if (READ_ONLY_UNLOCKED()) {
               s_editMode = 0;
-              g_model.beepANACenter ^= ((BeepANACenter)1<<m_posHorz);
+              g_model.beepANACenter ^= ((BeepANACenter)1<<menuHorizontalPosition);
               eeDirty(EE_MODEL);
             }
           }
@@ -633,11 +633,11 @@ void menuModelSetup(uint8_t event)
 #if defined(TARANIS_INTERNAL_PPM)
       case ITEM_MODEL_INTERNAL_MODULE_MODE:
         lcd_putsLeft(y, STR_MODE);
-        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].type, m_posHorz==0 ? attr : 0);
+        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
         if (IS_MODULE_XJT(INTERNAL_MODULE)) 
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[INTERNAL_MODULE].rfProtocol, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[INTERNAL_MODULE].rfProtocol, menuHorizontalPosition==1 ? attr : 0);
         if (attr && s_editMode>0) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               g_model.moduleData[INTERNAL_MODULE].type = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].type, MODULE_TYPE_NONE, MODULE_TYPE_COUNT-2, EE_MODEL, isModuleAvailable);
               if (checkIncDec_Ret) {
@@ -679,13 +679,13 @@ void menuModelSetup(uint8_t event)
 
       case ITEM_MODEL_EXTERNAL_MODULE_MODE:
         lcd_putsLeft(y, STR_MODE);
-        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].type, m_posHorz==0 ? attr : 0);
+        lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_TARANIS_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
         if (IS_MODULE_XJT(EXTERNAL_MODULE))
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].rfProtocol, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].rfProtocol, menuHorizontalPosition==1 ? attr : 0);
         else if (IS_MODULE_DSM2(EXTERNAL_MODULE))
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].rfProtocol, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].rfProtocol, menuHorizontalPosition==1 ? attr : 0);
         if (attr && s_editMode>0) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               g_model.moduleData[EXTERNAL_MODULE].type = checkIncDec(event, g_model.moduleData[EXTERNAL_MODULE].type, MODULE_TYPE_NONE, MODULE_TYPE_COUNT-1, EE_MODEL, isModuleAvailable);
               if (checkIncDec_Ret) {
@@ -720,12 +720,12 @@ void menuModelSetup(uint8_t event)
         ModuleData & moduleData = g_model.moduleData[moduleIdx];
         lcd_putsLeft(y, STR_CHANNELRANGE);
         if ((int8_t)PORT_CHANNELS_ROWS(moduleIdx) >= 0) {
-          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN, y, STR_CH, m_posHorz==0 ? attr : 0);
-          lcd_outdezAtt(lcdLastPos, y, moduleData.channelsStart+1, LEFT | (m_posHorz==0 ? attr : 0));
+          lcd_putsAtt(MODEL_SETUP_2ND_COLUMN, y, STR_CH, menuHorizontalPosition==0 ? attr : 0);
+          lcd_outdezAtt(lcdLastPos, y, moduleData.channelsStart+1, LEFT | (menuHorizontalPosition==0 ? attr : 0));
           lcd_putc(lcdLastPos, y, '-');
-          lcd_outdezAtt(lcdLastPos + FW+1, y, moduleData.channelsStart+NUM_CHANNELS(moduleIdx), LEFT | (m_posHorz==1 ? attr : 0));
+          lcd_outdezAtt(lcdLastPos + FW+1, y, moduleData.channelsStart+NUM_CHANNELS(moduleIdx), LEFT | (menuHorizontalPosition==1 ? attr : 0));
           if (attr && s_editMode>0) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.channelsStart, 32-8-moduleData.channelsCount);
                 break;
@@ -757,13 +757,13 @@ void menuModelSetup(uint8_t event)
         if (IS_MODULE_PPM(moduleIdx)) {
           lcd_putsLeft(y, STR_PPMFRAME);
           lcd_puts(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_MS);
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)moduleData.ppmFrameLength*5 + 225, (m_posHorz<=0 ? attr : 0) | PREC1|LEFT);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN, y, (int16_t)moduleData.ppmFrameLength*5 + 225, (menuHorizontalPosition<=0 ? attr : 0) | PREC1|LEFT);
           lcd_putc(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, 'u');
-          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (moduleData.ppmDelay*50)+300, (CURSOR_ON_LINE() || m_posHorz==1) ? attr : 0);
-          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, moduleData.ppmPulsePol ? '+' : '-', (CURSOR_ON_LINE() || m_posHorz==2) ? attr : 0);
+          lcd_outdezAtt(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (moduleData.ppmDelay*50)+300, (CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0);
+          lcd_putcAtt(MODEL_SETUP_2ND_COLUMN+10*FW, y, moduleData.ppmPulsePol ? '+' : '-', (CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0);
 
           if (attr && s_editMode>0) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR(event, moduleData.ppmFrameLength, -20, 35);
                 break;
@@ -777,7 +777,7 @@ void menuModelSetup(uint8_t event)
           }
         }
         else {
-          horzpos_t l_posHorz = m_posHorz;
+          horzpos_t l_posHorz = menuHorizontalPosition;
           coord_t xOffsetBind = MODEL_SETUP_BIND_OFS;
           if (IS_MODULE_XJT(moduleIdx) && g_model.moduleData[moduleIdx].rfProtocol == RF_PROTO_D8) {
             xOffsetBind = 0;
@@ -823,19 +823,19 @@ void menuModelSetup(uint8_t event)
         ModuleData & moduleData = g_model.moduleData[moduleIdx];
         lcd_putsLeft(y, TR_FAILSAFE);
         if (IS_MODULE_XJT(moduleIdx)) {
-          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VFAILSAFE, moduleData.failsafeMode, m_posHorz==0 ? attr : 0);
-          if (moduleData.failsafeMode == FAILSAFE_CUSTOM) lcd_putsAtt(MODEL_SETUP_2ND_COLUMN + MODEL_SETUP_SET_FAILSAFE_OFS, y, STR_SET, m_posHorz==1 ? attr : 0);
+          lcd_putsiAtt(MODEL_SETUP_2ND_COLUMN, y, STR_VFAILSAFE, moduleData.failsafeMode, menuHorizontalPosition==0 ? attr : 0);
+          if (moduleData.failsafeMode == FAILSAFE_CUSTOM) lcd_putsAtt(MODEL_SETUP_2ND_COLUMN + MODEL_SETUP_SET_FAILSAFE_OFS, y, STR_SET, menuHorizontalPosition==1 ? attr : 0);
           if (attr) {
             if (moduleData.failsafeMode != FAILSAFE_CUSTOM) {
-              m_posHorz = 0;
+              menuHorizontalPosition = 0;
             }
-            if (m_posHorz == 0) {
+            if (menuHorizontalPosition == 0) {
               if (s_editMode > 0) {
                 CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.failsafeMode, FAILSAFE_LAST);
                 if (checkIncDec_Ret) SEND_FAILSAFE_NOW(moduleIdx);
               }
             }
-            else if (m_posHorz == 1) {
+            else if (menuHorizontalPosition == 1) {
               s_editMode = 0;
               if (moduleData.failsafeMode==FAILSAFE_CUSTOM && event==EVT_KEY_FIRST(KEY_ENTER)) {
                 g_moduleIdx = moduleIdx;
@@ -871,14 +871,14 @@ void menuModelFailsafe(uint8_t event)
     killEvents(event);
     event = 0;
     if (s_editMode) {
-      g_model.moduleData[g_moduleIdx].failsafeChannels[m_posVert] = channelOutputs[m_posVert+channelStart];
+      g_model.moduleData[g_moduleIdx].failsafeChannels[menuVerticalPosition] = channelOutputs[menuVerticalPosition+channelStart];
       eeDirty(EE_MODEL);
       AUDIO_WARNING1();
       s_editMode = 0;
       SEND_FAILSAFE_NOW(g_moduleIdx);
     }
     else {
-      int16_t & failsafe = g_model.moduleData[g_moduleIdx].failsafeChannels[m_posVert];
+      int16_t & failsafe = g_model.moduleData[g_moduleIdx].failsafeChannels[menuVerticalPosition];
       if (failsafe < FAILSAFE_CHANNEL_HOLD)
         failsafe = FAILSAFE_CHANNEL_HOLD;
       else if (failsafe == FAILSAFE_CHANNEL_HOLD)
@@ -935,7 +935,7 @@ void menuModelFailsafe(uint8_t event)
   
         // Value
         LcdFlags flags = TINSIZE;
-        if (m_posVert == ch) {
+        if (menuVerticalPosition == ch) {
           flags |= INVERS;
           if (s_editMode) {
             if (failsafeValue == FAILSAFE_CHANNEL_HOLD || failsafeValue == FAILSAFE_CHANNEL_NOPULSE) {

--- a/radio/src/gui/Taranis/menu_model_setup.cpp
+++ b/radio/src/gui/Taranis/menu_model_setup.cpp
@@ -583,7 +583,7 @@ void menuModelSetup(uint8_t event)
               }
 
               // TODO add a new function
-              lcd_putsnAtt(x, y, STR_VSRCRAW+2+STR_VSRCRAW[0]*(NUM_STICKS+1+i), STR_VSRCRAW[0]-1, flags & ~(BSS|ZCHAR));
+              lcd_putsnAtt(x, y, STR_VSRCRAW+2+STR_VSRCRAW[0]*(NUM_STICKS+1+i), STR_VSRCRAW[0]-1, flags & ~ZCHAR);
               x = lcdNextPos+3;
             }
           }

--- a/radio/src/gui/Taranis/menu_model_setup.cpp
+++ b/radio/src/gui/Taranis/menu_model_setup.cpp
@@ -391,11 +391,11 @@ void menuModelSetup(uint8_t event)
 
       case ITEM_MODEL_EXTENDED_TRIMS:
         ON_OFF_MENU_ITEM(g_model.extendedTrims, MODEL_SETUP_2ND_COLUMN, y, STR_ETRIMS, menuHorizontalPosition<=0 ? attr : 0, event==EVT_KEY_BREAK(KEY_ENTER) ? event : 0);
-        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, menuHorizontalPosition>0  && !s_noHi ? attr : 0);
+        lcd_putsAtt(MODEL_SETUP_2ND_COLUMN+3*FW, y, STR_RESET_BTN, (menuHorizontalPosition>0  && !NO_HIGHLIGHT()) ? attr : 0);
         if (attr && menuHorizontalPosition>0) {
           s_editMode = 0;
           if (event==EVT_KEY_LONG(KEY_ENTER)) {
-            s_noHi = NO_HI_LEN;
+            START_NO_HIGHLIGHT();
             for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
               memclear(&g_model.flightModeData[i], TRIMS_ARRAY_SIZE);
             }
@@ -487,7 +487,7 @@ void menuModelSetup(uint8_t event)
 
               case EVT_KEY_LONG(KEY_ENTER):
                 if (menuHorizontalPosition < 0) {
-                  s_noHi = NO_HI_LEN;
+                  START_NO_HIGHLIGHT();
                   getMovedSwitch();
                   g_model.switchWarningState = switches_states;
                   AUDIO_WARNING1();

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -228,7 +228,7 @@ void menuModelSensor(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i + s_pgOfs;
+    int k = i + menuVerticalOffset;
 
     for (int j=0; j<k; j++) {
       if (mstate_tab[j+1] == HIDDEN_ROW) {
@@ -518,7 +518,7 @@ void menuModelTelemetry(uint8_t event)
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
-    int k = i + s_pgOfs;
+    int k = i + menuVerticalOffset;
     for (int j=0; j<=k; j++) {
       if (mstate_tab[j] == HIDDEN_ROW)
         k++;

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -505,8 +505,8 @@ void onTelemetryScriptFileSelectionMenu(const char *result)
 
 void menuModelTelemetry(uint8_t event)
 {
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     for (int i=0; i<MAX_SENSORS; i++) {
       delTelemetryIndex(i);
     }

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -492,7 +492,6 @@ void onTelemetryScriptFileSelectionMenu(const char *result)
   if (result == STR_UPDATE_LIST) {
     if (!listSdFiles(SCRIPTS_TELEM_PATH, SCRIPTS_EXT, sizeof(g_model.frsky.screens[screenIndex].script.file), NULL)) {
       POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
-      s_menu_flags = 0;
     }
   }
   else {
@@ -556,10 +555,10 @@ void menuModelTelemetry(uint8_t event)
         s_currIdx = index;
         if (event == EVT_KEY_LONG(KEY_ENTER)) {
           killEvents(event);
-          MENU_ADD_ITEM(STR_EDIT);
-          MENU_ADD_ITEM(STR_COPY);
-          MENU_ADD_ITEM(STR_DELETE);
-          menuHandler = onSensorMenu;
+          POPUP_MENU_ADD_ITEM(STR_EDIT);
+          POPUP_MENU_ADD_ITEM(STR_COPY);
+          POPUP_MENU_ADD_ITEM(STR_DELETE);
+          popupMenuHandler = onSensorMenu;
         }
         else if (event == EVT_KEY_BREAK(KEY_ENTER)) {
           pushMenu(menuModelSensor);
@@ -731,11 +730,10 @@ void menuModelTelemetry(uint8_t event)
           if (m_posHorz==1 && attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
             s_editMode = 0;
             if (listSdFiles(SCRIPTS_TELEM_PATH, SCRIPTS_EXT, sizeof(g_model.frsky.screens[screenIndex].script.file), g_model.frsky.screens[screenIndex].script.file)) {
-              menuHandler = onTelemetryScriptFileSelectionMenu;
+              popupMenuHandler = onTelemetryScriptFileSelectionMenu;
             }
             else {
               POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
-              s_menu_flags = 0;
             }
           }
         }

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -224,7 +224,7 @@ void menuModelSensor(uint8_t event)
 
   putsTelemetryChannelValue(SENSOR_2ND_COLUMN, 0, s_currIdx, getValue(MIXSRC_FIRST_TELEM+3*s_currIdx), LEFT);
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -261,10 +261,10 @@ void menuModelSensor(uint8_t event)
       case SENSOR_FIELD_ID:
         if (sensor->type == TELEM_TYPE_CUSTOM) {
           lcd_putsLeft(y, STR_ID);
-          lcd_outhex4(SENSOR_2ND_COLUMN, y, sensor->id, LEFT|(m_posHorz==0 ? attr : 0));
-          lcd_outdezAtt(SENSOR_3RD_COLUMN, y, sensor->instance, LEFT|(m_posHorz==1 ? attr : 0));
+          lcd_outhex4(SENSOR_2ND_COLUMN, y, sensor->id, LEFT|(menuHorizontalPosition==0 ? attr : 0));
+          lcd_outdezAtt(SENSOR_3RD_COLUMN, y, sensor->instance, LEFT|(menuHorizontalPosition==1 ? attr : 0));
           if (attr) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 sensor->id = checkIncDec(event, sensor->id, 0x0000, 0xffff, INCDEC_REP10|NO_INCDEC_MARKS);
                 break;
@@ -450,7 +450,7 @@ void menuModelSensor(uint8_t event)
 
 void onSensorMenu(const char *result)
 {
-  int index = m_posVert - ITEM_TELEMETRY_SENSOR1;
+  int index = menuVerticalPosition - ITEM_TELEMETRY_SENSOR1;
 
   if (index < MAX_SENSORS) {
     if (result == STR_EDIT) {
@@ -460,9 +460,9 @@ void onSensorMenu(const char *result)
       delTelemetryIndex(index);
       index += 1;
       if (index<MAX_SENSORS && isTelemetryFieldAvailable(index))
-        m_posVert += 1;
+        menuVerticalPosition += 1;
       else
-        m_posVert = ITEM_TELEMETRY_NEW_SENSOR;
+        menuVerticalPosition = ITEM_TELEMETRY_NEW_SENSOR;
     }
     else if (result == STR_COPY) {
       int newIndex = availableTelemetryIndex();
@@ -486,7 +486,7 @@ void onSensorMenu(const char *result)
 #if defined(LUA)
 void onTelemetryScriptFileSelectionMenu(const char *result)
 {
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
   int screenIndex = TELEMETRY_CURRENT_SCREEN(sub);
 
   if (result == STR_UPDATE_LIST) {
@@ -514,7 +514,7 @@ void menuModelTelemetry(uint8_t event)
   
   MENU(STR_MENUTELEMETRY, menuTabModel, e_Telemetry, ITEM_TELEMETRY_MAX, { TELEMETRY_TYPE_ROWS RSSI_ROWS SENSORS_ROWS VARIO_ROWS LABEL(TopBar), 0, 0, TELEMETRY_SCREEN_ROWS(0), TELEMETRY_SCREEN_ROWS(1), CASE_CPUARM(TELEMETRY_SCREEN_ROWS(2)) CASE_CPUARM(TELEMETRY_SCREEN_ROWS(3)) });
 
-  int sub = m_posVert;
+  int sub = menuVerticalPosition;
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
@@ -647,10 +647,10 @@ void menuModelTelemetry(uint8_t event)
 
       case ITEM_TELEMETRY_VARIO_RANGE:
         lcd_putsLeft(y, STR_RANGE);
-        lcd_outdezAtt(TELEM_COL2, y, -10+g_model.frsky.varioMin, (m_posHorz==0 ? attr : 0)|LEFT);
-        lcd_outdezAtt(TELEM_COL2+7*FW, y, 10+g_model.frsky.varioMax, (m_posHorz==1 ? attr : 0)|LEFT);
+        lcd_outdezAtt(TELEM_COL2, y, -10+g_model.frsky.varioMin, (menuHorizontalPosition==0 ? attr : 0)|LEFT);
+        lcd_outdezAtt(TELEM_COL2+7*FW, y, 10+g_model.frsky.varioMax, (menuHorizontalPosition==1 ? attr : 0)|LEFT);
         if (attr && s_editMode>0) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioMin, -7, 7);
               break;
@@ -663,11 +663,11 @@ void menuModelTelemetry(uint8_t event)
 
       case ITEM_TELEMETRY_VARIO_CENTER:
         lcd_putsLeft(y, STR_CENTER);
-        lcd_outdezAtt(TELEM_COL2, y, -5+g_model.frsky.varioCenterMin, (m_posHorz==0 ? attr : 0)|PREC1|LEFT);
-        lcd_outdezAtt(TELEM_COL2+7*FW, y, 5+g_model.frsky.varioCenterMax, (m_posHorz==1 ? attr : 0)|PREC1|LEFT);
-        lcd_putsiAtt(TELEM_COL3, y, STR_VVARIOCENTER, g_model.frsky.varioCenterSilent, (m_posHorz==2 ? attr : 0));
+        lcd_outdezAtt(TELEM_COL2, y, -5+g_model.frsky.varioCenterMin, (menuHorizontalPosition==0 ? attr : 0)|PREC1|LEFT);
+        lcd_outdezAtt(TELEM_COL2+7*FW, y, 5+g_model.frsky.varioCenterMax, (menuHorizontalPosition==1 ? attr : 0)|PREC1|LEFT);
+        lcd_putsiAtt(TELEM_COL3, y, STR_VVARIOCENTER, g_model.frsky.varioCenterSilent, (menuHorizontalPosition==2 ? attr : 0));
         if (attr && s_editMode>0) {
-          switch (m_posHorz) {
+          switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioCenterMin, -16, 5+min<int8_t>(10, g_model.frsky.varioCenterMax+5));
               break;
@@ -711,7 +711,7 @@ void menuModelTelemetry(uint8_t event)
         uint8_t screenIndex = TELEMETRY_CURRENT_SCREEN(k);
         putsStrIdx(0*FW, y, STR_SCREEN, screenIndex+1);
         TelemetryScreenType oldScreenType = TELEMETRY_SCREEN_TYPE(screenIndex);
-        TelemetryScreenType newScreenType = (TelemetryScreenType)selectMenuItem(TELEM_SCRTYPE_COL, y, PSTR(""), STR_VTELEMSCREENTYPE, oldScreenType, 0, TELEMETRY_SCREEN_TYPE_MAX, (m_posHorz==0 ? attr : 0), event);
+        TelemetryScreenType newScreenType = (TelemetryScreenType)selectMenuItem(TELEM_SCRTYPE_COL, y, PSTR(""), STR_VTELEMSCREENTYPE, oldScreenType, 0, TELEMETRY_SCREEN_TYPE_MAX, (menuHorizontalPosition==0 ? attr : 0), event);
         if (newScreenType != oldScreenType) {
           g_model.frsky.screensType = (g_model.frsky.screensType & (~(0x03 << (2*screenIndex)))) | (newScreenType << (2*screenIndex));
           memset(&g_model.frsky.screens[screenIndex], 0, sizeof(g_model.frsky.screens[screenIndex]));
@@ -723,11 +723,11 @@ void menuModelTelemetry(uint8_t event)
           // TODO better function name for ---
           // TODO function for these lines
           if (ZEXIST(scriptData.file))
-            lcd_putsnAtt(TELEM_SCRTYPE_COL+7*FW, y, scriptData.file, sizeof(scriptData.file), (m_posHorz==1 ? attr : 0));
+            lcd_putsnAtt(TELEM_SCRTYPE_COL+7*FW, y, scriptData.file, sizeof(scriptData.file), (menuHorizontalPosition==1 ? attr : 0));
           else
-            lcd_putsiAtt(TELEM_SCRTYPE_COL+7*FW, y, STR_VCSWFUNC, 0, (m_posHorz==1 ? attr : 0));
+            lcd_putsiAtt(TELEM_SCRTYPE_COL+7*FW, y, STR_VCSWFUNC, 0, (menuHorizontalPosition==1 ? attr : 0));
 
-          if (m_posHorz==1 && attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
+          if (menuHorizontalPosition==1 && attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
             s_editMode = 0;
             if (listSdFiles(SCRIPTS_TELEM_PATH, SCRIPTS_EXT, sizeof(g_model.frsky.screens[screenIndex].script.file), g_model.frsky.screens[screenIndex].script.file)) {
               popupMenuHandler = onTelemetryScriptFileSelectionMenu;
@@ -783,24 +783,24 @@ void menuModelTelemetry(uint8_t event)
         if (IS_BARS_SCREEN(screenIndex)) {
           FrSkyBarData & bar = g_model.frsky.screens[screenIndex].bars[lineIndex];
           source_t barSource = bar.source;
-          putsMixerSource(TELEM_COL1, y, barSource, m_posHorz==0 ? attr : 0);
+          putsMixerSource(TELEM_COL1, y, barSource, menuHorizontalPosition==0 ? attr : 0);
           int barMax = getMaximumValue(barSource);
           int barMin = -barMax;
           if (barSource) {
             if (barSource <= MIXSRC_LAST_CH) {
-              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, calc100toRESX(bar.barMin), (m_posHorz==1 ? attr : 0) | LEFT);
-              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, calc100toRESX(bar.barMax), (m_posHorz==2 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | LEFT);
             }
             else {
-              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, bar.barMin, (m_posHorz==1 ? attr : 0) | LEFT);
-              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, bar.barMax, (m_posHorz==2 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMIN, y, barSource, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | LEFT);
+              putsChannelValue(TELEM_BARS_COLMAX, y, barSource, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | LEFT);
             }
           }
           else if (attr) {
             MOVE_CURSOR_FROM_HERE();
           }
           if (attr && s_editMode>0) {
-            switch (m_posHorz) {
+            switch (menuHorizontalPosition) {
               case 0:
                 bar.source = checkIncDec(event, barSource, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
                 if (checkIncDec_Ret) {
@@ -827,7 +827,7 @@ void menuModelTelemetry(uint8_t event)
 #endif
         {
           for (int c=0; c<NUM_LINE_ITEMS; c++) {
-            LcdFlags cellAttr = (m_posHorz==c ? attr : 0);
+            LcdFlags cellAttr = (menuHorizontalPosition==c ? attr : 0);
             source_t & value = g_model.frsky.screens[screenIndex].lines[lineIndex].sources[c];
             const coord_t pos[] = {TELEM_COL1, TELEM_COL2, TELEM_COL3};
             putsMixerSource(pos[c], y, value, cellAttr);
@@ -835,7 +835,7 @@ void menuModelTelemetry(uint8_t event)
               value = checkIncDec(event, value, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
             }
           }
-          if (attr && m_posHorz == NUM_LINE_ITEMS) {
+          if (attr && menuHorizontalPosition == NUM_LINE_ITEMS) {
             REPEAT_LAST_CURSOR_MOVE();
           }
         }

--- a/radio/src/gui/Taranis/menus.cpp
+++ b/radio/src/gui/Taranis/menus.cpp
@@ -46,12 +46,14 @@ void popMenu()
   assert(g_menuStackPtr>0);
   g_menuStackPtr = g_menuStackPtr-1;
   menuEvent = EVT_ENTRY_UP;
+  TRACE("popMenu(%d)", g_menuStackPtr);
 }
 
 void chainMenu(MenuFuncP newMenu)
 {
   g_menuStack[g_menuStackPtr] = newMenu;
   menuEvent = EVT_ENTRY;
+  TRACE("chainMenu(%d, %p)", g_menuStackPtr, newMenu);
 }
 
 void pushMenu(MenuFuncP newMenu)
@@ -74,6 +76,7 @@ void pushMenu(MenuFuncP newMenu)
 
   g_menuStack[g_menuStackPtr] = newMenu;
   menuEvent = EVT_ENTRY;
+  TRACE("pushMenu(%d, %p)", g_menuStackPtr, newMenu);
 }
 
 void menuModelNotes(uint8_t event)

--- a/radio/src/gui/Taranis/menus.cpp
+++ b/radio/src/gui/Taranis/menus.cpp
@@ -36,47 +36,47 @@
 
 #include "../../opentx.h"
 
-MenuFuncP g_menuStack[5];
+menuHandlerFunc menuHandlers[5];
 uint8_t menuEvent = 0;
-uint8_t g_menuPos[4];
-uint8_t g_menuStackPtr = 0;
+uint8_t menuVerticalPositions[4];
+uint8_t menuLevel = 0;
 
 void popMenu()
 {
-  assert(g_menuStackPtr>0);
-  g_menuStackPtr = g_menuStackPtr-1;
+  assert(menuLevel>0);
+  menuLevel = menuLevel-1;
   menuEvent = EVT_ENTRY_UP;
-  TRACE("popMenu(%d)", g_menuStackPtr);
+  TRACE("popMenu(%d)", menuLevel);
 }
 
-void chainMenu(MenuFuncP newMenu)
+void chainMenu(menuHandlerFunc newMenu)
 {
-  g_menuStack[g_menuStackPtr] = newMenu;
+  menuHandlers[menuLevel] = newMenu;
   menuEvent = EVT_ENTRY;
-  TRACE("chainMenu(%d, %p)", g_menuStackPtr, newMenu);
+  TRACE("chainMenu(%d, %p)", menuLevel, newMenu);
 }
 
-void pushMenu(MenuFuncP newMenu)
+void pushMenu(menuHandlerFunc newMenu)
 {
   killEvents(KEY_ENTER);
 
-  if (g_menuStackPtr == 0) {
+  if (menuLevel == 0) {
     if (newMenu == menuGeneralSetup)
-      g_menuPos[0] = 1;
+      menuVerticalPositions[0] = 1;
     if (newMenu == menuModelSelect)
-      g_menuPos[0] = 0;
+      menuVerticalPositions[0] = 0;
   }
   else {
-    g_menuPos[g_menuStackPtr] = m_posVert;
+    menuVerticalPositions[menuLevel] = menuVerticalPosition;
   }
 
-  g_menuStackPtr++;
+  menuLevel++;
 
-  assert(g_menuStackPtr < DIM(g_menuStack));
+  assert(menuLevel < DIM(menuHandlers));
 
-  g_menuStack[g_menuStackPtr] = newMenu;
+  menuHandlers[menuLevel] = newMenu;
   menuEvent = EVT_ENTRY;
-  TRACE("pushMenu(%d, %p)", g_menuStackPtr, newMenu);
+  TRACE("pushMenu(%d, %p)", menuLevel, newMenu);
 }
 
 void menuModelNotes(uint8_t event)

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -321,14 +321,14 @@ extern void (*popupFunc)(uint8_t event);
 extern int16_t warningInputValue;
 extern int16_t warningInputValueMin;
 extern int16_t warningInputValueMax;
-extern uint8_t s_warning_info_flags;
+extern uint8_t warningInfoFlags;
 
 #define DISPLAY_WARNING       (*popupFunc)
 #define POPUP_WARNING(s)      (warningText = s, warningInfoText = 0, popupFunc = displayWarning)
 #define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
 #define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
-#define WARNING_INFO_FLAGS    s_warning_info_flags
-#define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, s_warning_info_flags = flags)
+#define WARNING_INFO_FLAGS    warningInfoFlags
+#define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, warningInfoFlags = flags)
 
 #define NAVIGATION_MENUS
 #define POPUP_MENU_ADD_ITEM(s) do { popupMenuOffsetType = MENU_OFFSET_INTERNAL; if (popupMenuNoItems < POPUP_MENU_MAX_LINES) popupMenuItems[popupMenuNoItems++] = s; } while (0)

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -57,36 +57,36 @@ typedef uint8_t & check_event_t;
 
 extern tmr10ms_t menuEntryTime;
 
-extern vertpos_t m_posVert;
-extern horzpos_t m_posHorz;
+extern vertpos_t menuVerticalPosition;
+extern horzpos_t menuHorizontalPosition;
 extern vertpos_t s_pgOfs;
 extern uint8_t s_noHi;
 extern uint8_t calibrationState;
 
 void menu_lcd_onoff(coord_t x, coord_t y, uint8_t value, LcdFlags attr);
 
-typedef void (*MenuFuncP)(uint8_t event);
+typedef void (*menuHandlerFunc)(uint8_t event);
 typedef void (*MenuFuncP_PROGMEM)(uint8_t event);
 extern const MenuFuncP_PROGMEM menuTabModel[];
 extern const MenuFuncP_PROGMEM menuTabGeneral[];
 extern const MenuFuncP_PROGMEM menuTabFPV[];
 extern const MenuFuncP_PROGMEM menuTabTelemetry[];
 
-extern MenuFuncP g_menuStack[5];
-extern uint8_t g_menuPos[4];
-extern uint8_t g_menuStackPtr;
+extern menuHandlerFunc menuHandlers[5];
+extern uint8_t menuVerticalPositions[4];
+extern uint8_t menuLevel;
 extern uint8_t menuEvent;
 
 /// goto given Menu, but substitute current menu in menuStack
-void chainMenu(MenuFuncP newMenu);
+void chainMenu(menuHandlerFunc newMenu);
 /// goto given Menu, store current menu in menuStack
-void pushMenu(MenuFuncP newMenu);
+void pushMenu(menuHandlerFunc newMenu);
 /// return to last menu in menustack
 void popMenu();
 ///deliver address of last menu which was popped from
-inline MenuFuncP lastPopMenu()
+inline menuHandlerFunc lastPopMenu()
 {
-  return g_menuStack[g_menuStackPtr+1];
+  return menuHandlers[menuLevel+1];
 }
 
 void doMainScreenGraphics();
@@ -223,11 +223,11 @@ bool isInputSourceAvailable(int source);
   var = checkIncDecGen(event, var, min, max)
 
 #define NAVIGATION_LINE_BY_LINE  0x40
-#define CURSOR_ON_LINE()         (m_posHorz<0)
+#define CURSOR_ON_LINE()         (menuHorizontalPosition<0)
 
 #define CHECK_FLAG_NO_SCREEN_INDEX   1
-void check(const char *title, check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow, uint8_t flags=0);
-void check_simple(const char *title, check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, vertpos_t maxrow);
+void check(const char *title, check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow, uint8_t flags=0);
+void check_simple(const char *title, check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, vertpos_t maxrow);
 void check_submenu_simple(const char *title, check_event_t event, uint8_t maxrow);
 
 void title(const pm_char * s);
@@ -381,8 +381,8 @@ void menuChannelsView(uint8_t event);
   #define IS_ROTARY_MOVE_LEFT        IS_ROTARY_RIGHT
 #endif
 
-#define REPEAT_LAST_CURSOR_MOVE() { if (CURSOR_MOVED_LEFT(event) || CURSOR_MOVED_RIGHT(event)) putEvent(event); else m_posHorz = 0; }
-#define MOVE_CURSOR_FROM_HERE()   if (m_posHorz > 0) REPEAT_LAST_CURSOR_MOVE()
+#define REPEAT_LAST_CURSOR_MOVE() { if (CURSOR_MOVED_LEFT(event) || CURSOR_MOVED_RIGHT(event)) putEvent(event); else menuHorizontalPosition = 0; }
+#define MOVE_CURSOR_FROM_HERE()   if (menuHorizontalPosition > 0) REPEAT_LAST_CURSOR_MOVE()
 
 #define POS_VERT_INIT            (menuTab ? (MAXCOL((uint16_t)0) >= HIDDEN_ROW ? (MAXCOL((uint16_t)1) >= HIDDEN_ROW ? 2 : 1) : 0) : 0)
 #define POS_HORZ_INIT(posVert)   ((COLATTR(posVert) & NAVIGATION_LINE_BY_LINE) ? -1 : 0)

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -298,11 +298,11 @@ void editName(coord_t x, coord_t y, char *name, uint8_t size, uint8_t event, uin
 #define WARNING_TYPE_CONFIRM   1
 #define WARNING_TYPE_INPUT     2
 
-extern const pm_char * s_warning;
-extern const pm_char * s_warning_info;
+extern const pm_char * warningText;
+extern const pm_char * warningInfoText;
 extern uint8_t         s_warning_info_len;
-extern uint8_t         s_warning_result;
-extern uint8_t         s_warning_type;
+extern uint8_t         warningResult;
+extern uint8_t         warningType;
 
 #define MENU_X            30
 #define MENU_Y            16
@@ -316,17 +316,17 @@ void displayPopup(const char *title);
 void displayWarning(uint8_t event);
 
 extern void (*popupFunc)(uint8_t event);
-extern int16_t s_warning_input_value;
-extern int16_t s_warning_input_min;
-extern int16_t s_warning_input_max;
+extern int16_t warningInputValue;
+extern int16_t warningInputValueMin;
+extern int16_t warningInputValueMax;
 extern uint8_t s_warning_info_flags;
 
 #define DISPLAY_WARNING       (*popupFunc)
-#define POPUP_WARNING(s)      (s_warning = s, s_warning_info = 0, popupFunc = displayWarning)
-#define POPUP_CONFIRMATION(s) (s_warning = s, s_warning_type = WARNING_TYPE_CONFIRM, s_warning_info = 0, popupFunc = displayWarning)
-#define POPUP_INPUT(s, func, start, min, max) (s_warning = s, s_warning_type = WARNING_TYPE_INPUT, popupFunc = func, s_warning_input_value = start, s_warning_input_min = min, s_warning_input_max = max)
+#define POPUP_WARNING(s)      (warningText = s, warningInfoText = 0, popupFunc = displayWarning)
+#define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
+#define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
 #define WARNING_INFO_FLAGS    s_warning_info_flags
-#define SET_WARNING_INFO(info, len, flags) (s_warning_info = info, s_warning_info_len = len, s_warning_info_flags = flags)
+#define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, s_warning_info_flags = flags)
 
 #define NAVIGATION_MENUS
 #define POPUP_MENU_ADD_ITEM(s) do { popupMenuOffsetType = MENU_OFFSET_INTERNAL; if (popupMenuNoItems < POPUP_MENU_MAX_LINES) popupMenuItems[popupMenuNoItems++] = s; } while (0)

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -59,7 +59,7 @@ extern tmr10ms_t menuEntryTime;
 
 extern vertpos_t menuVerticalPosition;
 extern horzpos_t menuHorizontalPosition;
-extern vertpos_t s_pgOfs;
+extern vertpos_t menuVerticalOffset;
 extern uint8_t s_noHi;
 extern uint8_t calibrationState;
 

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -329,22 +329,21 @@ extern uint8_t s_warning_info_flags;
 #define SET_WARNING_INFO(info, len, flags) (s_warning_info = info, s_warning_info_len = len, s_warning_info_flags = flags)
 
 #define NAVIGATION_MENUS
-#define MENU_ADD_ITEM(s) do { s_menu_offset_type = MENU_OFFSET_INTERNAL; if (s_menu_count < MENU_MAX_LINES) s_menu[s_menu_count++] = s; } while (0)
-#define MENU_MAX_LINES           12
+#define POPUP_MENU_ADD_ITEM(s) do { popupMenuOffsetType = MENU_OFFSET_INTERNAL; if (popupMenuNoItems < POPUP_MENU_MAX_LINES) popupMenuItems[popupMenuNoItems++] = s; } while (0)
+#define POPUP_MENU_MAX_LINES           12
 #define MENU_MAX_DISPLAY_LINES   6
-#define MENU_ADD_SD_ITEM(s) MENU_ADD_ITEM(s)
+#define POPUP_MENU_ADD_SD_ITEM(s) POPUP_MENU_ADD_ITEM(s)
 #define MENU_LINE_LENGTH (LEN_MODEL_NAME+12)
-extern const char *s_menu[MENU_MAX_LINES];
-extern uint16_t s_menu_count;
-extern uint8_t s_menu_flags;
-extern uint16_t s_menu_offset;
+extern const char *popupMenuItems[POPUP_MENU_MAX_LINES];
+extern uint16_t popupMenuNoItems;
+extern uint16_t popupMenuOffset;
 enum {
   MENU_OFFSET_INTERNAL,
   MENU_OFFSET_EXTERNAL
 };
-extern uint8_t s_menu_offset_type;
-const char * displayMenu(uint8_t event);
-extern void (*menuHandler)(const char *result);
+extern uint8_t popupMenuOffsetType;
+const char * displayPopupMenu(uint8_t event);
+extern void (*popupMenuHandler)(const char *result);
 
 #define STATUS_LINE_LENGTH 32
 extern char statusLineMsg[STATUS_LINE_LENGTH];

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -302,7 +302,7 @@ void editName(coord_t x, coord_t y, char *name, uint8_t size, uint8_t event, uin
 
 extern const pm_char * warningText;
 extern const pm_char * warningInfoText;
-extern uint8_t         s_warning_info_len;
+extern uint8_t         warningInfoLength;
 extern uint8_t         warningResult;
 extern uint8_t         warningType;
 
@@ -328,7 +328,7 @@ extern uint8_t warningInfoFlags;
 #define POPUP_CONFIRMATION(s) (warningText = s, warningType = WARNING_TYPE_CONFIRM, warningInfoText = 0, popupFunc = displayWarning)
 #define POPUP_INPUT(s, func, start, min, max) (warningText = s, warningType = WARNING_TYPE_INPUT, popupFunc = func, warningInputValue = start, warningInputValueMin = min, warningInputValueMax = max)
 #define WARNING_INFO_FLAGS    warningInfoFlags
-#define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, s_warning_info_len = len, warningInfoFlags = flags)
+#define SET_WARNING_INFO(info, len, flags) (warningInfoText = info, warningInfoLength = len, warningInfoFlags = flags)
 
 #define NAVIGATION_MENUS
 #define POPUP_MENU_ADD_ITEM(s) do { popupMenuOffsetType = MENU_OFFSET_INTERNAL; if (popupMenuNoItems < POPUP_MENU_MAX_LINES) popupMenuItems[popupMenuNoItems++] = s; } while (0)

--- a/radio/src/gui/Taranis/menus.h
+++ b/radio/src/gui/Taranis/menus.h
@@ -37,8 +37,6 @@
 #ifndef _MENUS_H_
 #define _MENUS_H_
 
-#define NO_HI_LEN  25
-
 #if defined(TRANSLATIONS_FR)
   #define MENU_COLUMNS         1
 #else
@@ -60,8 +58,12 @@ extern tmr10ms_t menuEntryTime;
 extern vertpos_t menuVerticalPosition;
 extern horzpos_t menuHorizontalPosition;
 extern vertpos_t menuVerticalOffset;
-extern uint8_t s_noHi;
 extern uint8_t calibrationState;
+
+// Temporary no highlight
+extern uint8_t noHighlightCounter;
+#define NO_HIGHLIGHT()        (noHighlightCounter > 0)
+#define START_NO_HIGHLIGHT()  do { noHighlightCounter = 25; } while(0)
 
 void menu_lcd_onoff(coord_t x, coord_t y, uint8_t value, LcdFlags attr);
 

--- a/radio/src/gui/Taranis/navigation.cpp
+++ b/radio/src/gui/Taranis/navigation.cpp
@@ -40,7 +40,7 @@ vertpos_t menuVerticalOffset;
 vertpos_t menuVerticalPosition;
 horzpos_t menuHorizontalPosition;
 int8_t s_editMode;
-uint8_t s_noHi;
+uint8_t noHighlightCounter;
 uint8_t calibrationState;
 int checkIncDecSelection = 0;
 

--- a/radio/src/gui/Taranis/navigation.cpp
+++ b/radio/src/gui/Taranis/navigation.cpp
@@ -37,8 +37,8 @@
 #include "../../opentx.h"
 
 vertpos_t s_pgOfs;
-vertpos_t m_posVert;
-horzpos_t m_posHorz;
+vertpos_t menuVerticalPosition;
+horzpos_t menuHorizontalPosition;
 int8_t s_editMode;
 uint8_t s_noHi;
 uint8_t calibrationState;
@@ -365,10 +365,10 @@ void onLongMenuPress(const char *result)
 
 tmr10ms_t menuEntryTime;
 
-void check(const char *name, check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t rowcount, uint8_t flags)
+void check(const char *name, check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t rowcount, uint8_t flags)
 {
-  vertpos_t l_posVert = m_posVert;
-  horzpos_t l_posHorz = m_posHorz;
+  vertpos_t l_posVert = menuVerticalPosition;
+  horzpos_t l_posHorz = menuHorizontalPosition;
 
   uint8_t maxcol = MAXCOL(l_posVert);
 
@@ -406,7 +406,7 @@ void check(const char *name, check_event_t event, uint8_t curr, const MenuFuncP 
     }
 
     if (!calibrationState && cc != curr) {
-      chainMenu((MenuFuncP)pgm_read_adr(&menuTab[cc]));
+      chainMenu((menuHandlerFunc)pgm_read_adr(&menuTab[cc]));
     }
 
     if (!(flags&CHECK_FLAG_NO_SCREEN_INDEX)) {
@@ -437,7 +437,7 @@ void check(const char *name, check_event_t event, uint8_t curr, const MenuFuncP 
 
     case EVT_ROTARY_BREAK:
       if (s_editMode > 1) break;
-      if (m_posHorz < 0 && maxcol > 0 && READ_ONLY_UNLOCKED()) {
+      if (menuHorizontalPosition < 0 && maxcol > 0 && READ_ONLY_UNLOCKED()) {
         l_posHorz = 0;
         break;
       }
@@ -604,12 +604,12 @@ void check(const char *name, check_event_t event, uint8_t curr, const MenuFuncP 
     title(name);
   }
 
-  m_posVert = l_posVert;
-  m_posHorz = l_posHorz;
+  menuVerticalPosition = l_posVert;
+  menuHorizontalPosition = l_posHorz;
 }
 
 
-void check_simple(const char *name, check_event_t event, uint8_t curr, const MenuFuncP *menuTab, uint8_t menuTabSize, vertpos_t rowcount)
+void check_simple(const char *name, check_event_t event, uint8_t curr, const menuHandlerFunc *menuTab, uint8_t menuTabSize, vertpos_t rowcount)
 {
   check(name, event, curr, menuTab, menuTabSize, 0, 0, rowcount);
 }
@@ -625,6 +625,6 @@ void repeatLastCursorMove(uint8_t event)
     putEvent(event);
   }
   else {
-    m_posHorz = 0;
+    menuHorizontalPosition = 0;
   }
 }

--- a/radio/src/gui/Taranis/navigation.cpp
+++ b/radio/src/gui/Taranis/navigation.cpp
@@ -273,40 +273,40 @@ int checkIncDec(unsigned int event, int val, int i_min, int i_max, unsigned int 
       
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
-          MENU_ADD_ITEM(STR_MENU_INPUTS);
+          POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }
 #if defined(LUA_MODEL_SCRIPTS)
       if (i_min <= MIXSRC_FIRST_LUA && i_max >= MIXSRC_FIRST_LUA) {
         if (getFirstAvailable(MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA, isSourceAvailable) != MIXSRC_NONE) {
-          MENU_ADD_ITEM(STR_MENU_LUA);
+          POPUP_MENU_ADD_ITEM(STR_MENU_LUA);
         }
       }
 #endif
-      if (i_min <= MIXSRC_FIRST_STICK && i_max >= MIXSRC_FIRST_STICK)      MENU_ADD_ITEM(STR_MENU_STICKS);
-      if (i_min <= MIXSRC_FIRST_POT && i_max >= MIXSRC_FIRST_POT)          MENU_ADD_ITEM(STR_MENU_POTS);
-      if (i_min <= MIXSRC_MAX && i_max >= MIXSRC_MAX)                      MENU_ADD_ITEM(STR_MENU_MAX);
+      if (i_min <= MIXSRC_FIRST_STICK && i_max >= MIXSRC_FIRST_STICK)      POPUP_MENU_ADD_ITEM(STR_MENU_STICKS);
+      if (i_min <= MIXSRC_FIRST_POT && i_max >= MIXSRC_FIRST_POT)          POPUP_MENU_ADD_ITEM(STR_MENU_POTS);
+      if (i_min <= MIXSRC_MAX && i_max >= MIXSRC_MAX)                      POPUP_MENU_ADD_ITEM(STR_MENU_MAX);
 #if defined(HELI)
-      if (i_min <= MIXSRC_FIRST_HELI && i_max >= MIXSRC_FIRST_HELI)        MENU_ADD_ITEM(STR_MENU_HELI);
+      if (i_min <= MIXSRC_FIRST_HELI && i_max >= MIXSRC_FIRST_HELI)        POPUP_MENU_ADD_ITEM(STR_MENU_HELI);
 #endif
-      if (i_min <= MIXSRC_FIRST_TRIM && i_max >= MIXSRC_FIRST_TRIM)        MENU_ADD_ITEM(STR_MENU_TRIMS);
-      if (i_min <= MIXSRC_FIRST_SWITCH && i_max >= MIXSRC_FIRST_SWITCH)    MENU_ADD_ITEM(STR_MENU_SWITCHES);
-      if (i_min <= MIXSRC_FIRST_TRAINER && i_max >= MIXSRC_FIRST_TRAINER)  MENU_ADD_ITEM(STR_MENU_TRAINER);
-      if (i_min <= MIXSRC_FIRST_CH && i_max >= MIXSRC_FIRST_CH)            MENU_ADD_ITEM(STR_MENU_CHANNELS);
+      if (i_min <= MIXSRC_FIRST_TRIM && i_max >= MIXSRC_FIRST_TRIM)        POPUP_MENU_ADD_ITEM(STR_MENU_TRIMS);
+      if (i_min <= MIXSRC_FIRST_SWITCH && i_max >= MIXSRC_FIRST_SWITCH)    POPUP_MENU_ADD_ITEM(STR_MENU_SWITCHES);
+      if (i_min <= MIXSRC_FIRST_TRAINER && i_max >= MIXSRC_FIRST_TRAINER)  POPUP_MENU_ADD_ITEM(STR_MENU_TRAINER);
+      if (i_min <= MIXSRC_FIRST_CH && i_max >= MIXSRC_FIRST_CH)            POPUP_MENU_ADD_ITEM(STR_MENU_CHANNELS);
       if (i_min <= MIXSRC_FIRST_GVAR && i_max >= MIXSRC_FIRST_GVAR && isValueAvailable(MIXSRC_FIRST_GVAR)) {
-        MENU_ADD_ITEM(STR_MENU_GVARS);
+        POPUP_MENU_ADD_ITEM(STR_MENU_GVARS);
       }
       
       if (i_min <= MIXSRC_FIRST_TELEM && i_max >= MIXSRC_FIRST_TELEM) {
         for (int i = 0; i < MAX_SENSORS; i++) {
           TelemetrySensor * sensor = & g_model.telemetrySensors[i];
           if (sensor->isAvailable()) {
-            MENU_ADD_ITEM(STR_MENU_TELEMETRY);
+            POPUP_MENU_ADD_ITEM(STR_MENU_TELEMETRY);
             break;
           }
         }
       }
-      menuHandler = onSourceLongEnterPress;
+      popupMenuHandler = onSourceLongEnterPress;
     }
     if (checkIncDecSelection != 0) {
       newval = checkIncDecSelection;
@@ -319,19 +319,19 @@ int checkIncDec(unsigned int event, int val, int i_min, int i_max, unsigned int 
     if (event == EVT_KEY_LONG(KEY_ENTER)) {
       killEvents(event);
       checkIncDecSelection = SWSRC_NONE;
-      if (i_min <= SWSRC_FIRST_SWITCH && i_max >= SWSRC_LAST_SWITCH)       MENU_ADD_ITEM(STR_MENU_SWITCHES);
-      if (i_min <= SWSRC_FIRST_TRIM && i_max >= SWSRC_LAST_TRIM)           MENU_ADD_ITEM(STR_MENU_TRIMS);
+      if (i_min <= SWSRC_FIRST_SWITCH && i_max >= SWSRC_LAST_SWITCH)       POPUP_MENU_ADD_ITEM(STR_MENU_SWITCHES);
+      if (i_min <= SWSRC_FIRST_TRIM && i_max >= SWSRC_LAST_TRIM)           POPUP_MENU_ADD_ITEM(STR_MENU_TRIMS);
       if (i_min <= SWSRC_FIRST_LOGICAL_SWITCH && i_max >= SWSRC_LAST_LOGICAL_SWITCH) {
         for (int i = 0; i < NUM_LOGICAL_SWITCH; i++) {
           if (isValueAvailable && isValueAvailable(SWSRC_FIRST_LOGICAL_SWITCH+i)) {
-            MENU_ADD_ITEM(STR_MENU_LOGICAL_SWITCHES);
+            POPUP_MENU_ADD_ITEM(STR_MENU_LOGICAL_SWITCHES);
             break;
           }
         }
       }
-      if (isValueAvailable && isValueAvailable(SWSRC_ON))                  MENU_ADD_ITEM(STR_MENU_OTHER);
-      if (isValueAvailable && isValueAvailable(-newval))                   MENU_ADD_ITEM(STR_MENU_INVERT);
-      menuHandler = onSwitchLongEnterPress;
+      if (isValueAvailable && isValueAvailable(SWSRC_ON))                  POPUP_MENU_ADD_ITEM(STR_MENU_OTHER);
+      if (isValueAvailable && isValueAvailable(-newval))                   POPUP_MENU_ADD_ITEM(STR_MENU_INVERT);
+      popupMenuHandler = onSwitchLongEnterPress;
       s_editMode = EDIT_MODIFY_FIELD;
     }
     if (checkIncDecSelection != 0) {
@@ -379,9 +379,9 @@ void check(const char *name, check_event_t event, uint8_t curr, const MenuFuncP 
         if (menuTab == menuTabModel) {
           killEvents(event);
           if (modelHasNotes()) {
-            MENU_ADD_SD_ITEM(STR_VIEW_CHANNELS);
-            MENU_ADD_ITEM(STR_VIEW_NOTES);
-            menuHandler = onLongMenuPress;
+            POPUP_MENU_ADD_SD_ITEM(STR_VIEW_CHANNELS);
+            POPUP_MENU_ADD_ITEM(STR_VIEW_NOTES);
+            popupMenuHandler = onLongMenuPress;
           }
           else {
             pushMenu(menuChannelsView);

--- a/radio/src/gui/Taranis/navigation.cpp
+++ b/radio/src/gui/Taranis/navigation.cpp
@@ -36,7 +36,7 @@
 
 #include "../../opentx.h"
 
-vertpos_t s_pgOfs;
+vertpos_t menuVerticalOffset;
 vertpos_t menuVerticalPosition;
 horzpos_t menuHorizontalPosition;
 int8_t s_editMode;
@@ -463,8 +463,8 @@ void check(const char *name, check_event_t event, uint8_t curr, const menuHandle
       else
       {
         uint8_t posVertInit = POS_VERT_INIT;
-        if (s_pgOfs != 0 || l_posVert != posVertInit) {
-          s_pgOfs = 0;
+        if (menuVerticalOffset != 0 || l_posVert != posVertInit) {
+          menuVerticalOffset = 0;
           l_posVert = posVertInit;
           l_posHorz = POS_HORZ_INIT(l_posVert);
         }
@@ -542,7 +542,7 @@ void check(const char *name, check_event_t event, uint8_t curr, const menuHandle
   int linesCount = rowcount;
 
   if (l_posVert == 0 || (l_posVert==1 && MAXCOL(vertpos_t(0)) >= HIDDEN_ROW) || (l_posVert==2 && MAXCOL(vertpos_t(0)) >= HIDDEN_ROW && MAXCOL(vertpos_t(1)) >= HIDDEN_ROW)) {
-    s_pgOfs = 0;
+    menuVerticalOffset = 0;
     if (horTab) {
       linesCount = 0;
       for (int i=0; i<rowcount; i++) {
@@ -556,13 +556,13 @@ void check(const char *name, check_event_t event, uint8_t curr, const menuHandle
     if (rowcount > NUM_BODY_LINES) {
       while (1) {
         vertpos_t firstLine = 0;
-        for (int numLines=0; firstLine<rowcount && numLines<s_pgOfs; firstLine++) {
+        for (int numLines=0; firstLine<rowcount && numLines<menuVerticalOffset; firstLine++) {
           if (firstLine>=horTabMax || horTab[firstLine] != HIDDEN_ROW) {
             numLines++;
           }
         }
         if (l_posVert < firstLine) {
-          s_pgOfs--;
+          menuVerticalOffset--;
         }
         else {
           vertpos_t lastLine = firstLine;
@@ -572,10 +572,10 @@ void check(const char *name, check_event_t event, uint8_t curr, const menuHandle
             }
           }
           if (l_posVert >= lastLine) {
-            s_pgOfs++;
+            menuVerticalOffset++;
           }
           else {
-            linesCount = s_pgOfs + NUM_BODY_LINES;
+            linesCount = menuVerticalOffset + NUM_BODY_LINES;
             for (int i=lastLine; i<rowcount; i++) {
               if (i>horTabMax || horTab[i] != HIDDEN_ROW) {
                 linesCount++;
@@ -588,16 +588,16 @@ void check(const char *name, check_event_t event, uint8_t curr, const menuHandle
     }
   }
   else {
-    if (l_posVert>=NUM_BODY_LINES+s_pgOfs) {
-      s_pgOfs = l_posVert-NUM_BODY_LINES+1;
+    if (l_posVert>=NUM_BODY_LINES+menuVerticalOffset) {
+      menuVerticalOffset = l_posVert-NUM_BODY_LINES+1;
     }
-    else if (l_posVert<s_pgOfs) {
-      s_pgOfs = l_posVert;
+    else if (l_posVert<menuVerticalOffset) {
+      menuVerticalOffset = l_posVert;
     }
   }
 
   if (scrollbar_X && linesCount > NUM_BODY_LINES) {
-    displayScrollbar(scrollbar_X, MENU_HEADER_HEIGHT, LCD_H-MENU_HEADER_HEIGHT, s_pgOfs, linesCount, NUM_BODY_LINES);
+    displayScrollbar(scrollbar_X, MENU_HEADER_HEIGHT, LCD_H-MENU_HEADER_HEIGHT, menuVerticalOffset, linesCount, NUM_BODY_LINES);
   }
 
   if (name) {

--- a/radio/src/gui/Taranis/popups.cpp
+++ b/radio/src/gui/Taranis/popups.cpp
@@ -36,15 +36,15 @@
 
 #include "../../opentx.h"
 
-const char *s_warning = NULL;
-const char *s_warning_info;
+const char *warningText = NULL;
+const char *warningInfoText;
 uint8_t     s_warning_info_len;
-uint8_t     s_warning_type;
-uint8_t     s_warning_result = 0;
+uint8_t     warningType;
+uint8_t     warningResult = 0;
 uint8_t     s_warning_info_flags = ZCHAR;
-int16_t     s_warning_input_value;
-int16_t     s_warning_input_min;
-int16_t     s_warning_input_max;
+int16_t     warningInputValue;
+int16_t     warningInputValueMin;
+int16_t     warningInputValueMax;
 void        (*popupFunc)(uint8_t event) = NULL;
 const char *popupMenuItems[POPUP_MENU_MAX_LINES];
 uint8_t     s_menu_item = 0;
@@ -58,7 +58,7 @@ void displayBox(const char *title)
   drawFilledRect(10, 16, LCD_W-20, 40, SOLID, ERASE);
   lcd_rect(10, 16, LCD_W-20, 40);
   lcd_putsn(WARNING_LINE_X, WARNING_LINE_Y, title, WARNING_LINE_LEN);
-  // could be a place for a s_warning_info
+  // could be a place for a warningInfoText
 }
 
 void displayPopup(const char *title)
@@ -98,26 +98,26 @@ void message(const pm_char *title, const pm_char *t, const char *last MESSAGE_SO
 
 void displayWarning(uint8_t event)
 {
-  s_warning_result = false;
-  displayBox(s_warning);
-  if (s_warning_info) {
-    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, s_warning_info, s_warning_info_len, WARNING_INFO_FLAGS);
+  warningResult = false;
+  displayBox(warningText);
+  if (warningInfoText) {
+    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, s_warning_info_len, WARNING_INFO_FLAGS);
   }
-  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, s_warning_type == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
+  lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, warningType == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
   switch (event) {
     case EVT_KEY_BREAK(KEY_ENTER):
-      if (s_warning_type == WARNING_TYPE_ASTERISK)
+      if (warningType == WARNING_TYPE_ASTERISK)
         break;
-      s_warning_result = true;
+      warningResult = true;
       // no break
     case EVT_KEY_BREAK(KEY_EXIT):
-      s_warning = NULL;
-      s_warning_type = WARNING_TYPE_ASTERISK;
+      warningText = NULL;
+      warningType = WARNING_TYPE_ASTERISK;
       break;
     default:
-      if (s_warning_type != WARNING_TYPE_INPUT) break;
+      if (warningType != WARNING_TYPE_INPUT) break;
       s_editMode = EDIT_MODIFY_FIELD;
-      s_warning_input_value = checkIncDec(event, s_warning_input_value, s_warning_input_min, s_warning_input_max);
+      warningInputValue = checkIncDec(event, warningInputValue, warningInputValueMin, warningInputValueMax);
       s_editMode = EDIT_SELECT_FIELD;
       break;
   }

--- a/radio/src/gui/Taranis/popups.cpp
+++ b/radio/src/gui/Taranis/popups.cpp
@@ -41,7 +41,7 @@ const char *warningInfoText;
 uint8_t     s_warning_info_len;
 uint8_t     warningType;
 uint8_t     warningResult = 0;
-uint8_t     s_warning_info_flags = ZCHAR;
+uint8_t     warningInfoFlags = ZCHAR;
 int16_t     warningInputValue;
 int16_t     warningInputValueMin;
 int16_t     warningInputValueMax;

--- a/radio/src/gui/Taranis/popups.cpp
+++ b/radio/src/gui/Taranis/popups.cpp
@@ -38,7 +38,7 @@
 
 const char *warningText = NULL;
 const char *warningInfoText;
-uint8_t     s_warning_info_len;
+uint8_t     warningInfoLength;
 uint8_t     warningType;
 uint8_t     warningResult = 0;
 uint8_t     warningInfoFlags = ZCHAR;
@@ -101,7 +101,7 @@ void displayWarning(uint8_t event)
   warningResult = false;
   displayBox(warningText);
   if (warningInfoText) {
-    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, s_warning_info_len, WARNING_INFO_FLAGS);
+    lcd_putsnAtt(WARNING_LINE_X, WARNING_LINE_Y+FH, warningInfoText, warningInfoLength, WARNING_INFO_FLAGS);
   }
   lcd_puts(WARNING_LINE_X, WARNING_LINE_Y+2*FH, warningType == WARNING_TYPE_ASTERISK ? STR_EXIT : STR_POPUPS);
   switch (event) {

--- a/radio/src/gui/Taranis/popups.cpp
+++ b/radio/src/gui/Taranis/popups.cpp
@@ -46,13 +46,12 @@ int16_t     s_warning_input_value;
 int16_t     s_warning_input_min;
 int16_t     s_warning_input_max;
 void        (*popupFunc)(uint8_t event) = NULL;
-const char *s_menu[MENU_MAX_LINES];
+const char *popupMenuItems[POPUP_MENU_MAX_LINES];
 uint8_t     s_menu_item = 0;
-uint16_t    s_menu_count = 0;
-uint8_t     s_menu_flags = 0;
-uint16_t    s_menu_offset = 0;
-uint8_t     s_menu_offset_type = MENU_OFFSET_INTERNAL;
-void        (*menuHandler)(const char *result);
+uint16_t    popupMenuNoItems = 0;
+uint16_t    popupMenuOffset = 0;
+uint8_t     popupMenuOffsetType = MENU_OFFSET_INTERNAL;
+void        (*popupMenuHandler)(const char *result);
 
 void displayBox(const char *title)
 {
@@ -124,22 +123,22 @@ void displayWarning(uint8_t event)
   }
 }
 
-const char * displayMenu(uint8_t event)
+const char * displayPopupMenu(uint8_t event)
 {
   const char * result = NULL;
 
-  uint8_t display_count = min<unsigned int>(s_menu_count, MENU_MAX_DISPLAY_LINES);
+  uint8_t display_count = min<unsigned int>(popupMenuNoItems, MENU_MAX_DISPLAY_LINES);
   uint8_t y = (display_count >= 5 ? MENU_Y - FH - 1 : MENU_Y);
   drawFilledRect(MENU_X, y, MENU_W, display_count * (FH+1) + 2, SOLID, ERASE);
   lcd_rect(MENU_X, y, MENU_W, display_count * (FH+1) + 2);
 
   for (uint8_t i=0; i<display_count; i++) {
-    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, s_menu[i+(s_menu_offset_type == MENU_OFFSET_INTERNAL ? s_menu_offset : 0)], s_menu_flags);
+    lcd_putsAtt(MENU_X+6, i*(FH+1) + y + 2, popupMenuItems[i+(popupMenuOffsetType == MENU_OFFSET_INTERNAL ? popupMenuOffset : 0)], 0);
     if (i == s_menu_item) drawFilledRect(MENU_X+1, i*(FH+1) + y + 1, MENU_W-2, 9);
   }
 
-  if (s_menu_count > display_count) {
-    displayScrollbar(MENU_X+MENU_W-1, y+1, MENU_MAX_DISPLAY_LINES * (FH+1), s_menu_offset, s_menu_count, display_count);
+  if (popupMenuNoItems > display_count) {
+    displayScrollbar(MENU_X+MENU_W-1, y+1, MENU_MAX_DISPLAY_LINES * (FH+1), popupMenuOffset, popupMenuNoItems, display_count);
   }
 
   switch(event) {
@@ -148,14 +147,14 @@ const char * displayMenu(uint8_t event)
       if (s_menu_item > 0) {
         s_menu_item--;
       }
-      else if (s_menu_offset > 0) {
-        s_menu_offset--;
+      else if (popupMenuOffset > 0) {
+        popupMenuOffset--;
         result = STR_UPDATE_LIST;
       }
       else {
         s_menu_item = min<uint8_t>(display_count, MENU_MAX_DISPLAY_LINES) - 1;
-        if (s_menu_count > MENU_MAX_DISPLAY_LINES) {
-          s_menu_offset = s_menu_count - MENU_MAX_DISPLAY_LINES;
+        if (popupMenuNoItems > MENU_MAX_DISPLAY_LINES) {
+          popupMenuOffset = popupMenuNoItems - MENU_MAX_DISPLAY_LINES;
           result = STR_UPDATE_LIST;
         }
       }
@@ -163,30 +162,29 @@ const char * displayMenu(uint8_t event)
 
     case EVT_KEY_FIRST(KEY_MOVE_DOWN):
     case EVT_KEY_REPT(KEY_MOVE_DOWN):
-      if (s_menu_item < display_count - 1 && s_menu_offset + s_menu_item + 1 < s_menu_count) {
+      if (s_menu_item < display_count - 1 && popupMenuOffset + s_menu_item + 1 < popupMenuNoItems) {
         s_menu_item++;
       }
-      else if (s_menu_count > s_menu_offset + display_count) {
-        s_menu_offset++;
+      else if (popupMenuNoItems > popupMenuOffset + display_count) {
+        popupMenuOffset++;
         result = STR_UPDATE_LIST;
       }
       else {
         s_menu_item = 0;
-        if (s_menu_offset) {
-          s_menu_offset = 0;
+        if (popupMenuOffset) {
+          popupMenuOffset = 0;
           result = STR_UPDATE_LIST;
         }
       }
       break;
     CASE_EVT_ROTARY_BREAK
     case EVT_KEY_BREAK(KEY_ENTER):
-      result = s_menu[s_menu_item + (s_menu_offset_type == MENU_OFFSET_INTERNAL ? s_menu_offset : 0)];
+      result = popupMenuItems[s_menu_item + (popupMenuOffsetType == MENU_OFFSET_INTERNAL ? popupMenuOffset : 0)];
       // no break
     case EVT_KEY_BREAK(KEY_EXIT):
-      s_menu_count = 0;
+      popupMenuNoItems = 0;
       s_menu_item = 0;
-      s_menu_flags = 0;
-      s_menu_offset = 0;
+      popupMenuOffset = 0;
       break;
   }
 

--- a/radio/src/gui/Taranis/view_main.cpp
+++ b/radio/src/gui/Taranis/view_main.cpp
@@ -368,11 +368,11 @@ void onMainViewMenu(const char *result)
     pushModelNotes();
   }
   else if (result == STR_RESET_SUBMENU) {
-    MENU_ADD_ITEM(STR_RESET_FLIGHT);
-    MENU_ADD_ITEM(STR_RESET_TIMER1);
-    MENU_ADD_ITEM(STR_RESET_TIMER2);
-    MENU_ADD_ITEM(STR_RESET_TIMER3);
-    MENU_ADD_ITEM(STR_RESET_TELEMETRY);
+    POPUP_MENU_ADD_ITEM(STR_RESET_FLIGHT);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER1);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER2);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TIMER3);
+    POPUP_MENU_ADD_ITEM(STR_RESET_TELEMETRY);
   }
   else if (result == STR_RESET_TELEMETRY) {
     telemetryReset();
@@ -484,12 +484,12 @@ void menuMainView(uint8_t event)
     case EVT_KEY_LONG(KEY_ENTER):
       killEvents(event);
       if (modelHasNotes()) {
-        MENU_ADD_ITEM(STR_VIEW_NOTES);
+        POPUP_MENU_ADD_ITEM(STR_VIEW_NOTES);
       }
-      MENU_ADD_ITEM(STR_RESET_SUBMENU);
-      MENU_ADD_ITEM(STR_STATISTICS);
-      MENU_ADD_ITEM(STR_ABOUT_US);
-      menuHandler = onMainViewMenu;
+      POPUP_MENU_ADD_ITEM(STR_RESET_SUBMENU);
+      POPUP_MENU_ADD_ITEM(STR_STATISTICS);
+      POPUP_MENU_ADD_ITEM(STR_ABOUT_US);
+      popupMenuHandler = onMainViewMenu;
       break;
 
 #if MENUS_LOCK != 2/*no menus*/

--- a/radio/src/gui/Taranis/view_statistics.cpp
+++ b/radio/src/gui/Taranis/view_statistics.cpp
@@ -232,7 +232,7 @@ void menuTraceBuffer(uint8_t event)
 
   for (uint8_t i=0; i<LCD_LINES-2; i++) {
     y = 1 + (i+2)*FH;
-    k = i+s_pgOfs;
+    k = i+menuVerticalOffset;
 
     //item
     lcd_outdezAtt(0, y, k, LEFT | (sub==k ? INVERS : 0));

--- a/radio/src/gui/Taranis/view_statistics.cpp
+++ b/radio/src/gui/Taranis/view_statistics.cpp
@@ -112,8 +112,8 @@ void menuStatisticsDebug(uint8_t event)
   TITLE(STR_MENUDEBUG);
 
 #if defined(WATCHDOG_TEST)
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     // do a user requested watchdog test
     TRACE("Performing watchdog test");
     pausePulses();

--- a/radio/src/gui/Taranis/view_statistics.cpp
+++ b/radio/src/gui/Taranis/view_statistics.cpp
@@ -223,7 +223,7 @@ void menuTraceBuffer(uint8_t event)
 
   uint8_t y = 0;
   uint8_t k = 0;
-  int8_t sub = m_posVert;
+  int8_t sub = menuVerticalPosition;
 
   lcd_putc(0, FH, '#');
   lcd_puts(4*FW, FH, "Time");

--- a/radio/src/gui/Taranis/view_telemetry.cpp
+++ b/radio/src/gui/Taranis/view_telemetry.cpp
@@ -230,6 +230,7 @@ void menuTelemetryFrsky(uint8_t event)
 
   switch (event) {
     case EVT_KEY_FIRST(KEY_EXIT):
+    case EVT_KEY_LONG(KEY_EXIT):
       killEvents(event);
       chainMenu(menuMainView);
       break;

--- a/radio/src/gui/Taranis/view_telemetry.cpp
+++ b/radio/src/gui/Taranis/view_telemetry.cpp
@@ -250,9 +250,9 @@ void menuTelemetryFrsky(uint8_t event)
 
     case EVT_KEY_LONG(KEY_ENTER):
       killEvents(event);
-      MENU_ADD_ITEM(STR_RESET_TELEMETRY);
-      MENU_ADD_ITEM(STR_RESET_FLIGHT);
-      menuHandler = onMainViewMenu;
+      POPUP_MENU_ADD_ITEM(STR_RESET_TELEMETRY);
+      POPUP_MENU_ADD_ITEM(STR_RESET_FLIGHT);
+      popupMenuHandler = onMainViewMenu;
       break;
   }
 

--- a/radio/src/gui/Taranis/view_text.cpp
+++ b/radio/src/gui/Taranis/view_text.cpp
@@ -56,13 +56,13 @@ void readTextFile(int & lines_count)
 
   result = f_open(&file, s_text_file, FA_OPEN_EXISTING | FA_READ);
   if (result == FR_OK) {
-    for (int i=0; i<TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz)==FR_OK && sz==1 && (lines_count==0 || current_line-s_pgOfs<LCD_LINES-1); i++) {
+    for (int i=0; i<TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz)==FR_OK && sz==1 && (lines_count==0 || current_line-menuVerticalOffset<LCD_LINES-1); i++) {
       if (c == '\n') {
         ++current_line;
         line_length = 0;
         escape = 0;
       }
-      else if (c!='\r' && current_line>=s_pgOfs && current_line-s_pgOfs<LCD_LINES-1 && line_length<LCD_COLS) {
+      else if (c!='\r' && current_line>=menuVerticalOffset && current_line-menuVerticalOffset<LCD_LINES-1 && line_length<LCD_COLS) {
         if (c=='\\' && escape==0) {
           escape = 1;
           continue;
@@ -89,7 +89,7 @@ void readTextFile(int & lines_count)
           c = 0x1D; //tab
         }
         escape = 0;
-        s_text_screen[current_line-s_pgOfs][line_length++] = c;
+        s_text_screen[current_line-menuVerticalOffset][line_length++] = c;
       }
     }
     if (c != '\n') {
@@ -109,24 +109,24 @@ void menuTextView(uint8_t event)
 
   switch (event) {
     case EVT_ENTRY:
-      s_pgOfs = 0;
+      menuVerticalOffset = 0;
       lines_count = 0;
       readTextFile(lines_count);
       break;
 
     case EVT_KEY_FIRST(KEY_UP):
-      if (s_pgOfs == 0)
+      if (menuVerticalOffset == 0)
         break;
       else
-        s_pgOfs--;
+        menuVerticalOffset--;
       readTextFile(lines_count);
       break;
 
     case EVT_KEY_FIRST(KEY_DOWN):
-      if (s_pgOfs+LCD_LINES-1 >= lines_count)
+      if (menuVerticalOffset+LCD_LINES-1 >= lines_count)
         break;
       else
-        ++s_pgOfs;
+        ++menuVerticalOffset;
       readTextFile(lines_count);
       break;
 
@@ -149,7 +149,7 @@ void menuTextView(uint8_t event)
   lcd_invert_line(0);
 
   if (lines_count > LCD_LINES-1) {
-    displayScrollbar(LCD_W-1, FH, LCD_H-FH, s_pgOfs, lines_count, LCD_LINES-1);
+    displayScrollbar(LCD_W-1, FH, LCD_H-FH, menuVerticalOffset, lines_count, LCD_LINES-1);
   }
 }
 

--- a/radio/src/gui/Taranis/widgets.cpp
+++ b/radio/src/gui/Taranis/widgets.cpp
@@ -255,7 +255,7 @@ void drawStatusLine()
     }
 
     drawFilledRect(0, LCD_H-statusLineHeight, LCD_W, FH, SOLID, ERASE);
-    lcd_putsAtt(5, LCD_H+1-statusLineHeight, statusLineMsg, BSS);
+    lcd_putsAtt(5, LCD_H+1-statusLineHeight, statusLineMsg, 0);
     drawFilledRect(0, LCD_H-statusLineHeight, LCD_W, FH, SOLID);
   }
 }

--- a/radio/src/gui/Taranis/widgets.cpp
+++ b/radio/src/gui/Taranis/widgets.cpp
@@ -144,7 +144,7 @@ select_menu_value_t selectMenuItem(coord_t x, coord_t y, const pm_char *label, c
 {
   lcd_putsColumnLeft(x, y, label);
   if (values) lcd_putsiAtt(x, y, values, value-min, attr);
-  if (attr) value = checkIncDec(event, value, min, max, (g_menuPos[0] == 0) ? EE_MODEL : EE_GENERAL);
+  if (attr) value = checkIncDec(event, value, min, max, (menuVerticalPositions[0] == 0) ? EE_MODEL : EE_GENERAL);
   return value;
 }
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -525,8 +525,9 @@ TODO table of events/masks
 static int luaKillEvents(lua_State *L)
 {
   uint8_t key = EVT_KEY_MASK(luaL_checkinteger(L, 1));
-  // prevent killing ENT and EXIT
-  if (key != KEY_EXIT && key != KEY_ENTER) {
+  // prevent killing PAGE, ENT and EXIT (only in telemetry scripts)
+  // todo add which tpye of scrip is running before p_call()
+  if (key != KEY_EXIT && key != KEY_ENTER && key != KEY_PAGE) {
     killEvents(key);
   }
   return 0;

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -524,8 +524,11 @@ TODO table of events/masks
 */
 static int luaKillEvents(lua_State *L)
 {
-  int event = luaL_checkinteger(L, 1);
-  killEvents(event);
+  uint8_t key = EVT_KEY_MASK(luaL_checkinteger(L, 1));
+  // prevent killing ENT and EXIT
+  if (key != KEY_EXIT && key != KEY_ENTER) {
+    killEvents(key);
+  }
   return 0;
 }
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -600,23 +600,23 @@ Run function (key pressed)
 static int luaPopupInput(lua_State *L)
 {
   uint8_t event = luaL_checkinteger(L, 2);
-  s_warning_input_value = luaL_checkinteger(L, 3);
-  s_warning_input_min = luaL_checkinteger(L, 4);
-  s_warning_input_max = luaL_checkinteger(L, 5);
-  s_warning = luaL_checkstring(L, 1);
-  s_warning_type = WARNING_TYPE_INPUT;
+  warningInputValue = luaL_checkinteger(L, 3);
+  warningInputValueMin = luaL_checkinteger(L, 4);
+  warningInputValueMax = luaL_checkinteger(L, 5);
+  warningText = luaL_checkstring(L, 1);
+  warningType = WARNING_TYPE_INPUT;
   displayWarning(event);
-  if (s_warning_result) {
-    s_warning_result = 0;
+  if (warningResult) {
+    warningResult = 0;
     lua_pushstring(L, "OK");
   }
-  else if (!s_warning) {
+  else if (!warningText) {
     lua_pushstring(L, "CANCEL");
   }
   else {
-    lua_pushinteger(L, s_warning_input_value);
+    lua_pushinteger(L, warningInputValue);
   }
-  s_warning = NULL;
+  warningText = NULL;
   return 1;
 }
 

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -658,7 +658,7 @@ bool luaDoOneRunPermanentScript(uint8_t evt, int i, uint32_t scriptType)
     filename = script.file;
 #endif
     if ((scriptType & RUN_TELEM_FG_SCRIPT) && 
-        (g_menuStack[0]==menuTelemetryFrsky && sid.reference==SCRIPT_TELEMETRY_FIRST+s_frsky_view)) {
+        (menuHandlers[0]==menuTelemetryFrsky && sid.reference==SCRIPT_TELEMETRY_FIRST+s_frsky_view)) {
       lua_rawgeti(L, LUA_REGISTRYINDEX, sid.run);
       lua_pushinteger(L, evt);
       inputsCount = 1;

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -479,10 +479,10 @@ void displayLuaError(const char * title)
 
 void displayAcknowledgeLuaError(uint8_t event)
 {
-  s_warning_result = false;
-  displayLuaError(s_warning);
+  warningResult = false;
+  displayLuaError(warningText);
   if (event == EVT_KEY_BREAK(KEY_EXIT)) {
-    s_warning = NULL;
+    warningText = NULL;
   }
 }
 
@@ -519,7 +519,7 @@ void luaError(uint8_t error, bool acknowledge)
   }
 
   if (acknowledge) {
-    s_warning = errorTitle;
+    warningText = errorTitle;
     popupFunc = displayAcknowledgeLuaError;
   }
   else {

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -155,7 +155,17 @@ void perMain()
   bool standaloneScriptWasRun = luaTask(evt, RUN_STNDAL_SCRIPT, true);
   bool refreshScreen = true;
   if (!standaloneScriptWasRun) {
-    refreshScreen = !luaTask(evt, RUN_TELEM_FG_SCRIPT, true);
+    if (luaTask(evt, RUN_TELEM_FG_SCRIPT, true)) {
+      // the telemetry screen is active
+      refreshScreen = false;
+      // filter out keys that are used by the telemetry scripts
+      // PLUS, MINUS and MENU (all events)
+      // ENT (leave long press for telemetry reset menu)
+      uint8_t key = EVT_KEY_MASK(evt);
+      if (key == KEY_PLUS || key == KEY_MINUS || key == KEY_MENU || (key == KEY_ENTER && !EVT_KEY_LONG(evt))) {
+        evt = 0;
+      }
+    } 
   }
 
   t0 = get_tmr10ms() - t0;

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -189,7 +189,7 @@ void perMain()
 #endif
   {
     // normal GUI from menus
-    const char *warn = s_warning;
+    const char *warn = warningText;
     bool popupMenuActive = (popupMenuNoItems > 0);
     if (refreshScreen) {
       lcd_clear();

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -196,8 +196,8 @@ void perMain()
     }
     if (menuEvent) {
       // we have a popupMenuActive entry or exit event 
-      m_posVert = menuEvent == EVT_ENTRY_UP ? g_menuPos[g_menuStackPtr] : 0;
-      m_posHorz = 0;
+      menuVerticalPosition = (menuEvent == EVT_ENTRY_UP) ? menuVerticalPositions[menuLevel] : 0;
+      menuHorizontalPosition = 0;
       evt = menuEvent;
       if (menuEvent == EVT_ENTRY_UP) {
         TRACE("menuEvent EVT_ENTRY_UP");
@@ -214,7 +214,7 @@ void perMain()
       menuEvent = 0;
       AUDIO_MENUS();
     }
-    g_menuStack[g_menuStackPtr]((warn || popupMenuActive) ? 0 : evt);
+    menuHandlers[menuLevel]((warn || popupMenuActive) ? 0 : evt);
     if (warn) DISPLAY_WARNING(evt);
     if (popupMenuActive) {
       if (!inMenu) {

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -160,10 +160,15 @@ void perMain()
       refreshScreen = false;
       // filter out keys that are used by the telemetry scripts
       // PLUS, MINUS and MENU (all events)
-      // ENT (leave long press for telemetry reset menu)
+      // ENT (short)
+      // EXIT (short)
       uint8_t key = EVT_KEY_MASK(evt);
-      if (key == KEY_PLUS || key == KEY_MINUS || key == KEY_MENU || (key == KEY_ENTER && !EVT_KEY_LONG(evt))) {
-        evt = 0;
+      if (evt) {
+        if (key == KEY_PLUS || key == KEY_MINUS || key == KEY_MENU || 
+           (!IS_KEY_LONG(evt) && (key == KEY_ENTER || key == KEY_EXIT))) {
+          // TRACE("Telemetry script event 0x%02x killed", evt);
+          evt = 0;
+        }
       }
     } 
   }

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -99,7 +99,37 @@ void checkEeprom()
   }
 }
 
-bool inMenu = false;
+void handleGui(uint8_t event) {
+  // if Lua standalone, run it and don't clear the screen (Lua will do it)
+  // else if Lua telemetry view, run it and don't clear the screen
+  // else clear scren and show normal menus 
+#if defined(LUA)
+  if (luaTask(event, RUN_STNDAL_SCRIPT, true)) {
+    // standalone script is active
+  }
+  else if (luaTask(event, RUN_TELEM_FG_SCRIPT, true)) {
+    // the telemetry screen is active
+    // prevent events from keys MENU, UP, DOWN, ENT(short) and EXIT(short) from reaching the normal menus,
+    // so Lua telemetry script can fully use them
+    if (event) {
+      uint8_t key = EVT_KEY_MASK(event);
+      // no need to filter out MENU and ENT(short), because they are not used by menuTelemetryFrsky()
+      if (key == KEY_PLUS || key == KEY_MINUS || (!IS_KEY_LONG(event) && key == KEY_EXIT)) {
+        // TRACE("Telemetry script event 0x%02x killed", event);
+        event = 0;
+      }
+    }
+    menuHandlers[menuLevel](event);
+    // todo     drawStatusLine(); here???
+  }
+  else 
+#endif
+  {
+    lcd_clear();
+    menuHandlers[menuLevel](event);
+    drawStatusLine();
+  }
+}
 
 bool inPopupMenu = false;
 
@@ -116,17 +146,10 @@ void perMain()
   checkTrainerSettings();
   checkBattery();
 
-  uint8_t evt = getEvent(false);
-  if (evt && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) backlightOn(); // on keypress turn the light on
-  checkBacklight();
-#if defined(NAVIGATION_STICKS)
-  uint8_t sticks_evt = getSticksNavigationEvent();
-  if (sticks_evt) evt = sticks_evt;
-#endif
-
 #if defined(USB_MASS_STORAGE)
   if (usbPlugged()) {
     // disable access to menus
+    lcdRefreshWait();
     lcd_clear();
     menuMainView(0);
     lcdRefresh();
@@ -135,6 +158,7 @@ void perMain()
 #endif
 
 #if defined(LUA)
+  // TODO better lua stopwatch
   uint32_t t0 = get_tmr10ms();
   static uint32_t lastLuaTime = 0;
   uint16_t interval = (lastLuaTime == 0 ? 0 : (t0 - lastLuaTime));
@@ -146,6 +170,12 @@ void perMain()
   // run Lua scripts that don't use LCD (to use CPU time while LCD DMA is running)
   luaTask(0, RUN_MIX_SCRIPT | RUN_FUNC_SCRIPT | RUN_TELEM_BG_SCRIPT, false);
 
+  t0 = get_tmr10ms() - t0;
+  if (t0 > maxLuaDuration) {
+    maxLuaDuration = t0;
+  }
+#endif //#if defined(LUA)
+
   // wait for LCD DMA to finish before continuing, because code from this point 
   // is allowed to change the contents of LCD buffer
   // 
@@ -153,88 +183,66 @@ void perMain()
   //
   lcdRefreshWait();
 
-  // draw LCD from menus or from Lua script
-  // run Lua scripts that use LCD
-
-  bool standaloneScriptWasRun = luaTask(evt, RUN_STNDAL_SCRIPT, true);
-  bool refreshScreen = true;
-  if (!standaloneScriptWasRun) {
-    if (luaTask(evt, RUN_TELEM_FG_SCRIPT, true)) {
-      // the telemetry screen is active
-      refreshScreen = false;
-      // filter out keys that are used by the telemetry scripts
-      // PLUS, MINUS and MENU (all events)
-      // ENT (short)
-      // EXIT (short)
-      uint8_t key = EVT_KEY_MASK(evt);
-      if (evt) {
-        if (key == KEY_PLUS || key == KEY_MINUS || key == KEY_MENU || 
-           (!IS_KEY_LONG(evt) && (key == KEY_ENTER || key == KEY_EXIT))) {
-          // TRACE("Telemetry script event 0x%02x killed", evt);
-          evt = 0;
-        }
-      }
-    } 
-  }
-
-  t0 = get_tmr10ms() - t0;
-  if (t0 > maxLuaDuration) {
-    maxLuaDuration = t0;
-  }
-
-  if (!standaloneScriptWasRun)
-#else
-  lcdRefreshWait();   // WARNING: make sure no code above this line does any change to the LCD display buffer!
-  const bool refreshScreen = true;
-#endif
-  {
-    // normal GUI from menus
-    const char *warn = warningText;
-    bool popupMenuActive = (popupMenuNoItems > 0);
-    if (refreshScreen) {
-      lcd_clear();
+  // get event
+  uint8_t evt;
+  if (menuEvent) {
+    // we have a popupMenuActive entry or exit event 
+    menuVerticalPosition = (menuEvent == EVT_ENTRY_UP) ? menuVerticalPositions[menuLevel] : 0;
+    menuHorizontalPosition = 0;
+    evt = menuEvent;
+    if (menuEvent == EVT_ENTRY_UP) {
+      TRACE("menuEvent EVT_ENTRY_UP");
     }
-    if (menuEvent) {
-      // we have a popupMenuActive entry or exit event 
-      menuVerticalPosition = (menuEvent == EVT_ENTRY_UP) ? menuVerticalPositions[menuLevel] : 0;
-      menuHorizontalPosition = 0;
-      evt = menuEvent;
-      if (menuEvent == EVT_ENTRY_UP) {
-        TRACE("menuEvent EVT_ENTRY_UP");
-      }
-      else if (menuEvent == EVT_MENU_UP) {
-        TRACE("menuEvent EVT_MENU_UP");
-      }
-      else if (menuEvent == EVT_ENTRY) {
-        TRACE("menuEvent EVT_ENTRY");
-      }
-      else {
-        TRACE("menuEvent 0x%02x", menuEvent);
-      }
-      menuEvent = 0;
-      AUDIO_MENUS();
+    else if (menuEvent == EVT_MENU_UP) {
+      TRACE("menuEvent EVT_MENU_UP");
     }
-    menuHandlers[menuLevel]((warn || popupMenuActive) ? 0 : evt);
-    if (warn) DISPLAY_WARNING(evt);
-    if (popupMenuActive) {
-      if (!inMenu) {
-        TRACE("Popup Menu started");
-        inMenu = true;
-      }
-      const char * result = displayPopupMenu(evt);
-      if (result) {
-        TRACE("popupMenuHandler(%s)", result);
-        popupMenuHandler(result);
-        putEvent(EVT_MENU_UP);
-      }
+    else if (menuEvent == EVT_ENTRY) {
+      TRACE("menuEvent EVT_ENTRY");
     }
     else {
-      if (inMenu) {
-        TRACE("Popup Menu ended");
-        inMenu = false;
-      }
+      TRACE("menuEvent 0x%02x", menuEvent);
     }
-    drawStatusLine();
+    menuEvent = 0;
+    AUDIO_MENUS();
+  }
+  else {
+    evt = getEvent(false);
+    if (evt && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) backlightOn(); // on keypress turn the light on
+    checkBacklight();
+#if defined(NAVIGATION_STICKS)
+    uint8_t sticks_evt = getSticksNavigationEvent();
+    if (sticks_evt) evt = sticks_evt;
+#endif
+  }
+
+  if (warningText) {
+    // show warning on top of the normal menus
+    handleGui(0); // suppress events, they are handled by the warning
+    DISPLAY_WARNING(evt);
+  }
+  else if (popupMenuNoItems > 0) {
+    // popup menu is active display it on top of normal menus 
+    handleGui(0); // suppress events, they are handled by the popup
+    if (!inPopupMenu) {
+      TRACE("Popup Menu started");
+      inPopupMenu = true;
+    }
+    const char * result = displayPopupMenu(evt);
+    if (result) {
+      TRACE("popupMenuHandler(%s)", result);
+      popupMenuHandler(result);
+      putEvent(EVT_MENU_UP);
+      // todo should we handle this event immediately??
+      // handleGui(EVT_MENU_UP)
+    }
+  }
+  else {
+    // normal menus
+    if (inPopupMenu) {
+      TRACE("Popup Menu ended");
+      inPopupMenu = false;
+    }
+    handleGui(evt);
   }
 
   lcdRefresh();

--- a/radio/src/main_avr.cpp
+++ b/radio/src/main_avr.cpp
@@ -130,7 +130,7 @@ void perMain()
 
 #if defined(GUI)
   const char *warn = s_warning;
-  uint8_t menu = s_menu_count;
+  bool popupMenuActive = (popupMenuNoItems > 0);
 
   if(IS_LCD_REFRESH_ALLOWED()){//No need to redraw until lcdRefresh_ST7920(0) below completely refreshes the display.
       lcd_clear();
@@ -141,15 +141,15 @@ void perMain()
         menuEvent = 0;
         AUDIO_MENUS();
       }
-      g_menuStack[g_menuStackPtr]((warn || menu) ? 0 : evt);
+      g_menuStack[g_menuStackPtr]((warn || popupMenuActive) ? 0 : evt);
 
 
       if (warn) DISPLAY_WARNING(evt);
 #if defined(NAVIGATION_MENUS)
-      if (menu) {
-        const char * result = displayMenu(evt);
+      if (popupMenuActive) {
+        const char * result = displayPopupMenu(evt);
         if (result) {
-          menuHandler(result);
+          popupMenuHandler(result);
           putEvent(EVT_MENU_UP);
         }
       }

--- a/radio/src/main_avr.cpp
+++ b/radio/src/main_avr.cpp
@@ -135,13 +135,13 @@ void perMain()
   if(IS_LCD_REFRESH_ALLOWED()){//No need to redraw until lcdRefresh_ST7920(0) below completely refreshes the display.
       lcd_clear();
       if (menuEvent) {
-        m_posVert = menuEvent == EVT_ENTRY_UP ? g_menuPos[g_menuStackPtr] : 0;
-        m_posHorz = 0;
+        menuVerticalPosition = menuEvent == EVT_ENTRY_UP ? menuVerticalPositions[menuLevel] : 0;
+        menuHorizontalPosition = 0;
         evt = menuEvent;
         menuEvent = 0;
         AUDIO_MENUS();
       }
-      g_menuStack[g_menuStackPtr]((warn || popupMenuActive) ? 0 : evt);
+      menuHandlers[menuLevel]((warn || popupMenuActive) ? 0 : evt);
 
 
       if (warn) DISPLAY_WARNING(evt);

--- a/radio/src/main_avr.cpp
+++ b/radio/src/main_avr.cpp
@@ -129,7 +129,7 @@ void perMain()
 #endif
 
 #if defined(GUI)
-  const char *warn = s_warning;
+  const char *warn = warningText;
   bool popupMenuActive = (popupMenuNoItems > 0);
 
   if(IS_LCD_REFRESH_ALLOWED()){//No need to redraw until lcdRefresh_ST7920(0) below completely refreshes the display.

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -151,7 +151,7 @@ void per10ms()
 #if defined(GUI)
   if (lightOffCounter) lightOffCounter--;
   if (flashCounter) flashCounter--;
-  if (s_noHi) s_noHi--;
+  if (noHighlightCounter) noHighlightCounter--;
 #endif
 
   if (trimsCheckTimer) trimsCheckTimer--;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2624,11 +2624,11 @@ uint32_t pwrCheck()
           uint8_t evt = getEvent(false);
           DISPLAY_WARNING(evt);
           lcdRefresh();
-          if (s_warning_result == true) {
+          if (warningResult == true) {
             pwr_check_state = PWR_CHECK_OFF;
             return e_power_off;
           }
-          else if (!s_warning) {
+          else if (!warningText) {
             // shutdown has been cancelled
             pwr_check_state = PWR_CHECK_PAUSED;
             return e_power_on;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1997,7 +1997,7 @@ void checkBattery()
   static uint8_t counter = 0;
 #if defined(GUI) && !defined(COLORLCD)
   // TODO not the right menu I think ...
-  if (g_menuStack[g_menuStackPtr] == menuGeneralDiagAna) {
+  if (menuHandlers[menuLevel] == menuGeneralDiagAna) {
     g_vbat100mV = 0;
     counter = 0;
   }
@@ -2491,9 +2491,9 @@ int main(void)
   stackPaint();
 
 #if defined(GUI)
-  g_menuStack[0] = menuMainView;
+  menuHandlers[0] = menuMainView;
   #if MENUS_LOCK != 2/*no menus*/
-    g_menuStack[1] = menuModelSelect;
+    menuHandlers[1] = menuModelSelect;
   #endif
 #endif
 

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1534,7 +1534,7 @@ union ReusableBuffer
         uint16_t eepromfree;
 #endif
 #if defined(SDCARD)
-        char menu_bss[MENU_MAX_LINES][MENU_LINE_LENGTH];
+        char menu_bss[POPUP_MENU_MAX_LINES][MENU_LINE_LENGTH];
         char mainname[45]; // because reused for SD backup / restore, max backup filename 44 chars: "/MODELS/MODEL0134353-2014-06-19-04-51-27.bin"
 #else
         char mainname[LEN_MODEL_NAME];

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -97,7 +97,6 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
   }
 
   popupMenuNoItems = 0;
-  s_menu_flags = BSS;
 
   FRESULT res = f_opendir(&dir, path);        /* Open the directory */
   if (res == FR_OK) {

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -98,7 +98,7 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
 
   popupMenuNoItems = 0;
 #if !defined(CPUARM)
-  s_menu_flags = BSS;
+  popupMenuFlags = BSS;
 #endif
 
   FRESULT res = f_opendir(&dir, path);        /* Open the directory */

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -52,9 +52,9 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
 #endif
 
 #if defined(PCBTARANIS)
-  s_menu_offset_type = MENU_OFFSET_EXTERNAL;
+  popupMenuOffsetType = MENU_OFFSET_EXTERNAL;
 #endif
-  static uint16_t s_last_menu_offset = 0;
+  static uint16_t lastpopupMenuOffset = 0;
 
 #if defined(CPUARM)
   static uint8_t s_last_flags;
@@ -75,19 +75,19 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
   }
 #endif
 
-  if (s_menu_offset == 0) {
-    s_last_menu_offset = 0;
+  if (popupMenuOffset == 0) {
+    lastpopupMenuOffset = 0;
     memset(reusableBuffer.modelsel.menu_bss, 0, sizeof(reusableBuffer.modelsel.menu_bss));
   }
-  else if (s_menu_offset == s_menu_count - MENU_MAX_DISPLAY_LINES) {
-    s_last_menu_offset = 0xffff;
+  else if (popupMenuOffset == popupMenuNoItems - MENU_MAX_DISPLAY_LINES) {
+    lastpopupMenuOffset = 0xffff;
     memset(reusableBuffer.modelsel.menu_bss, 0, sizeof(reusableBuffer.modelsel.menu_bss));
   }
-  else if (s_menu_offset == s_last_menu_offset) {
+  else if (popupMenuOffset == lastpopupMenuOffset) {
     // should not happen, only there because of Murphy's law
     return true;
   }
-  else if (s_menu_offset > s_last_menu_offset) {
+  else if (popupMenuOffset > lastpopupMenuOffset) {
     memmove(reusableBuffer.modelsel.menu_bss[0], reusableBuffer.modelsel.menu_bss[1], (MENU_MAX_DISPLAY_LINES-1)*MENU_LINE_LENGTH);
     memset(reusableBuffer.modelsel.menu_bss[MENU_MAX_DISPLAY_LINES-1], 0xff, MENU_LINE_LENGTH);
   }
@@ -96,22 +96,22 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
     memset(reusableBuffer.modelsel.menu_bss[0], 0, MENU_LINE_LENGTH);
   }
 
-  s_menu_count = 0;
+  popupMenuNoItems = 0;
   s_menu_flags = BSS;
 
   FRESULT res = f_opendir(&dir, path);        /* Open the directory */
   if (res == FR_OK) {
 
     if (flags & LIST_NONE_SD_FILE) {
-      s_menu_count++;
+      popupMenuNoItems++;
       if (selection) {
-        s_last_menu_offset++;
+        lastpopupMenuOffset++;
       }
-      else if (s_menu_offset==0 || s_menu_offset < s_last_menu_offset) {
+      else if (popupMenuOffset==0 || popupMenuOffset < lastpopupMenuOffset) {
         char *line = reusableBuffer.modelsel.menu_bss[0];
         memset(line, 0, MENU_LINE_LENGTH);
         strcpy(line, "---");
-        s_menu[0] = line;
+        popupMenuItems[0] = line;
       }
     }
 
@@ -128,12 +128,12 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
       uint8_t len = strlen(fn);
       if (len < 5 || len > maxlen+4 || strcasecmp(fn+len-4, extension) || (fno.fattrib & AM_DIR)) continue;
 
-      s_menu_count++;
+      popupMenuNoItems++;
       fn[len-4] = '\0';
 
-      if (s_menu_offset == 0) {
+      if (popupMenuOffset == 0) {
         if (selection && strncasecmp(fn, selection, maxlen) < 0) {
-          s_last_menu_offset++;
+          lastpopupMenuOffset++;
         }
         else {
           for (uint8_t i=0; i<MENU_MAX_DISPLAY_LINES; i++) {
@@ -146,12 +146,12 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
             }
           }
         }
-        for (uint8_t i=0; i<min(s_menu_count, (uint16_t)MENU_MAX_DISPLAY_LINES); i++) {
-          s_menu[i] = reusableBuffer.modelsel.menu_bss[i];
+        for (uint8_t i=0; i<min(popupMenuNoItems, (uint16_t)MENU_MAX_DISPLAY_LINES); i++) {
+          popupMenuItems[i] = reusableBuffer.modelsel.menu_bss[i];
         }
 
       }
-      else if (s_last_menu_offset == 0xffff) {
+      else if (lastpopupMenuOffset == 0xffff) {
         for (int i=MENU_MAX_DISPLAY_LINES-1; i>=0; i--) {
           char *line = reusableBuffer.modelsel.menu_bss[i];
           if (line[0] == '\0' || strcasecmp(fn, line) > 0) {
@@ -161,11 +161,11 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
             break;
           }
         }
-        for (uint8_t i=0; i<min(s_menu_count, (uint16_t)MENU_MAX_DISPLAY_LINES); i++) {
-          s_menu[i] = reusableBuffer.modelsel.menu_bss[i];
+        for (uint8_t i=0; i<min(popupMenuNoItems, (uint16_t)MENU_MAX_DISPLAY_LINES); i++) {
+          popupMenuItems[i] = reusableBuffer.modelsel.menu_bss[i];
         }
       }
-      else if (s_menu_offset > s_last_menu_offset) {
+      else if (popupMenuOffset > lastpopupMenuOffset) {
         if (strcasecmp(fn, reusableBuffer.modelsel.menu_bss[MENU_MAX_DISPLAY_LINES-2]) > 0 && strcasecmp(fn, reusableBuffer.modelsel.menu_bss[MENU_MAX_DISPLAY_LINES-1]) < 0) {
           memset(reusableBuffer.modelsel.menu_bss[MENU_MAX_DISPLAY_LINES-1], 0, MENU_LINE_LENGTH);
           strcpy(reusableBuffer.modelsel.menu_bss[MENU_MAX_DISPLAY_LINES-1], fn);
@@ -180,12 +180,12 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
     }
   }
 
-  if (s_menu_offset > 0)
-    s_last_menu_offset = s_menu_offset;
+  if (popupMenuOffset > 0)
+    lastpopupMenuOffset = popupMenuOffset;
   else
-    s_menu_offset = s_last_menu_offset;
+    popupMenuOffset = lastpopupMenuOffset;
 
-  return s_menu_count;
+  return popupMenuNoItems;
 }
 
 #if defined(CPUARM) && defined(SDCARD)

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -97,6 +97,9 @@ bool listSdFiles(const char *path, const char *extension, const uint8_t maxlen, 
   }
 
   popupMenuNoItems = 0;
+#if !defined(CPUARM)
+  s_menu_flags = BSS;
+#endif
 
   FRESULT res = f_opendir(&dir, path);        /* Open the directory */
   if (res == FR_OK) {

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -335,9 +335,9 @@ void *main_thread(void *)
     
     s_current_protocol[0] = 255;
 
-    g_menuStackPtr = 0;
-    g_menuStack[0] = menuMainView;
-    g_menuStack[1] = menuModelSelect;
+    menuLevel = 0;
+    menuHandlers[0] = menuMainView;
+    menuHandlers[1] = menuModelSelect;
 
     eeReadAll(); // load general setup and selected model
 

--- a/radio/src/targets/sky9x/diskio.cpp
+++ b/radio/src/targets/sky9x/diskio.cpp
@@ -1314,7 +1314,7 @@ DRESULT disk_read (
 /* Write Sector(s)                                                       */
 /*-----------------------------------------------------------------------*/
 
-extern const char * s_warning;
+extern const char * warningText;
 
 DRESULT disk_write (
                                         BYTE drv,                       /* Physical drive nmuber (0) */

--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -178,7 +178,7 @@ void parseTelemHubByte(uint8_t byte)
         // First received GPS position => Pilot GPS position
         getGpsPilotPosition();
       }
-      else if (frskyData.hub.gpsDistNeeded || g_menuStack[g_menuStackPtr] == menuTelemetryFrsky) {
+      else if (frskyData.hub.gpsDistNeeded || menuHandlers[menuLevel] == menuTelemetryFrsky) {
         getGpsDistance();
       }
       break;

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -62,8 +62,8 @@ int main(int argc, char **argv)
   QCoreApplication app(argc, argv);
   simuInit();
   StartEepromThread(NULL);
-  g_menuStackPtr = 0;
-  g_menuStack[0] = menuMainView;
+  menuLevel = 0;
+  menuHandlers[0] = menuMainView;
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
…ry scripts

I think this is the right solution:
* all keys are seen by the Lua scripts
* Lua scripts can not use killEvents() on ENT and EXIT
* if a telemetry script has run, filter out the keys PLUS, MINUS, ENT (only short),  EXIT (only short) and MENU from the menu system. These keys can now be used freely in the telemetry scripts.

Tested in simu.

Closes #2469. Replaces #3051

Updated description (added EXIT short)