### PR TITLE
Projectkk2glider/gps clock to rtc improvements

### DIFF
--- a/radio/src/gui/480x272/model_telemetry.cpp
+++ b/radio/src/gui/480x272/model_telemetry.cpp
@@ -75,6 +75,7 @@ enum MenuModelTelemetryFrskyItems {
 #define TELEM_COL2                    200
 #define TELEM_COL3                    275
 #define TELEM_COL4                    350
+#define TELEM_COL5                    425
 
 #define IF_FAS_OFFSET(x)              x,
 #define IS_RANGE_DEFINED(k)           (g_model.frsky.channels[k].ratio > 0)
@@ -443,11 +444,11 @@ bool menuModelTelemetryFrsky(event_t event)
           // Spektrum does not (yet?) really support multiple sensor of the same type. But a lot of
           // different sensor display the same information (e.g. voltage, capacity). Show the id
           // of the sensor in the overview to ease figuring out what sensors belong together
-          lcdDrawHexNumber(TELEM_COL4, y, sensor->id, LEFT);
+          lcdDrawHexNumber(TELEM_COL5, y, sensor->id, LEFT);
         } else
 #endif
       if (sensor->type == TELEM_TYPE_CUSTOM && !g_model.ignoreSensorIds) {
-        lcdDrawNumber(TELEM_COL4, y, sensor->instance, LEFT);
+        lcdDrawNumber(TELEM_COL5, y, sensor->instance, LEFT);
       }
       if (attr) {
         s_editMode = 0;
@@ -477,7 +478,7 @@ bool menuModelTelemetryFrsky(event_t event)
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_TELEMETRY_SENSORS);
         lcdDrawText(TELEM_COL2, y, STR_VALUE, 0);
         if (!g_model.ignoreSensorIds && !IS_SPEKTRUM_PROTOCOL()) {
-          lcdDrawText(TELEM_COL4, y, STR_ID, 0);
+          lcdDrawText(TELEM_COL5, y, STR_ID, 0);
         }
         break;
 

--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -116,7 +116,7 @@ bool menuRadioSetup(event_t event)
     CASE_HAPTIC(LABEL(HAPTIC)) CASE_HAPTIC(0) CASE_HAPTIC(0) CASE_HAPTIC(0)
     LABEL(ALARMS), 0, 0, 0,
     LABEL(BACKLIGHT), 0, 0, 0, 0, 0,
-    CASE_GPS(LABEL(GPS)) CASE_GPS(0) CASE_GPS(0)
+    CASE_GPS(LABEL(GPS)) CASE_GPS(0) CASE_GPS(0) CASE_GPS(0)
     CASE_PXX(0) 0, 0, 0, 0, 0, 0, 1/*to force edit mode*/ });
 
   if (event == EVT_ENTRY) {

--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -74,6 +74,7 @@ enum menuRadioSetupItems {
   // CASE_SPLASH_PARAM(ITEM_SETUP_DISABLE_SPLASH)
   CASE_GPS(ITEM_SETUP_LABEL_GPS)
   CASE_GPS(ITEM_SETUP_TIMEZONE)
+  CASE_GPS(ITEM_SETUP_ADJUST_RTC)
   CASE_GPS(ITEM_SETUP_GPSFORMAT)
   CASE_PXX(ITEM_SETUP_COUNTRYCODE)
   ITEM_SETUP_LANGUAGE,
@@ -415,6 +416,11 @@ bool menuRadioSetup(event_t event)
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_TIMEZONE);
         lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.timezone, attr|LEFT);
         if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.timezone, -12, 12);
+        break;
+
+      case ITEM_SETUP_ADJUST_RTC:
+        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_ADJUST_RTC);
+        g_eeGeneral.adjustRTC = editCheckBox(g_eeGeneral.adjustRTC, RADIO_SETUP_2ND_COLUMN, y, attr, event ) ;
         break;
 
       case ITEM_SETUP_GPSFORMAT:

--- a/radio/src/rtc.cpp
+++ b/radio/src/rtc.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -81,62 +81,53 @@ extern void rtcdriver_settime(struct gtm * t);
 /* Verify a requirement at compile-time (unlike assert, which is runtime).  */
 #define verify(name, assertion) struct name { char a[(assertion) ? 1 : -1]; }
 
