### PR TITLE
3djc/taranis/X9E fix for pots and sliders checks

### DIFF
--- a/radio/src/gui/212x64/radio_hardware.cpp
+++ b/radio/src/gui/212x64/radio_hardware.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -103,8 +103,6 @@ void menuRadioHardware(event_t event)
       case ITEM_RADIO_HARDWARE_STICK2:
       case ITEM_RADIO_HARDWARE_STICK3:
       case ITEM_RADIO_HARDWARE_STICK4:
-      case ITEM_RADIO_HARDWARE_LS:
-      case ITEM_RADIO_HARDWARE_RS:
       {
         int idx = (k<=ITEM_RADIO_HARDWARE_STICK4 ? k-ITEM_RADIO_HARDWARE_STICK1 : k-ITEM_RADIO_HARDWARE_LS+MIXSRC_SLIDER1-MIXSRC_Rud);
         lcdDrawTextAtIndex(INDENT_WIDTH, y, STR_VSRCRAW, idx+1, 0);
@@ -115,14 +113,16 @@ void menuRadioHardware(event_t event)
         break;
       }
 #if defined(PCBX9E)
+      case ITEM_RADIO_HARDWARE_LS:
+      case ITEM_RADIO_HARDWARE_RS:
       case ITEM_RADIO_HARDWARE_LS2:
       case ITEM_RADIO_HARDWARE_RS2:
       {
-        int idx = k - ITEM_RADIO_HARDWARE_LS2;
+        int idx = k - ITEM_RADIO_HARDWARE_LS;
         uint8_t mask = (0x01 << idx);
-        lcdDrawTextAtIndex(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+NUM_XPOTS+2+idx+1, menuHorizontalPosition < 0 ? attr : 0);
-        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx]) || (attr && menuHorizontalPosition == 0))
-          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+2+idx], LEN_ANA_NAME, event, attr && menuHorizontalPosition == 0);
+        lcdDrawTextAtIndex(INDENT_WIDTH, y, STR_VSRCRAW, NUM_STICKS+NUM_XPOTS+idx+1, menuHorizontalPosition < 0 ? attr : 0);
+        if (ZEXIST(g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+idx]) || (attr && menuHorizontalPosition == 0))
+          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.anaNames[NUM_STICKS+NUM_XPOTS+idx], LEN_ANA_NAME, event, attr && menuHorizontalPosition == 0);
         else
           lcdDrawTextAtIndex(HW_SETTINGS_COLUMN, y, STR_MMMINV, 0, 0);
         uint8_t potType = (g_eeGeneral.slidersConfig & mask) >> idx;

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -302,7 +302,7 @@ void memswap(void * a, void * b, uint8_t size);
   #define POT_CONFIG(x)             ((g_eeGeneral.potsConfig >> (2*((x)-POT1)))&0x03)
   #define IS_POT_MULTIPOS(x)        (IS_POT(x) && POT_CONFIG(x)==POT_MULTIPOS_SWITCH)
   #define IS_POT_WITHOUT_DETENT(x)  (IS_POT(x) && POT_CONFIG(x)==POT_WITHOUT_DETENT)
-  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER1)))))
+  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER3)))))
   #define IS_POT_AVAILABLE(x)       (IS_POT(x) && POT_CONFIG(x)!=POT_NONE)
   #define IS_POT_OR_SLIDER_AVAILABLE(x)   (IS_POT_AVAILABLE(x) || IS_SLIDER_AVAILABLE(x))
   #define IS_MULTIPOS_CALIBRATED(cal)     (cal->count>0 && cal->count<XPOTS_MULTIPOS_COUNT)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -297,16 +297,13 @@
 #endif
 
 void memswap(void * a, void * b, uint8_t size);
-#if defined(PCBX9D) || defined(PCBX9DP) || defined(PCBHORUS)
-  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER1)))))
-#elif defined(PCBX9E)
-  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER3)))))
-#endif
+
 #if defined(PCBX9D) || defined(PCBX9DP) || defined(PCBX9E) || defined(PCBHORUS)
   #define POT_CONFIG(x)             ((g_eeGeneral.potsConfig >> (2*((x)-POT1)))&0x03)
   #define IS_POT_MULTIPOS(x)        (IS_POT(x) && POT_CONFIG(x)==POT_MULTIPOS_SWITCH)
   #define IS_POT_WITHOUT_DETENT(x)  (IS_POT(x) && POT_CONFIG(x)==POT_WITHOUT_DETENT)
   #define IS_POT_AVAILABLE(x)       (IS_POT(x) && POT_CONFIG(x)!=POT_NONE)
