### PR TITLE
Fix gcc 5.4 compiler warnings

### DIFF
--- a/radio/src/targets/taranis/flash_driver.cpp
+++ b/radio/src/targets/taranis/flash_driver.cpp
@@ -37,7 +37,7 @@ void unlockFlash()
 
 void lockFlash()
 {
-  while (!FLASH->SR & FLASH_SR_BSY);
+  while (!(FLASH->SR & FLASH_SR_BSY));
   FLASH->CR |= FLASH_CR_LOCK;
 }
 


### PR DESCRIPTION
The order preference in flash_driver would evaluate ! before & but I think checking the bit first is what was intended