-verify (gtime_t_is_integer, TYPE_IS_INTEGER (gtime_t));
-verify (twos_complement_arithmetic, TYPE_TWOS_COMPLEMENT (int));
+verify(gtime_t_is_integer, TYPE_IS_INTEGER(gtime_t));
+verify(twos_complement_arithmetic, TYPE_TWOS_COMPLEMENT(int));
 /* The code also assumes that signed integer overflow silently wraps
    around, but this assumption can't be stated without causing a
    diagnostic on some hosts.  */
 
 #define EPOCH_YEAR 1970
 #define TM_YEAR_BASE 1900
-verify (base_year_is_a_multiple_of_100, TM_YEAR_BASE % 100 == 0);
+verify(base_year_is_a_multiple_of_100, TM_YEAR_BASE % 100 == 0);
 
 /* Return 1 if YEAR + TM_YEAR_BASE is a leap year.  */
-static inline int
-leapyear (long int year)
+static inline int leapyear(long int year)
 {
   /* Don't add YEAR to TM_YEAR_BASE, as that might overflow.
      Also, work even if YEAR is negative.  */
-  return
-    ((year & 3) == 0
-     && (year % 100 != 0
-         || ((year / 100) & 3) == (- (TM_YEAR_BASE / 100) & 3)));
+  return ((year & 3) == 0
+          && (year % 100 != 0
+              || ((year / 100) & 3) == (-(TM_YEAR_BASE / 100) & 3)));
 }
 