+  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER3)))))
   #define IS_POT_OR_SLIDER_AVAILABLE(x)   (IS_POT_AVAILABLE(x) || IS_SLIDER_AVAILABLE(x))
   #define IS_MULTIPOS_CALIBRATED(cal)     (cal->count>0 && cal->count<XPOTS_MULTIPOS_COUNT)
 #elif defined(PCBFLAMENCO)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -297,12 +297,15 @@
 #endif
 
 void memswap(void * a, void * b, uint8_t size);
-
+#if defined(PCBX9D) || defined(PCBX9DP) || defined(PCBHORUS)
+  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER1)))))
+#elif defined(PCBX9E)
+  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER3)))))
+#endif
 #if defined(PCBX9D) || defined(PCBX9DP) || defined(PCBX9E) || defined(PCBHORUS)
   #define POT_CONFIG(x)             ((g_eeGeneral.potsConfig >> (2*((x)-POT1)))&0x03)
   #define IS_POT_MULTIPOS(x)        (IS_POT(x) && POT_CONFIG(x)==POT_MULTIPOS_SWITCH)
   #define IS_POT_WITHOUT_DETENT(x)  (IS_POT(x) && POT_CONFIG(x)==POT_WITHOUT_DETENT)
-  #define IS_SLIDER_AVAILABLE(x)    ((x) == SLIDER1 || (x) == SLIDER2 || (IS_SLIDER(x) && (g_eeGeneral.slidersConfig & (0x01 << ((x)-SLIDER3)))))
   #define IS_POT_AVAILABLE(x)       (IS_POT(x) && POT_CONFIG(x)!=POT_NONE)
   #define IS_POT_OR_SLIDER_AVAILABLE(x)   (IS_POT_AVAILABLE(x) || IS_SLIDER_AVAILABLE(x))
   #define IS_MULTIPOS_CALIBRATED(cal)     (cal->count>0 && cal->count<XPOTS_MULTIPOS_COUNT)

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -863,6 +863,7 @@ void checkSwitches()
             continue;
           }
           if (!(g_model.potsWarnEnabled & (1 << i))) {
+            TRACE("POT:%d WANT:%d GOT:%d STATUS:%s", i, g_model.potsWarnPosition[i],GET_LOWRES_POT_POSITION(i), (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) ? "FAIL" : "PASS");
             if (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) {
 #if defined(COLORLCD)
               char s[8];

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -775,7 +775,7 @@ void checkSwitches()
       evalFlightModeMixes(e_perout_mode_normal, 0);
       bad_pots = 0;
       for (int i=0; i<NUM_POTS+NUM_SLIDERS; i++) {
-        if (!IS_POT_OR_SLIDER_AVAILABLE(i)) {
+        if (!IS_POT_OR_SLIDER_AVAILABLE(POT1+i)) {
           continue;
         }
         if (!(g_model.potsWarnEnabled & (1 << i)) && (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1)) {
@@ -859,11 +859,10 @@ void checkSwitches()
           x = 60;
         }
         for (int i=0; i<NUM_POTS+NUM_SLIDERS; i++) {
-          if (!IS_POT_OR_SLIDER_AVAILABLE(i)) {
+          if (!IS_POT_OR_SLIDER_AVAILABLE(POT1+i)) {
             continue;
           }
           if (!(g_model.potsWarnEnabled & (1 << i))) {
-            TRACE("POT:%d WANT:%d GOT:%d STATUS:%s", i, g_model.potsWarnPosition[i],GET_LOWRES_POT_POSITION(i), (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) ? "FAIL" : "PASS");
             if (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) {
 #if defined(COLORLCD)
               char s[8];


### PR DESCRIPTION
WARNING :
- you WILL need to go in hardware menu to review sliders and pots assignents
- you also NEED to go to calibration (where you will now see the 4 sliders and the 2 pots (X9E))