### PR TITLE
3djc/fix #3965

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,7 +1300,7 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if (abs(after+before) < (abs(after)+abs(before))) { //forcing a stop a centerered trim when changing sides
+    if (before != 0 && (!(after < 0) == (before < 0))) { //forcing a stop a centerered trim when changing sides
       after = 0;
     }
     if (!thro && after==0 && before!=0) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,7 +1300,7 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if (abs(after) <= (trimInc+1)) { // magnetic 0
+    if (abs(after+before) < (abs(after)+abs(before))) { //forcing a stop a centerered trim when changing sides
       after = 0;
     }
     if (!thro && after==0 && before!=0) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,6 +1300,9 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
+    if (abs(after) <= (trimInc+1)) { // magnetic 0
+      after = 0;
+    }
     if (!thro && after==0 && before!=0) {
       beepTrim = true;
       AUDIO_TRIM_MIDDLE();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,10 +1300,8 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if (before != 0 && (!(after < 0) == (before < 0))) { //forcing a stop a centerered trim when changing sides
+    if (!thro && (!(after < 0) == (before < 0)) && before!=0) { //forcing a stop at centerered trim when changing sides
       after = 0;
-    }
-    if (!thro && after==0 && before!=0) {
       beepTrim = true;
       AUDIO_TRIM_MIDDLE();
       pauseEvents(event);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,7 +1300,7 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if (!thro && (!(after < 0) == (before < 0)) && before!=0) { //forcing a stop at centerered trim when changing sides
+    if (!thro && ((after < 0) != (before < 0)) && before!=0) { //forcing a stop at centerered trim when changing sides
       after = 0;
       beepTrim = true;
       AUDIO_TRIM_MIDDLE();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,7 +1300,7 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if (before != 0 && (!(after < 0) == (before < 0))) { //forcing a stop a centerered trim when changing sides
+    if ((before !=0 ) && (abs(before) < v)) { //forcing a stop a centerered trim when changing sides
       after = 0;
     }
     if (!thro && after==0 && before!=0) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1300,7 +1300,7 @@ uint8_t checkTrim(event_t event)
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
-    if ((before !=0 ) && (abs(before) < v)) { //forcing a stop a centerered trim when changing sides
+    if (before != 0 && (!(after < 0) == (before < 0))) { //forcing a stop a centerered trim when changing sides
       after = 0;
     }
     if (!thro && after==0 && before!=0) {


### PR DESCRIPTION
This forces a stop at 0 in the following scenarios:
- you hit ext trims limit, then go back center with trims on coarse
- by changing trim steps, you end up in a place that does not stop at 0 (ex : fine, move to 12, set coarse, you move back to +4 and then -4 without center stop

Please someone check avr binary size , I have strange results on my compile pc

This fixes #3965 
