### PR TITLE
[Taranis] fixed placement of decimal point in SMLSIZE font

### DIFF
--- a/radio/src/gui/taranis/lcd.cpp
+++ b/radio/src/gui/taranis/lcd.cpp
@@ -404,8 +404,8 @@ void lcdDrawNumber(coord_t x, coord_t y, int32_t val, LcdFlags flags, uint8_t le
         xn = x;
       }
       else if (smlsize) {
-        x -= 1;
-        lcdDrawPoint(x-1, y+5);
+        x -= 2;
+        lcdDrawPoint(x, y+5);
         if ((flags&INVERS) && ((~flags & BLINK) || BLINK_ON_PHASE)) {
           lcdDrawSolidVerticalLine(x-1, y, 7);
         }


### PR DESCRIPTION
[Compiled and Tested]
Decimal point needed to be shifted one pixel to the left.
This is a correction also appearing in #2666
Same as #3348 but for branch next.