### PR TITLE
3djc/faster local commit tests

### DIFF
--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -5,12 +5,16 @@ CORES=2
 for i in "$@"
 do
 case $i in
-    -c=*|--cores=*)
+    -j=*|--jobs=*)
       CORES="${i#*=}"
       shift
       ;;
+    -j*)
+      CORES="${i#*j}"
+      shift
+      ;;
     *)
-      echo 'Usage : commit-test.sh --cores=2'
+      echo 'Usage : commit-test.sh --jobs=2'
       exit
       ;;
 esac
@@ -30,98 +34,98 @@ cd build
 # OpenTX on 9X stock with FrSky telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on 9X stock with Ardupilot telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
-make -j$(CORES) firmware
+make -j${CORES} firmware
 
 # OpenTX on 9X stock with JETI telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
-make -j$(CORES) firmware
+make -j${CORES} firmware
 
 # OpenTX on Mega2560
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on Mega2560 with Mavlink telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on gruvin9x board
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on Sky9x
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on AR9X
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on X7D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X7D -DHELI=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on X9D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on X9D+
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on Taranis X9E
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+make -j${CORES} gtests ; ./gtests
 
 # OpenTX on Horus beta boards
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-# make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+# make -j${CORES} gtests ; ./gtests
 
 # OpenTX on Horus
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$(CORES) firmware
-make -j$(CORES) simu
-# make -j$(CORES) gtests ; ./gtests
+make -j${CORES} firmware
+make -j${CORES} simu
+# make -j${CORES} gtests ; ./gtests
 
 # Companion
 rm -rf *
 cmake ${COMMON_OPTIONS} ${SRCDIR}
-make -j$(CORES)
+make -j${CORES}

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -c=8
+CORES=2
+for i in "$@"
+do
+case $i in
+    -c=*|--cores=*)
+      CORES="${i#*=}"
+      shift
+      ;;
+    *)
+      echo 'Usage : commit-test.sh --cores=2'
+      exit
+      ;;
+esac
+done
+
 # Stops on first error, echo on
 set -e
 set -x
@@ -8,118 +24,104 @@ SCRIPT=$(readlink -f "$0")
 SRCDIR=$(dirname "$SCRIPT")/..
 COMMON_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/opt/qt55"
 
-# Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -c=8
-for i in "$@"
-do
-case $i in
-    -c=*|--cores=*)
-    cores="${i#*=}"
-    shift
-    ;;
-    *)
-    cores=2
-    ;;
-esac
-done
-
 mkdir build || true
 cd build
 
 # OpenTX on 9X stock with FrSky telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on 9X stock with Ardupilot telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
-make -j$cores firmware
+make -j$CORES firmware
 
 # OpenTX on 9X stock with JETI telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
-make -j$cores firmware
+make -j$CORES firmware
 
 # OpenTX on Mega2560
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on Mega2560 with Mavlink telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on gruvin9x board
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on Sky9x
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on AR9X
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on X7D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X7D -DHELI=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on X9D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on X9D+
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on Taranis X9E
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+make -j$CORES gtests ; ./gtests
 
 # OpenTX on Horus beta boards
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-# make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+# make -j$CORES gtests ; ./gtests
 
 # OpenTX on Horus
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$cores firmware
-make -j$cores simu
-# make -j$cores gtests ; ./gtests
+make -j$CORES firmware
+make -j$CORES simu
+# make -j$CORES gtests ; ./gtests
 
 # Companion
 rm -rf *
 cmake ${COMMON_OPTIONS} ${SRCDIR}
-make -j$cores
+make -j$CORES

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -8,105 +8,118 @@ SCRIPT=$(readlink -f "$0")
 SRCDIR=$(dirname "$SCRIPT")/..
 COMMON_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/opt/qt55"
 
+# Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -c=8
+for i in "$@"
+do
+case $i in
+    -c=*|--cores=*)
+    cores="${i#*=}"
+    shift
+    ;;
+    *)
+    cores=2
+    ;;
+esac
+done
+
 mkdir build || true
-cd build 
+cd build
 
 # OpenTX on 9X stock with FrSky telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on 9X stock with Ardupilot telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
-make -j2 firmware
+make -j$cores firmware
 
 # OpenTX on 9X stock with JETI telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
-make -j2 firmware
+make -j$cores firmware
 
 # OpenTX on Mega2560
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on Mega2560 with Mavlink telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on gruvin9x board
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on Sky9x
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on AR9X
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on X7D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X7D -DHELI=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on X9D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on X9D+
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on Taranis X9E
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+make -j$cores gtests ; ./gtests
 
 # OpenTX on Horus beta boards
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-# make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+# make -j$cores gtests ; ./gtests
 
 # OpenTX on Horus
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j2 firmware
-make -j2 simu
-# make -j2 gtests ; ./gtests
+make -j$cores firmware
+make -j$cores simu
+# make -j$cores gtests ; ./gtests
 
 # Companion
 rm -rf *
 cmake ${COMMON_OPTIONS} ${SRCDIR}
-make -j2
-
+make -j$cores

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -30,98 +30,98 @@ cd build
 # OpenTX on 9X stock with FrSky telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on 9X stock with Ardupilot telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
-make -j$CORES firmware
+make -j$(CORES) firmware
 
 # OpenTX on 9X stock with JETI telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
-make -j$CORES firmware
+make -j$(CORES) firmware
 
 # OpenTX on Mega2560
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on Mega2560 with Mavlink telemetry
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on gruvin9x board
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on Sky9x
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on AR9X
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on X7D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X7D -DHELI=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on X9D
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on X9D+
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on Taranis X9E
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DWARNINGS_AS_ERRORS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on Horus beta boards
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-# make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+# make -j$(CORES) gtests ; ./gtests
 
 # OpenTX on Horus
 rm -rf *
 cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=NO -DUSB=SERIAL -DCLI=YES -DDEBUG=YES -DGVARS=YES ${SRCDIR}
-make -j$CORES firmware
-make -j$CORES simu
-# make -j$CORES gtests ; ./gtests
+make -j$(CORES) firmware
+make -j$(CORES) simu
+# make -j$(CORES) gtests ; ./gtests
 
 # Companion
 rm -rf *
 cmake ${COMMON_OPTIONS} ${SRCDIR}
-make -j$CORES
+make -j$(CORES)

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -c=8
+# Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -j8
 CORES=2
 for i in "$@"
 do
 case $i in
-    -j=*|--jobs=*)
+    --jobs=*)
       CORES="${i#*=}"
       shift
       ;;
@@ -14,7 +14,7 @@ case $i in
       shift
       ;;
     *)
-      echo 'Usage : commit-test.sh --jobs=2'
+      echo 'Usage : commit-test.sh --jobs=2 or commit-test.sh -j2'
       exit
       ;;
 esac


### PR DESCRIPTION
Allow passing desired core usage for commit-tests (speed up local execution)
Usage:
commit-tests.sh -j=8
or
commit-tests.sh --jobs=8

Passing no arguments defaults to two cores used

On an i7@3.7Ghz : 2 cores : 13m14secs
with 8 cores : 8m11secs