### PR TITLE
Haptic feedback in lua scripts

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -694,6 +694,32 @@ static int luaPlayTone(lua_State * L)
 }
 
 /*luadoc
+@function luaPlayHaptic(duration, pause [, flags])
+
+Generate haptic feedback
+
+@param duration (number) length of the haptic feedback in milliseconds
+
+@param pause (number) length of the silence after haptic feedback in milliseconds
+
+@param flags (number):
+ * `0 or not present` play with normal priority
+ * `PLAY_NOW` play immediately
+
+@status current Introduced in 2.2.0
+*/
+static int luaPlayHaptic(lua_State * L)
+{
+#if defined(HAPTIC)
+  int length = luaL_checkinteger(L, 1);
+  int pause = luaL_checkinteger(L, 2);
+  int flags = luaL_optinteger(L, 3, 0);
+  haptic.play(length, pause, flags);
+#endif
+  return 0;
+}
+
+/*luadoc
 @function killEvents(key)
 
 Stops key state machine.
@@ -866,6 +892,7 @@ const luaL_Reg opentxLib[] = {
   { "playNumber", luaPlayNumber },
   { "playDuration", luaPlayDuration },
   { "playTone", luaPlayTone },
+  { "playHaptic", luaPlayHaptic },
   { "popupInput", luaPopupInput },
   { "defaultStick", luaDefaultStick },
   { "defaultChannel", luaDefaultChannel },


### PR DESCRIPTION
This is my attempt to add haptic feedback support to lua scripts. I used haptic.play() even though OpenTX usually uses haptic.event() to generate haptic feedback. Tested working using the script below. I played with the parameters of that script but it seems that only "pause" has any effect, which is how long the haptic feedback is on. That value does not seem to correspond to milliseconds or even centiseconds... Thanks!


local inputs = {{"length", VALUE, 0, 100, 0}, {"pause", VALUE, 0, 100, 0}, {"flags", VALUE, 0, 1000, 16}, {"RepeatT", VALUE,0,100,10}}

local last_reset = getTime()

local function run(length,pause,flags,RepeatT)
local timer = getTime()
	if (timer - last_reset) > RepeatT*10 then -- times 10 to convert to tenths of seconds
		last_reset = timer
        playHaptic(length,pause,flags)
    end
end

return {run=run, input=inputs}
