### PR TITLE
Fix building OpenTX under OS X

### DIFF
--- a/radio/util/generate_datacopy.py
+++ b/radio/util/generate_datacopy.py
@@ -7,6 +7,10 @@ import clang.cindex
 import time
 import os
 
+if sys.platform == "darwin":
+    clang.cindex.Config.set_library_file('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib')
+
+
 structs = []
 
 def build_struct(cursor):


### PR DESCRIPTION
The clang.index python library does not look in the default path where the library is installed