### PR TITLE
Avoid conditional directives that split up parts of statements.

### DIFF
--- a/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
+++ b/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
@@ -261,6 +261,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 	mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan); ///< The currently decoded message
 	mavlink_status_t* status = mavlink_get_channel_status(chan); ///< The current decode status
 	int bufferIndex = 0;
+	int checker = 0;
 
 	status->msg_received = 0;
 
@@ -278,13 +279,13 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 		break;
 
 	case MAVLINK_PARSE_STATE_GOT_STX:
-			if (status->msg_received 
+		checker = status->msg_received; 
 /* Support shorter buffers than the
    default maximum packet size */
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
-				|| c > MAVLINK_MAX_PAYLOAD_LEN
+		checker = checker || c > MAVLINK_MAX_PAYLOAD_LEN;
 #endif
-				)
+		if (checker)
 		{
 			status->buffer_overrun++;
 			status->parse_error++;

--- a/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
+++ b/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
@@ -285,7 +285,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
 		checker = checker || c > MAVLINK_MAX_PAYLOAD_LEN;
 #endif
-		if (checker){
+		if (checker) {
 			status->buffer_overrun++;
 			status->parse_error++;
 			status->msg_received = 0;

--- a/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
+++ b/radio/src/thirdparty/GCS_MAVLink/include_v1.0/mavlink_helpers.h
@@ -285,8 +285,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
 		checker = checker || c > MAVLINK_MAX_PAYLOAD_LEN;
 #endif
-		if (checker)
-		{
+		if (checker){
 			status->buffer_overrun++;
 			status->parse_error++;
 			status->msg_received = 0;

--- a/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -446,8 +446,7 @@ static int8_t SCSI_StartStopUnit(uint8_t lun, uint8_t *params)
 #else
   check_lun = (lun < 1); 
 #endif
-  if (check_lun)
-  {
+  if (check_lun){
     if (params[4] & 1) {
       // lun to be active
       lunReady[lun] = 1 ;

--- a/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -439,13 +439,15 @@ extern uint8_t lunReady[] ;
 static int8_t SCSI_StartStopUnit(uint8_t lun, uint8_t *params)
 {
   MSC_BOT_DataLen = 0;
-  
+  int check_lun;  
+
 #if defined(BOOT)
-  if (lun < 2) 
+  check_lun = (lun < 2); 
 #else
-  if (lun < 1) 
+  check_lun = (lun < 1); 
 #endif
-    {
+  if (check_lun)
+  {
     if (params[4] & 1) {
       // lun to be active
       lunReady[lun] = 1 ;

--- a/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
+++ b/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.1.0/Libraries/STM32_USB_Device_Library/Class/msc/src/usbd_msc_scsi.c
@@ -446,7 +446,7 @@ static int8_t SCSI_StartStopUnit(uint8_t lun, uint8_t *params)
 #else
   check_lun = (lun < 1); 
 #endif
-  if (check_lun){
+  if (check_lun) {
     if (params[4] & 1) {
       // lun to be active
       lunReady[lun] = 1 ;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.