### PR TITLE
3djc/horus enable perm scripts

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -330,7 +330,7 @@ bool luaLoadMixScript(uint8_t index)
 bool luaLoadFunctionScript(uint8_t index)
 {
   CustomFunctionData & fn = g_model.customFn[index];
-  
+
   if (fn.func == FUNC_PLAY_SCRIPT && ZEXIST(fn.play.name)) {
     if (luaScriptsCount < MAX_SCRIPTS) {
       ScriptInternalData & sid = scriptInternalData[luaScriptsCount++];

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -330,7 +330,6 @@ bool luaLoadMixScript(uint8_t index)
 bool luaLoadFunctionScript(uint8_t index)
 {
   CustomFunctionData & fn = g_model.customFn[index];
-
   if (fn.func == FUNC_PLAY_SCRIPT && ZEXIST(fn.play.name)) {
     if (luaScriptsCount < MAX_SCRIPTS) {
       ScriptInternalData & sid = scriptInternalData[luaScriptsCount++];
@@ -739,9 +738,9 @@ bool luaTask(event_t evt, uint8_t scriptType, bool allowLcdUsage)
 #if !defined(COLORLCD)
       luaInit();
       if (luaState == INTERPRETER_PANIC) return false;
+#endif
       luaLoadPermanentScripts();
       if (luaState == INTERPRETER_PANIC) return false;
-#endif
     }
 
     for (int i=0; i<luaScriptsCount; i++) {

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -330,6 +330,7 @@ bool luaLoadMixScript(uint8_t index)
 bool luaLoadFunctionScript(uint8_t index)
 {
   CustomFunctionData & fn = g_model.customFn[index];
+  
   if (fn.func == FUNC_PLAY_SCRIPT && ZEXIST(fn.play.name)) {
     if (luaScriptsCount < MAX_SCRIPTS) {
       ScriptInternalData & sid = scriptInternalData[luaScriptsCount++];


### PR DESCRIPTION
This allows mixer scripts and the likes to be run
Also fixes custom lua script screen (right portion was never appearing)