### PR TITLE
3djc/fix #3777

### DIFF
--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -105,10 +105,11 @@ void onModelSelectMenu(const char * result)
     storageFlushCurrentModel();
     storageCheck(true);
     memcpy(g_eeGeneral.currModelFilename, currentModel->name, LEN_MODEL_FILENAME);
-    loadModel(g_eeGeneral.currModelFilename);
+    loadModel(g_eeGeneral.currModelFilename, false);
     storageDirty(EE_GENERAL);
     storageCheck(true);
     chainMenu(menuMainView);
+    postModelLoad(true);
   }
   else if (result == STR_DELETE_MODEL) {
     POPUP_CONFIRMATION(STR_DELETEMODEL);

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -105,10 +105,10 @@ void onModelSelectMenu(const char * result)
     storageFlushCurrentModel();
     storageCheck(true);
     memcpy(g_eeGeneral.currModelFilename, currentModel->name, LEN_MODEL_FILENAME);
-    chainMenu(menuMainView);
     loadModel(g_eeGeneral.currModelFilename);
     storageDirty(EE_GENERAL);
     storageCheck(true);
+    chainMenu(menuMainView);
   }
   else if (result == STR_DELETE_MODEL) {
     POPUP_CONFIRMATION(STR_DELETEMODEL);

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -105,10 +105,10 @@ void onModelSelectMenu(const char * result)
     storageFlushCurrentModel();
     storageCheck(true);
     memcpy(g_eeGeneral.currModelFilename, currentModel->name, LEN_MODEL_FILENAME);
+    chainMenu(menuMainView);
     loadModel(g_eeGeneral.currModelFilename);
     storageDirty(EE_GENERAL);
     storageCheck(true);
-    chainMenu(menuMainView);
   }
   else if (result == STR_DELETE_MODEL) {
     POPUP_CONFIRMATION(STR_DELETEMODEL);


### PR DESCRIPTION
Delay the checks until after the main menu is launched to avoid the model notes to be overwritten even before appearing.

This fixes #3777