### PR TITLE
Mark gtest variables cached

### DIFF
--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(GTEST_INCDIR /usr/include/gtest CACHE string "location of Googletest includes")
-set(GTEST_SRCDIR /usr/src/gtest CACHE string "location of Googletest directory")
+set(GTEST_INCDIR /usr/include/gtest CACHE string "Location of Google Test includes")
+set(GTEST_SRCDIR /usr/src/gtest CACHE string "Location of Google Test directory")
 
 if(EXISTS "${GTEST_SRCDIR}/src/gtest-all.cc")
   if(Qt5Widgets_FOUND)

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(GTEST_INCDIR /usr/include/gtest)
-set(GTEST_SRCDIR /usr/src/gtest)
+set(GTEST_INCDIR /usr/include/gtest CACHE string "location of Googletest includes")
+set(GTEST_SRCDIR /usr/src/gtest CACHE string "location of Googletest directory")
 
 if(EXISTS "${GTEST_SRCDIR}/src/gtest-all.cc")
   if(Qt5Widgets_FOUND)


### PR DESCRIPTION
Set GTEST location variables as CACHE so they can be modified when gtest is in a different location from the cmake call (/usr/src, /usr/include is not writable on OS X)