### PR TITLE
Fix alignment bug of pulses data array

### DIFF
--- a/radio/src/pulses/pulses_arm.h
+++ b/radio/src/pulses/pulses_arm.h
@@ -115,13 +115,20 @@ union ModulePulsesData {
 #endif
   PpmPulsesData ppm;
   CrossfirePulsesData crossfire;
-};
+} __DMA;
+
+/* The __DMA keyword is required to align the struct inside the modulePulsesData below,
+ * which is also defined to be __DMA aligned.
+ * Arrays in C/C++ are always defined to be *contiguously*. The first byte of the second element is therefore always
+ * sizeof(ModulePulsesData). __DMA is required for sizeof(ModulePulsesData) to be a multiple of the alignment.
+ */
+
+extern ModulePulsesData modulePulsesData[NUM_MODULES];
 
 union TrainerPulsesData {
   PpmPulsesData ppm;
 };
 
-extern ModulePulsesData modulePulsesData[NUM_MODULES];
 extern TrainerPulsesData trainerPulsesData;
 extern const uint16_t CRCTable[];
 


### PR DESCRIPTION
The second element of the modulePulsesData was never forced to be correctly aligned. Without the new
pulses and without the Multimodule code the second element was never misaligned since the PXX pulses
union member was always the largest member and was 4 byte aligned by coincidence, also making the
second modulePulseData array member 4 byte aligned.

With the Multimodule option enabled the dsm pulses struct becomes the largest union member with 607 bytes
and the second modulePulsesData is not aligned to anything anymore which completely screws up the pulses
generation.

Forcing the alignment of the ModulePulsesData fixes this issue.