### PR TITLE
Fix Atmel ARM Linker script for gcc 5.4.1

### DIFF
--- a/radio/src/targets/sky9x/sam3s2c_flash.ld
+++ b/radio/src/targets/sky9x/sam3s2c_flash.ld
@@ -86,6 +86,9 @@ SECTIONS
       . = ALIGN(4);        /* Align the start of the rodata part */
       *(.rodata)
       *(.rodata.*)
+
+      KEEP (*(.init))
+      KEEP (*(.fini))
       
       . = ALIGN(4);        /* Align the end of the section */
    } > FLASH = 0

--- a/radio/src/targets/sky9x/sam3s4c_flash.ld
+++ b/radio/src/targets/sky9x/sam3s4c_flash.ld
@@ -93,7 +93,10 @@ SECTIONS
       . = ALIGN(4);        /* Align the start of the rodata part */
       *(.rodata)
       *(.rodata.*)
-      
+
+      KEEP (*(.init))
+      KEEP (*(.fini))
+
       . = ALIGN(4);        /* Align the end of the section */
    } > FLASH = 0
    _etext = .;             /* Provide the name for the end of this section */

--- a/radio/src/targets/sky9x/sam3s8c_flash.ld
+++ b/radio/src/targets/sky9x/sam3s8c_flash.ld
@@ -92,7 +92,10 @@ SECTIONS
       . = ALIGN(4);        /* Align the start of the rodata part */
       *(.rodata)
       *(.rodata.*)
-      
+
+      KEEP (*(.init))
+      KEEP (*(.fini))
+
       . = ALIGN(4);        /* Align the end of the section */
    } > FLASH = 0
    _etext = .;             /* Provide the name for the end of this section */


### PR DESCRIPTION
Copy .init and .fni section over from the STM32 linker scripts to make targets like AR9X buildable again. Tested by @sreichholf on a AR9X board