### PR TITLE
Sport: provide method to add sensors from lua

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -902,6 +902,28 @@ static int luaDefaultChannel(lua_State * L)
   return 1;
 }
 
+/*luadoc
+@function registerSensor()
+
+Transmit data back to the general environment as a discoverable sensor, all RAW units
+
+@param instance (number) sensor data ID
+
+@param id (number) data ID
+
+@param data (number) the value transmitted by the sensor
+
+@status current Introduced in 2.2.0
+*/
+static int luaRegisterSensor(lua_State * L)
+{
+  uint8_t instance = luaL_checkunsigned(L, 1);
+  uint16_t id = luaL_checkunsigned(L, 2);
+  uint32_t data = luaL_checkunsigned(L, 3);
+  sportProcessTelemetryPacket(id, 0, instance, data);
+  return 0;
+}
+
 const luaL_Reg opentxLib[] = {
   { "getTime", luaGetTime },
   { "getDateTime", luaGetDateTime },
@@ -919,6 +941,7 @@ const luaL_Reg opentxLib[] = {
   { "popupInput", luaPopupInput },
   { "defaultStick", luaDefaultStick },
   { "defaultChannel", luaDefaultChannel },
+  { "registerSensor", luaRegisterSensor },
   { "killEvents", luaKillEvents },
 #if !defined(COLORLCD)
   { "GREY", luaGrey },

--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -420,6 +420,7 @@ void frskyDSendNextAlarm();
 void frskyDProcessPacket(uint8_t *packet);
 
 // FrSky S.PORT Telemetry Protocol
+void sportProcessTelemetryPacket(uint16_t id, uint8_t subId, uint8_t instance, uint32_t data, TelemetryUnit unit=UNIT_RAW);
 void sportProcessTelemetryPacket(uint8_t * packet);
 
 void telemetryWakeup();

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -98,7 +98,7 @@ bool checkSportPacket(uint8_t *packet)
 uint16_t servosState;
 uint16_t rboxState;
 
-void sportProcessTelemetryPacket(uint16_t id, uint8_t subId, uint8_t instance, uint32_t data, TelemetryUnit unit=UNIT_RAW)
+void sportProcessTelemetryPacket(uint16_t id, uint8_t subId, uint8_t instance, uint32_t data, TelemetryUnit unit)
 {
   const FrSkySportSensor * sensor = getFrSkySportSensor(id, subId);
   uint8_t precision = 0;


### PR DESCRIPTION
Useful for DIY passthrough to bring standard sensorIDs/dataIDs/values back to OpenTX for general use. For example, for using Alt, VARIO, VFAS in the OpenTX environment, this alleviates the need to transmit them separately. They can be transmitted "compressed" via the DIY passthrough and brought back from lua as standard sensors...
