### PR TITLE
Projectkk2glider/issue 3096 table layout optonal

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -33,6 +33,12 @@ IF(DEBUG_IMPORT)
     MESSAGE( STATUS "EEPROM import debugging enabled" )
 ENDIF(DEBUG_IMPORT)
 
+OPTION(TABLE_LAYOUT "Use QTableWidget for grid layouts") # Disabled by default
+IF(TABLE_LAYOUT)
+    ADD_DEFINITIONS( -DTABLE_LAYOUT)
+    MESSAGE( STATUS "Using QTableWidget" )
+ENDIF(TABLE_LAYOUT)
+
 MESSAGE( STATUS "Looking for XercesC " )
 FIND_PACKAGE(XercesC)
 IF ( XERCESC_FOUND )

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -12,6 +12,8 @@
 #include "simulatorinterface.h"
 #include "firmwareinterface.h"
 
+Stopwatch gStopwatch("global");
+
 const QColor colors[C9X_MAX_CURVES] = {
   QColor(0,0,127),
   QColor(0,127,0),
@@ -1009,7 +1011,6 @@ TableLayout::TableLayout(QWidget * parent, int rowCount, const QStringList & hea
   tableWidget->setColumnCount(headerLabels.size());
   tableWidget->setShowGrid(false);
   tableWidget->verticalHeader()->setVisible(false);
-  tableWidget->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
   tableWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
   tableWidget->setSelectionMode(QAbstractItemView::NoSelection);
   tableWidget->setFrameStyle(QFrame::NoFrame | QFrame::Plain);

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -998,6 +998,7 @@ QStringList extractLatLon(const QString & position)
 
 TableLayout::TableLayout(QWidget * parent, int rowCount, const QStringList & headerLabels)
 {
+#if defined(TABLE_LAYOUT)
   tableWidget = new QTableWidget(parent);
   QVBoxLayout * layout = new QVBoxLayout();
   layout->addWidget(tableWidget);
@@ -1014,19 +1015,73 @@ TableLayout::TableLayout(QWidget * parent, int rowCount, const QStringList & hea
   tableWidget->setFrameStyle(QFrame::NoFrame | QFrame::Plain);
   tableWidget->setStyleSheet("QTableWidget {background-color: transparent;}");
   tableWidget->setHorizontalHeaderLabels(headerLabels);
+#else
+  gridWidget = new QGridLayout(parent);
+
+  int col = 0;
+  foreach(QString text, headerLabels) {
+    QLabel *label = new QLabel();
+    label->setFrameShape(QFrame::Panel);
+    label->setFrameShadow(QFrame::Raised);
+    label->setMidLineWidth(0);
+    label->setAlignment(Qt::AlignCenter);
+    label->setMargin(5);
+    label->setText(text);
+    // if (!minimize)
+    //   label->setMinimumWidth(100);
+    gridWidget->addWidget(label, 0, col++);
+  }
+#endif
 }
 
 void TableLayout::addWidget(int row, int column, QWidget * widget)
 {
+#if defined(TABLE_LAYOUT)
   QHBoxLayout * layout = new QHBoxLayout(tableWidget);
   layout->addWidget(widget);
   addLayout(row, column, layout);
+#else
+  gridWidget->addWidget(widget, row + 1, column);
+#endif
 }
 
 void TableLayout::addLayout(int row, int column, QLayout * layout)
 {
+#if defined(TABLE_LAYOUT)
   layout->setContentsMargins(1, 3, 1, 3);
   QWidget * containerWidget = new QWidget(tableWidget);
   containerWidget->setLayout(layout);
   tableWidget->setCellWidget(row, column, containerWidget);
+#else
+  gridWidget->addLayout(layout, row + 1, column);
+#endif
+}
+
+void TableLayout::resizeColumnsToContents() 
+{
+#if defined(TABLE_LAYOUT)
+  tableWidget->resizeColumnsToContents();
+#else
+#endif
+}
+
+void TableLayout::setColumnWidth(int col, int width) 
+{
+#if defined(TABLE_LAYOUT)
+  tableWidget->setColumnWidth(col, width);
+#else
+#endif
+}
+
+void TableLayout::pushRowsUp(int row) 
+{
+#if defined(TABLE_LAYOUT)
+#else
+  // Push the rows up
+  QSpacerItem * spacer = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding );
+  gridWidget->addItem(spacer, row, 0);
+#endif
+  // Push rows upward
+  // addDoubleSpring(gridLayout, 5, num_fsw+1);
+
 }

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -2,6 +2,8 @@
 #define HELPERS_H
 
 #include <QtGui>
+#include <QTableWidget>
+#include <QGridLayout>
 #include "eeprominterface.h"
 
 extern const QColor colors[C9X_MAX_CURVES];
@@ -210,9 +212,16 @@ public:
   void addWidget(int row, int column, QWidget * widget);
   void addLayout(int row, int column, QLayout * layout);
 
-  QTableWidget * getTableWidget() { return tableWidget; };
+  void resizeColumnsToContents();
+  void setColumnWidth(int col, int width);
+  void pushRowsUp(int row); 
+
 private:
-  QTableWidget * tableWidget;  
+#if defined(TABLE_LAYOUT)
+  QTableWidget * tableWidget; 
+#else
+  QGridLayout * gridWidget; 
+#endif
 };
 
 #endif // HELPERS_H

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -4,6 +4,7 @@
 #include <QtGui>
 #include <QTableWidget>
 #include <QGridLayout>
+#include <QDebug>
 #include "eeprominterface.h"
 
 extern const QColor colors[C9X_MAX_CURVES];
@@ -223,5 +224,40 @@ private:
   QGridLayout * gridWidget; 
 #endif
 };
