### PR TITLE
Abort cmake if leftover files of 2.1 are found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ if ((NOT FOX_FOUND) AND (NOT WIN32))
   message("Libfox not found, simu target will not be available")
 endif()
 
+# Check for a file that is typically left from a OpenTX 2.1 build and abort if found
+if (EXISTS ${RADIO_SRC_DIRECTORY}/stamp.h OR EXISTS ${RADIO_SRC_DIRECTORY}/translations/en.h)
+   message(FATAL_ERROR "Source directory contains files leftover from a OpenTX 2.1 build. Please run `git clean -f` in source directory (Careful: Will remove any extra files) or do a new clean git checkout")
+endif()
+
 include(Macros)
 today(DATE)
 now(TIME)


### PR DESCRIPTION
This is becoming a FAQ. File selection might not be perfect but is good enough to trigger the error.