### PR TITLE
Projectkk2glider/sensor persistent

### DIFF
--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -619,7 +619,7 @@ void TelemetrySensorPanel::update()
   ui->source4->setVisible(sources34FieldsDisplayed);
   ui->autoOffset->setVisible(sensor.unit != SensorData::UNIT_RPMS && isConfigurable);
   ui->filter->setVisible(isConfigurable);
-  ui->persistent->setVisible((sensor.type == SensorData::TELEM_TYPE_CALCULATED && sensor.formula == SensorData::TELEM_FORMULA_CONSUMPTION) || isConfigurable);
+  ui->persistent->setVisible(sensor.type == SensorData::TELEM_TYPE_CALCULATED);
 
   lock = false;
 }

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -435,6 +435,9 @@ void menuModelSensor(uint8_t event)
         
       case SENSOR_FIELD_PERSISTENT:
         ON_OFF_MENU_ITEM(sensor->persistent, SENSOR_2ND_COLUMN, y, NO_INDENT(STR_PERSISTENT), attr, event);
+        if (checkIncDec_Ret && !sensor->persistent) {
+          sensor->persistentValue = 0;
+        }
         break;
 
       case SENSOR_FIELD_LOGS:

--- a/radio/src/gui/Taranis/menu_model_telemetry.cpp
+++ b/radio/src/gui/Taranis/menu_model_telemetry.cpp
@@ -213,7 +213,7 @@ bool isSensorAvailable(int sensor)
 #define SENSOR_AUTOOFFSET_ROWS (sensor->unit != UNIT_RPMS && sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_ONLYPOS_ROWS    (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_FILTER_ROWS     (sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
-#define SENSOR_PERSISTENT_ROWS ((sensor->type == TELEM_TYPE_CALCULATED && sensor->formula == TELEM_FORMULA_CONSUMPTION) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
+#define SENSOR_PERSISTENT_ROWS (sensor->type == TELEM_TYPE_CALCULATED ? (uint8_t)0 : HIDDEN_ROW)
 
 void menuModelSensor(uint8_t event)
 {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1964,10 +1964,6 @@ void opentxClose()
         sensor.persistentValue = telemetryItems[i].value;
         eeDirty(EE_MODEL);
       }
-      else if (!sensor.persistent) {
-        sensor.persistentValue = 0;
-        eeDirty(EE_MODEL);
-      }
     }
   }
 #endif


### PR DESCRIPTION
First a little background. I have two very similar models on the same radio (9XE with 2.1.8) but at the radio power off one model took much longer to shut down :open_mouth: . This bothered me, since I know I have no setting that would change the model EEPROM.

So I fired up the `simu` with gdb and found out that the culprit is the `calculated sensor` in the affected model. But that sensor does not have the `persistent` option checked!

So my first commit addresses this issue: there is no need to zero saved persistent value on every shutdown. There isn't even the need to zero it out when the persistent gets deselected, but I did it anyway. 

Second commit only shows `persistent` option for the sensors that actually have their value saved at the model save. This are all calculated type sensors.