+
+
+class Stopwatch
+{
+public:
+  Stopwatch(const QString & name) :
+    name(name), total(0) {
+    timer.start();
+  };
+  ~Stopwatch() {};
+
+  void restart() {
+    total = 0;
+    timer.restart();
+  };
+
+  void report() {
+    qint64 elapsed = timer.restart();
+    total += elapsed;
+    qDebug() << name << QString("%1 ms [%2 ms]").arg(elapsed).arg(total);
+  };
+
+  void report(const QString & text) {
+    qint64 elapsed = timer.restart();
+    total += elapsed;
+    qDebug() << name << text << QString("%1 ms [%2 ms]").arg(elapsed).arg(total);
+  };
+
+private:
+  QString name;
+  QElapsedTimer timer;
+  qint64 total;
+};
+
+extern Stopwatch gStopwatch;
 
 #endif // HELPERS_H

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -179,11 +179,16 @@ void MdiChild::modelEdit()
     QApplication::setOverrideCursor(Qt::WaitCursor);
     checkAndInitModel( row );
     ModelData &model = radioData.models[row - 1];
+    gStopwatch.restart();
+    gStopwatch.report("ModelEdit creation");
     ModelEdit *t = new ModelEdit(this, radioData, (row - 1), GetCurrentFirmware()/*firmware*/);
+    gStopwatch.report("ModelEdit created");
     t->setWindowTitle(tr("Editing model %1: ").arg(row) + model.name);
     connect(t, SIGNAL(modified()), this, SLOT(setModified()));
+    gStopwatch.report("STARTING MODEL EDIT");
     t->show();
     QApplication::restoreOverrideCursor();
+    gStopwatch.report("ModelEdit shown");
   }
 }
 

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -169,7 +169,8 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
   }
 
   disableMouseScrolling();
-  tableLayout->getTableWidget()->resizeColumnsToContents();
+  tableLayout->resizeColumnsToContents();
+  tableLayout->pushRowsUp(firmware->getCapability(Outputs)+1);
 }
 
 Channels::~Channels()

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -39,11 +39,14 @@ LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout *tableLayout, int row,
   }
   
   spinbox->setSingleStep(displayStep*internalStep);
+  spinbox->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 
   QHBoxLayout * horizontalLayout = new QHBoxLayout();
   QCheckBox * gv = new QCheckBox(QObject::tr("GV"));
+  gv->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   horizontalLayout->addWidget(gv);
   QComboBox * cb = new QComboBox();
+  cb->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
   horizontalLayout->addWidget(cb);
   horizontalLayout->addWidget(spinbox);
   tableLayout->addLayout(row, col, horizontalLayout);

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -45,9 +45,7 @@ LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout *tableLayout, int row,
   horizontalLayout->addWidget(gv);
   QComboBox * cb = new QComboBox();
   horizontalLayout->addWidget(cb);
-  cb->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   horizontalLayout->addWidget(spinbox);
-  spinbox->setMinimumWidth(80);
   tableLayout->addLayout(row, col, horizontalLayout);
   gvarGroup = new GVarGroup(gv, spinbox, cb, value, deflt, min, max, displayStep, allowGVars);
 }

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -76,6 +76,8 @@ void LimitsGroup::updateMinMax(int max)
 Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
   ModelPanel(parent, model, generalSettings, firmware)
 {
+  Stopwatch s1("Channels");
+
   int channelNameMaxLen = firmware->getCapability(ChannelsName);
 
   QStringList headerLabels;
@@ -91,6 +93,8 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
   if (firmware->getCapability(SYMLimits))
     headerLabels << tr("Linear Subtrim");
   TableLayout * tableLayout = new TableLayout(this, firmware->getCapability(LogicalSwitches), headerLabels);
+
+  s1.report("header");
 
   for (int i=0; i<firmware->getCapability(Outputs); i++) {
     int col = 0;
@@ -167,10 +171,12 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
       tableLayout->addWidget(i, col++, symlimits);
     }
   }
