### PR TITLE
fix log playback when log frequency is .1s

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -659,7 +659,7 @@ void TelemetrySimulator::LogPlaybackController::calcLogFrequency()
     QDateTime logTime = parseTransmittterTimestamp(csvRecords[i]);
     // ugh - no timespan in this Qt version
     double timeDiff = (logTime.toMSecsSinceEpoch() - lastTime.toMSecsSinceEpoch()) / 1000.0;
-    if ((timeDiff > 0.1) && (timeDiff < logFrequency)) {
+    if ((timeDiff > 0.09) && (timeDiff < logFrequency)) {
       logFrequency = timeDiff;
     }
     lastTime = logTime;


### PR DESCRIPTION
The log playback is extremely slow if the log frequency is .1s. So slow that it doesn't look like the playback is even working.

This fixes the issue.