### PR TITLE
Kilrah/timers22

### DIFF
--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -1626,7 +1626,9 @@ class Firmware {
     }
 
     virtual int getCapability(const Capability) = 0;
-
+    
+    virtual QTime getMaxTimerStart() = 0;
+    
     virtual bool isTelemetrySourceAvailable(int source) = 0;
 
     virtual int isAvailable(PulsesProtocol proto, int port=0) = 0;

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -813,6 +813,16 @@ int OpenTxFirmware::getCapability(const Capability capability)
   }
 }
 
+QTime OpenTxFirmware::getMaxTimerStart()
+{
+  if (IS_TARANIS(board))
+    return QTime(23, 59, 59);
+  else if (IS_ARM(board))
+    return QTime(8, 59, 59);
+  else
+    return QTime(0, 59, 59);
+}
+
 bool OpenTxFirmware::isTelemetrySourceAvailable(int source)
 {
   if (IS_TARANIS(board) && (source == TELEMETRY_SOURCE_RSSI_TX))

--- a/companion/src/firmwares/opentx/opentxinterface.h
+++ b/companion/src/firmwares/opentx/opentxinterface.h
@@ -118,6 +118,8 @@ class OpenTxFirmware: public Firmware {
     virtual QString getFirmwareUrl();
 
     virtual int getCapability(const Capability);
+    
+    virtual QTime getMaxTimerStart();
 
     virtual bool isTelemetrySourceAvailable(int source);
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -397,7 +397,7 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
     else if (func>=FuncSetTimer1 && func<=FuncSetTimer3) {
       if (modified) cfn.param = QTimeS(fswtchParamTime[i]->time()).seconds();
       fswtchParamTime[i]->setMinimumTime(QTime(0, 0, 0));
-      fswtchParamTime[i]->setMaximumTime(QTime(0, 59, 59));
+      fswtchParamTime[i]->setMaximumTime(firmware->getMaxTimerStart());
       fswtchParamTime[i]->setTime(QTimeS(cfn.param));
       widgetsMask |= CUSTOM_FUNCTION_TIME_PARAM + CUSTOM_FUNCTION_ENABLE;
     }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -42,6 +42,8 @@ TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, Ge
     ui->countdownBeep->addItem(tr("Voice"), TimerData::COUNTDOWN_VOICE);
     ui->countdownBeep->addItem(tr("Haptic"), TimerData::COUNTDOWN_HAPTIC);
   }
+  
+  ui->value->setMaximumTime(firmware->getMaxTimerStart());
 
   ui->persistent->setField(timer.persistent, this);
   ui->persistent->addItem(tr("Not persistent"), 0);
@@ -66,9 +68,11 @@ TimerPanel::~TimerPanel()
 
 void TimerPanel::update()
 {
-  int min = timer.val / 60;
-  int sec = timer.val % 60;
-  ui->value->setTime(QTime(0, min, sec));
+  int hour = timer.val / 3600;
+  int min = (timer.val - (hour * 3600)) / 60;
+  int sec = (timer.val - (hour * 3600)) % 60;
+
+  ui->value->setTime(QTime(hour, min, sec));
 
   if (firmware->getCapability(PermTimers)) {
     int sign = 1;
@@ -94,7 +98,7 @@ QWidget * TimerPanel::getLastFocus()
 
 void TimerPanel::on_value_editingFinished()
 {
-  timer.val = ui->value->time().minute()*60 + ui->value->time().second();
+  timer.val = ui->value->time().hour()*3600 + ui->value->time().minute()*60 + ui->value->time().second();
   emit modified();
 }
 

--- a/companion/src/modeledit/setup_timer.ui
+++ b/companion/src/modeledit/setup_timer.ui
@@ -18,7 +18,7 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <property name="spacing">
-    <number>-1</number>
+    <number>6</number>
    </property>
    <property name="margin">
     <number>0</number>
@@ -39,10 +39,10 @@
       <bool>true</bool>
      </property>
      <property name="currentSection">
-      <enum>QDateTimeEdit::MinuteSection</enum>
+      <enum>QDateTimeEdit::HourSection</enum>
      </property>
      <property name="displayFormat">
-      <string notr="true">mm:ss</string>
+      <string notr="true">hh:mm:ss</string>
      </property>
     </widget>
    </item>

--- a/radio/src/gui/9x/lcd.cpp
+++ b/radio/src/gui/9x/lcd.cpp
@@ -609,7 +609,7 @@ void putsTimer(coord_t x, coord_t y, putstime_t tme, LcdFlags att, LcdFlags att2
 
 #if defined(CPUARM)
   char separator = ':';
-  if (tme >= 3600 && (~att & DBLSIZE)) {
+  if (tme >= 3600) {
     qr = div(qr.quot, 60);
     separator = CHR_HOUR;
   }
@@ -617,6 +617,10 @@ void putsTimer(coord_t x, coord_t y, putstime_t tme, LcdFlags att, LcdFlags att2
 #define separator ':'
 #endif
   lcdDrawNumber(x, y, qr.quot, att|LEADING0|LEFT, 2);
+#if defined(CPUARM)
+  if (separator == CHR_HOUR)
+    att &= ~DBLSIZE;
+#endif
 #if defined(CPUARM) && defined(RTCLOCK)
   if (att&TIMEBLINK)
     lcdDrawChar(lcdLastPos, y, separator, BLINK);

--- a/radio/src/gui/9x/menu_model_custom_functions.cpp
+++ b/radio/src/gui/9x/menu_model_custom_functions.cpp
@@ -196,7 +196,7 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
 #endif
 #if defined(CPUARM)
           else if (func == FUNC_SET_TIMER) {
-            val_max = 59*60+59;
+            val_max = 539*60+59;
             putsTimer(MODEL_CUSTOM_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT, attr);
           }
 #endif

--- a/radio/src/gui/9x/menu_model_setup.cpp
+++ b/radio/src/gui/9x/menu_model_setup.cpp
@@ -205,13 +205,14 @@ void menuModelSetup(uint8_t event)
               break;
             }
             case 1:
-              CHECK_INCDEC_MODELVAR_ZERO(event, qr.quot, 59);
+              CHECK_INCDEC_MODELVAR_ZERO(event, qr.quot, 539); // 8:59
               timer->start = qr.rem + qr.quot*60;
               break;
             case 2:
               qr.rem -= checkIncDecModel(event, qr.rem+2, 1, 62)-2;
               timer->start -= qr.rem ;
               if ((int16_t)timer->start < 0) timer->start=0;
+              if ((int16_t)timer->start > 5999) timer->start=32399; // 8:59:59
               break;
           }
         }
@@ -285,6 +286,8 @@ void menuModelSetup(uint8_t event)
               case 2:
                 qr.rem -= checkIncDecModel(event, qr.rem+2, 1, 62)-2;
                 timer->start -= qr.rem ;
+                if ((int16_t)timer->start < 0) timer->start=0;
+                if ((int32_t)timer->start > 3599) timer->start=3599; // 59:59
                 break;
             }
           }

--- a/radio/src/gui/horus/menu_model_setup.cpp
+++ b/radio/src/gui/horus/menu_model_setup.cpp
@@ -104,7 +104,7 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, evt_t event)
   }
   drawStringWithIndex(MENUS_MARGIN_LEFT, y, STR_TIMER, timerIdx+1);
   putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, (menuHorizontalPosition<=0 ? attr : 0));
