### PR TITLE
tell dfu-util to boot the device to boot after flashing

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -1083,7 +1083,7 @@ endif()
 
 if(CPU_FAMILY STREQUAL STM32)
   add_custom_target(flash
-    COMMAND dfu-util --alt 0 --dfuse-address 0x08000000 -d 0483:df11 -D firmware.bin
+    COMMAND dfu-util --alt 0 --dfuse-address 0x08000000:leave -d 0483:df11 -D firmware.bin
     DEPENDS firmware
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )


### PR DESCRIPTION
Only tested on my X9D+. It allows me to boot the device into the OpenTX firmware by using 'make flash' (on switch must be on), combined with -DUSB=SERIAL and -DCLI=YES and the reboot command I can test a new firmware on the device without removing/plugging the usb cable