### PR TITLE
Enables lcd.drawGauge on Horus

### DIFF
--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -417,7 +417,7 @@ static int luaLcdDrawFilledRectangle(lua_State *L)
 
 
 /*luadoc
-@function lcd.drawGauge(x, y, w, h, fill, maxfill)
+@function lcd.drawGauge(x, y, w, h, fill, maxfill [, flags])
 
 Draw a simple gauge that is filled based upon fill value
 
@@ -444,7 +444,7 @@ static int luaLcdDrawGauge(lua_State *L)
   int h = luaL_checkinteger(L, 4);
   int num = luaL_checkinteger(L, 5);
   int den = luaL_checkinteger(L, 6);
-  int flags = luaL_optinteger(L, 7,0);
+  unsigned int flags = luaL_optunsigned(L, 7, 0);
   lcdDrawRect(x, y, w, h);
   uint8_t len = limit((uint8_t)1, uint8_t(w*num/den), uint8_t(w));
   lcdDrawSolidFilledRect(x+1, y+1, len, h-2, flags);

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -415,7 +415,7 @@ static int luaLcdDrawFilledRectangle(lua_State *L)
   return 0;
 }
 
-#if !defined(COLORLCD)
+
 /*luadoc
 @function lcd.drawGauge(x, y, w, h, fill, maxfill)
 
@@ -444,13 +444,13 @@ static int luaLcdDrawGauge(lua_State *L)
   int h = luaL_checkinteger(L, 4);
   int num = luaL_checkinteger(L, 5);
   int den = luaL_checkinteger(L, 6);
-  // int flags = luaL_checkinteger(L, 7);
+  int flags = luaL_optinteger(L, 7,0);
   lcdDrawRect(x, y, w, h);
   uint8_t len = limit((uint8_t)1, uint8_t(w*num/den), uint8_t(w));
-  lcdDrawSolidFilledRect(x+1, y+1, len, h-2);
+  lcdDrawSolidFilledRect(x+1, y+1, len, h-2, flags);
   return 0;
 }
-#endif
+
 
 #if !defined(COLORLCD)
 /*luadoc
@@ -590,12 +590,12 @@ const luaL_Reg lcdLib[] = {
   { "drawChannel", luaLcdDrawChannel },
   { "drawSwitch", luaLcdDrawSwitch },
   { "drawSource", luaLcdDrawSource },
+  { "drawGauge", luaLcdDrawGauge },
 #if defined(COLORLCD)
   { "setColor", luaLcdSetColor },
   { "RGB", luaRGB },
 #else
   { "getLastPos", luaLcdGetLastPos },
-  { "drawGauge", luaLcdDrawGauge },
   { "drawPixmap", luaLcdDrawPixmap },
   { "drawScreenTitle", luaLcdDrawScreenTitle },
   { "drawCombobox", luaLcdDrawCombobox },


### PR DESCRIPTION
This enables lcd.drawGauge on Horus also. No usage difference with other platforms. Unsure why it wasn't initialy included, so beware !