### PR TITLE
Fixed a problem with precesion 0,0 0,00

### DIFF
--- a/radio/src/translations/tts_de.cpp
+++ b/radio/src/translations/tts_de.cpp
@@ -136,7 +136,12 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       PUSH_NUMBER_PROMPT(qr.rem);
     }
     else {
-      PUSH_NUMBER_PROMPT(qr.quot);
+      if (qr.quot == 1) {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_EIN);
+      }
+      else {
+        PUSH_NUMBER_PROMPT(qr.quot);
+      }
     }
     DE_PUSH_UNIT_PROMPT(unit);
     return;


### PR DESCRIPTION
When precesion is set to 0,0 or 0,00 and the choosen value is 1,0 or 1,00 following happens:
eins meter
This is incorrect so i coded another part in the else part of "qr.rem > 0"  that checks if qr.quot is 1. If it is following happens now:
ein meter