### PR TITLE
Fixes #3178: USB driver changed interrupt grouping which affected int…

### DIFF
--- a/radio/src/targets/taranis/usb_bsp.c
+++ b/radio/src/targets/taranis/usb_bsp.c
@@ -83,14 +83,8 @@ void USB_OTG_BSP_Deinit(USB_OTG_CORE_HANDLE *pdev)
 */
 void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
 {
-  NVIC_InitTypeDef NVIC_InitStructure; 
-  
-  NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
-  NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  NVIC_Init(&NVIC_InitStructure);  
+  NVIC_SetPriority(OTG_FS_IRQn, 11); // Lower priority interrupt
+  NVIC_EnableIRQ(OTG_FS_IRQn);
 }
 
 /**
@@ -101,14 +95,7 @@ void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
 */
 void USB_OTG_BSP_DisableInterrupt(USB_OTG_CORE_HANDLE *pdev)
 {
-  NVIC_InitTypeDef NVIC_InitStructure; 
-  
-  NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
-  NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
-  NVIC_Init(&NVIC_InitStructure);  
+  NVIC_DisableIRQ(OTG_FS_IRQn);
 }
 
 


### PR DESCRIPTION
…errupt priorities (fix suggested by Michael Blandford)

I recommend not merging right now for 2.1.8. It was tested on my Taranis, but should be tested some more time on the next branch (changes there done in commit 14841590b9e092d6daf7056426c449e601c15b12).


Closes #3178 