### PR TITLE
Add 'Z' as key to the rotary encoder emulation

### DIFF
--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -364,7 +364,7 @@ long Open9xSim::onTimeout(FXObject*, FXSelector, void*)
       if (!rotencAction) ROTARY_ENCODER_NAVIGATION_VALUE += ROTARY_ENCODER_GRANULARITY;
       rotencAction = true;
     }
-    else if (getApp()->getKeyState(KEY_W)) {
+    else if (getApp()->getKeyState(KEY_W) || getApp()->getKeyState(KEY_Z)) {    
       if (!rotencAction) ROTARY_ENCODER_NAVIGATION_VALUE -= ROTARY_ENCODER_GRANULARITY;
       rotencAction = true;
     }


### PR DESCRIPTION
This helps us people with non AZERTY keyboards that have Z left to the X. Doesn't help German layouts with 'Y' next to 'X' but that key is already used as trim key.