### PR TITLE
fixed fq777-124 and assan protocol selection

### DIFF
--- a/radio/src/pulses/multi_arm.cpp
+++ b/radio/src/pulses/multi_arm.cpp
@@ -131,8 +131,8 @@ void setupPulsesMultimodule(unsigned int port)
   if (type >=15)
     type= type +1;
 
-  // 23 is again a FrSky protocol so shift again
-  if (type >= 23)
+  // 25 is again a FrSky protocol (FrskyV) so shift again
+  if (type >= 25)
      type = type + 1;
 
   if (g_model.moduleData[port].getMultiProtocol(true) == MM_RF_PROTO_FRSKY) {


### PR DESCRIPTION
Fixed protocol selection for FQ777-124 and Assan protocols. These were being skipped because the code assumed FRSKYV had an ID of 23 when it actually has an ID of 25 in the multiprotocol tx module code.