### PR TITLE
Fixes #3459 Rotary encoders linked flight mode can freeze Companion

### DIFF
--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -232,8 +232,9 @@ void FlightModePanel::update()
     int idx = phase.rotaryEncoders[i];
     FlightModeData *phasere = &phase;
     while (idx > 1024) {
-      idx -= 1025;
-      phasere = &model->flightModeData[idx];
+      int nextPhase = idx - 1025;
+      if (nextPhase >= phaseIdx) nextPhase += 1;
+      phasere = &model->flightModeData[nextPhase];
       idx = phasere->rotaryEncoders[i];
       reValues[i]->setDisabled(true);
     }


### PR DESCRIPTION
Used the GVars logic for the fix.

Only compiled and tested on Ubuntu 14.04