### PR TITLE
Fixes #4103 Companion Special Functions parameters not cleared

### DIFF
--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -323,8 +323,11 @@ void CustomFunctionsPanel::functionEdited()
   if (!lock) {
     lock = true;
     int index = sender()->property("index").toInt();
-    fswtchParamArmT[index]->setCurrentIndex(0);
-    refreshCustomFunction(index, true);
+    RawSwitch swtch = functions[index].swtch;
+    functions[index].clear();
+    functions[index].swtch = swtch;
+    functions[index].func = (AssignFunc)fswtchFunc[index]->itemData(fswtchFunc[index]->currentIndex()).toInt();
+    refreshCustomFunction(index);
     emit modified();
     lock = false;
   }


### PR DESCRIPTION
Companion re-initialise a Special or Global Function's parameters when the selected function is changed #4103