### PR TITLE
[Taranis] fixed placement of decimal point in SMLSIZE font

### DIFF
--- a/radio/src/gui/Taranis/lcd.cpp
+++ b/radio/src/gui/Taranis/lcd.cpp
@@ -421,7 +421,7 @@ void lcd_outdezNAtt(coord_t x, coord_t y, lcdint_t val, LcdFlags flags, uint8_t 
       }
       else if (smlsize) {
         x -= 2;
-        lcd_plot(x+1, y+5);
+        lcd_plot(x, y+5);
         if ((flags&INVERS) && ((~flags & BLINK) || BLINK_ON_PHASE)) {
           lcd_vline(x+1, y, 7);
         }


### PR DESCRIPTION
[Compiled and Tested]
Decimal point needed to be shifted one pixel to the left.
This is a correction also appearing in #2666
The next branch needs to be corrected too, and I will submit a pull request for that branch right away.