### PR TITLE
taranis: RX DMA for USART3 and s.bus

### DIFF
--- a/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
+++ b/companion/src/firmwares/opentx/simulator/opentxsimulator.cpp
@@ -89,7 +89,9 @@ namespace NAMESPACE {
 #include "radio/src/audio_arm.cpp"
 #include "radio/src/telemetry/telemetry.cpp"
 #include "radio/src/telemetry/frsky_sport.cpp"
+#if defined (PCBTARANIS)
 #include "radio/src/sbus.cpp"
+#endif
 #include "radio/src/crc16.cpp"
 #else
 #include "radio/src/main_avr.cpp"

--- a/radio/src/sbus.cpp
+++ b/radio/src/sbus.cpp
@@ -49,7 +49,6 @@
 
 #define SBUS_CH_CENTER        0x3E0
 
-Fifo<32> sbusFifo;
 uint8_t SbusFrame[SBUS_MAX_FRAME_SIZE];
 uint16_t SbusTimer ;
 uint8_t SbusIndex = 0 ;
@@ -92,7 +91,7 @@ void processSbusInput()
 {
   uint8_t rxchar;
   uint32_t active = 0;
-  while (sbusFifo.pop(rxchar)) {
+  while (serial_get_sbus_char(&rxchar)) {
     active = 1;
     SbusFrame[SbusIndex++] = rxchar;
     if (SbusIndex > SBUS_MAX_FRAME_SIZE-1) {

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -1265,6 +1265,7 @@ FlagStatus USART_GetFlagStatus(USART_TypeDef* USARTx, uint16_t USART_FLAG) { ret
 void GPIO_PinAFConfig(GPIO_TypeDef* GPIOx, uint16_t GPIO_PinSource, uint8_t GPIO_AF) { }
 void USART_Init(USART_TypeDef* USARTx, USART_InitTypeDef* USART_InitStruct) { }
 void USART_Cmd(USART_TypeDef* USARTx, FunctionalState NewState) { }
+void USART_DMACmd(USART_TypeDef* USARTx, uint16_t USART_DMAReq, FunctionalState NewState) { }
 void USART_ITConfig(USART_TypeDef* USARTx, uint16_t USART_IT, FunctionalState NewState) { }
 void RCC_PLLI2SConfig(uint32_t PLLI2SN, uint32_t PLLI2SR) { }
 void RCC_PLLI2SCmd(FunctionalState NewState) { }

--- a/radio/src/targets/taranis/board_taranis.h
+++ b/radio/src/targets/taranis/board_taranis.h
@@ -223,6 +223,7 @@ void stop_cppm_on_heartbeat_capture(void);
 void init_sbus_on_heartbeat_capture(void);
 void stop_sbus_on_heartbeat_capture(void);
 void set_trainer_ppm_parameters(uint32_t idleTime, uint32_t delay, uint32_t positive);
+int serial_get_sbus_char(uint8_t *ch);
 
 // Keys driver
 void keysInit(void);
@@ -334,6 +335,7 @@ void hapticOff(void);
 #define DEBUG_BAUDRATE                 115200
 void serial2Init(unsigned int mode, unsigned int protocol);
 void serial2Putc(char c);
+int serial2DMAPoll(uint8_t *ch);
 #define serial2TelemetryInit(protocol) serial2Init(UART_MODE_TELEMETRY, protocol)
 void serial2SbusInit(void);
 void serial2Stop(void);

--- a/radio/src/targets/taranis/serial2_driver.cpp
+++ b/radio/src/targets/taranis/serial2_driver.cpp
@@ -82,8 +82,8 @@ void uart3Setup(unsigned int baudrate, bool dma)
     USART_ITConfig(SERIAL_USART, USART_IT_TXE, DISABLE);
     DMA_StructInit(&DMA_InitStructure);
     DMA_InitStructure.DMA_Channel = DMA_Channel_4;
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&SERIAL_USART->DR;
-    DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)dma_buf;
+    DMA_InitStructure.DMA_PeripheralBaseAddr = CONVERT_PTR_UINT(&SERIAL_USART->DR);
+    DMA_InitStructure.DMA_Memory0BaseAddr = CONVERT_PTR_UINT(dma_buf);
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
     DMA_InitStructure.DMA_BufferSize = sizeof(dma_buf);
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;

--- a/radio/src/targets/taranis/trainer_driver.cpp
+++ b/radio/src/targets/taranis/trainer_driver.cpp
@@ -36,7 +36,7 @@
 
 #include "../../opentx.h"
 
-extern Fifo<32> sbusFifo;
+Fifo<32> sbusFifo;
 
 #define setupTrainerPulses() setupPulsesPPM(TRAINER_MODULE)
 
@@ -258,3 +258,15 @@ extern "C" void HEARTBEAT_USART_IRQHandler()
   }
 }
 #endif
+
+int serial_get_sbus_char(uint8_t *ch) 
+{
+  switch (currentTrainerMode) {
+          case TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE:
+                  return sbusFifo.pop(*ch);
+          case TRAINER_MODE_MASTER_BATTERY_COMPARTMENT:
+                  return serial2DMAPoll(ch);
+          default:
+                  return false;
+  }
+}

--- a/radio/src/targets/taranis/trainer_driver.cpp
+++ b/radio/src/targets/taranis/trainer_driver.cpp
@@ -262,11 +262,11 @@ extern "C" void HEARTBEAT_USART_IRQHandler()
 int serial_get_sbus_char(uint8_t *ch) 
 {
   switch (currentTrainerMode) {
-          case TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE:
-                  return sbusFifo.pop(*ch);
-          case TRAINER_MODE_MASTER_BATTERY_COMPARTMENT:
-                  return serial2DMAPoll(ch);
-          default:
-                  return false;
+    case TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE:
+      return sbusFifo.pop(*ch);
+    case TRAINER_MODE_MASTER_BATTERY_COMPARTMENT:
+      return serial2DMAPoll(ch);
+    default:
+      return false;
   }
 }


### PR DESCRIPTION
Replaced s.bus fifo with DMA ring buffer to get rid of overrun errors. If you like the idea, it can be extended to other serial port functions. It seems that RX DMA for USART6 is also possible (some dma streams need to be re-assigned).
I tested it on my taranis x9d.