+  s1.report("add elements");
 
   disableMouseScrolling();
   tableLayout->resizeColumnsToContents();
   tableLayout->pushRowsUp(firmware->getCapability(Outputs)+1);
+  s1.report("end");
 }
 
 Channels::~Channels()

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -196,8 +196,9 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   lock = false;
 
   update();
-  tableLayout->getTableWidget()->resizeColumnsToContents();
-  tableLayout->getTableWidget()->setColumnWidth(3, 300);
+  tableLayout->resizeColumnsToContents();
+  tableLayout->setColumnWidth(3, 300);
+  tableLayout->pushRowsUp(num_fsw+1);
 }
 
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -43,8 +43,7 @@ void RepeatComboBox::update()
 
 CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware):
   GenericPanel(parent, model, generalSettings, firmware),
-  functions(model ? model->customFn : generalSettings.customFn),
-  initialized(false)
+  functions(model ? model->customFn : generalSettings.customFn)
 #if defined(PHONON)
   ,
   phononCurrent(-1),
@@ -52,6 +51,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   clickOutput(NULL)
 #endif
 {
+  Stopwatch s1("CustomFunctionsPanel - populate"); 
   lock = true;
   int num_fsw = model ? firmware->getCapability(CustomFunctions) : firmware->getCapability(GlobalFunctions);
 
@@ -67,6 +67,8 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     }
   }
 
+  s1.report("get tracks");
+
   if (IS_TARANIS(firmware->getBoard())) {
     scriptsSet = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS", QStringList() << "*.lua", firmware->getCapability(VoicesMaxLength));
     for (int i=0; i<num_fsw; i++) {
@@ -78,6 +80,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
       }
     }
   }
+  s1.report("get scripts");
 
   CompanionIcon playIcon("play.png");
 
@@ -98,21 +101,26 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
     connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(fsw_customContextMenuRequested(QPoint)));
     tableLayout->addWidget(i, 0, label);
+    // s1.report("label");
 
     // The switch
     fswtchSwtch[i] = new QComboBox(this);
     fswtchSwtch[i]->setProperty("index", i);
