### PR TITLE
Fix GVar display combobox

### DIFF
--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -277,6 +277,8 @@ void CurveGroup::gvarCBChanged(int state)
   if (!lock) {
     if (state) {
       curve.value = 10000+1; // TODO constant in EEpromInterface ...
+      lastType = -1; // quickfix for issue #3518: force refresh of curveValueCB at next update() to set current index to GV1
+      
     }
     else {
       curve.value = 0; // TODO could be better


### PR DESCRIPTION
quickfix for issue #3518: GVar combobox not being refreshed when GV checkbox (re-)selected


*added by projectkk2glider:* Closes #3518 