### PR TITLE
Fixes #3549: disable trim processing in while shutdown is in progress…

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1944,6 +1944,11 @@ void opentxStart()
 #if defined(CPUARM) || defined(CPUM2560)
 void opentxClose()
 {
+#if defined(CPUARM)
+  watchdogSetTimeout(2000/*20s*/);
+#endif
+  pausePulses();   // stop mixer task to disable trims processing while in shutdown
+
   AUDIO_BYE();
 
 #if defined(FRSKY)

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -192,8 +192,6 @@ void menusTask(void * pdata)
   topLcdOff();
 #endif
 
-  BACKLIGHT_OFF();
-
 #if defined(PCBTARANIS)
   displaySleepBitmap();
 #else


### PR DESCRIPTION
…, do no turn of the back-light before the shutdown

Closes #3549 