+    populateSwitchCB(fswtchSwtch[i], functions[i].swtch, generalSettings, model ? SpecialFunctionsContext : GlobalFunctionsContext);
     fswtchSwtch[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     fswtchSwtch[i]->setMaxVisibleItems(10);
     connect(fswtchSwtch[i], SIGNAL(currentIndexChanged(int)), this, SLOT(customFunctionEdited()));
     tableLayout->addWidget(i, 1, fswtchSwtch[i]);
+    // s1.report("switch");
 
     // The function
     fswtchFunc[i] = new QComboBox(this);
     fswtchFunc[i]->setProperty("index", i);
+    populateFuncCB(fswtchFunc[i], functions[i].func);
     fswtchFunc[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(fswtchFunc[i], SIGNAL(currentIndexChanged(int)), this, SLOT(functionEdited()));
     tableLayout->addWidget(i, 2, fswtchFunc[i]);
+    // s1.report("func");
 
     // The parameters
     QHBoxLayout * paramLayout = new QHBoxLayout();
@@ -120,6 +128,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
 
     fswtchGVmode[i] = new QComboBox(this);
     fswtchGVmode[i]->setProperty("index", i);
+    populateGVmodeCB(fswtchGVmode[i], functions[i].adjustMode);
     fswtchGVmode[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(fswtchGVmode[i], SIGNAL(currentIndexChanged(int)), this, SLOT(customFunctionEdited()));
     paramLayout->addWidget(fswtchGVmode[i]);
@@ -146,6 +155,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
 
     fswtchParamT[i] = new QComboBox(this);
     fswtchParamT[i]->setProperty("index", i);
+    populateFuncParamCB(fswtchParamT[i], functions[i].func, functions[i].param, functions[i].adjustMode);
     paramLayout->addWidget(fswtchParamT[i]);
     fswtchParamT[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(fswtchParamT[i], SIGNAL(currentIndexChanged(int)), this, SLOT(customFunctionEdited()));
@@ -190,17 +200,21 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     repeatLayout->addWidget(fswtchEnable[i], i+1);
     connect(fswtchEnable[i], SIGNAL(stateChanged(int)), this, SLOT(customFunctionEdited()));
   }
+  s1.report("add items");
 
   disableMouseScrolling();
+  s1.report("disableMouseScrolling");
 
   lock = false;
 
   update();
+  s1.report("update");
   tableLayout->resizeColumnsToContents();
+  s1.report("resizeColumnsToContents");
   tableLayout->setColumnWidth(3, 300);
   tableLayout->pushRowsUp(num_fsw+1);
+  s1.report("end");
 }
-
 
 CustomFunctionsPanel::~CustomFunctionsPanel()
 {
@@ -522,15 +536,8 @@ void CustomFunctionsPanel::update()
   lock = true;
   int num_fsw = model ? firmware->getCapability(CustomFunctions) : firmware->getCapability(GlobalFunctions);
   for (int i=0; i<num_fsw; i++) {
-    if (!initialized) {
-      populateSwitchCB(fswtchSwtch[i], functions[i].swtch, generalSettings, model ? SpecialFunctionsContext : GlobalFunctionsContext);
-      populateFuncCB(fswtchFunc[i], functions[i].func);
-      populateGVmodeCB(fswtchGVmode[i], functions[i].adjustMode);
-      populateFuncParamCB(fswtchParamT[i], functions[i].func, functions[i].param, functions[i].adjustMode);
-    }
     refreshCustomFunction(i);
   }
-  initialized = true;
   lock = false;
 }
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -107,7 +107,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     fswtchSwtch[i] = new QComboBox(this);
     fswtchSwtch[i]->setProperty("index", i);
     populateSwitchCB(fswtchSwtch[i], functions[i].swtch, generalSettings, model ? SpecialFunctionsContext : GlobalFunctionsContext);
-    fswtchSwtch[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    fswtchSwtch[i]->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Minimum);
     fswtchSwtch[i]->setMaxVisibleItems(10);
     connect(fswtchSwtch[i], SIGNAL(currentIndexChanged(int)), this, SLOT(customFunctionEdited()));
     tableLayout->addWidget(i, 1, fswtchSwtch[i]);
@@ -117,7 +117,6 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     fswtchFunc[i] = new QComboBox(this);
     fswtchFunc[i]->setProperty("index", i);
     populateFuncCB(fswtchFunc[i], functions[i].func);
-    fswtchFunc[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(fswtchFunc[i], SIGNAL(currentIndexChanged(int)), this, SLOT(functionEdited()));
     tableLayout->addWidget(i, 2, fswtchFunc[i]);
     // s1.report("func");
@@ -136,6 +135,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     fswtchParamGV[i] = new QCheckBox(this);
     fswtchParamGV[i]->setProperty("index", i);
     fswtchParamGV[i]->setText("GV");
+    fswtchParamGV[i]->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Minimum);
     connect(fswtchParamGV[i], SIGNAL(stateChanged(int)), this, SLOT(customFunctionEdited()));
     paramLayout->addWidget(fswtchParamGV[i]);
 
@@ -189,7 +189,6 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     QHBoxLayout * repeatLayout = new QHBoxLayout();
     tableLayout->addLayout(i, 4, repeatLayout);
     fswtchRepeat[i] = new RepeatComboBox(this, functions[i].repeatParam);
-    fswtchRepeat[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     repeatLayout->addWidget(fswtchRepeat[i], i+1);
     connect(fswtchRepeat[i], SIGNAL(modified()), this, SLOT(onChildModified()));
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -180,6 +180,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
 
 #ifdef PHONON
     playBT[i] = new QPushButton(this);
+    playBT[i]->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     playBT[i]->setProperty("index", i);
     playBT[i]->setIcon(playIcon);
     paramLayout->addWidget(playBT[i]);

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -66,7 +66,6 @@ class CustomFunctionsPanel : public GenericPanel
     void populateGVmodeCB(QComboBox *b, unsigned int value);
     void populateFuncParamCB(QComboBox *b, uint function, unsigned int value, unsigned int adjustmode=0);
 
-    bool initialized;
     QSet<QString> tracksSet;
     QSet<QString> scriptsSet;
     int phononCurrent;

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -11,6 +11,8 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   ModelPanel(parent, model, generalSettings, firmware),
   selectedSwitch(0)
 {
+  Stopwatch s1("LogicalSwitchesPanel"); 
+
   int channelsMax = model.getChannelsMax(true);
 
   QStringList headerLabels;
@@ -20,6 +22,7 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   }
   TableLayout * tableLayout = new TableLayout(this, firmware->getCapability(LogicalSwitches), headerLabels);
 
+  s1.report("header");
 
   lock = true;
   for (int i=0; i<firmware->getCapability(LogicalSwitches); i++) {
@@ -123,11 +126,14 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
     }
   }
 
+  s1.report("added elements");
+
   disableMouseScrolling();
   lock = false;
   update();
   tableLayout->resizeColumnsToContents();
   tableLayout->pushRowsUp(firmware->getCapability(LogicalSwitches)+1);
+  s1.report("end");
 }
 
 LogicalSwitchesPanel::~LogicalSwitchesPanel()

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -46,9 +46,9 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
     QHBoxLayout *v1Layout = new QHBoxLayout();
     cswitchSource1[i] = new QComboBox(this);
     cswitchSource1[i]->setProperty("index",i);
-    cswitchSource1[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(cswitchSource1[i], SIGNAL(currentIndexChanged(int)), this, SLOT(v1Edited(int)));
     v1Layout->addWidget(cswitchSource1[i]);
+    cswitchSource1[i]->setVisible(false);
     cswitchValue[i] = new QDoubleSpinBox(this);
     cswitchValue[i]->setMaximum(channelsMax);
     cswitchValue[i]->setMinimum(-channelsMax);
@@ -64,7 +64,6 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
     QHBoxLayout *v2Layout = new QHBoxLayout();
     cswitchSource2[i] = new QComboBox(this);
     cswitchSource2[i]->setProperty("index", i);
-    cswitchSource2[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(cswitchSource2[i], SIGNAL(currentIndexChanged(int)), this, SLOT(v2Edited(int)));
     v2Layout->addWidget(cswitchSource2[i]);
     cswitchSource2[i]->setVisible(false);
@@ -97,7 +96,6 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
     // AND
     cswitchAnd[i] = new QComboBox(this);
     cswitchAnd[i]->setProperty("index", i);
-    cswitchAnd[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     connect(cswitchAnd[i], SIGNAL(currentIndexChanged(int)), this, SLOT(andEdited(int)));
     tableLayout->addWidget(i, 4, cswitchAnd[i]);
 

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -126,7 +126,8 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   disableMouseScrolling();
   lock = false;
   update();
-  tableLayout->getTableWidget()->resizeColumnsToContents();
+  tableLayout->resizeColumnsToContents();
+  tableLayout->pushRowsUp(firmware->getCapability(LogicalSwitches)+1);
 }
 
 LogicalSwitchesPanel::~LogicalSwitchesPanel()

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -23,6 +23,9 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   generalSettings(radioData.generalSettings),
   firmware(firmware)
 {
+  Stopwatch s1("ModelEdit");
+  gStopwatch.report("ModelEdit start constructor");
+
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("edit.png"));
   restoreGeometry(g.modelEditGeo());  
@@ -33,16 +36,23 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
     addTab(new HeliPanel(this, model, generalSettings, firmware), tr("Heli"));
   addTab(new FlightModesPanel(this, model, generalSettings, firmware), tr("Flight Modes"));
   addTab(new InputsPanel(this, model, generalSettings, firmware), tr("Inputs"));
+  s1.report("inputs");
   addTab(new MixesPanel(this, model, generalSettings, firmware), tr("Mixes"));
+  s1.report("Mixes");
   Channels * chnPanel = new Channels(this, model, generalSettings, firmware);
   addTab(chnPanel, tr("Outputs"));
+  s1.report("Outputs");
   addTab(new Curves(this, model, generalSettings, firmware), tr("Curves"));
   addTab(new LogicalSwitchesPanel(this, model, generalSettings, firmware), tr("Logical Switches"));
+  s1.report("LS");
   addTab(new CustomFunctionsPanel(this, &model, generalSettings, firmware), tr("Special Functions"));
+  s1.report("CF");
   if (firmware->getCapability(Telemetry) & TM_HASTELEMETRY)
     addTab(new TelemetryPanel(this, model, generalSettings, firmware), tr("Telemetry"));
     
   connect(setupPanel, SIGNAL(extendedLimitsToggled()), chnPanel, SLOT(refreshExtendedLimits()));
+  s1.report("end");
+  gStopwatch.report("ModelEdit end constructor");
 }
 
 ModelEdit::~ModelEdit()


### PR DESCRIPTION
I think the best option for now is to disable the new table layout until the solution for the slowness is found. 

For that I prepared this pull that adds a compile time option to use or not the new table layout. The change in time is not so significant on my system (cca 2.5 times faster) but should be almost the same as before I added table layout.

The code when using grid layout is not 100% the same as before, but should be pretty similar.

Use `cmake -D TABLE_LAYOUT=yes ` to go back to table layout (for testing).

Related to issue #3096