### PR TITLE
Fixes #3547: Flight modes linked trims display value error

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1523,9 +1523,7 @@ int ModelData::getTrimValue(int phaseIdx, int trimIdx)
       }
       else {
         phaseIdx = phase.trimRef[trimIdx];
-        if (phase.trimMode[trimIdx] == 0)
-          result = 0;
-        else
+        if (phase.trimMode[trimIdx] != 0)
           result += phase.trim[trimIdx];
       }
     }


### PR DESCRIPTION
Fixes display error in Companion when a trim in a linked flight mode sequence has Own Value