### PR TITLE
Fixes #3642: sdInit() now called in one place only (inside the opentx…

### DIFF
--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -497,16 +497,13 @@ void audioTask(void * pdata)
 
   setSampleRate(AUDIO_SAMPLE_RATE);
 
-#if !defined(EEPROM)
-  AUDIO_HELLO();
-#elif defined(SDCARD)
+  while (!sdMounted()) {
+    CoTickDelay(10);
+  }
+
   if (!unexpectedShutdown) {
-#if defined(EEPROM)
-    sdInit();
-#endif
     AUDIO_HELLO();
   }
-#endif
 
   while (1) {
     audioQueue.wakeup();

--- a/radio/src/gui/horus/gui.h
+++ b/radio/src/gui/horus/gui.h
@@ -85,4 +85,3 @@ void drawCurveCoord(int x, int y, const char * text, bool active=false);
 void drawCurvePoint(int x, int y, LcdFlags color);
 
 extern Layout * customScreens[MAX_CUSTOM_SCREENS];
-extern Topbar * topbar;

--- a/radio/src/gui/horus/layout.cpp
+++ b/radio/src/gui/horus/layout.cpp
@@ -64,5 +64,5 @@ void loadCustomScreens()
     customScreens[0] = registeredLayouts[0]->create(&g_model.screenData[0].layoutData);
   }
 
-  topbar->load();
+  loadTopBar();
 }

--- a/radio/src/gui/horus/screens_setup.cpp
+++ b/radio/src/gui/horus/screens_setup.cpp
@@ -314,7 +314,7 @@ bool menuWidgetsSetup(evt_t event)
     Zone zone = currentContainer->getZone(i);
     LcdFlags color;
     int padding, thickness;
