### PR TITLE
Fix static initialization order problem with Horus GUI

### DIFF
--- a/radio/src/gui/480x272/layout.cpp
+++ b/radio/src/gui/480x272/layout.cpp
@@ -20,8 +20,14 @@
 
 #include "opentx.h"
 
-const LayoutFactory * registeredLayouts[MAX_REGISTERED_LAYOUTS]; // TODO dynamic
 unsigned int countRegisteredLayouts = 0;
+
+const LayoutFactory ** getRegisteredLayouts()
+{
+  static const LayoutFactory * layouts[MAX_REGISTERED_LAYOUTS]; // TODO dynamic
+  return layouts;
+}
+
 void registerLayout(const LayoutFactory * factory)
 {
   if (countRegisteredLayouts < MAX_REGISTERED_LAYOUTS) {

--- a/radio/src/gui/480x272/layout.cpp
+++ b/radio/src/gui/480x272/layout.cpp
@@ -32,14 +32,14 @@ void registerLayout(const LayoutFactory * factory)
 {
   if (countRegisteredLayouts < MAX_REGISTERED_LAYOUTS) {
     TRACE("register layout %s", factory->getName());
-    registeredLayouts[countRegisteredLayouts++] = factory;
+    getRegisteredLayouts()[countRegisteredLayouts++] = factory;
   }
 }
 
 const LayoutFactory * getLayoutFactory(const char * name)
 {
   for (unsigned int i=0; i<countRegisteredLayouts; i++) {
-    const LayoutFactory * factory = registeredLayouts[i];
+    const LayoutFactory * factory = getRegisteredLayouts()[i];
     if (!strcmp(name, factory->getName())) {
       return factory;
     }
@@ -67,7 +67,7 @@ void loadCustomScreens()
   }
 
   if (customScreens[0] == NULL) {
-    customScreens[0] = registeredLayouts[0]->create(&g_model.screenData[0].layoutData);
+    customScreens[0] = getRegisteredLayouts()[0]->create(&g_model.screenData[0].layoutData);
   }
 
   topbar->load();

--- a/radio/src/gui/480x272/layout.cpp
+++ b/radio/src/gui/480x272/layout.cpp
@@ -20,28 +20,26 @@
 
 #include "opentx.h"
 
-unsigned int countRegisteredLayouts = 0;
-
-const LayoutFactory ** getRegisteredLayouts()
+std::list<const LayoutFactory *> & getRegisteredLayouts()
 {
-  static const LayoutFactory * layouts[MAX_REGISTERED_LAYOUTS]; // TODO dynamic
+  static std::list<const LayoutFactory *> layouts;
   return layouts;
 }
 
 void registerLayout(const LayoutFactory * factory)
 {
-  if (countRegisteredLayouts < MAX_REGISTERED_LAYOUTS) {
+  if (getRegisteredLayouts().size() < MAX_REGISTERED_LAYOUTS) {
     TRACE("register layout %s", factory->getName());
-    getRegisteredLayouts()[countRegisteredLayouts++] = factory;
+    getRegisteredLayouts().push_back(factory);
   }
 }
 
 const LayoutFactory * getLayoutFactory(const char * name)
 {
-  for (unsigned int i=0; i<countRegisteredLayouts; i++) {
-    const LayoutFactory * factory = getRegisteredLayouts()[i];
-    if (!strcmp(name, factory->getName())) {
-      return factory;
+  std::list<const LayoutFactory *>::const_iterator it = getRegisteredLayouts().cbegin();
+  for (; it != getRegisteredLayouts().cend(); ++it) {
+    if (!strcmp(name, (*it)->getName())) {
+      return (*it);
     }
   }
   return NULL;
@@ -66,8 +64,8 @@ void loadCustomScreens()
     customScreens[i] = loadLayout(name, &g_model.screenData[i].layoutData);
   }
 
-  if (customScreens[0] == NULL) {
-    customScreens[0] = getRegisteredLayouts()[0]->create(&g_model.screenData[0].layoutData);
+  if (customScreens[0] == NULL && getRegisteredLayouts().size()) {
+    customScreens[0] = getRegisteredLayouts().front()->create(&g_model.screenData[0].layoutData);
   }
 
   topbar->load();

--- a/radio/src/gui/480x272/layout.h
+++ b/radio/src/gui/480x272/layout.h
@@ -52,7 +52,7 @@ class Layout: public WidgetsContainer<MAX_LAYOUT_ZONES, MAX_LAYOUT_OPTIONS>
     const LayoutFactory * factory;
 };
 
-void registerLayout(const LayoutFactory * factory);
+extern void registerLayout(const LayoutFactory * factory);
 
 class LayoutFactory
 {
@@ -113,11 +113,12 @@ class BaseLayoutFactory: public LayoutFactory
     const ZoneOption * options;
 };
 
-#define MAX_REGISTERED_LAYOUTS 10
-
-extern unsigned int countRegisteredLayouts;
-extern const LayoutFactory * registeredLayouts[MAX_REGISTERED_LAYOUTS];
 Layout * loadLayout(const char * name, Layout::PersistentData * persistentData);
 void loadCustomScreens();
+
+#define MAX_REGISTERED_LAYOUTS          10
+extern unsigned int countRegisteredLayouts;
+#define registeredLayouts      getRegisteredLayouts()
+extern const LayoutFactory **  getRegisteredLayouts();
 
 #endif // _LAYOUT_H_

--- a/radio/src/gui/480x272/layout.h
+++ b/radio/src/gui/480x272/layout.h
@@ -52,7 +52,7 @@ class Layout: public WidgetsContainer<MAX_LAYOUT_ZONES, MAX_LAYOUT_OPTIONS>
     const LayoutFactory * factory;
 };
 
-extern void registerLayout(const LayoutFactory * factory);
+void registerLayout(const LayoutFactory * factory);
 
 class LayoutFactory
 {
@@ -118,7 +118,6 @@ void loadCustomScreens();
 
 #define MAX_REGISTERED_LAYOUTS          10
 extern unsigned int countRegisteredLayouts;
-#define registeredLayouts      getRegisteredLayouts()
-extern const LayoutFactory **  getRegisteredLayouts();
+const LayoutFactory **  getRegisteredLayouts();
 
 #endif // _LAYOUT_H_

--- a/radio/src/gui/480x272/layout.h
+++ b/radio/src/gui/480x272/layout.h
@@ -21,6 +21,7 @@
 #ifndef _LAYOUT_H_
 #define _LAYOUT_H_
 
+#include <list>
 #include "widgets_container.h"
 
 #define MAX_LAYOUT_ZONES               10
@@ -117,7 +118,6 @@ Layout * loadLayout(const char * name, Layout::PersistentData * persistentData);
 void loadCustomScreens();
 
 #define MAX_REGISTERED_LAYOUTS          10
-extern unsigned int countRegisteredLayouts;
-const LayoutFactory **  getRegisteredLayouts();
+std::list<const LayoutFactory *> & getRegisteredLayouts();
 
 #endif // _LAYOUT_H_

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -282,7 +282,8 @@ void drawTimerMode(coord_t x, coord_t y, int32_t mode, LcdFlags att)
     if (mode < TMRMODE_COUNT) {
       lcdDrawTextAtIndex(x, y, STR_VTMRMODES, mode, att);
       return;
-    } else {
+    }
+    else {
       mode -= (TMRMODE_COUNT-1);
     }
   }

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -279,10 +279,12 @@ void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags flags)
 void drawTimerMode(coord_t x, coord_t y, int32_t mode, LcdFlags att)
 {
   if (mode >= 0) {
-    if (mode < TMRMODE_COUNT)
+    if (mode < TMRMODE_COUNT) {
       lcdDrawTextAtIndex(x, y, STR_VTMRMODES, mode, att);
-    else
+      return;
+    } else {
       mode -= (TMRMODE_COUNT-1);
+    }
   }
   drawSwitch(x, y, mode, att);
 }

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -280,7 +280,7 @@ void drawTimerMode(coord_t x, coord_t y, int32_t mode, LcdFlags att)
 {
   if (mode >= 0) {
     if (mode < TMRMODE_COUNT)
-      return lcdDrawTextAtIndex(x, y, STR_VTMRMODES, mode, att);
+      lcdDrawTextAtIndex(x, y, STR_VTMRMODES, mode, att);
     else
       mode -= (TMRMODE_COUNT-1);
   }

--- a/radio/src/gui/480x272/screens_setup.cpp
+++ b/radio/src/gui/480x272/screens_setup.cpp
@@ -219,10 +219,10 @@ bool menuWidgetChoice(event_t event)
     {
       previousWidget = currentContainer->getWidget(currentZone);
       currentContainer->setWidget(currentZone, NULL);
-      iterator = registeredWidgets.begin();
+      iterator = getRegisteredWidgets().begin();
       if (previousWidget) {
         const WidgetFactory * factory = previousWidget->getFactory();
-        for (std::list<const WidgetFactory *>::iterator it = registeredWidgets.begin(); it != registeredWidgets.end(); ++it) {
+        for (std::list<const WidgetFactory *>::iterator it = getRegisteredWidgets().begin(); it != getRegisteredWidgets().end(); ++it) {
           if (factory->getName() == (*it)->getName()) {
             iterator = it;
             break;
@@ -247,7 +247,7 @@ bool menuWidgetChoice(event_t event)
       return false;
 
     case EVT_ROTARY_RIGHT:
-      if (iterator != registeredWidgets.end() && iterator != --registeredWidgets.end()) {
+      if (iterator != getRegisteredWidgets().end() && iterator != --getRegisteredWidgets().end()) {
         ++iterator;
         delete currentWidget;
         currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
@@ -255,7 +255,7 @@ bool menuWidgetChoice(event_t event)
       break;
 
     case EVT_ROTARY_LEFT:
-      if (iterator != registeredWidgets.begin()) {
+      if (iterator != getRegisteredWidgets().begin()) {
         --iterator;
         delete currentWidget;
         currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
@@ -439,7 +439,7 @@ bool menuScreensTheme(event_t event)
     switch (k) {
       case ITEM_SCREEN_SETUP_THEME: {
         lcdDrawText(MENUS_MARGIN_LEFT, y + FH / 2, STR_THEME);
-        Theme * new_theme = editThemeChoice<Theme>(SCREENS_SETUP_2ND_COLUMN, y, registeredThemes, countRegisteredThemes, theme, needsOffsetCheck, attr, event);
+        Theme * new_theme = editThemeChoice<Theme>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredThemes(), countRegisteredThemes, theme, needsOffsetCheck, attr, event);
         if (new_theme) {
           new_theme->init();
           loadTheme(new_theme);
@@ -523,7 +523,7 @@ bool menuScreenSetup(int index, event_t event)
       case ITEM_SCREEN_SETUP_LAYOUT:
       {
         lcdDrawText(MENUS_MARGIN_LEFT, y + FH / 2, STR_LAYOUT);
-        const LayoutFactory * factory = editThemeChoice<const LayoutFactory>(SCREENS_SETUP_2ND_COLUMN, y, registeredLayouts, countRegisteredLayouts, currentScreen->getFactory(), needsOffsetCheck, attr, event);
+        const LayoutFactory * factory = editThemeChoice<const LayoutFactory>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredLayouts(), countRegisteredLayouts, currentScreen->getFactory(), needsOffsetCheck, attr, event);
         if (factory) {
           delete customScreens[index];
           currentScreen = customScreens[index] = factory->create(&g_model.screenData[index].layoutData);
@@ -611,8 +611,8 @@ bool menuScreenAdd(event_t event)
   menuPageCount = updateMainviewsMenu();
 
   if (event == EVT_KEY_FIRST(KEY_ENTER)) {
-    customScreens[menuPageCount-2] = registeredLayouts[0]->create(&g_model.screenData[menuPageCount-2].layoutData);
-    strncpy(g_model.screenData[menuPageCount-2].layoutName, registeredLayouts[0]->getName(), sizeof(g_model.screenData[menuPageCount-2].layoutName));
+    customScreens[menuPageCount-2] = getRegisteredLayouts()[0]->create(&g_model.screenData[menuPageCount-2].layoutData);
+    strncpy(g_model.screenData[menuPageCount-2].layoutName, getRegisteredLayouts()[0]->getName(), sizeof(g_model.screenData[menuPageCount-2].layoutName));
     s_editMode = 0;
     menuHorizontalPosition = -1;
     killEvents(KEY_ENTER);

--- a/radio/src/gui/480x272/screens_setup.cpp
+++ b/radio/src/gui/480x272/screens_setup.cpp
@@ -209,9 +209,9 @@ bool menuWidgetSettings(event_t event)
 
 bool menuWidgetChoice(event_t event)
 {
-  static Widget * previousWidget;
-  static Widget * currentWidget;
-  static std::list<const WidgetFactory *>::iterator iterator;
+  static Widget * previousWidget = NULL;
+  static Widget * currentWidget = NULL;
+  static std::list<const WidgetFactory *>::const_iterator iterator;
   static Widget::PersistentData tempData;
 
   switch (event) {
@@ -219,45 +219,55 @@ bool menuWidgetChoice(event_t event)
     {
       previousWidget = currentContainer->getWidget(currentZone);
       currentContainer->setWidget(currentZone, NULL);
-      iterator = getRegisteredWidgets().begin();
+      iterator = getRegisteredWidgets().cbegin();
       if (previousWidget) {
         const WidgetFactory * factory = previousWidget->getFactory();
-        for (std::list<const WidgetFactory *>::iterator it = getRegisteredWidgets().begin(); it != getRegisteredWidgets().end(); ++it) {
+        std::list<const WidgetFactory *>::const_iterator it = getRegisteredWidgets().cbegin();
+        for (; it != getRegisteredWidgets().cend(); ++it) {
           if (factory->getName() == (*it)->getName()) {
             iterator = it;
             break;
           }
         }
       }
-      currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
+      if (iterator != getRegisteredWidgets().cend())
+        currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
       break;
     }
 
     case EVT_KEY_FIRST(KEY_EXIT):
-      delete currentWidget;
-      currentContainer->setWidget(currentZone, previousWidget);
+      if (previousWidget) {
+        if (currentWidget)
+          delete currentWidget;
+        currentContainer->setWidget(currentZone, previousWidget);
+      }
       popMenu();
       return false;
 
     case EVT_KEY_FIRST(KEY_ENTER):
-      delete previousWidget;
-      currentContainer->createWidget(currentZone, *iterator);
-      storageDirty(EE_MODEL);
+      if (iterator != getRegisteredWidgets().cend()) {
+        if (previousWidget)
+          delete previousWidget;
+        currentContainer->createWidget(currentZone, *iterator);
+        storageDirty(EE_MODEL);
+      }
       popMenu();
       return false;
 
     case EVT_ROTARY_RIGHT:
-      if (iterator != getRegisteredWidgets().end() && iterator != --getRegisteredWidgets().end()) {
+      if (iterator != getRegisteredWidgets().cend() && iterator != --getRegisteredWidgets().cend()) {
         ++iterator;
-        delete currentWidget;
+        if (currentWidget)
+          delete currentWidget;
         currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
       }
       break;
 
     case EVT_ROTARY_LEFT:
-      if (iterator != getRegisteredWidgets().begin()) {
+      if (iterator != getRegisteredWidgets().cbegin()) {
         --iterator;
-        delete currentWidget;
+        if (currentWidget)
+          delete currentWidget;
         currentWidget = (*iterator)->create(currentContainer->getZone(currentZone), &tempData);
       }
       break;
@@ -271,13 +281,19 @@ bool menuWidgetChoice(event_t event)
   lcdDrawFilledRect(zone.x-2, 0, zone.w+4, zone.y-2, SOLID, OVERLAY_COLOR | (8<<24));
   lcdDrawFilledRect(zone.x-2, zone.y+zone.h+2, zone.w+4, LCD_H-zone.y-zone.h-2, SOLID, OVERLAY_COLOR | (8<<24));
 
-  currentWidget->refresh();
+  if (currentWidget)
+    currentWidget->refresh();
 
-  lcdDrawBitmapPattern(zone.x-10, zone.y+zone.h/2-10, LBM_SWIPE_CIRCLE, TEXT_INVERTED_BGCOLOR);
-  lcdDrawBitmapPattern(zone.x-10, zone.y+zone.h/2-10, LBM_SWIPE_LEFT, TEXT_INVERTED_COLOR);
-  lcdDrawBitmapPattern(zone.x+zone.w-9, zone.y+zone.h/2-10, LBM_SWIPE_CIRCLE, TEXT_INVERTED_BGCOLOR);
-  lcdDrawBitmapPattern(zone.x+zone.w-9, zone.y+zone.h/2-10, LBM_SWIPE_RIGHT, TEXT_INVERTED_COLOR);
-  lcdDrawText(zone.x + zone.w, zone.y-1, currentWidget->getFactory()->getName(), RIGHT | TEXT_COLOR | SMLSIZE | INVERS);
+  if (iterator != getRegisteredWidgets().cbegin()) {
+    lcdDrawBitmapPattern(zone.x-10, zone.y+zone.h/2-10, LBM_SWIPE_CIRCLE, TEXT_INVERTED_BGCOLOR);
+    lcdDrawBitmapPattern(zone.x-10, zone.y+zone.h/2-10, LBM_SWIPE_LEFT, TEXT_INVERTED_COLOR);
+  }
+  if (iterator != --getRegisteredWidgets().cend()) {
+    lcdDrawBitmapPattern(zone.x+zone.w-9, zone.y+zone.h/2-10, LBM_SWIPE_CIRCLE, TEXT_INVERTED_BGCOLOR);
+    lcdDrawBitmapPattern(zone.x+zone.w-9, zone.y+zone.h/2-10, LBM_SWIPE_RIGHT, TEXT_INVERTED_COLOR);
+  }
+  if (currentWidget)
+    lcdDrawText(zone.x + zone.w, zone.y-1, currentWidget->getFactory()->getName(), RIGHT | TEXT_COLOR | SMLSIZE | INVERS);
 
   return true;
 }
@@ -351,16 +367,20 @@ bool menuWidgetsSetup(event_t event)
 }
 
 template <class T>
-T * editThemeChoice(coord_t x, coord_t y, T * array[], uint8_t count, T * current, bool needsOffsetCheck, LcdFlags attr, event_t event)
+T * editThemeChoice(coord_t x, coord_t y, std::list<T *> & elList, T * current, bool needsOffsetCheck, LcdFlags attr, event_t event)
 {
-  static uint8_t menuHorizontalOffset;
-
+  static uint8_t menuHorizontalOffset = 0;
+  uint8_t elCount = elList.size(), last, idx;
+  coord_t pos;
   int currentIndex = 0;
-  for (unsigned int i=0; i<count; i++) {
-    if (array[i] == current) {
-      currentIndex = i;
+  typename std::list<T *>::const_iterator elItr = elList.cbegin();
+
+  if (!elCount)
+    return NULL;
+
+  for (; elItr != elList.cend(); ++elItr, ++currentIndex) {
+    if ((*elItr) == current)
       break;
-    }
   }
 
   if (event == EVT_ENTRY) {
@@ -378,7 +398,7 @@ T * editThemeChoice(coord_t x, coord_t y, T * array[], uint8_t count, T * curren
   }
   if (attr) {
     if (menuHorizontalPosition < 0) {
-      lcdDrawSolidFilledRect(x-3, y-1, min<uint8_t>(4, count)*56+1, 2*FH-5, TEXT_INVERTED_BGCOLOR);
+      lcdDrawSolidFilledRect(x-3, y-1, min<uint8_t>(4, elCount)*56+1, 2*FH-5, TEXT_INVERTED_BGCOLOR);
     }
     else {
       if (needsOffsetCheck) {
@@ -392,20 +412,29 @@ T * editThemeChoice(coord_t x, coord_t y, T * array[], uint8_t count, T * curren
       }
     }
   }
-  unsigned int last = min<int>(menuHorizontalOffset + 4, count);
-  for (unsigned int i=menuHorizontalOffset, pos=x; i<last; i++, pos += 56) {
-    T * element = array[i];
-    element->drawThumb(pos, y+1, current == element ? ((attr && menuHorizontalPosition < 0) ? TEXT_INVERTED_COLOR : TEXT_INVERTED_BGCOLOR) : LINE_COLOR);
+  last = min<uint8_t>(menuHorizontalOffset + 4, elCount);
+  idx = menuHorizontalOffset;
+  pos = x;
+  elItr = elList.cbegin();
+  std::advance(elItr, min<uint8_t>(menuHorizontalOffset, elCount - 1));
+  for (; idx < last && elItr != elList.cend(); ++idx, ++elItr, pos += 56) {
+    (*elItr)->drawThumb(pos, y+1, current == (*elItr) ? ((attr && menuHorizontalPosition < 0) ? TEXT_INVERTED_COLOR : TEXT_INVERTED_BGCOLOR) : LINE_COLOR);
   }
-  if (count > 4) {
+  if (elCount > 4) {
     lcdDrawBitmapPattern(x - 12, y+1, LBM_CARROUSSEL_LEFT, menuHorizontalOffset > 0 ? LINE_COLOR : CURVE_AXIS_COLOR);
-    lcdDrawBitmapPattern(x + 4 * 56, y+1, LBM_CARROUSSEL_RIGHT, last < countRegisteredLayouts ? LINE_COLOR : CURVE_AXIS_COLOR);
+    lcdDrawBitmapPattern(x + 4 * 56, y+1, LBM_CARROUSSEL_RIGHT, last < getRegisteredLayouts().size() ? LINE_COLOR : CURVE_AXIS_COLOR);
   }
   if (attr && menuHorizontalPosition >= 0) {
     lcdDrawSolidRect(x + (menuHorizontalPosition - menuHorizontalOffset) * 56 - 3, y - 1, 57, 35, 1, TEXT_INVERTED_BGCOLOR);
     if (event == EVT_KEY_FIRST(KEY_ENTER)) {
       s_editMode = 0;
-      return array[menuHorizontalPosition];
+      elItr = elList.cbegin();
+      if (menuHorizontalPosition < (int)elList.size())
+        std::advance(elItr, menuHorizontalPosition);
+      if (elItr != elList.cend())
+        return (*elItr);
+      else
+        return NULL;
     }
   }
   return NULL;
@@ -424,7 +453,7 @@ bool menuScreensTheme(event_t event)
   linesCount = ITEM_SCREEN_SETUP_THEME_OPTION1 + optionsCount + 1;
 
   menuPageCount = updateMainviewsMenu();
-  uint8_t mstate_tab[2 + MAX_THEME_OPTIONS + 1] = { uint8_t(NAVIGATION_LINE_BY_LINE|uint8_t(countRegisteredThemes-1)), ORPHAN_ROW };
+  uint8_t mstate_tab[2 + MAX_THEME_OPTIONS + 1] = { uint8_t(NAVIGATION_LINE_BY_LINE | uint8_t(getRegisteredThemes().size()-1)), ORPHAN_ROW };
   for (int i=0; i<optionsCount; i++) {
     mstate_tab[2+i] = getZoneOptionColumns(&options[i]);
   }
@@ -439,7 +468,7 @@ bool menuScreensTheme(event_t event)
     switch (k) {
       case ITEM_SCREEN_SETUP_THEME: {
         lcdDrawText(MENUS_MARGIN_LEFT, y + FH / 2, STR_THEME);
-        Theme * new_theme = editThemeChoice<Theme>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredThemes(), countRegisteredThemes, theme, needsOffsetCheck, attr, event);
+        Theme * new_theme = editThemeChoice<Theme>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredThemes(), theme, needsOffsetCheck, attr, event);
         if (new_theme) {
           new_theme->init();
           loadTheme(new_theme);
@@ -506,7 +535,7 @@ bool menuScreenSetup(int index, event_t event)
   if (menuPageCount > 3)
     ++linesCount;
 
-  uint8_t mstate_tab[2 + MAX_LAYOUT_OPTIONS + 1] = { uint8_t(NAVIGATION_LINE_BY_LINE|uint8_t(countRegisteredLayouts-1)), ORPHAN_ROW };
+  uint8_t mstate_tab[2 + MAX_LAYOUT_OPTIONS + 1] = { uint8_t(NAVIGATION_LINE_BY_LINE | uint8_t(getRegisteredLayouts().size()-1)), ORPHAN_ROW };
   for (int i=0; i<optionsCount; i++) {
     mstate_tab[3+i] = getZoneOptionColumns(&options[i]);
   }
@@ -523,7 +552,7 @@ bool menuScreenSetup(int index, event_t event)
       case ITEM_SCREEN_SETUP_LAYOUT:
       {
         lcdDrawText(MENUS_MARGIN_LEFT, y + FH / 2, STR_LAYOUT);
-        const LayoutFactory * factory = editThemeChoice<const LayoutFactory>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredLayouts(), countRegisteredLayouts, currentScreen->getFactory(), needsOffsetCheck, attr, event);
+        const LayoutFactory * factory = editThemeChoice<const LayoutFactory>(SCREENS_SETUP_2ND_COLUMN, y, getRegisteredLayouts(), currentScreen->getFactory(), needsOffsetCheck, attr, event);
         if (factory) {
           delete customScreens[index];
           currentScreen = customScreens[index] = factory->create(&g_model.screenData[index].layoutData);
@@ -610,9 +639,10 @@ bool menuScreenAdd(event_t event)
 {
   menuPageCount = updateMainviewsMenu();
 
-  if (event == EVT_KEY_FIRST(KEY_ENTER)) {
-    customScreens[menuPageCount-2] = getRegisteredLayouts()[0]->create(&g_model.screenData[menuPageCount-2].layoutData);
-    strncpy(g_model.screenData[menuPageCount-2].layoutName, getRegisteredLayouts()[0]->getName(), sizeof(g_model.screenData[menuPageCount-2].layoutName));
+  if (event == EVT_KEY_FIRST(KEY_ENTER) && getRegisteredLayouts().size()) {
+    const LayoutFactory * lf = getRegisteredLayouts().front();
+    customScreens[menuPageCount-2] = lf->create(&g_model.screenData[menuPageCount-2].layoutData);
+    strncpy(g_model.screenData[menuPageCount-2].layoutName, lf->getName(), sizeof(g_model.screenData[menuPageCount-2].layoutName));
     s_editMode = 0;
     menuHorizontalPosition = -1;
     killEvents(KEY_ENTER);

--- a/radio/src/gui/480x272/theme.cpp
+++ b/radio/src/gui/480x272/theme.cpp
@@ -23,6 +23,21 @@
 const BitmapBuffer * Theme::asterisk = NULL;
 const BitmapBuffer * Theme::question = NULL;
 const BitmapBuffer * Theme::busy = NULL;
+unsigned int countRegisteredThemes = 0;
+
+Theme ** getRegisteredThemes()
+{
+  static Theme * themes[MAX_REGISTERED_THEMES]; // TODO dynamic
+  return themes;
+}
+
+void registerTheme(Theme * theme)
+{
+  if (countRegisteredThemes < MAX_REGISTERED_THEMES) {
+    TRACE("register theme %s", theme->getName());
+    registeredThemes[countRegisteredThemes++] = theme;
+  }
+}
 
 void Theme::init() const
 {
@@ -109,16 +124,6 @@ void Theme::drawMessageBox(const char * title, const char * text, const char * a
 
   if (action) {
     lcdDrawText(WARNING_LINE_X, WARNING_INFOLINE_Y+24, action);
-  }
-}
-
-Theme * registeredThemes[MAX_REGISTERED_THEMES]; // TODO dynamic
-unsigned int countRegisteredThemes = 0;
-void registerTheme(Theme * theme)
-{
-  if (countRegisteredThemes < MAX_REGISTERED_THEMES) {
-    TRACE("register theme %s", theme->getName());
-    registeredThemes[countRegisteredThemes++] = theme;
   }
 }
 

--- a/radio/src/gui/480x272/theme.cpp
+++ b/radio/src/gui/480x272/theme.cpp
@@ -23,19 +23,18 @@
 const BitmapBuffer * Theme::asterisk = NULL;
 const BitmapBuffer * Theme::question = NULL;
 const BitmapBuffer * Theme::busy = NULL;
-unsigned int countRegisteredThemes = 0;
 
-Theme ** getRegisteredThemes()
+std::list<Theme *> & getRegisteredThemes()
 {
-  static Theme * themes[MAX_REGISTERED_THEMES]; // TODO dynamic
+  static std::list<Theme *> themes;
   return themes;
 }
 
 void registerTheme(Theme * theme)
 {
-  if (countRegisteredThemes < MAX_REGISTERED_THEMES) {
+  if (getRegisteredThemes().size() < MAX_REGISTERED_THEMES) {
     TRACE("register theme %s", theme->getName());
-    getRegisteredThemes()[countRegisteredThemes++] = theme;
+    getRegisteredThemes().push_back(theme);
   }
 }
 
@@ -129,10 +128,10 @@ void Theme::drawMessageBox(const char * title, const char * text, const char * a
 
 Theme * getTheme(const char * name)
 {
-  for (unsigned int i=0; i<countRegisteredThemes; i++) {
-    Theme * theme = getRegisteredThemes()[i];
-    if (!strcmp(name, theme->getName())) {
-      return theme;
+  std::list<Theme *>::const_iterator it = getRegisteredThemes().cbegin();
+  for (; it != getRegisteredThemes().cend(); ++it) {
+    if (!strcmp(name, (*it)->getName())) {
+      return (*it);
     }
   }
   return NULL;

--- a/radio/src/gui/480x272/theme.cpp
+++ b/radio/src/gui/480x272/theme.cpp
@@ -35,7 +35,7 @@ void registerTheme(Theme * theme)
 {
   if (countRegisteredThemes < MAX_REGISTERED_THEMES) {
     TRACE("register theme %s", theme->getName());
-    registeredThemes[countRegisteredThemes++] = theme;
+    getRegisteredThemes()[countRegisteredThemes++] = theme;
   }
 }
 
@@ -130,7 +130,7 @@ void Theme::drawMessageBox(const char * title, const char * text, const char * a
 Theme * getTheme(const char * name)
 {
   for (unsigned int i=0; i<countRegisteredThemes; i++) {
-    Theme * theme = registeredThemes[i];
+    Theme * theme = getRegisteredThemes()[i];
     if (!strcmp(name, theme->getName())) {
       return theme;
     }

--- a/radio/src/gui/480x272/theme.h
+++ b/radio/src/gui/480x272/theme.h
@@ -26,7 +26,7 @@ class BitmapBuffer;
 #define MAX_THEME_OPTIONS              5
 
 class Theme;
-void registerTheme(Theme * theme);
+extern void registerTheme(Theme * theme);
 
 class Theme
 {
@@ -91,13 +91,13 @@ inline const char * getThemePath(const char * filename)
   return theme->getFilePath(filename);
 }
 
-#define MAX_REGISTERED_THEMES          10
-extern unsigned int countRegisteredThemes;
-void registerTheme(Theme * theme);
-extern Theme * registeredThemes[MAX_REGISTERED_THEMES]; // TODO dynamic
-
 Theme * getTheme(const char * name);
 void loadTheme(Theme * theme);
 void loadTheme();
+
+#define MAX_REGISTERED_THEMES          10
+extern unsigned int countRegisteredThemes;
+#define registeredThemes    getRegisteredThemes()
+extern Theme ** getRegisteredThemes();
 
 #endif // _THEME_H_

--- a/radio/src/gui/480x272/theme.h
+++ b/radio/src/gui/480x272/theme.h
@@ -21,6 +21,8 @@
 #ifndef _THEME_H_
 #define _THEME_H_
 
+#include <list>
+
 class BitmapBuffer;
 
 #define MAX_THEME_OPTIONS              5
@@ -96,7 +98,6 @@ void loadTheme(Theme * theme);
 void loadTheme();
 
 #define MAX_REGISTERED_THEMES          10
-extern unsigned int countRegisteredThemes;
-Theme ** getRegisteredThemes();
+std::list<Theme *> & getRegisteredThemes();
 
 #endif // _THEME_H_

--- a/radio/src/gui/480x272/theme.h
+++ b/radio/src/gui/480x272/theme.h
@@ -26,7 +26,7 @@ class BitmapBuffer;
 #define MAX_THEME_OPTIONS              5
 
 class Theme;
-extern void registerTheme(Theme * theme);
+void registerTheme(Theme * theme);
 
 class Theme
 {
@@ -97,7 +97,6 @@ void loadTheme();
 
 #define MAX_REGISTERED_THEMES          10
 extern unsigned int countRegisteredThemes;
-#define registeredThemes    getRegisteredThemes()
-extern Theme ** getRegisteredThemes();
+Theme ** getRegisteredThemes();
 
 #endif // _THEME_H_

--- a/radio/src/gui/480x272/widget.cpp
+++ b/radio/src/gui/480x272/widget.cpp
@@ -20,7 +20,12 @@
 
 #include "opentx.h"
 
-std::list<const WidgetFactory *> registeredWidgets;
+std::list<const WidgetFactory *> & getRegisteredWidgets()
+{
+  static std::list<const WidgetFactory *> widgets;
+  return widgets;
+}
+
 void registerWidget(const WidgetFactory * factory)
 {
   TRACE("register widget %s", factory->getName());

--- a/radio/src/gui/480x272/widget.cpp
+++ b/radio/src/gui/480x272/widget.cpp
@@ -28,16 +28,18 @@ std::list<const WidgetFactory *> & getRegisteredWidgets()
 
 void registerWidget(const WidgetFactory * factory)
 {
-  TRACE("register widget %s", factory->getName());
-  getRegisteredWidgets().push_back(factory);
+  if (getRegisteredWidgets().size() < MAX_REGISTERED_WIDGETS) {
+    TRACE("register widget %s", factory->getName());
+    getRegisteredWidgets().push_back(factory);
+  }
 }
 
 const WidgetFactory * getWidgetFactory(const char * name)
 {
-  for (std::list<const WidgetFactory *>::iterator it = getRegisteredWidgets().begin(); it != getRegisteredWidgets().end();++it) {
-    const WidgetFactory * factory = *it;
-    if (!strcmp(name, factory->getName())) {
-      return factory;
+  std::list<const WidgetFactory *>::const_iterator it = getRegisteredWidgets().cbegin();
+  for (; it != getRegisteredWidgets().cend();++it) {
+    if (!strcmp(name, (*it)->getName())) {
+      return (*it);
     }
   }
   return NULL;

--- a/radio/src/gui/480x272/widget.cpp
+++ b/radio/src/gui/480x272/widget.cpp
@@ -29,12 +29,12 @@ std::list<const WidgetFactory *> & getRegisteredWidgets()
 void registerWidget(const WidgetFactory * factory)
 {
   TRACE("register widget %s", factory->getName());
-  registeredWidgets.push_back(factory);
+  getRegisteredWidgets().push_back(factory);
 }
 
 const WidgetFactory * getWidgetFactory(const char * name)
 {
-  for (std::list<const WidgetFactory *>::iterator it = registeredWidgets.begin(); it != registeredWidgets.end();++it) {
+  for (std::list<const WidgetFactory *>::iterator it = getRegisteredWidgets().begin(); it != getRegisteredWidgets().end();++it) {
     const WidgetFactory * factory = *it;
     if (!strcmp(name, factory->getName())) {
       return factory;

--- a/radio/src/gui/480x272/widget.h
+++ b/radio/src/gui/480x272/widget.h
@@ -121,7 +121,7 @@ class Widget
     PersistentData * persistentData;
 };
 
-extern void registerWidget(const WidgetFactory * factory);
+void registerWidget(const WidgetFactory * factory);
 
 class WidgetFactory
 {
@@ -186,8 +186,7 @@ inline const ZoneOption * Widget::getOptions() const
   return getFactory()->getOptions();
 }
 
-#define registeredWidgets    getRegisteredWidgets()
-extern std::list<const WidgetFactory *> & getRegisteredWidgets();
+std::list<const WidgetFactory *> & getRegisteredWidgets();
 Widget * loadWidget(const char * name, const Zone & zone, Widget::PersistentData * persistentData);
 
 #endif // _WIDGET_H_

--- a/radio/src/gui/480x272/widget.h
+++ b/radio/src/gui/480x272/widget.h
@@ -121,7 +121,7 @@ class Widget
     PersistentData * persistentData;
 };
 
-void registerWidget(const WidgetFactory * factory);
+extern void registerWidget(const WidgetFactory * factory);
 
 class WidgetFactory
 {
@@ -186,7 +186,8 @@ inline const ZoneOption * Widget::getOptions() const
   return getFactory()->getOptions();
 }
 
-extern std::list<const WidgetFactory *> registeredWidgets;
+#define registeredWidgets    getRegisteredWidgets()
+extern std::list<const WidgetFactory *> & getRegisteredWidgets();
 Widget * loadWidget(const char * name, const Zone & zone, Widget::PersistentData * persistentData);
 
 #endif // _WIDGET_H_

--- a/radio/src/gui/480x272/widget.h
+++ b/radio/src/gui/480x272/widget.h
@@ -186,7 +186,9 @@ inline const ZoneOption * Widget::getOptions() const
   return getFactory()->getOptions();
 }
 
-std::list<const WidgetFactory *> & getRegisteredWidgets();
 Widget * loadWidget(const char * name, const Zone & zone, Widget::PersistentData * persistentData);
+
+#define MAX_REGISTERED_WIDGETS          20  // TODO: arbitrary limit, not checked
+std::list<const WidgetFactory *> & getRegisteredWidgets();
 
 #endif // _WIDGET_H_


### PR DESCRIPTION
Fixes static initialization order problem with Layout, Theme, & Widget factories.  I discovered this when building simu with MinGW-w64.  The initialization depended purely on compiler "luck."

See [What’s the “static initialization order fiasco”?](https://isocpp.org/wiki/faq/ctors#static-init-order).

For example compare the registration order on Linux vs. Windows (from simu startup log):

Linux g++4.9:
```
$ ./simulator22
register theme Darkblue
register theme Default
register layout Layout1x1
register layout Layout2P1
register layout Layout2x1
register layout Layout2x2
register layout Layout2x4
register widget Gauge
register widget ModelBmp
register widget Outputs
register widget Text
register widget Timer
register widget Value
registering "opentx-horus" simulator
```
Windows MinGW-w64 4.9 & 5.3
```
> simulator.exe
register widget Value
register widget Timer
register widget Text
register widget Outputs
register widget ModelBmp
register widget Gauge
register layout Layout2x4
register layout Layout2x2
register layout Layout2x1
register layout Layout2P1
register layout Layout1x1
register theme Default
register theme Darkblue
registering "opentx-horus" simulator
```
(Yes, the opposite... from same exact CMakeLists, compiler/linker options, and source code.)

Anyway, the Horus simulator would crash hard when trying to register the first widget because the global `std::list <const WidgetFactory *> registeredWidgets` hadn't been initialized yet.  Took me a while to figure that one out!

I've built this on Linux and Windows with several gcc versions, both firmware and simu.  But I have no actual Horus to test with.

As an aside, with some minor changes everything now builds and runs great using Qt5.5 or 5.7 with MinGW toolchains (and GNU Arm Embedded for the firmware, naturally).  The whole CMake project, including fw, can be configured, built, and edited from QtCreator with a stock Qt "kit" plus SDL and dirent downloads.  Coming up in a separate PR. 

-Max