### PR TITLE
Give BattCheck a 'selective' memory

### DIFF
--- a/radio/sdcard/horus/WIDGETS/BattCheck/main.lua
+++ b/radio/sdcard/horus/WIDGETS/BattCheck/main.lua
@@ -62,6 +62,9 @@ local function getCels(sensor)
     for k, v in pairs(liveCellData) do
       if v < histCellData[k] then histCellData[k] = v end
     end
+  else
+    -- erase low cell memory when you change lipo
+    histCellData = {}
   end
   return liveCellData
 end


### PR DESCRIPTION
Forget about lowest cell when you change lipo without changing model or turning radio off