### PR TITLE
Make abs macro AVR specific. This fixes gcc >= 6.2 compile issues. 

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -872,14 +872,14 @@ void doLoopCommonActions();
 
 #define BITMASK(bit) (1<<(bit))
 
-/// liefert Dimension eines Arrays
+/// retruns the number of elements of an array
 #define DIM(arr) (sizeof((arr))/sizeof((arr)[0]))
 
-/// liefert Betrag des Arguments
+/// AVR compîler does not optimize 'abs' well
+#if defined(__AVR_LIBC_MAJOR__)
 template<class t> FORCEINLINE t abs(t a) { return a>0?a:-a; }
-/// liefert das Minimum der Argumente
+#endif
 template<class t> FORCEINLINE t min(t a, t b) { return a<b?a:b; }
-/// liefert das Maximum der Argumente
 template<class t> FORCEINLINE t max(t a, t b) { return a>b?a:b; }
 template<class t> FORCEINLINE t sgn(t a) { return a>0 ? 1 : (a < 0 ? -1 : 0); }
 template<class t> FORCEINLINE t limit(t mi, t x, t ma) { return min(max(mi,x),ma); }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -872,13 +872,9 @@ void doLoopCommonActions();
 
 #define BITMASK(bit) (1<<(bit))
 
-/// retruns the number of elements of an array
+/// returns the number of elements of an array
 #define DIM(arr) (sizeof((arr))/sizeof((arr)[0]))
 
-/// AVR compîler does not optimize 'abs' well
-#if defined(__AVR_LIBC_MAJOR__)
-template<class t> FORCEINLINE t abs(t a) { return a>0?a:-a; }
-#endif
 template<class t> FORCEINLINE t min(t a, t b) { return a<b?a:b; }
 template<class t> FORCEINLINE t max(t a, t b) { return a>b?a:b; }
 template<class t> FORCEINLINE t sgn(t a) { return a>0 ? 1 : (a < 0 ? -1 : 0); }


### PR DESCRIPTION
Tested on gcc 6.2 and 4.9.2

PLEASE test on CLANG and Visual Studio