-    if (currentContainer == topbar) {
+    if (currentContainer == getTopBar()) {
       color = MENU_TITLE_COLOR;
       padding = 2;
       thickness = 1;
@@ -468,7 +468,7 @@ bool menuScreensTheme(evt_t event)
           drawButton(SCREENS_SETUP_2ND_COLUMN, y, "Setup", attr);
           if (attr && event == EVT_KEY_FIRST(KEY_ENTER)) {
             currentScreen = customScreens[0];
-            currentContainer = topbar;
+            currentContainer = getTopBar();
             pushMenu(menuWidgetsSetup);
           }
         }

--- a/radio/src/gui/horus/topbar.cpp
+++ b/radio/src/gui/horus/topbar.cpp
@@ -21,7 +21,7 @@
 #include "opentx.h"
 
 
-static Topbar * topbar;
+static Topbar * topbar = 0;
 
 unsigned int Topbar::getZonesCount() const
 {
@@ -52,6 +52,19 @@ void drawTopbarDatetime()
 
   getTimerString(str, getValue(MIXSRC_TX_TIME));
   lcdDrawText(DATETIME_MIDDLE, DATETIME_LINE2, str, SMLSIZE|TEXT_INVERTED_COLOR|CENTERED);
+}
+
+Topbar * getTopBar()
+{
+  return topbar;
+}
+
+void loadTopBar()
+{
+  if (!topbar) {
+    topbar = new Topbar(&g_model.topbarData);  
+  }
+  topbar->load();
 }
 
 void drawTopBar()

--- a/radio/src/gui/horus/topbar.cpp
+++ b/radio/src/gui/horus/topbar.cpp
@@ -20,6 +20,9 @@
 
 #include "opentx.h"
 
+
+static Topbar * topbar;
+
 unsigned int Topbar::getZonesCount() const
 {
   return MAX_TOPBAR_ZONES;
@@ -88,6 +91,9 @@ void drawTopBar()
     lcdDrawSolidFilledRect(LCD_W-122+4*i, 30, 2, 8, i >= bars ? MENU_TITLE_DISABLE_COLOR : MENU_TITLE_COLOR);
   }
 
+  if (!topbar) {
+    topbar = new Topbar(&g_model.topbarData);  
+  }
   topbar->refresh();
 
 #if 0

--- a/radio/src/gui/horus/view_main.cpp
+++ b/radio/src/gui/horus/view_main.cpp
@@ -30,7 +30,6 @@
 #define POTS_LINE_Y                    (LCD_H-20)
 
 Layout * customScreens[MAX_CUSTOM_SCREENS] = { 0, 0, 0, 0, 0 };
-Topbar * topbar;
 
 void drawMainPots()
 {

--- a/radio/src/gui/horus/widgets.h
+++ b/radio/src/gui/horus/widgets.h
@@ -76,6 +76,8 @@ void drawSleepBitmap();
 void drawShutdownBitmap(uint32_t index);
 
 // Main view standard widgets
+Topbar * getTopBar();
+void loadTopBar();
 void drawTopBar();
 void drawMainPots();
 void drawTrims(uint8_t flightMode);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2492,7 +2492,7 @@ void opentxInit(OPENTX_INIT_ARGS)
     unexpectedShutdown = 1;
   }
   else {
-#if defined(SDCARD)
+#if defined(SDCARD) && !defined(PCBMEGA2560)
     sdInit();
 #endif
   }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2509,7 +2509,6 @@ void opentxInit(OPENTX_INIT_ARGS)
 #endif
 
 #if defined(COLORLCD)
-  topbar = new Topbar(&g_model.topbarData);
   luaInit();
 #endif
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2488,16 +2488,14 @@ void opentxInit(OPENTX_INIT_ARGS)
   rtcInit();    // RTC must be initialized before rambackupRestore() is called
 #endif
 
-#if !defined(EEPROM)
-  if (!UNEXPECTED_SHUTDOWN()) {
-    sdInit();
+  if (UNEXPECTED_SHUTDOWN()) {
+    unexpectedShutdown = 1;
   }
+  else {
+#if defined(SDCARD)
+    sdInit();
 #endif
-
-#if defined(COLORLCD)
-  topbar = new Topbar(&g_model.topbarData);
-  luaInit();
-#endif
+  }
 
 #if defined(RAMBACKUP)
   if (UNEXPECTED_SHUTDOWN()) {
@@ -2510,10 +2508,9 @@ void opentxInit(OPENTX_INIT_ARGS)
   storageReadAll();
 #endif
 
-#if defined(CPUARM)
-  if (UNEXPECTED_SHUTDOWN()) {
-    unexpectedShutdown = 1;
-  }
+#if defined(COLORLCD)
+  topbar = new Topbar(&g_model.topbarData);
+  luaInit();
 #endif
 
 #if defined(PCBTARANIS)
@@ -2552,13 +2549,7 @@ void opentxInit(OPENTX_INIT_ARGS)
 
   if (g_eeGeneral.backlightMode != e_backlight_mode_off) backlightOn(); // on Tx start turn the light on
 
-  if (UNEXPECTED_SHUTDOWN()) {
-#if !defined(CPUARM)
-    // is done above on ARM
-    unexpectedShutdown = 1;
-#endif
-  }
-  else {
+  if (!UNEXPECTED_SHUTDOWN()) {
     opentxStart();
   }
 

--- a/radio/src/storage/sdcard_raw.cpp
+++ b/radio/src/storage/sdcard_raw.cpp
@@ -171,8 +171,6 @@ void storageCheck(bool immediately)
 
 void storageReadAll()
 {
-  sdInit();
-
   if (loadGeneralSettings() != NULL) {
     storageEraseAll(true);
   }

--- a/radio/src/targets/horus/board_horus.h
+++ b/radio/src/targets/horus/board_horus.h
@@ -113,6 +113,7 @@ extern "C" {
 #endif
 void delaysInit(void);
 void delay_01us(uint16_t nb);
+void delay_us(uint16_t nb);
 void delay_ms(uint32_t ms);
 #ifdef __cplusplus
 }

--- a/radio/src/targets/taranis/diskio.cpp
+++ b/radio/src/targets/taranis/diskio.cpp
@@ -953,7 +953,6 @@ void sdInit(void)
 // TODO shouldn't be there!
 void sdInit(void)
 {
-  TRACE("sdInit");
   ioMutex = CoCreateMutex();
   if (ioMutex >= CFG_MAX_MUTEX ) {
     //sd error

--- a/radio/src/targets/taranis/diskio.cpp
+++ b/radio/src/targets/taranis/diskio.cpp
@@ -953,6 +953,7 @@ void sdInit(void)
 // TODO shouldn't be there!
 void sdInit(void)
 {
+  TRACE("sdInit");
   ioMutex = CoCreateMutex();
   if (ioMutex >= CFG_MAX_MUTEX ) {
     //sd error


### PR DESCRIPTION
…Init()). Some reordering of opentxInit().

Please review carefully and test. I only tested on Taranis. 

The SD card is now initialized in `opentxInit()`. Before this change `referenceModelAudioFiles()` was being executed before SD was initialized. 

I also rearanged the flow of   `opentxInit()` to make it more simple and clear. 

I think  there was also bug - the `topbar = new Topbar(&g_model.topbarData)` was callled before the model data was read.
