### PR TITLE
Fixes #3492: delay_01us() and delay_ms() functions were generating wr…

### DIFF
--- a/radio/src/targets/horus/adc_driver.cpp
+++ b/radio/src/targets/horus/adc_driver.cpp
@@ -165,9 +165,9 @@ uint32_t adcReadNextSPIChannel(uint8_t index)
   //
   //        delay value       A5 change     Time needed for adcRead()
   //          1               16            0.154ms - 0.156ms
-  //        300               5             0.197ms - 0.199ms
-  //        500               0             0.225ms - 0.243ms
-  delay_01us(300);
+  //         38               5             0.197ms - 0.199ms
+  //         62               0             0.225ms - 0.243ms
+  delay_01us(40);
 
   for (uint8_t i = 0; i < 4; i++) {
     ADC_CS_LOW();

--- a/radio/src/targets/horus/board_horus.h
+++ b/radio/src/targets/horus/board_horus.h
@@ -112,7 +112,7 @@ extern "C" {
 #endif
 void delaysInit(void);
 void delay_01us(uint16_t nb);
-void delay_ms(uint16_t nb);
+void delay_ms(uint32_t ms);
 #ifdef __cplusplus
 }
 #endif

--- a/radio/src/targets/horus/delays.c
+++ b/radio/src/targets/horus/delays.c
@@ -25,25 +25,23 @@ void delaysInit(void)
   // Timer13
   RCC->APB1ENR |= RCC_APB1ENR_TIM13EN;           // Enable clock
   TIM13->PSC = (PERI1_FREQUENCY * TIMER_MULT_APB1) / 10000000 - 1;      // 0.1uS 
-  TIM13->CCER = 0;
-  TIM13->CCMR1 = 0;
-  TIM13->CR1 = 0x02;
-  TIM13->DIER = 0;
-}
-	
-void delay_01us(uint16_t nb)
-{
-  TIM13->EGR = 1;
-  TIM13->CNT = 0;
-  TIM13->CR1 = 0x03;
-  while (TIM13->CNT < nb);
-  TIM13->CR1 = 0x02;
+  TIM13->ARR = 0xFFFF;
+  TIM13->EGR = TIM_EGR_UG;    // generate update event
 }
 
-void delay_ms(uint16_t nb)
+void delay_01us(uint16_t nb)
 {
-  uint16_t i;
-  for (i=0; i<nb; i++) {
-    delay_01us(10000);
+  TIM13->EGR = TIM_EGR_UG;    // generate update event (this also resets counter)
+  TIM13->SR &= ~TIM_SR_CC1IF; // clear CC flag
+  TIM13->CCR1 = nb;           // set CC value
+  TIM13->CR1 |= TIM_CR1_CEN;  // start timer
+  while((TIM13->SR & TIM_SR_CC1IF) == 0);
+  TIM13->CR1 &= ~TIM_CR1_CEN; // stop timer
+}
+
+void delay_ms(uint32_t ms)
+{
+  while(ms--) {
+    delay_01us(10500);    // delay adjusted for the fact that ideal prescaler would be 8.4 but 8 is used
   }
 }

--- a/radio/src/targets/taranis/board_taranis.h
+++ b/radio/src/targets/taranis/board_taranis.h
@@ -139,7 +139,7 @@ extern "C" {
 #endif
 void delaysInit(void);
 void delay_01us(uint16_t nb);
-void delay(uint32_t ms);
+void delay_ms(uint32_t ms);
 #ifdef __cplusplus
 }
 #endif

--- a/radio/src/targets/taranis/lcd_driver.cpp
+++ b/radio/src/targets/taranis/lcd_driver.cpp
@@ -70,7 +70,7 @@ void initLcdSpi()
 static void LCD_Init()
 {
   WriteCommand(0x2F);   //Internal pump control
-  delay(20);
+  delay_ms(20);
   WriteCommand(0x24);   //Temperature compensation
   WriteCommand(0xE9);   //set bias=1/10
   WriteCommand(0x81);   //Set Vop
@@ -105,7 +105,7 @@ static void LCD_Init()
 static void LCD_Init()
 {	
   AspiCmd(0x2B);   //Panel loading set ,Internal VLCD.
-  delay(20);
+  delay_ms(20);
   AspiCmd(0x25);   //Temperature compensation curve definition: 0x25 = -0.05%/oC
   AspiCmd(0xEA);	//set bias=1/10 :Command table NO.27
   AspiCmd(0x81);	//Set Vop
@@ -349,7 +349,7 @@ void lcdOff()
   to re-init LCD without any delay
   */
   AspiCmd(0xAE);    //LCD sleep
-  delay(3);	        //wait for caps to drain
+  delay_ms(3);	        //wait for caps to drain
 }
 
 /*
@@ -357,7 +357,7 @@ void lcdOff()
   soon as possible after the reset because LCD takes a lot of
   time to properly power-on.
 
-  Make sure that delay() is functional before calling this function!
+  Make sure that delay_ms() is functional before calling this function!
 */
 void lcdInit()
 {
@@ -367,7 +367,7 @@ void lcdInit()
 
   //reset LCD module
   LCD_RST_LOW();
-  delay(1);       // only 3 us needed according to data-sheet, we use 1 ms
+  delay_ms(1);       // only 3 us needed according to data-sheet, we use 1 ms
   LCD_RST_HIGH();
 }
 
@@ -404,13 +404,13 @@ void lcdInitFinish()
 #if !defined(BOOT)
     while(g_tmr10ms < (RESET_WAIT_DELAY_MS/10)) {};    //wait measured from the power-on
 #else
-    delay(RESET_WAIT_DELAY_MS);
+    delay_ms(RESET_WAIT_DELAY_MS);
 #endif
   }
   
   LCD_Init();
   AspiCmd(0xAF);	//dc2=1, IC into exit SLEEP MODE, dc3=1 gray=ON, dc4=1 Green Enhanc mode disabled
-  delay(20);      //needed for internal DC-DC converter startup
+  delay_ms(20);      //needed for internal DC-DC converter startup
 }
 
 void lcdSetRefVolt(uint8_t val)


### PR DESCRIPTION
…ong delays (6 times shorter on Taranis, 8 times on X9E and Horus). Important delays adjusted, function names and code unified.


There is one problem remaining: the delay_01us(1) is now much longer than before. Now it is (I believe, I haven't measured) around 0.2us + call overhead. This is due to the fact that timer registers get updated/reset on the timer input clock.

So before delay_01us(1) was more like 1/8 of 0.1us - despite that all code that used it worked!. 

Therefore the delay_01us() for small values (let say less than 10) should be improved.

This change for example increases ADC acquisition time on Horus from 0.199ms to 0.199ms.