### PR TITLE
Fix analog input order for sky9x != REVA

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1401,6 +1401,10 @@ tmr10ms_t jitterResetTime = 0;
 #if !defined(SIMU)
 uint16_t anaIn(uint8_t chan)
 {
+#if defined(PCBSKY9X) && !defined(REVA)
+  static const pm_char skyAna[] PROGMEM = {1,5,7,0,4,6,2,3};
+  chan = skyAna[chan];
+#endif
 #if defined(VIRTUAL_INPUTS)
   return ANA_FILT(chan);
 #else


### PR DESCRIPTION
Analog inputs were completely mixed up on my AR9X (and i guess for every other sky9x except REVA)

So i'm not sure this is the proper way to fix it but least it's gives a direction about what's wrong ;).

