### PR TITLE
Fix channel count on dsm2 module, purely cosmetic (closes issue #3673)

### DIFF
--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -767,7 +767,7 @@ void menuModelSetup(uint8_t event)
               if (checkIncDec_Ret) {
                 g_model.moduleData[EXTERNAL_MODULE].rfProtocol = 0;
                 g_model.moduleData[EXTERNAL_MODULE].channelsStart = 0;
-                g_model.moduleData[EXTERNAL_MODULE].channelsCount = 0;
+                g_model.moduleData[EXTERNAL_MODULE].channelsCount = min<int8_t>(0, MAX_EXTERNAL_MODULE_CHANNELS());
               }
               break;
             case 1:

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -404,7 +404,8 @@ void memswap(void * a, void * b, uint8_t size);
 #endif
 
 #if defined(CPUARM)
-  static const int8_t maxChannelsModules[] = { 0, 8, 8, -2, 8 }; // relative to 8!
+// Order is the same as in enum Protocols in myeeprom.h (none, ppm, xjt, dsm, crossfire, multi)
+  static const int8_t maxChannelsModules[] = { 0, 8, 8, -2, 8, 8 }; // relative to 8!
   static const int8_t maxChannelsXJT[] = { 0, 8, 0, 4 }; // relative to 8!
   #define MAX_TRAINER_CHANNELS()            (8)
 #endif


### PR DESCRIPTION
Taranis menu always use 8 channels as default opposed to 9x and Horus, which use the maximum number as default channel count (which is 6 on dsm2). This commit does not change that logic.