### PR TITLE
Re #3724: added smoothing filter for rotary encoder speed

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -142,9 +142,11 @@ void per10ms()
       putEvent(scrollRE < 0 ? EVT_ROTARY_LEFT : EVT_ROTARY_RIGHT);
     }
 #if defined(CPUARM)
+    // rotary encoder navigation speed (acceleration) detection/calculation
     if (scrollRE) {
       static uint32_t lastTick = 0;
-      uint32_t delay = get_tmr10ms() - lastTick;
+      static uint32_t delay = 0;
+      delay = (((get_tmr10ms() - lastTick) << 3) + delay) >> 1;   // Modified moving average filter used for smoother change of speed
       lastTick = get_tmr10ms();
       if (delay < ROTENC_DELAY_HIGHSPEED)
         rotencSpeed = ROTENC_HIGHSPEED;

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -527,22 +527,22 @@ extern uint8_t channel_order(uint8_t x);
 #endif
 
 #if defined(ROTARY_ENCODERS)
-#define IS_ROTARY_ENCODER_NAVIGATION_ENABLE()  g_eeGeneral.reNavigation
-extern volatile rotenc_t rotencValue[ROTARY_ENCODERS];
-#define ROTARY_ENCODER_NAVIGATION_VALUE        rotencValue[g_eeGeneral.reNavigation - 1]
+  #define IS_ROTARY_ENCODER_NAVIGATION_ENABLE()  g_eeGeneral.reNavigation
+  extern volatile rotenc_t rotencValue[ROTARY_ENCODERS];
+  #define ROTARY_ENCODER_NAVIGATION_VALUE        rotencValue[g_eeGeneral.reNavigation - 1]
 #elif defined(ROTARY_ENCODER_NAVIGATION)
-#define IS_ROTARY_ENCODER_NAVIGATION_ENABLE()  true
-extern volatile rotenc_t rotencValue[1];
-#define ROTARY_ENCODER_NAVIGATION_VALUE        rotencValue[0]
+  #define IS_ROTARY_ENCODER_NAVIGATION_ENABLE()  true
+  extern volatile rotenc_t rotencValue[1];
+  #define ROTARY_ENCODER_NAVIGATION_VALUE        rotencValue[0]
 #endif
 
 #if defined(CPUARM) && defined(ROTARY_ENCODER_NAVIGATION)
-extern uint8_t rotencSpeed;
-#define ROTENC_LOWSPEED                1
-#define ROTENC_MIDSPEED                5
-#define ROTENC_HIGHSPEED               50
-#define ROTENC_DELAY_MIDSPEED          4
-#define ROTENC_DELAY_HIGHSPEED         2
+  extern uint8_t rotencSpeed;
+  #define ROTENC_LOWSPEED              1
+  #define ROTENC_MIDSPEED              5
+  #define ROTENC_HIGHSPEED             50
+  #define ROTENC_DELAY_MIDSPEED        32
+  #define ROTENC_DELAY_HIGHSPEED       16
 #endif
 
 #define HEART_TIMER_10MS               1


### PR DESCRIPTION
I like this better than #3724 the transition between speeds is more smooth. Try it and merge if you like it.