### PR TITLE
Fixed #3473: New model global variables and rotary encoders initialisation and trim controls behaviour

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1410,8 +1410,7 @@ void ModelData::clear()
     moduleData[1].protocol = PULSES_OFF;
   }
   for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
-    flightModeData[i].clear();
-    flightModeData[i].setDefaultLinkedFlightModes(i);
+    flightModeData[i].clear(i);
   }
   clearInputs();
   clearMixes();
@@ -1843,8 +1842,9 @@ SimulatorInterface *GetCurrentFirmwareSimulator()
     return NULL;
 }
 
-void FlightModeData::setDefaultLinkedFlightModes(const int phase)
+void FlightModeData::clear(const int phase)
 {
+  memset(this, 0, sizeof(FlightModeData));
   if (phase != 0) {
     for (int idx=0; idx<C9X_MAX_GVARS; idx++) {
       gvars[idx] = 1025;

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1411,6 +1411,7 @@ void ModelData::clear()
   }
   for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
     flightModeData[i].clear();
+    flightModeData[i].setDefaultLinkedFlightModes(i);
   }
   clearInputs();
   clearMixes();
@@ -1841,3 +1842,16 @@ SimulatorInterface *GetCurrentFirmwareSimulator()
   else
     return NULL;
 }
+
+void FlightModeData::setDefaultLinkedFlightModes(const int phase)
+{
+  if (phase != 0) {
+    for (int idx=0; idx<C9X_MAX_GVARS; idx++) {
+      gvars[idx] = 1025;
+    }
+    for (int idx=0; idx<C9X_MAX_ENCODERS; idx++) {
+      rotaryEncoders[idx] = 1025;
+    }
+  }
+}
+

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -632,7 +632,7 @@ class CustomFunctionData { // Function Switches data
 
 class FlightModeData {
   public:
-    FlightModeData() { clear(); }
+    FlightModeData() { clear(0); }
     int trimMode[NUM_STICKS];
     int trimRef[NUM_STICKS];
     int trim[NUM_STICKS];
@@ -642,8 +642,7 @@ class FlightModeData {
     unsigned int fadeOut;
     int rotaryEncoders[C9X_MAX_ENCODERS];
     int gvars[C9X_MAX_GVARS];
-    void clear() { memset(this, 0, sizeof(FlightModeData)); }
-    void setDefaultLinkedFlightModes(const int phase);
+    void clear(const int phase);
 };
 
 class SwashRingData { // Swash Ring data

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -640,9 +640,10 @@ class FlightModeData {
     char name[10+1];
     unsigned int fadeIn;
     unsigned int fadeOut;
-    int rotaryEncoders[2];
+    int rotaryEncoders[C9X_MAX_ENCODERS];
     int gvars[C9X_MAX_GVARS];
     void clear() { memset(this, 0, sizeof(FlightModeData)); }
+    void setDefaultLinkedFlightModes(const int phase);
 };
 
 class SwashRingData { // Swash Ring data

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -469,11 +469,11 @@ void FlightModePanel::fmClear()
       pswtch->setCurrentIndex(pswtch->findText(item.toString()));
       if (gvCount > 0 && (firmware->getCapability(GvarsFlightModes))) {
         for (int i=0; i<gvCount; i++) {
-          gvUse[i]->setCurrentIndex((phase.gvars[i] > 1024 ? (phase.gvars[i] - 1024) : phase.gvars[i]));
+          gvUse[i]->setCurrentIndex((phase.gvars[i] > 1024 ? (phase.gvars[i] - 1024) : 0));
         }
       }
       for (int i=0; i<reCount; i++) {
-        reUse[i]->setCurrentIndex((phase.rotaryEncoders[i] > 1024 ? (phase.rotaryEncoders[i] - 1024) : phase.rotaryEncoders[i]));
+        reUse[i]->setCurrentIndex((phase.rotaryEncoders[i] > 1024 ? (phase.rotaryEncoders[i] - 1024) : 0));
       }
       lock = false;
     }

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -452,8 +452,7 @@ void FlightModePanel::fmClear()
 {
   int res = QMessageBox::question(this, "Companion", tr("Clear all current Flight Mode properties?"), QMessageBox::Yes | QMessageBox::No);
   if (res == QMessageBox::Yes) {
-    phase.clear();
-    phase.setDefaultLinkedFlightModes(phaseIdx);
+    phase.clear(phaseIdx);
     if (phaseIdx == 0) {
       if (IS_TARANIS(GetEepromInterface()->getBoard())) {
         for (int i=0; i < gvCount; ++i) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -450,6 +450,14 @@ void modelDefault(uint8_t id)
   }
 #endif
 
+#if defined(FLIGHT_MODES) && defined(ROTARY_ENCODERS)
+  for (int p=1; p<MAX_FLIGHT_MODES; p++) {
+    for (int i=0; i<ROTARY_ENCODERS; i++) {
+      g_model.flightModeData[p].rotaryEncoders[i] = ROTARY_ENCODER_MAX+1;
+    }
+  }
+#endif
+
 #if defined(MAVLINK)
   g_model.mavlink.rc_rssi_scale = 15;
   g_model.mavlink.pc_rssi_en = 1;


### PR DESCRIPTION
Fixes #3473 Companion initialise global variables and rotary encoders to linked to Flight mode 0.
Companion trims disabled when linked to other flight mode except when + own as offset.
Radio initialise rotary encoders linked to Flight mode 0.
