### PR TITLE
Fixes #3473: Inconsistent new model global variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - sudo apt-get update    
 
 install:
-  - sudo apt-get install -y lcov cmake cmake-data bc curl gcc-arm-none-eabi gcc-avr avr-libc avrdude libqtcore4 libqt4-dev qt4-qmake g++ libxerces-c-dev xsdcxx libsdl1.2-dev libusb-1.0-0 libphonon-dev phonon libqtwebkit-dev python-qt4 python-qt4-dev libfox-1.6-dev libgtest-dev
+  - sudo apt-get install --yes --force-yes lcov cmake cmake-data bc curl gcc-arm-none-eabi gcc-avr avr-libc avrdude libqtcore4 libqt4-dev qt4-qmake g++ libxerces-c-dev xsdcxx libsdl1.2-dev libusb-1.0-0 libphonon-dev phonon libqtwebkit-dev python-qt4 python-qt4-dev libfox-1.6-dev libgtest-dev
 
 script:
   - radio/util/commit-tests.sh

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1410,8 +1410,7 @@ void ModelData::clear()
     moduleData[1].protocol = PULSES_OFF;
   }
   for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
-    flightModeData[i].clear();
-    flightModeData[i].setDefaultLinkedFlightModes(i);
+    flightModeData[i].clear(i);
   }
   clearInputs();
   clearMixes();
@@ -1845,8 +1844,9 @@ SimulatorInterface *GetCurrentFirmwareSimulator()
     return NULL;
 }
 
-void FlightModeData::setDefaultLinkedFlightModes(const int phase)
+void FlightModeData::clear(const int phase)
 {
+  memset(this, 0, sizeof(FlightModeData));
   if (phase != 0) {
     for (int idx=0; idx<C9X_MAX_GVARS; idx++) {
       gvars[idx] = 1025;

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1411,6 +1411,7 @@ void ModelData::clear()
   }
   for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
     flightModeData[i].clear();
+    flightModeData[i].setDefaultLinkedFlightModes(i);
   }
   clearInputs();
   clearMixes();
@@ -1843,3 +1844,16 @@ SimulatorInterface *GetCurrentFirmwareSimulator()
   else
     return NULL;
 }
+
+void FlightModeData::setDefaultLinkedFlightModes(const int phase)
+{
+  if (phase != 0) {
+    for (int idx=0; idx<C9X_MAX_GVARS; idx++) {
+      gvars[idx] = 1025;
+    }
+    for (int idx=0; idx<C9X_MAX_ENCODERS; idx++) {
+      rotaryEncoders[idx] = 1025;
+    }
+  }
+}
+

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -632,7 +632,7 @@ class CustomFunctionData { // Function Switches data
 
 class FlightModeData {
   public:
-    FlightModeData() { clear(); }
+    FlightModeData() { clear(0); }
     int trimMode[NUM_STICKS];
     int trimRef[NUM_STICKS];
     int trim[NUM_STICKS];
@@ -642,8 +642,7 @@ class FlightModeData {
     unsigned int fadeOut;
     int rotaryEncoders[C9X_MAX_ENCODERS];
     int gvars[C9X_MAX_GVARS];
-    void clear() { memset(this, 0, sizeof(FlightModeData)); }
-    void setDefaultLinkedFlightModes(const int phase);
+    void clear(const int phase);
 };
 
 class SwashRingData { // Swash Ring data

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -640,9 +640,10 @@ class FlightModeData {
     char name[10+1];
     unsigned int fadeIn;
     unsigned int fadeOut;
-    int rotaryEncoders[2];
+    int rotaryEncoders[C9X_MAX_ENCODERS];
     int gvars[C9X_MAX_GVARS];
     void clear() { memset(this, 0, sizeof(FlightModeData)); }
+    void setDefaultLinkedFlightModes(const int phase);
 };
 
 class SwashRingData { // Swash Ring data

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -469,11 +469,11 @@ void FlightModePanel::fmClear()
       pswtch->setCurrentIndex(pswtch->findText(item.toString()));
       if (gvCount > 0 && (firmware->getCapability(GvarsFlightModes))) {
         for (int i=0; i<gvCount; i++) {
-          gvUse[i]->setCurrentIndex((phase.gvars[i] > 1024 ? (phase.gvars[i] - 1024) : phase.gvars[i]));
+          gvUse[i]->setCurrentIndex((phase.gvars[i] > 1024 ? (phase.gvars[i] - 1024) : 0));
         }
       }
       for (int i=0; i<reCount; i++) {
-        reUse[i]->setCurrentIndex((phase.rotaryEncoders[i] > 1024 ? (phase.rotaryEncoders[i] - 1024) : phase.rotaryEncoders[i]));
+        reUse[i]->setCurrentIndex((phase.rotaryEncoders[i] > 1024 ? (phase.rotaryEncoders[i] - 1024) : 0));
       }
       lock = false;
     }

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -452,8 +452,7 @@ void FlightModePanel::fmClear()
 {
   int res = QMessageBox::question(this, "Companion", tr("Clear all current Flight Mode properties?"), QMessageBox::Yes | QMessageBox::No);
   if (res == QMessageBox::Yes) {
-    phase.clear();
-    phase.setDefaultLinkedFlightModes(phaseIdx);
+    phase.clear(phaseIdx);
     if (phaseIdx == 0) {
       if (IS_TARANIS(GetEepromInterface()->getBoard())) {
         for (int i=0; i < gvCount; ++i) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -450,6 +450,14 @@ void modelDefault(uint8_t id)
   }
 #endif
 
+#if defined(FLIGHT_MODES) && defined(ROTARY_ENCODERS)
+  for (int p=1; p<MAX_FLIGHT_MODES; p++) {
+    for (int i=0; i<ROTARY_ENCODERS; i++) {
+      g_model.flightModeData[p].rotaryEncoders[i] = ROTARY_ENCODER_MAX+1;
+    }
+  }
+#endif
+
 #if defined(MAVLINK)
   g_model.mavlink.rc_rssi_scale = 15;
   g_model.mavlink.pc_rssi_en = 1;


### PR DESCRIPTION
Global variables default to same as radio ie Flight Mode 0 value.
Rotary encoders default to Flight Mode 0 value for general flight mode consistency however this now differs from radio. (being new contributor not confident on radio code but if someone would like to provide the diff I'll include in this pull).
Trim controls disabled when flight mode linked except for +Own trim.
Fixed Companion program crash when opening a model with rotary encoder linked flight modes.