-  putsTimer(MODEL_SETUP_2ND_COLUMN+50, y, timer->start, (menuHorizontalPosition!=0 ? attr : 0));
+  putsTimer(MODEL_SETUP_2ND_COLUMN+50, y, timer->start, (menuHorizontalPosition==1 ? attr|TIMEHOUR : TIMEHOUR));
   if (attr && s_editMode>0) {
     switch (menuHorizontalPosition) {
       case 0:

--- a/radio/src/gui/horus/menu_model_setup.cpp
+++ b/radio/src/gui/horus/menu_model_setup.cpp
@@ -100,7 +100,7 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, evt_t event)
 {
   TimerData * timer = &g_model.timers[timerIdx];
   if (attr && menuHorizontalPosition < 0) {
-    lcdDrawSolidFilledRect(MODEL_SETUP_2ND_COLUMN-INVERT_HORZ_MARGIN, y-INVERT_VERT_MARGIN+1, 90+2*INVERT_HORZ_MARGIN, INVERT_LINE_HEIGHT, TEXT_INVERTED_BGCOLOR);
+    lcdDrawSolidFilledRect(MODEL_SETUP_2ND_COLUMN-INVERT_HORZ_MARGIN, y-INVERT_VERT_MARGIN+1, 115+2*INVERT_HORZ_MARGIN, INVERT_LINE_HEIGHT, TEXT_INVERTED_BGCOLOR);
   }
   drawStringWithIndex(MENUS_MARGIN_LEFT, y, STR_TIMER, timerIdx+1);
   putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, (menuHorizontalPosition<=0 ? attr : 0));

--- a/radio/src/gui/horus/widgets/timer.cpp
+++ b/radio/src/gui/horus/widgets/timer.cpp
@@ -45,8 +45,13 @@ void TimerWidget::refresh()
   TimerState & timerState = timersStates[index];
 
   if (zone.w >= 180 && zone.h >= 70) {
-    lcdDrawBitmapPattern(zone.x, zone.y, LBM_TIMER_BACKGROUND, MAINVIEW_PANES_COLOR);
-    if (timerData.start) {
+    if (timerState.val >= 0 || !(timerState.val % 2)) {
+      lcdDrawBitmapPattern(zone.x, zone.y, LBM_TIMER_BACKGROUND, MAINVIEW_PANES_COLOR);
+    }
+    else {
+      lcdDrawBitmapPattern(zone.x, zone.y, LBM_TIMER_BACKGROUND, HEADER_BGCOLOR);
+    }
+    if (timerData.start && timerState.val >= 0) {
       lcdDrawBitmapPatternPie(
         zone.x + 2,
         zone.y + 3, LBM_RSCALE, MAINVIEW_GRAPHICS_COLOR, 0,
@@ -67,21 +72,24 @@ void TimerWidget::refresh()
     drawStringWithIndex(zone.x + 137, zone.y + 17, "TMR", index + 1, SMLSIZE | TEXT_COLOR);
   }
   else {
-    drawStringWithIndex(zone.x, zone.y, "TMR", index + 1, SMLSIZE | TEXT_INVERTED_COLOR);
+    if (timerState.val < 0 && timerState.val % 2) {
+      lcdDrawSolidFilledRect(zone.x, zone.y, zone.w, zone.h, HEADER_ICON_BGCOLOR);
+    }
+    drawStringWithIndex(zone.x + 2, zone.y, "TMR", index + 1, SMLSIZE | TEXT_INVERTED_COLOR);
     if (zone.w > 100 && zone.h > 40) {
       if (abs(timerState.val) >= 3600) {
-        putsTimer(zone.x, zone.y + 16, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | TIMEHOUR);
+        putsTimer(zone.x + 3, zone.y + 16, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | TIMEHOUR);
       }
       else {
-        putsTimer(zone.x, zone.y + 16, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | MIDSIZE);
+        putsTimer(zone.x + 3, zone.y + 16, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | MIDSIZE);
       }
     }
     else {
       if (abs(timerState.val) >= 3600) {
-        putsTimer(zone.x, zone.y + 14, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | SMLSIZE | TIMEHOUR);
+        putsTimer(zone.x + 3, zone.y + 14, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT | SMLSIZE | TIMEHOUR);
       }
       else {
-        putsTimer(zone.x, zone.y + 14, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT);
+        putsTimer(zone.x + 3, zone.y + 14, abs(timerState.val), TEXT_INVERTED_COLOR | LEFT);
       }
     }
   }

--- a/radio/src/gui/taranis/menu_model_custom_functions.cpp
+++ b/radio/src/gui/taranis/menu_model_custom_functions.cpp
@@ -267,8 +267,8 @@ void menuCustomFunctions(uint8_t event, CustomFunctionData * functions, CustomFu
             lcdDrawTextAtIndex(MODEL_CUSTOM_FUNC_3RD_COLUMN, y, "\004Int.Ext.", CFN_PARAM(cfn), attr);
           }
           else if (func == FUNC_SET_TIMER) {
-            val_max = 59*60+59;
-            putsTimer(MODEL_CUSTOM_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT, attr);
+            val_max = 539*60+59; //8:59:59
+            putsTimer(MODEL_CUSTOM_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT|TIMEHOUR, attr);
           }
           else if (func == FUNC_PLAY_SOUND) {
             val_max = AU_SPECIAL_SOUND_LAST-AU_SPECIAL_SOUND_FIRST-1;

--- a/radio/src/gui/taranis/menu_model_setup.cpp
+++ b/radio/src/gui/taranis/menu_model_setup.cpp
@@ -123,7 +123,7 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, uint8_t event)
   drawStringWithIndex(0*FW, y, STR_TIMER, timerIdx+1);
   putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
   putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr|TIMEHOUR : TIMEHOUR, menuHorizontalPosition==2 ? attr|TIMEHOUR : TIMEHOUR);
-  if (attr && menuHorizontalPosition < 0) drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, 11*FW, FH+1);
+  if (attr && menuHorizontalPosition < 0) lcdDrawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, 11*FW, FH+1);
   if (attr && s_editMode>0) {
     div_t qr = div(timer->start, 60);
     switch (menuHorizontalPosition) {

--- a/radio/src/gui/taranis/menu_model_setup.cpp
+++ b/radio/src/gui/taranis/menu_model_setup.cpp
@@ -122,9 +122,8 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, uint8_t event)
   TimerData * timer = &g_model.timers[timerIdx];
   drawStringWithIndex(0*FW, y, STR_TIMER, timerIdx+1);
   putsTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
-
-  putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr : 0, menuHorizontalPosition==2 ? attr : 0);
-  if (attr && menuHorizontalPosition < 0) lcdDrawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, LCD_W-MODEL_SETUP_2ND_COLUMN-MENUS_SCROLLBAR_WIDTH+1, FH+1);
+  putsTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, menuHorizontalPosition==1 ? attr|TIMEHOUR : TIMEHOUR, menuHorizontalPosition==2 ? attr|TIMEHOUR : TIMEHOUR);
+  if (attr && menuHorizontalPosition < 0) drawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, 11*FW, FH+1);
   if (attr && s_editMode>0) {
     div_t qr = div(timer->start, 60);
     switch (menuHorizontalPosition) {
@@ -148,13 +147,14 @@ void editTimerMode(int timerIdx, coord_t y, LcdFlags attr, uint8_t event)
         break;
       }
       case 1:
-        CHECK_INCDEC_MODELVAR_ZERO(event, qr.quot, 59);
+        qr.quot = checkIncDec(event, qr.quot, 0, 1439, EE_MODEL | NO_INCDEC_MARKS); // 23h59
         timer->start = qr.rem + qr.quot*60;
         break;
       case 2:
         qr.rem -= checkIncDecModel(event, qr.rem+2, 1, 62)-2;
         timer->start -= qr.rem ;
         if ((int16_t)timer->start < 0) timer->start=0;
+        if ((int32_t)timer->start > 86399) timer->start=86399; // 23h59:59
         break;
     }
   }


### PR DESCRIPTION
Same as #3378 for next.

Given the recent key layout change that doesn't allow using the keys to edit values anymore it is now impossible to set the timer start value conveniently (would need to turn the encoder hundreds of times to set a couple of hours start time). Code simplifications that have been done in the timer display function don't allow the convenient trick used on Taranis for separate seconds/minute adjustment, so that needs to be reworked. Maybe with separate hour/min/sec due to the encoder. 