### PR TITLE
Enable DSM protocols on all targets that define DSM2 macro.

### DIFF
--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -80,7 +80,7 @@ void setupPulses(unsigned int port)
         case MODULE_TYPE_XJT:
           required_protocol = PROTO_PXX;
           break;
-#if defined(PCBTARANIS) && defined(DSM2)
+#if defined(DSM2)
         case MODULE_TYPE_DSM2:
           required_protocol = limit<uint8_t>(PROTO_DSM2_LP45, PROTO_DSM2_LP45+g_model.moduleData[EXTERNAL_MODULE].rfProtocol, PROTO_DSM2_DSMX);
           // The module is set to OFF during one second before BIND start


### PR DESCRIPTION
Enable DSM protocols on all targets that define DSM2 macro, not just on Taranis.
#3279 