### PR TITLE
Fixes 3472: circular linked global variables and rotary encoders in Companion

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1536,16 +1536,57 @@ bool ModelData::isGVarLinked(int phaseIdx, int gvarIdx)
   return flightModeData[phaseIdx].gvars[gvarIdx] > 1024;
 }
 
-int ModelData::getGVarValue(int phaseIdx, int gvarIdx)
+bool ModelData::isGVarLinkedCircular(int phaseIdx, int gvarIdx)
 {
-  int idx = flightModeData[phaseIdx].gvars[gvarIdx];
-  for (int i=0; idx>1024 && i<C9X_MAX_FLIGHT_MODES; i++) {
-    int nextPhase = idx - 1025;
+  for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
+    int val = flightModeData[phaseIdx].gvars[gvarIdx];
+    if ((phaseIdx==0) || (val<=1024)) return false;
+    int nextPhase = val - 1025;
     if (nextPhase >= phaseIdx) nextPhase += 1;
     phaseIdx = nextPhase;
-    idx = flightModeData[phaseIdx].gvars[gvarIdx];
   }
-  return idx;
+  return true;
+}
+
+int ModelData::getGVarValue(int phaseIdx, int gvarIdx)
+{
+  for (int i=0; i<C9X_MAX_FLIGHT_MODES; i++) {
+    int val = flightModeData[phaseIdx].gvars[gvarIdx];
+    if ((phaseIdx==0) || (val<=1024)) return val;
+    int nextPhase = val - 1025;
+    if (nextPhase >= phaseIdx) nextPhase += 1;
+    phaseIdx = nextPhase;
+  }
+  return flightModeData[0].gvars[gvarIdx];  // circular linked
+}
+
+bool ModelData::isRELinked(int phaseIdx, int reIdx)
+{
+  return flightModeData[phaseIdx].rotaryEncoders[reIdx] > 1024;
+}
+
+bool ModelData::isRELinkedCircular(int phaseIdx, int reIdx)
+{
+  for (int i=0; i<C9X_MAX_ENCODERS; i++) {
+    int val = flightModeData[phaseIdx].rotaryEncoders[reIdx];
+    if ((phaseIdx==0) || (val<=1024)) return false;
+    int nextPhase = val - 1025;
+    if (nextPhase >= phaseIdx) nextPhase += 1;
+    phaseIdx = nextPhase;
+  }
+  return true;
+}
+
+int ModelData::getREValue(int phaseIdx, int reIdx)
+{
+  for (int i=0; i<C9X_MAX_ENCODERS; i++) {
+    int val = flightModeData[phaseIdx].rotaryEncoders[reIdx];
+    if ((phaseIdx==0) || (val<=1024)) return val;
+    int nextPhase = val - 1025;
+    if (nextPhase >= phaseIdx) nextPhase += 1;
+    phaseIdx = nextPhase;
+  }
+  return flightModeData[0].rotaryEncoders[reIdx];  // circular linked
 }
 
 void ModelData::setTrimValue(int phaseIdx, int trimIdx, int value)

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -1078,7 +1078,12 @@ class ModelData {
     void setTrimValue(int phaseIdx, int trimIdx, int value);
 
     bool isGVarLinked(int phaseIdx, int gvarIdx);
+    bool isGVarLinkedCircular(int phaseIdx, int gvarIdx);
     int getGVarValue(int phaseIdx, int gvarIdx);
+
+    bool isRELinked(int phaseIdx, int reIdx);
+    bool isRELinkedCircular(int phaseIdx, int reIdx);
+    int getREValue(int phaseIdx, int reIdx);
 
     ModelData removeGlobalVars();
 

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -227,18 +227,11 @@ void FlightModePanel::update()
     }
   }
 
-  for (int i=0; i<reCount; i++) {    
-    reValues[i]->setDisabled(false);
-    int idx = phase.rotaryEncoders[i];
-    FlightModeData *phasere = &phase;
-    while (idx > 1024) {
-      int nextPhase = idx - 1025;
-      if (nextPhase >= phaseIdx) nextPhase += 1;
-      phasere = &model->flightModeData[nextPhase];
-      idx = phasere->rotaryEncoders[i];
-      reValues[i]->setDisabled(true);
+  if (ui->reGB->isVisible()) {
+    for (int i=0; i<reCount; i++) {    
+      reValues[i]->setDisabled(model->isRELinked(phaseIdx, i));
+      reValues[i]->setValue(model->getREValue(phaseIdx, i));
     }
-    reValues[i]->setValue(phasere->rotaryEncoders[i]);
   }
 }
 
@@ -339,6 +332,8 @@ void FlightModePanel::phaseGVUse_currentIndexChanged(int index)
       phase.gvars[gvar] = 1024 + index;
     }
     update();
+    if (model->isGVarLinkedCircular(phaseIdx,gvar))
+      QMessageBox::warning(this, "Companion", tr("Warning: Global variable links back to itself. Flight Mode 0 value used."));
     emit modified();
     lock = false;
   }
@@ -375,8 +370,10 @@ void FlightModePanel::phaseREUse_currentIndexChanged(int index)
       phase.rotaryEncoders[re] = 1024 + index;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ;
     }
     update();
-    lock = false;
+    if (model->isRELinkedCircular(phaseIdx,re))
+      QMessageBox::warning(this, "Companion", tr("Warning: Rotary encoder links back to itself. Flight Mode 0 value used."));
     emit modified();
+    lock = false;
   }
 }
 


### PR DESCRIPTION
Fixes #3472 Circular linked global variables.
Fixes circular linked rotary encoders.
Warn user when creating circular links.
Move rotary encoder code to ModelData class for consistency with global variables.