### PR TITLE
Fix issue 4957 Taranis splash screens formatted incorrectly.

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -337,7 +337,7 @@ bool AppPreferencesDialog::displayImage( QString fileName )
 
   // Use the firmware name to determine splash width
   int width = SPLASH_WIDTH;
-  if (g.profile[g.id()].fwType().contains("taranis"))
+  if (g.profile[g.id()].fwType().contains("x9d"))
     width = SPLASHX9D_WIDTH;
   
   ui->imageLabel->setPixmap( makePixMap( image, g.profile[g.id()].fwType()));

--- a/companion/src/customizesplashdialog.cpp
+++ b/companion/src/customizesplashdialog.cpp
@@ -54,14 +54,14 @@ bool Side::displayImage( QString fileName, Source pictSource )
     if (pictSource== PICT)
       *format = image.width()>WIDTH_9X ? LCDTARANIS : LCD9X;
     else if (pictSource == PROFILE)
-      *format = (g.profile[g.id()].fwType().contains("taranis")) ? LCDTARANIS : LCD9X; 
+      *format = (g.profile[g.id()].fwType().contains("x9d")) ? LCDTARANIS : LCD9X; 
   }
   if (image.isNull()) {
     return false;
   }
   // Load image
   if (*format==LCDTARANIS) {
-    imageLabel->setPixmap( makePixMap( image, "taranis" ));
+    imageLabel->setPixmap( makePixMap( image, "x9d" ));
     imageLabel->setFixedSize(WIDTH_TARANIS*2, HEIGHT_TARANIS*2);
   }
   else {

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -834,7 +834,7 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
 
 QPixmap makePixMap( QImage image, QString firmwareType )
 {
-  if (firmwareType.contains( "taranis" )) {
+  if (firmwareType.contains( "x9d" )) {
     image = image.convertToFormat(QImage::Format_RGB32);
     QRgb col;
     int gray;


### PR DESCRIPTION
Fix issue 4957 Taranis splash screens formatted incorrectly (for 9x) due to missed taranis to x9d name changes.