### PR TITLE
Dsbeach/issue3141 fx key to reload scripts

### DIFF
--- a/companion/src/firmwares/er9x/simulator/er9xsimulator.h
+++ b/companion/src/firmwares/er9x/simulator/er9xsimulator.h
@@ -60,6 +60,8 @@ class Er9xSimulator : public SimulatorInterface {
 
     virtual void setTrainerInput(unsigned int inputNumber, int16_t value) {};
 
+    virtual void setLuaStateReloadPermanentScripts() {};
+
   protected:
 
     Er9xInterface * er9xInterface;

--- a/companion/src/firmwares/ersky9x/simulator/ersky9xsimulator.h
+++ b/companion/src/firmwares/ersky9x/simulator/ersky9xsimulator.h
@@ -60,6 +60,8 @@ class Ersky9xSimulator : public SimulatorInterface {
 
     virtual void setTrainerInput(unsigned int inputNumber, int16_t value) {};
 
+    virtual void setLuaStateReloadPermanentScripts() {};
+
   protected:
 
     Ersky9xInterface * ersky9xInterface;

--- a/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
+++ b/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
@@ -527,6 +527,14 @@ uint16_t OpenTxSimulator::getSensorRatio(uint16_t id)
   return 0;
 }
 
+void OpenTxSimulator::setLuaStateReloadPermanentScripts()
+{
+#if defined(LUA)
+  luaState = INTERPRETER_RELOAD_PERMANENT_SCRIPTS;
+#endif
+}
+
+
 void OpenTxSimulator::setTrainerInput(unsigned int inputNumber, ::int16_t value)
 {
 #define SETTRAINER_IMPORT

--- a/companion/src/firmwares/opentx/simulator/opentxsimulator.h
+++ b/companion/src/firmwares/opentx/simulator/opentxsimulator.h
@@ -129,6 +129,9 @@ class DLLEXPORT OpenTxSimulator : public SimulatorInterface {
     virtual void setTrainerInput(unsigned int inputNumber, int16_t value);
 
     virtual void installTraceHook(void (*callback)(const char *));
+
+    virtual void setLuaStateReloadPermanentScripts();
+
 };
 
 }

--- a/companion/src/simulation/simulatordialog-taranis.ui
+++ b/companion/src/simulation/simulatordialog-taranis.ui
@@ -1763,6 +1763,16 @@ QPushButton:checked {
        </property>
       </widget>
      </item>
+      <item>
+        <widget class="QPushButton" name="luaReload">
+          <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+            <string>PF7 - Reload Lua Scripts</string>
+          </property>
+        </widget>
+      </item>
     </layout>
    </item>
   </layout>

--- a/companion/src/simulation/simulatordialog.cpp
+++ b/companion/src/simulation/simulatordialog.cpp
@@ -67,6 +67,7 @@ SimulatorDialog::SimulatorDialog(QWidget * parent, SimulatorInterface *simulator
   new QShortcut(QKeySequence(Qt::Key_F4), this, SLOT(openTelemetrySimulator()));
   new QShortcut(QKeySequence(Qt::Key_F5), this, SLOT(openTrainerSimulator()));
   new QShortcut(QKeySequence(Qt::Key_F6), this, SLOT(openDebugOutput()));
+  new QShortcut(QKeySequence(Qt::Key_F7), this, SLOT(luaReload()));
   traceCallbackInstance = this;
 }
 
@@ -212,6 +213,7 @@ SimulatorDialogTaranis::SimulatorDialogTaranis(QWidget * parent, SimulatorInterf
   connect(ui->telemSim, SIGNAL(released()), this, SLOT(openTelemetrySimulator()));
   connect(ui->trainerSim, SIGNAL(released()), this, SLOT(openTrainerSimulator()));
   connect(ui->debugConsole, SIGNAL(released()), this, SLOT(openDebugOutput()));
+  connect(ui->luaReload, SIGNAL(released()), this, SLOT(luaReload()));
 }
 
 SimulatorDialogTaranis::~SimulatorDialogTaranis()
@@ -319,6 +321,12 @@ void SimulatorDialog::openDebugOutput()
   else if (!DebugOut->isVisible()) {
     DebugOut->show();
   }
+}
+
+void SimulatorDialog::luaReload()
+{
+  // force a reload of the lua environment (as if a standalone script were run)
+  simulator->setLuaStateReloadPermanentScripts();
 }
 
 void SimulatorDialog::onDebugOutputClose()

--- a/companion/src/simulation/simulatordialog.h
+++ b/companion/src/simulation/simulatordialog.h
@@ -151,6 +151,7 @@ class SimulatorDialog : public QDialog
     void openTrainerSimulator();
     void openDebugOutput();
     void onDebugOutputClose();
+    void luaReload();
 
 #ifdef JOYSTICKS
     void onjoystickAxisValueChanged(int axis, int value);

--- a/companion/src/simulation/simulatorinterface.h
+++ b/companion/src/simulation/simulatorinterface.h
@@ -106,6 +106,8 @@ class SimulatorInterface
     virtual void setTrainerInput(unsigned int inputNumber, int16_t value) = 0;
 
     virtual void installTraceHook(void (*callback)(const char *)) = 0;
+
+    virtual void setLuaStateReloadPermanentScripts() = 0;
 };
 
 class SimulatorFactory {


### PR DESCRIPTION
Fixes #3141 Fx key to reload Lua scripts

Added PF7 - Reload Lua Scripts

Implemented via one liner - luaState = INTERPRETER_RELOAD_PERMANENT_SCRIPTS which forces a re-initialization of the Lua environment.

Very handy for script modification and debugging.