### PR TITLE
Projectkk2glider/new jitter filter

### DIFF
--- a/radio/src/gui/9X/menu_general_calib.cpp
+++ b/radio/src/gui/9X/menu_general_calib.cpp
@@ -39,6 +39,14 @@
 #define XPOT_DELTA 10
 #define XPOT_DELAY 10 /* cycles */
 
+enum CalibrationState {
+  CALIB_START = 0,
+  CALIB_SET_MIDPOINT,
+  CALIB_MOVE_STICKS,
+  CALIB_STORE,
+  CALIB_FINISHED
+};
+
 void menuCommonCalib(uint8_t event)
 {
   for (uint8_t i=0; i<NUM_STICKS+NUM_POTS; i++) { // get low and high vals for sticks and trims
@@ -57,7 +65,7 @@ void menuCommonCalib(uint8_t event)
   switch (event)
   {
     case EVT_ENTRY:
-      reusableBuffer.calib.state = 0;
+      reusableBuffer.calib.state = CALIB_START;
       break;
 
     case EVT_KEY_BREAK(KEY_ENTER):
@@ -66,14 +74,14 @@ void menuCommonCalib(uint8_t event)
   }
 
   switch (reusableBuffer.calib.state) {
-    case 0:
+    case CALIB_START:
       // START CALIBRATION
       if (!READ_ONLY()) {
         lcd_putsLeft(MENU_HEADER_HEIGHT+2*FH, STR_MENUTOSTART);
       }
       break;
 
-    case 1:
+    case CALIB_SET_MIDPOINT:
       // SET MIDPOINT
       lcd_putsAtt(0*FW, MENU_HEADER_HEIGHT+FH, STR_SETMIDPOINT, INVERS);
       lcd_putsLeft(MENU_HEADER_HEIGHT+2*FH, STR_MENUWHENDONE);
@@ -85,7 +93,7 @@ void menuCommonCalib(uint8_t event)
       }
       break;
 
-    case 2:
+    case CALIB_MOVE_STICKS:
       // MOVE STICKS/POTS
       STICK_SCROLL_DISABLE();
       lcd_putsAtt(0*FW, MENU_HEADER_HEIGHT+FH, STR_MOVESTICKSPOTS, INVERS);
@@ -102,14 +110,14 @@ void menuCommonCalib(uint8_t event)
       }
       break;
 
-    case 3:
+    case CALIB_STORE:
       g_eeGeneral.chkSum = evalChkSum();
       eeDirty(EE_GENERAL);
-      reusableBuffer.calib.state = 4;
+      reusableBuffer.calib.state = CALIB_FINISHED;
       break;
 
     default:
-      reusableBuffer.calib.state = 0;
+      reusableBuffer.calib.state = CALIB_START;
       break;
   }
 
@@ -121,7 +129,7 @@ void menuGeneralCalib(uint8_t event)
   check_simple(event, e_Calib, menuTabGeneral, DIM(menuTabGeneral), 0);
 
   if (menuEvent) {
-    calibrationState = 0;
+    calibrationState = CALIB_START;
   }
 
   TITLE(STR_MENUCALIBRATION);
