### PR TITLE
Fixes #3580 9X companion 2.0.19 :Gvar as subtrim in the Servos screen

### DIFF
--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -32,7 +32,9 @@ LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout * tableLayout, int row
 
   if (IS_TARANIS(firmware->getBoard()) || deflt == 0 /*it's the offset*/) {
     spinbox->setDecimals(1);
-    allowGVars = true;
+    if (IS_TARANIS(firmware->getBoard())) {
+      allowGVars = true;
+    }
   }
   else {
     internalStep *= 10;


### PR DESCRIPTION
Fixes #3580 9X companion 2.0.19 :Gvar as subtrim in the Servos screen

No experience with 9X so based the change based on @projectkk2glider comment on Issue.

Tested on Ubuntu 14.04 with 9X radio profile