-const unsigned short int __mon_yday[2][13] =
-  {
-    /* Normal years.  */
-    { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
-    /* Leap years.  */
-    { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
-  };
+const unsigned short int __mon_yday[2][13] = {
+  /* Normal years.  */
+  { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
+  /* Leap years.  */
+  { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
+};
 
 /* Compute the `struct tm' representation of *T,
    offset OFFSET seconds east of UTC,
    and store year, yday, mon, mday, wday, hour, min, sec into *TP.
    Return nonzero if successful.  */
-int
-__offtime (
-     gtime_t *t,
-     long int offset,
-     struct gtm *tp)
+int __offtime(gtime_t * t, long int offset, struct gtm * tp)
 {
   long int days, rem, y;
-  const unsigned short int *ip;
+  const unsigned short int * ip;
 
   days = *t / SECS_PER_DAY;
   rem = *t % SECS_PER_DAY;
   rem += offset;
-  while (rem < 0)
-    {
-      rem += SECS_PER_DAY;
-      --days;
-    }
-  while (rem >= (long int)SECS_PER_DAY)
-    {
-      rem -= SECS_PER_DAY;
-      ++days;
-    }
+  while (rem < 0) {
+    rem += SECS_PER_DAY;
+    --days;
+  }
+  while (rem >= (long int)SECS_PER_DAY) {
+    rem -= SECS_PER_DAY;
+    ++days;
+  }
   tp->tm_hour = rem / SECS_PER_HOUR;
   rem %= SECS_PER_HOUR;
   tp->tm_min = rem / 60;
@@ -148,29 +139,25 @@ __offtime (
   y = 1970;
 
 #define DIV(a, b) ((a) / (b) - ((a) % (b) < 0))
-#define LEAPS_THRU_END_OF(y) (DIV (y, 4) - DIV (y, 100) + DIV (y, 400))
+#define LEAPS_THRU_END_OF(y) (DIV(y, 4) - DIV(y, 100) + DIV(y, 400))
 
-  while (days < 0 || days >= (leapyear (y) ? 366 : 365))
-    {
-      /* Guess a corrected year, assuming 365 days per year.  */
-      long int yg = y + days / 365 - (days % 365 < 0);
+  while (days < 0 || days >= (leapyear(y) ? 366 : 365)) {
+    /* Guess a corrected year, assuming 365 days per year.  */
+    long int yg = y + days / 365 - (days % 365 < 0);
 
-      /* Adjust DAYS and Y to match the guessed year.  */
-      days -= ((yg - y) * 365
-               + LEAPS_THRU_END_OF (yg - 1)
-               - LEAPS_THRU_END_OF (y - 1));
-      y = yg;
-    }
+    /* Adjust DAYS and Y to match the guessed year.  */
+    days -= ((yg - y) * 365 + LEAPS_THRU_END_OF(yg - 1) - LEAPS_THRU_END_OF(y - 1));
+    y = yg;
+  }
   tp->tm_year = y - 1900;
-  if (tp->tm_year != y - 1900)
-    {
-      /* The year cannot be represented due to overflow.  */
-      // __set_errno (EOVERFLOW);
-      return 0;
-    }
+  if (tp->tm_year != y - 1900) {
+    /* The year cannot be represented due to overflow.  */
+    // __set_errno (EOVERFLOW);
+    return 0;
+  }
   tp->tm_yday = days;
   ip = __mon_yday[leapyear(y)];
-  for (y = 11; days < (long int) ip[y]; --y)
+  for (y = 11; days < (long int)ip[y]; --y)
     continue;
   days -= ip[y];
   tp->tm_mon = y;
@@ -180,8 +167,7 @@ __offtime (
 
 /* time_r function implementations */
 // G: No time zones in our implementation so just do the converion from gtime_t to struct tm
-struct gtm *
-__localtime_r (gtime_t * t, struct gtm * tp)
+struct gtm * __localtime_r(gtime_t * t, struct gtm * tp)
 {
   __offtime(t, 0, tp);
   return tp;
@@ -199,22 +185,20 @@ __localtime_r (gtime_t * t, struct gtm * tp)
    The result may overflow.  It is the caller's responsibility to
    detect overflow.  */
 
-static inline gtime_t
-ydhms_diff (long int year1, long int yday1, int hour1, int min1, int sec1,
-            int year0, int yday0, int hour0, int min0, int sec0)
+static inline gtime_t ydhms_diff(long int year1, long int yday1, int hour1, int min1, int sec1,
+                                 int year0, int yday0, int hour0, int min0, int sec0)
 {
-  verify (C99_integer_division, -1 / 2 == 0);
-  verify (long_int_year_and_yday_are_wide_enough,
-          INT_MAX <= LONG_MAX / 2 || TIME_T_MAX <= UINT_MAX);
+  verify(C99_integer_division, -1 / 2 == 0);
+  verify(long_int_year_and_yday_are_wide_enough, INT_MAX <= LONG_MAX / 2 || TIME_T_MAX <= UINT_MAX);
 
   /* Compute intervening leap days correctly even if year is negative.
      Take care to avoid integer overflow here.  */
-  int a4 = SHR (year1, 2) + SHR (TM_YEAR_BASE, 2) - ! (year1 & 3);
-  int b4 = SHR (year0, 2) + SHR (TM_YEAR_BASE, 2) - ! (year0 & 3);
+  int a4 = SHR(year1, 2) + SHR(TM_YEAR_BASE, 2) - !(year1 & 3);
+  int b4 = SHR(year0, 2) + SHR(TM_YEAR_BASE, 2) - !(year0 & 3);
   int a100 = a4 / 25 - (a4 % 25 < 0);
   int b100 = b4 / 25 - (b4 % 25 < 0);
-  int a400 = SHR (a100, 2);
-  int b400 = SHR (b100, 2);
+  int a400 = SHR(a100, 2);
+  int b400 = SHR(b100, 2);
   int intervening_leap_days = (a4 - b4) - (a100 - b100) + (a400 - b400);
 
   /* Compute the desired time in gtime_t precision.  Overflow might
@@ -234,19 +218,17 @@ ydhms_diff (long int year1, long int yday1, int hour1, int min1, int sec1,
    If TP is null, return a value not equal to *T; this avoids false matches.
    If overflow occurs, yield the minimal or maximal value, except do not
    yield a value equal to *T.  */
-static gtime_t
-guess_time_tm (long int year, long int yday, int hour, int min, int sec,
-               gtime_t *t, struct gtm *tp)
+static gtime_t guess_time_tm(long int year, long int yday, int hour, int min, int sec,
+                             gtime_t * t, struct gtm * tp)
 {
-  if (tp)
-    {
-      gtime_t d = ydhms_diff (year, yday, hour, min, sec,
-                             tp->tm_year, tp->tm_yday,
-                             tp->tm_hour, tp->tm_min, tp->tm_sec);
-      gtime_t t1 = *t + d;
-      if ((t1 < *t) == (TYPE_SIGNED (gtime_t) ? d < 0 : TIME_T_MAX / 2 < d))
-        return t1;
-    }
+  if (tp) {
+    gtime_t d = ydhms_diff(year, yday, hour, min, sec,
+                           tp->tm_year, tp->tm_yday,
+                           tp->tm_hour, tp->tm_min, tp->tm_sec);
+    gtime_t t1 = *t + d;
+    if ((t1 < *t) == (TYPE_SIGNED(gtime_t) ? d < 0 : TIME_T_MAX / 2 < d))
+      return t1;
+  }
 
   /* Overflow occurred one way or another.  Return the nearest result
      that is actually in range, except don't report a zero difference
@@ -261,40 +243,31 @@ guess_time_tm (long int year, long int yday, int hour, int min, int sec,
 /* Use CONVERT to convert *T to a broken down time in *TP.
    If *T is out of range for conversion, adjust it so that
    it is the nearest in-range value and then convert that.  */
-static struct gtm *
-ranged_convert (struct gtm *(*convert) (gtime_t *, struct gtm *),
-                gtime_t *t, struct gtm *tp)
+static struct gtm * ranged_convert(struct gtm *(*convert)(gtime_t *, struct gtm *), gtime_t * t, struct gtm * tp)
 {
-  struct gtm *r = convert (t, tp);
+  struct gtm * r = convert(t, tp);
 
-  if (!r && *t)
-    {
-      gtime_t bad = *t;
-      gtime_t ok = 0;
+  if (!r && *t) {
+    gtime_t bad = *t;
+    gtime_t ok = 0;
 
-      /* BAD is a known unconvertible gtime_t, and OK is a known good one.
-         Use binary search to narrow the range between BAD and OK until
-         they differ by 1.  */
-      while (bad != ok + (bad < 0 ? -1 : 1))
-        {
-          gtime_t mid = *t = (bad < 0
-                             ? bad + ((ok - bad) >> 1)
-                             : ok + ((bad - ok) >> 1));
-          r = convert (t, tp);
-          if (r)
-            ok = mid;
-          else
-            bad = mid;
-        }
-
-      if (!r && ok)
-        {
-          /* The last conversion attempt failed;
-             revert to the most recent successful attempt.  */
-          *t = ok;
-          r = convert (t, tp);
-        }
+    /* BAD is a known unconvertible gtime_t, and OK is a known good one.
+       Use binary search to narrow the range between BAD and OK until
+       they differ by 1.  */
+    while (bad != ok + (bad < 0 ? -1 : 1)) {
+      gtime_t mid = *t = (bad < 0 ? bad + ((ok - bad) >> 1) : ok + ((bad - ok) >> 1));
+      r = convert(t, tp);
+      if (r) ok = mid;
+      else  bad = mid;
     }
+
+    if (!r && ok) {
+      /* The last conversion attempt failed;
+         revert to the most recent successful attempt.  */
+      *t = ok;
+      r = convert(t, tp);
+    }
+  }
 
   return r;
 }
@@ -305,10 +278,9 @@ ranged_convert (struct gtm *(*convert) (gtime_t *, struct gtm *),
    compared to what the result would be for UTC without leap seconds.
    If *OFFSET's guess is correct, only one CONVERT call is needed.
    This function is external because it is used also by timegm.c.  */
-gtime_t
-__mktime_internal (struct gtm *tp,
-                   struct gtm *(*convert) (gtime_t *, struct gtm *),
-                   gtime_t *offset)
+gtime_t __mktime_internal(struct gtm * tp,
+                          struct gtm *(*convert)(gtime_t *, struct gtm *),
+                          gtime_t * offset)
 {
   gtime_t t, gt, t0, t1, t2;
   struct gtm tm;
@@ -342,9 +314,7 @@ __mktime_internal (struct gtm *tp,
 
   /* Calculate day of year from year, month, and day of month.
      The result need not be in range.  */
-  int mon_yday = ((__mon_yday[leapyear (year)]
-                   [mon_remainder + 12 * negative_mon_remainder])
-                  - 1);
+  int mon_yday = ((__mon_yday[leapyear(year)][mon_remainder + 12 * negative_mon_remainder]) - 1);
   long int lmday = mday;
   long int yday = mon_yday + lmday;
 
@@ -367,112 +337,103 @@ __mktime_internal (struct gtm *tp,
   /* Invert CONVERT by probing.  First assume the same offset as last
      time.  */
 
-  t0 = ydhms_diff (year, yday, hour, min, sec,
-                   EPOCH_YEAR - TM_YEAR_BASE, 0, 0, 0, - guessed_offset);
+  t0 = ydhms_diff(year, yday, hour, min, sec, EPOCH_YEAR - TM_YEAR_BASE, 0, 0, 0, -guessed_offset);
 
-  if (TIME_T_MAX / INT_MAX / 366 / 24 / 60 / 60 < 3)
-    {
-      /* gtime_t isn't large enough to rule out overflows, so check
-         for major overflows.  A gross check suffices, since if t0
-         has overflowed, it is off by a multiple of TIME_T_MAX -
-         TIME_T_MIN + 1.  So ignore any component of the difference
-         that is bounded by a small value.  */
+  if (TIME_T_MAX / INT_MAX / 366 / 24 / 60 / 60 < 3) {
+    /* gtime_t isn't large enough to rule out overflows, so check
+       for major overflows.  A gross check suffices, since if t0
+       has overflowed, it is off by a multiple of TIME_T_MAX -
+       TIME_T_MIN + 1.  So ignore any component of the difference
+       that is bounded by a small value.  */
 
-      /* Approximate log base 2 of the number of time units per
-         biennium.  A biennium is 2 years; use this unit instead of
-         years to avoid integer overflow.  For example, 2 average
-         Gregorian years are 2 * 365.2425 * 24 * 60 * 60 seconds,
-         which is 63113904 seconds, and rint (log2 (63113904)) is
-         26.  */
-      int ALOG2_SECONDS_PER_BIENNIUM = 26;
-      int ALOG2_MINUTES_PER_BIENNIUM = 20;
-      int ALOG2_HOURS_PER_BIENNIUM = 14;
-      int ALOG2_DAYS_PER_BIENNIUM = 10;
-      int LOG2_YEARS_PER_BIENNIUM = 1;
+    /* Approximate log base 2 of the number of time units per
+       biennium.  A biennium is 2 years; use this unit instead of
+       years to avoid integer overflow.  For example, 2 average
+       Gregorian years are 2 * 365.2425 * 24 * 60 * 60 seconds,
+       which is 63113904 seconds, and rint (log2 (63113904)) is
+       26.  */
+    int ALOG2_SECONDS_PER_BIENNIUM = 26;
+    int ALOG2_MINUTES_PER_BIENNIUM = 20;
+    int ALOG2_HOURS_PER_BIENNIUM = 14;
+    int ALOG2_DAYS_PER_BIENNIUM = 10;
+    int LOG2_YEARS_PER_BIENNIUM = 1;
 
-      int approx_requested_biennia =
-        (SHR (year_requested, LOG2_YEARS_PER_BIENNIUM)
-         - SHR (EPOCH_YEAR - TM_YEAR_BASE, LOG2_YEARS_PER_BIENNIUM)
-         + SHR (mday, ALOG2_DAYS_PER_BIENNIUM)
-         + SHR (hour, ALOG2_HOURS_PER_BIENNIUM)
-         + SHR (min, ALOG2_MINUTES_PER_BIENNIUM)
-         + (LEAP_SECONDS_POSSIBLE
-            ? 0
-            : SHR (sec, ALOG2_SECONDS_PER_BIENNIUM)));
+    int approx_requested_biennia =
+      (SHR(year_requested, LOG2_YEARS_PER_BIENNIUM)
+       - SHR(EPOCH_YEAR - TM_YEAR_BASE, LOG2_YEARS_PER_BIENNIUM)
+       + SHR(mday, ALOG2_DAYS_PER_BIENNIUM)
+       + SHR(hour, ALOG2_HOURS_PER_BIENNIUM)
+       + SHR(min, ALOG2_MINUTES_PER_BIENNIUM)
+       + (LEAP_SECONDS_POSSIBLE
+          ? 0
+          : SHR(sec, ALOG2_SECONDS_PER_BIENNIUM)));
 
-      int approx_biennia = SHR (t0, ALOG2_SECONDS_PER_BIENNIUM);
-      int diff = approx_biennia - approx_requested_biennia;
-      int abs_diff = diff < 0 ? - diff : diff;
+    int approx_biennia = SHR(t0, ALOG2_SECONDS_PER_BIENNIUM);
+    int diff = approx_biennia - approx_requested_biennia;
+    int abs_diff = diff < 0 ? -diff : diff;
 
-      /* IRIX 4.0.5 cc miscalculates TIME_T_MIN / 3: it erroneously
-         gives a positive value of 715827882.  Setting a variable
-         first then doing math on it seems to work.
-         (ghazi@caip.rutgers.edu) */
-      gtime_t time_t_max = TIME_T_MAX;
-      gtime_t time_t_min = TIME_T_MIN;
-      gtime_t overflow_threshold =
-        (time_t_max / 3 - time_t_min / 3) >> ALOG2_SECONDS_PER_BIENNIUM;
+    /* IRIX 4.0.5 cc miscalculates TIME_T_MIN / 3: it erroneously
+       gives a positive value of 715827882.  Setting a variable
+       first then doing math on it seems to work.
+       (ghazi@caip.rutgers.edu) */
+    gtime_t time_t_max = TIME_T_MAX;
+    gtime_t time_t_min = TIME_T_MIN;
+    gtime_t overflow_threshold = (time_t_max / 3 - time_t_min / 3) >> ALOG2_SECONDS_PER_BIENNIUM;
 
+    if (overflow_threshold < abs_diff) {
+      /* Overflow occurred.  Try repairing it; this might work if
+         the time zone offset is enough to undo the overflow.  */
+      gtime_t repaired_t0 = -1 - t0;
+      approx_biennia = SHR(repaired_t0, ALOG2_SECONDS_PER_BIENNIUM);
+      diff = approx_biennia - approx_requested_biennia;
+      abs_diff = diff < 0 ? -diff : diff;
       if (overflow_threshold < abs_diff)
-        {
-          /* Overflow occurred.  Try repairing it; this might work if
-             the time zone offset is enough to undo the overflow.  */
-          gtime_t repaired_t0 = -1 - t0;
-          approx_biennia = SHR (repaired_t0, ALOG2_SECONDS_PER_BIENNIUM);
-          diff = approx_biennia - approx_requested_biennia;
-          abs_diff = diff < 0 ? - diff : diff;
-          if (overflow_threshold < abs_diff)
-            return -1;
-          guessed_offset += repaired_t0 - t0;
-          t0 = repaired_t0;
-        }
+        return -1;
+      guessed_offset += repaired_t0 - t0;
+      t0 = repaired_t0;
     }
+  }
 
   /* Repeatedly use the error to improve the guess.  */
-
   for (t = t1 = t2 = t0;
-       (gt = guess_time_tm (year, yday, hour, min, sec, &t,
-                            ranged_convert (convert, &t, &tm)),
-        t != gt);
-       t1 = t2, t2 = t, t = gt)
+       (gt = guess_time_tm(year, yday, hour, min, sec, &t, ranged_convert(convert, &t, &tm)), t != gt);
+       t1 = t2, t2 = t, t = gt) {
     if (t == t1 && t != t2)
       goto offset_found;
     else if (--remaining_probes == 0)
       return -1;
+  }
 
  offset_found:
   *offset = guessed_offset + t - t0;
 
-  if (LEAP_SECONDS_POSSIBLE && sec_requested != tm.tm_sec)
-    {
-      /* Adjust time to reflect the tm_sec requested, not the normalized value.
-         Also, repair any damage from a false match due to a leap second.  */
-      int sec_adjustment = (sec == 0 && tm.tm_sec == 60) - sec;
-      t1 = t + sec_requested;
-      t2 = t1 + sec_adjustment;
-      if (((t1 < t) != (sec_requested < 0))
-          | ((t2 < t1) != (sec_adjustment < 0))
-          | ! convert (&t2, &tm))
-        return -1;
-      t = t2;
-    }
+  if (LEAP_SECONDS_POSSIBLE && sec_requested != tm.tm_sec) {
+    /* Adjust time to reflect the tm_sec requested, not the normalized value.
+       Also, repair any damage from a false match due to a leap second.  */
+    int sec_adjustment = (sec == 0 && tm.tm_sec == 60) - sec;
+    t1 = t + sec_requested;
+    t2 = t1 + sec_adjustment;
+    if (((t1 < t) != (sec_requested < 0))
+        | ((t2 < t1) != (sec_adjustment < 0))
+        | !convert(&t2, &tm))
+      return -1;
+    t = t2;
+  }
 
   *tp = tm;
   return t;
 }
 
 /* Convert *TP to a gtime_t value.  */
-gtime_t
-gmktime (struct gtm *tp)
+gtime_t gmktime(struct gtm * tp)
 {
   // no time zone stuff. Just do the math ;)
   static gtime_t localtime_offset;
-  return __mktime_internal (tp, __localtime_r, &localtime_offset);
+  return __mktime_internal(tp, __localtime_r, &localtime_offset);
 }
 
 /* Fill a (struct tm) TP* from a given gtime_t time stamp */
-gtime_t
-filltm(gtime_t *t, struct gtm *tp)
+gtime_t filltm(gtime_t * t, struct gtm * tp)
 {
   return __offtime(t, 0, tp);
 }
@@ -497,15 +458,15 @@ void gettime(struct gtm * tm)
 uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec)
 {
   static tmr10ms_t lastRtcAdjust = 0;
-  if ((get_tmr10ms()-lastRtcAdjust) > (RTC_ADJUST_PERIOD*100)) {
+  if ((get_tmr10ms() - lastRtcAdjust) > (RTC_ADJUST_PERIOD * 100)) {
     lastRtcAdjust = get_tmr10ms();
 
     struct gtm t;
     gettime(&t);
     if ((hour == 0 && min == 0) || (hour == 23 && min == 59)) return 0;
 
-    if (t.tm_year != (year-1900) || t.tm_mon != (mon-1) || t.tm_mday != day ||
-        (abs((t.tm_hour-hour)*3600 + (t.tm_min-min)*60 + (t.tm_sec-sec)) > RTC_ADJUST_TRESHOLD)) {
+    if (t.tm_year != (year - 1900) || t.tm_mon != (mon - 1) || t.tm_mday != day ||
+        (abs((t.tm_hour - hour) * 3600 + (t.tm_min - min) * 60 + (t.tm_sec - sec)) > RTC_ADJUST_TRESHOLD)) {
       // we adjust RTC only if difference is > 20 seconds
       t.tm_year = year - 1900;
       t.tm_mon  = mon - 1;

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -44,13 +44,14 @@ extern gtime_t g_rtcTime;
 extern uint8_t g_ms100; // global to allow time set function to reset to zero
 
 void rtcInit();
+void rtcSetTime(const struct gtm * tm);
+gtime_t gmktime (struct gtm *tm);
+uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
 
 #if defined(__cplusplus) && !defined(SIMU)
 extern "C" {
 #endif
-void rtcSetTime(struct gtm * tm);
 void gettime(struct gtm * tm);
-gtime_t gmktime (struct gtm *tm);
 #if defined(__cplusplus) && !defined(SIMU)
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -22,6 +22,8 @@
 
 void rtcSetTime(const struct gtm * t)
 {
+  g_ms100 = 0; // start of next second begins now
+
   RTC_TimeTypeDef RTC_TimeStruct;
   RTC_DateTypeDef RTC_DateStruct;
 

--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -20,7 +20,7 @@
 
 #include "opentx.h"
 
-void rtcSetTime(struct gtm * t)
+void rtcSetTime(const struct gtm * t)
 {
   RTC_TimeTypeDef RTC_TimeStruct;
   RTC_DateTypeDef RTC_DateStruct;

--- a/radio/src/targets/gruvin9x/rtc_driver.cpp
+++ b/radio/src/targets/gruvin9x/rtc_driver.cpp
@@ -265,7 +265,6 @@ void rtcGetTime(struct gtm * utm)
 
 void rtcSetTime(const struct gtm * t)
 {
-  g_rtcTime = gmktime(t); // update local timestamp and get wday calculated
   g_ms100 = 0; // start of next second begins now
 
   RTC rtc;

--- a/radio/src/targets/gruvin9x/rtc_driver.cpp
+++ b/radio/src/targets/gruvin9x/rtc_driver.cpp
@@ -263,7 +263,7 @@ void rtcGetTime(struct gtm * utm)
   utm->tm_wday = rtc.wday - 1;
 }
 
-void rtcSetTime(struct gtm * t)
+void rtcSetTime(const struct gtm * t)
 {
   g_rtcTime = gmktime(t); // update local timestamp and get wday calculated
   g_ms100 = 0; // start of next second begins now

--- a/radio/src/targets/mega2560/board.cpp
+++ b/radio/src/targets/mega2560/board.cpp
@@ -236,3 +236,8 @@ ISR(INT3_vect)     // Arduino2560 IO18 (portD pin3)
 #endif
 }  
        
+// RTC driver
+void rtcSetTime(const struct gtm * tm)
+{
+  
+}

--- a/radio/src/targets/sky9x/rtc_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_driver.cpp
@@ -236,7 +236,7 @@ struct t_i2cTime
   uint8_t Time[7] ;
 } I2CTime ;
 
-void rtcSetTime(struct gtm * t)
+void rtcSetTime(const struct gtm * t)
 {
   g_rtcTime = gmktime(t); // update local timestamp and get wday calculated
   g_ms100 = 0; // start of next second begins now

--- a/radio/src/targets/sky9x/rtc_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_driver.cpp
@@ -238,7 +238,6 @@ struct t_i2cTime
 
 void rtcSetTime(const struct gtm * t)
 {
-  g_rtcTime = gmktime(t); // update local timestamp and get wday calculated
   g_ms100 = 0; // start of next second begins now
 
   I2CTime.setCode = 0x74 ;    // Tiny SET TIME CODE command

--- a/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
@@ -60,7 +60,7 @@ void writeRtc(gtm* ptr)
   i2cWriteBuffer(DS3231_I2C_ADDR, read_buffer, 1, buffer, 7);
 }
 
-void rtcSetTime(struct gtm * t)
+void rtcSetTime(const struct gtm * t)
 {
   writeRtc(t);
 }

--- a/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
@@ -42,9 +42,8 @@ void readRtc()
   g_rtcTime = gmktime(&utm);
 }
 
-void writeRtc(gtm* ptr)
+void writeRtc(const gtm* ptr)
 {
-  g_rtcTime = gmktime(ptr);
   g_ms100 = 0; // start of next second begins now
   uint8_t buffer[7];
   uint8_t read_buffer[7];
@@ -62,7 +61,6 @@ void writeRtc(gtm* ptr)
 
 void rtcSetTime(const struct gtm * t)
 {
-  g_ms100 = 0; // start of next second begins now
   writeRtc(t);
 }
 

--- a/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
@@ -62,6 +62,7 @@ void writeRtc(gtm* ptr)
 
 void rtcSetTime(const struct gtm * t)
 {
+  g_ms100 = 0; // start of next second begins now
   writeRtc(t);
 }
 

--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -178,12 +178,6 @@ void parseTelemHubByte(uint8_t byte)
       frskyUpdateCells();
       break;
 
-#if defined(GPS)
-    case offsetof(FrskyTelemetryData, hour):
-      telemetryData.hub.hour = ((uint8_t)(telemetryData.hub.hour + g_eeGeneral.timezone + 24)) % 24;
-      break;
-#endif
-
     case offsetof(FrskyTelemetryData, accelX):
     case offsetof(FrskyTelemetryData, accelY):
     case offsetof(FrskyTelemetryData, accelZ):

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -84,7 +84,7 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
       }
     }
     else {
-      datetime.hour = ((uint8_t) ((data & 0xff000000) >> 24) + g_eeGeneral.timezone + 24) % 24;
+      datetime.hour = (uint8_t) ((data & 0xff000000) >> 24);
       datetime.min = (uint8_t) ((data & 0x00ff0000) >> 16);
       datetime.sec = (uint16_t) ((data & 0x0000ff00) >> 8);
       if (datetime.datestate == 1) {
@@ -131,7 +131,7 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
   }
   else if (unit == UNIT_DATETIME_HOUR_MIN) {
     uint32_t data = uint32_t(newVal);
-    datetime.hour = ((data & 0xFF) + g_eeGeneral.timezone + 24) % 24;
+    datetime.hour = (data & 0xFF);
     datetime.min = data >> 8;
   }
   else if (unit == UNIT_DATETIME_SEC) {


### PR DESCRIPTION
Both internal and receiver GPS can now adjust RTC clock. I think we had a couple of bugs with existing GPS date/time code, most notable: time zone was not handled properly (hours roll-over, day-rollover, etc..) The easiest way to solve this was to keep the GPS clocks in UTC, so this will change display and Lua values for GPS. Still thinking what to do about that.

I also messed with function definitions (adding const) and that brought up a lot of changes for other radios. But it should be OK.

I have successfully tested:
 * RTC clock was set by internal GPS on my Horus
 * RTC clock was set by external GPS on Horus simulator