@@ -130,8 +138,8 @@ void menuGeneralCalib(uint8_t event)
 
 void menuFirstCalib(uint8_t event)
 {
-  if (event == EVT_KEY_BREAK(KEY_EXIT) || reusableBuffer.calib.state == 4) {
-    calibrationState = 0;
+  if (event == EVT_KEY_BREAK(KEY_EXIT) || reusableBuffer.calib.state == CALIB_FINISHED) {
+    calibrationState = CALIB_START;
     chainMenu(menuMainView);
   }
   else {

--- a/radio/src/gui/Taranis/menu_general_calib.cpp
+++ b/radio/src/gui/Taranis/menu_general_calib.cpp
@@ -41,6 +41,14 @@
 #define BAR_SPACING   12
 #define BAR_HEIGHT    22
 
+enum CalibrationState {
+  CALIB_START = 0,
+  CALIB_SET_MIDPOINT,
+  CALIB_MOVE_STICKS,
+  CALIB_STORE,
+  CALIB_FINISHED
+};
+
 void drawPotsBars()
 {
   // Optimization by Mike Blandford
@@ -101,7 +109,7 @@ void menuCommonCalib(uint8_t event)
   {
     case EVT_ENTRY:
     case EVT_KEY_BREAK(KEY_EXIT):
-      reusableBuffer.calib.state = 0;
+      reusableBuffer.calib.state = CALIB_START;
       break;
 
     case EVT_KEY_BREAK(KEY_ENTER):
@@ -110,14 +118,14 @@ void menuCommonCalib(uint8_t event)
   }
 
   switch (reusableBuffer.calib.state) {
-    case 0:
+    case CALIB_START:
       // START CALIBRATION
       if (!READ_ONLY()) {
         lcd_putsLeft(MENU_HEADER_HEIGHT+2*FH, STR_MENUTOSTART);
       }
       break;
 
-    case 1:
+    case CALIB_SET_MIDPOINT:
       // SET MIDPOINT
       lcd_putsAtt(0*FW, MENU_HEADER_HEIGHT+FH, STR_SETMIDPOINT, INVERS);
       lcd_putsLeft(MENU_HEADER_HEIGHT+2*FH, STR_MENUWHENDONE);
@@ -133,7 +141,7 @@ void menuCommonCalib(uint8_t event)
       }
       break;
 
-    case 2:
+    case CALIB_MOVE_STICKS:
       // MOVE STICKS/POTS
       STICK_SCROLL_DISABLE();
       lcd_putsAtt(0*FW, MENU_HEADER_HEIGHT+FH, STR_MOVESTICKSPOTS, INVERS);
@@ -150,7 +158,7 @@ void menuCommonCalib(uint8_t event)
       }
       break;
 
-    case 3:
+    case CALIB_STORE:
       for (uint8_t i=POT1; i<=POT_LAST; i++) {
         int idx = i - POT1;
         int count = reusableBuffer.calib.xpotsCalib[idx].stepsCount;
@@ -176,11 +184,11 @@ void menuCommonCalib(uint8_t event)
       }
       g_eeGeneral.chkSum = evalChkSum();
       eeDirty(EE_GENERAL);
-      reusableBuffer.calib.state = 4;
+      reusableBuffer.calib.state = CALIB_FINISHED;
       break;
 
     default:
-      reusableBuffer.calib.state = 0;
+      reusableBuffer.calib.state = CALIB_START;
       break;
   }
 
@@ -190,7 +198,7 @@ void menuCommonCalib(uint8_t event)
 #if 0
   for (int i=POT1; i<=POT_LAST; i++) {
     uint8_t steps = 0;
-    if (reusableBuffer.calib.state == 2) {
+    if (reusableBuffer.calib.state == CALIB_MOVE_STICKS) {
       steps = reusableBuffer.calib.xpotsCalib[i-POT1].stepsCount;
     }
     else if (IS_POT_MULTIPOS(i)) {
@@ -209,14 +217,14 @@ void menuGeneralCalib(uint8_t event)
   check_simple(STR_MENUCALIBRATION, event, e_Calib, menuTabGeneral, DIM(menuTabGeneral), 0);
   menuCommonCalib(READ_ONLY() ? 0 : event);
   if (menuEvent) {
-    calibrationState = 0;
+    calibrationState = CALIB_START;
   }
 }
 
 void menuFirstCalib(uint8_t event)
 {
-  if (event == EVT_KEY_BREAK(KEY_EXIT) || reusableBuffer.calib.state == 4) {
-    calibrationState = 0;
+  if (event == EVT_KEY_BREAK(KEY_EXIT) || reusableBuffer.calib.state == CALIB_FINISHED) {
+    calibrationState = CALIB_START;
     chainMenu(menuMainView);
   }
   else {

--- a/radio/src/gui/Taranis/menu_general_calib.cpp
+++ b/radio/src/gui/Taranis/menu_general_calib.cpp
@@ -75,6 +75,8 @@ void menuCommonCalib(uint8_t event)
       uint8_t idx = i - POT1;
       int count = reusableBuffer.calib.xpotsCalib[idx].stepsCount;
       if (IS_POT_MULTIPOS(i) && count <= XPOTS_MULTIPOS_COUNT) {
+        // use raw analog value for multipos calibraton, anaIn() already has multipos decoded value
+        vt = getAnalogValue(i) >> 1;
         if (reusableBuffer.calib.xpotsCalib[idx].lastCount == 0 || vt < reusableBuffer.calib.xpotsCalib[idx].lastPosition - XPOT_DELTA || vt > reusableBuffer.calib.xpotsCalib[idx].lastPosition + XPOT_DELTA) {
           reusableBuffer.calib.xpotsCalib[idx].lastPosition = vt;
           reusableBuffer.calib.xpotsCalib[idx].lastCount = 1;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1429,17 +1429,35 @@ uint16_t BandGap ;
 #endif
 
 #if defined(JITTER_MEASURE)
-JitterMeter<uint16_t> rawJitter[NUMBER_ANALOG];
-JitterMeter<uint16_t> avgJitter[NUMBER_ANALOG];
-tmr10ms_t jitterResetTime = 0;
-#define JITTER_MEASURE_ACTIVE()   (menuHandlers[menuLevel] == menuGeneralDiagAna)
-#endif  // defined(JITTER_MEASURE)
+  JitterMeter<uint16_t> rawJitter[NUMBER_ANALOG];
+  JitterMeter<uint16_t> avgJitter[NUMBER_ANALOG];
+  tmr10ms_t jitterResetTime = 0;
+  #define JITTER_MEASURE_ACTIVE()   (menuHandlers[menuLevel] == menuGeneralDiagAna)
+#endif
+
+
+#if defined(VIRTUALINPUTS) && defined(JITTER_FILTER)
+  #define JITTER_FILTER_STRENGTH  4         // tune this value, bigger value - more filtering (range: 1-5) (see explanation below)
+  #define ANALOG_SCALE            1         // tune this value, bigger value - more filtering (range: 0-3) (see explanation below)
+
+  #define JITTER_ALPHA            (1<<JITTER_FILTER_STRENGTH)
+  #define ANALOG_MULTIPLIER       (1<<ANALOG_SCALE)
+  #define ANA_FILT(chan)          (s_anaFilt[chan] / (JITTER_ALPHA * ANALOG_MULTIPLIER))
+  #if (JITTER_ALPHA * ANALOG_MULTIPLIER > 32)
+    #error "JITTER_FILTER_STRENGTH and ANALOG_SCALE are too big, their summ should be <= 5 !!!"
+  #endif
+#else
+  #define JITTER_ALPHA            1
+  #define ANALOG_MULTIPLIER       1
+  #define ANA_FILT(chan)          (s_anaFilt[chan])
+#endif
+
 
 #if !defined(SIMU)
 uint16_t anaIn(uint8_t chan)
 {
 #if defined(VIRTUALINPUTS)
-  return s_anaFilt[chan];
+  return ANA_FILT(chan);
 #elif defined(PCBSKY9X) && !defined(REVA)
   static const uint8_t crossAna[]={1,5,7,0,4,6,2,3};
   if (chan == TX_CURRENT) {
@@ -1473,6 +1491,7 @@ void getADC()
 
 #if defined(JITTER_MEASURE)
   if (JITTER_MEASURE_ACTIVE() && jitterResetTime < get_tmr10ms()) {
+    // reset jitter measurement every second
     for (uint32_t x=0; x<NUMBER_ANALOG; x++) {
       rawJitter[x].reset();
       avgJitter[x].reset();
@@ -1484,62 +1503,88 @@ void getADC()
   for (uint32_t i=0; i<4; i++) {
     adcRead();
     for (uint32_t x=0; x<NUMBER_ANALOG; x++) {
-#if defined(JITTER_MEASURE)
       uint16_t val = getAnalogValue(x);
+#if defined(JITTER_MEASURE)
       if (JITTER_MEASURE_ACTIVE()) {
         rawJitter[x].measure(val);
       }
+#endif
       temp[x] += val;
-#else
-      temp[x] += getAnalogValue(x);
-#endif
     }
-#if defined(VIRTUALINPUTS)
-    if (calibrationState) break;
-#endif
   }
 
   for (uint32_t x=0; x<NUMBER_ANALOG; x++) {
-    uint16_t v = temp[x] >> 3;
+    uint16_t v = temp[x] >> (3 - ANALOG_SCALE);
 
-#if defined(VIRTUALINPUTS)
-
-    if (calibrationState) {
-      v = temp[x] >> 1;
+#if defined(VIRTUALINPUTS) && defined(JITTER_FILTER)
+    // Jitter filter: 
+    //    * pass trough any big change directly
+    //    * for small change use Modified moving average (MMA) filter
+    //
+    // Explanation:
+    //
+    // Normal MMA filter has this formula:   
+    //            <out> = ((ALPHA-1)*<out> + <in>)/ALPHA
+    //
+    // If calculation is done this way with integer arithmetics, then any small change in
+    // input signal is lost. One way to combat that, is to rearrange the formula somewhat,
+    // to store a more precise (larger) number between iterations. The basic idea is to 
+    // store undivided value between iterations. Therefore an new variable <filtered> is 
+    // used. The new formula becomes:
+    //           <filtered> = <filtered> - <filtered>/ALPHA + <in>
+    //           <out> = <filtered>/ALPHA  (use only when out is needed)
+    //
+    // The above formula with a maximum allowed ALPHA value (we are limited by 
+    // the 16 bit s_anaFilt[]) was tested on the radio. The resulting signal still had
+    // some jitter (a value of 1 was observed). The jitter might be bigger on other 
+    // radios.
+    //
+    // So another idea is to use larger input values for filtering. So instead of using
+    // input in a range from 0 to 2047, we use twice larger number (temp[x] is divided less)
+    //
+    // This also means that ALPHA must be lowered (remember 16 bit limit), but test results
+    // have proved that this kind of filtering gives better results. So the recommended values
+    // for filter are:
+    //     JITTER_FILTER_STRENGTH  4
+    //     ANALOG_SCALE            1
+    //
+    // Variables mapping:
+    //   * <in> = v
+    //   * <out> = s_anaFilt[x]
+    uint16_t previous = s_anaFilt[x] / JITTER_ALPHA;
+    uint16_t diff = (v > previous) ? (v - previous) : (previous - v);
+    if (diff < 10 * ANALOG_MULTIPLIER) {
+      // apply jitter filter
+      s_anaFilt[x] = (s_anaFilt[x] - previous) + v;
     }
-#if defined(JITTER_FILTER)
-    else {
-      // jitter filter
-      uint16_t diff = (v > s_anaFilt[x]) ? (v - s_anaFilt[x]) : (s_anaFilt[x] - v);
-      if (diff < 10) {
-        // apply filter
-        v = (7 * s_anaFilt[x] + v) >> 3;
-      }
-    }
+    else
 #endif
+    {
+    	//use unfiltered value
+      s_anaFilt[x] = v * JITTER_ALPHA;
+    }
 
 #if defined(JITTER_MEASURE)
     if (JITTER_MEASURE_ACTIVE()) {
-      avgJitter[x].measure(v);
+      avgJitter[x].measure(ANA_FILT(x));
     }
 #endif
 
+#if defined(VIRTUALINPUTS)
+    #define ANAFILT_MAX    (2 * RESX * JITTER_ALPHA * ANALOG_MULTIPLIER - 1)
     StepsCalibData * calib = (StepsCalibData *) &g_eeGeneral.calib[x];
-    if (!calibrationState && IS_POT_MULTIPOS(x) && calib->count>0 && calib->count<XPOTS_MULTIPOS_COUNT) {
-      uint8_t vShifted = (v >> 4);
-      s_anaFilt[x] = 2*RESX;
-      for (int i=0; i<calib->count; i++) {
+    if (!calibrationState && IS_POT_MULTIPOS(x) && IS_MULTIPOS_CALIBRATED(calib)) {
+      // TODO: consider adding another low pass filter to eliminate multipos switching glitches
+      uint8_t vShifted = ANA_FILT(x) >> 4;
+      s_anaFilt[x] = ANAFILT_MAX;
+      for (uint32_t i=0; i<calib->count; i++) {
         if (vShifted < calib->steps[i]) {
-          s_anaFilt[x] = i*2*RESX/calib->count;
+          s_anaFilt[x] = (i * ANAFILT_MAX) / calib->count;
           break;
         }
       }
     }
-    else 
-#endif
-    {
-      s_anaFilt[x] = v;
-    }
+#endif   // defined(VIRTUALINPUTS)
   }
 }
 #endif

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1447,6 +1447,7 @@ uint16_t BandGap ;
     #error "JITTER_FILTER_STRENGTH and ANALOG_SCALE are too big, their summ should be <= 5 !!!"
   #endif
 #else
+  #define ANALOG_SCALE            0
   #define JITTER_ALPHA            1
   #define ANALOG_MULTIPLIER       1
   #define ANA_FILT(chan)          (s_anaFilt[chan])

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -396,6 +396,7 @@
 #endif
 
 #define IS_POT(x)                   ((x)>=POT1 && (x)<=POT_LAST)
+#define IS_MULTIPOS_CALIBRATED(cal) (cal->count>0 && cal->count<XPOTS_MULTIPOS_COUNT)
 
 #define GET_LOWRES_POT_POSITION(i)  (getValue(MIXSRC_FIRST_POT+(i)) >> 4)
 #define SAVE_POT_POSITION(i)        g_model.potsWarnPosition[i] = GET_LOWRES_POT_POSITION(i)

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -177,7 +177,7 @@ void getSwitchesPosition(bool startup)
   for (int i=0; i<NUM_XPOTS; i++) {
     if (IS_POT_MULTIPOS(POT1+i)) {
       StepsCalibData * calib = (StepsCalibData *) &g_eeGeneral.calib[POT1+i];
-      if (calib->count>0 && calib->count<XPOTS_MULTIPOS_COUNT) {
+      if (IS_MULTIPOS_CALIBRATED(calib)) {
         uint8_t pos = anaIn(POT1+i) / (2*RESX/calib->count);
         uint8_t previousPos = potsPos[i] >> 4;
         uint8_t previousStoredPos = potsPos[i] & 0x0F;


### PR DESCRIPTION
I am not at all happy with the jitter filter in #3240. While testing it I found out that it does not pass trough very small changes of stick postilion. This is especially true if the input ADC signal has small noise level. The problem is in the filter formula and integer arithmetics.

So, I've came up with a much better solution (in my view) that still uses the same amount of RAM, but give much more precise result in term of small stick movement. The filter can also be tuned. It's implementation is documented in the code comments.

The new method also changes what kind of input signal is used for analog calibration:
 * before raw unfiltered (noisy value) was used, this sometimes resulted in a poor center stick value.
 * now a filtered value is also used for the calibration.

Same goes for multi-pos switch, a filtered value is used. The multi-pos **was not tested** by me, since I don't have any radio with it. So somebody else should check that it still works! I also have another idea for multi-pos - to implement low pass filter to help combat glitches while slowly switching the multi-pos switch (I have read on forums that some users see occasional glitches there).

The jitter filter could be more powerful and more precise in the future (if needed), but it would require a change in `s_anaFilt[]` from 16bit to 32bit. This would take more RAM. Perhaps we should implement it for better radios (X9E and Horus). 

