### PR TITLE
Standalone simulator startup options

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -59,6 +59,18 @@ enum BoardEnum {
 #define CPN_MAX_KEYS                   32
 #define CPN_MAX_MOUSE_ANALOGS          2
 
+#define HEX_FILES_FILTER              "HEX files (*.hex);;"
+#define BIN_FILES_FILTER              "BIN files (*.bin);;"
+#define DFU_FILES_FILTER              "DFU files (*.dfu);;"
+#define EEPE_FILES_FILTER             "EEPE EEPROM files (*.eepe);;"
+#define OTX_FILES_FILTER              "OpenTX files (*.otx);;"
+#define EEPROM_FILES_FILTER           "EEPE files (*.eepe *.bin *.hex);;" EEPE_FILES_FILTER BIN_FILES_FILTER HEX_FILES_FILTER
+#define FLASH_FILES_FILTER            "FLASH files (*.bin *.hex *.dfu);;" BIN_FILES_FILTER HEX_FILES_FILTER DFU_FILES_FILTER
+#define EXTERNAL_EEPROM_FILES_FILTER  "EEPROM files (*.bin *.hex);;" BIN_FILES_FILTER HEX_FILES_FILTER
+#define ER9X_EEPROM_FILE_TYPE         "ER9X_EEPROM_FILE"
+#define EEPE_EEPROM_FILE_HEADER       "EEPE EEPROM FILE"
+#define EEPE_MODEL_FILE_HEADER        "EEPE MODEL FILE"
+
 const char * const ARROW_LEFT = "\xE2\x86\x90";
 const char * const ARROW_UP = "\xE2\x86\x91";
 const char * const ARROW_RIGHT = "\xE2\x86\x92";

--- a/companion/src/flashfirmwaredialog.h
+++ b/companion/src/flashfirmwaredialog.h
@@ -26,18 +26,6 @@
 #include "firmwareinterface.h"
 #include "xmlinterface.h"
 
-#define HEX_FILES_FILTER              "HEX files (*.hex);;"
-#define BIN_FILES_FILTER              "BIN files (*.bin);;"
-#define DFU_FILES_FILTER              "DFU files (*.dfu);;"
-#define EEPE_FILES_FILTER             "EEPE EEPROM files (*.eepe);;"
-#define OTX_FILES_FILTER              "OpenTX files (*.otx);;"
-#define EEPROM_FILES_FILTER           "EEPE files (*.eepe *.bin *.hex);;" EEPE_FILES_FILTER BIN_FILES_FILTER HEX_FILES_FILTER
-#define FLASH_FILES_FILTER            "FLASH files (*.bin *.hex *.dfu);;" BIN_FILES_FILTER HEX_FILES_FILTER DFU_FILES_FILTER
-#define EXTERNAL_EEPROM_FILES_FILTER  "EEPROM files (*.bin *.hex);;" BIN_FILES_FILTER HEX_FILES_FILTER
-#define ER9X_EEPROM_FILE_TYPE         "ER9X_EEPROM_FILE"
-#define EEPE_EEPROM_FILE_HEADER       "EEPE EEPROM FILE"
-#define EEPE_MODEL_FILE_HEADER        "EEPE MODEL FILE"
-
 namespace Ui
 {
   class FlashFirmwareDialog;

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -814,6 +814,7 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
   if (simulator) {
 #if defined(WIN32) && defined(WIN_USE_CONSOLE_STDIO)
     AllocConsole();
+    SetConsoleTitle("Companion Console");
     freopen("conin$", "r", stdin);
     freopen("conout$", "w", stdout);
     freopen("conout$", "w", stderr);
@@ -863,11 +864,11 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
     }
 
     dialog->exec();
+    delete dialog;
+    delete simuData;
 #if defined(WIN32) && defined(WIN_USE_CONSOLE_STDIO)
     FreeConsole();
 #endif
-    delete dialog;
-    delete simuData;
   }
   else {
     QMessageBox::warning(NULL,

--- a/companion/src/simulation/simulatordialog.cpp
+++ b/companion/src/simulation/simulatordialog.cpp
@@ -108,7 +108,7 @@ void SimulatorDialog::closeEvent (QCloseEvent *)
 {
   simulator->stop();
   timer->stop();
-  //g.simuWinGeo(GetCurrentFirmware()->getId(), saveGeometry());
+  g.profile[g.id()].simuWinGeo(saveGeometry());
 }
 
 void SimulatorDialog::showEvent(QShowEvent * event)
@@ -343,7 +343,7 @@ void SimulatorDialog::initUi(T * ui)
   setupGVarsDisplay();
   setTrims();
 
-  //restoreGeometry(g.simuWinGeo(GetCurrentFirmware()->getId()));
+  restoreGeometry(g.profile[g.id()].simuWinGeo());
 
   if (flags & SIMULATOR_FLAGS_NOTX)
     tabWidget->setCurrentIndex(1);

--- a/companion/src/simulation/simulatordialog.cpp
+++ b/companion/src/simulation/simulatordialog.cpp
@@ -115,7 +115,7 @@ void SimulatorDialog::showEvent(QShowEvent * event)
 {
   static bool firstShow = true;
   if (firstShow) {
-    if (flags & SIMULATOR_FLAGS_STICK_MODE_LEFT) {
+    if (flags & SIMULATOR_FLAGS_STICK_MODE_LEFT || ((flags & SIMULATOR_FLAGS_STANDALONE) && (g.profile[g.id()].defaultMode() & 1))) {
       vJoyLeft->setStickConstraint(VirtualJoystickWidget::HOLD_Y, true);
       vJoyLeft->setStickY(1);
     }

--- a/companion/src/simulation/simulatordialog.h
+++ b/companion/src/simulation/simulatordialog.h
@@ -73,8 +73,8 @@ class SimulatorDialog : public QDialog
 
     void start(const char * filename);
     void start(QByteArray & eeprom);
+    void setRadioProfileId(int value);
     virtual void traceCallback(const char * text);
-
 
   protected:
     template <class T> void initUi(T * ui);
@@ -110,16 +110,18 @@ class SimulatorDialog : public QDialog
 #endif
 
     SimulatorInterface *simulator;
+    int radioProfileId;
     unsigned int lastPhase;
 
-    void setupTimer();
     QFrame * createLogicalSwitch(QWidget * parent, int switchNo, QVector<QLabel *> & labels);
     void setupOutputsDisplay();
     void setupGVarsDisplay();
 
+    void startCommon();
+    void setupTimer();
+
     void centerSticks();
     void setTrims();
-
     void setValues();
     virtual void getValues() = 0;
     int getValue(qint8 i);

--- a/companion/src/simulation/simulatordialog.h
+++ b/companion/src/simulation/simulatordialog.h
@@ -54,11 +54,12 @@ class VirtualJoystickWidget;
 #define SIMULATOR_FLAGS_S1                4
 #define SIMULATOR_FLAGS_S2                8
 #define SIMULATOR_FLAGS_S3               16
-#define SIMULATOR_FLAGS_S4               32 // reserved for the future
+#define SIMULATOR_FLAGS_S4               32  // reserved for the future
 #define SIMULATOR_FLAGS_S1_MULTI         64
 #define SIMULATOR_FLAGS_S2_MULTI        128
 #define SIMULATOR_FLAGS_S3_MULTI        256
-#define SIMULATOR_FLAGS_S4_MULTI        512 // reserved for the future
+#define SIMULATOR_FLAGS_S4_MULTI        512  // reserved for the future
+#define SIMULATOR_FLAGS_STANDALONE     1024  // started from stanalone simulator
 
 void traceCb(const char * text);
 

--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -19,20 +19,22 @@
  */
 
 #include <QApplication>
-#include <QTranslator>
+//#include <QTranslator>
 #include <QLocale>
 #include <QString>
 #include <QDir>
-#include <QFileInfo>
-#include <QSplashScreen>
-#include <QThread>
 #include <QDebug>
 #include <QTextStream>
+#include <QDialog>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QToolButton>
 #if defined(JOYSTICKS) || defined(SIMU_AUDIO)
   #include <SDL.h>
   #undef main
 #endif
 #include "simulatordialog.h"
+#include "constants.h"
 #include "eeprominterface.h"
 #include "appdata.h"
 #include "qxtcommandoptions.h"
@@ -62,11 +64,156 @@ class MyProxyStyle : public QProxyStyle
  };
 #endif
 
-void showMessage(const QString & message, enum QMessageBox::Icon icon = QMessageBox::NoIcon) {
+typedef struct
+{
+  int profileId;
+  QString firmwareId;
+  QString eepromFileName;
+} simulatorOptions_t;
+
+
+QDir g_eepromDirectory;
+
+int finish(int exitCode);
+
+void showMessage(const QString & message, enum QMessageBox::Icon icon = QMessageBox::NoIcon)
+{
   QMessageBox msgBox;
   msgBox.setText(message);
   msgBox.setIcon(icon);
   msgBox.exec();
+}
+
+QString radioEepromFileName(QString firmwareId)
+{
+  QString eepromFileName = "";
+  QString radioId = firmwareId;
+  int pos = firmwareId.indexOf("-");
+  if (pos > 0) {
+    radioId = firmwareId.mid(pos+1);
+    pos = radioId.lastIndexOf("-");
+    if (pos > 0) {
+      radioId = radioId.mid(0, pos);
+    }
+  }
+  eepromFileName = QString("eeprom-%1.bin").arg(radioId);
+  eepromFileName = g_eepromDirectory.filePath(eepromFileName.toLatin1());
+  // qDebug() << "radioId" << radioId << "eepromFileName" << eepromFileName;
+
+  return eepromFileName;
+}
+
+bool startupOptionsDialog(simulatorOptions_t &opts)
+{
+  bool ret = false;
+  QString label;
+
+  QDialog * dialog = new QDialog();
+  dialog->setWindowFlags(dialog->windowFlags() & (~ Qt::WindowContextHelpButtonHint));
+
+  QFormLayout * form = new QFormLayout(dialog);
+  form->addRow(new QLabel(QObject::tr("Simulator Startup Options:")));
+
+  label = QObject::tr("Profile:");
+  QComboBox * cbProf = new QComboBox();
+  cbProf->setToolTip(QObject::tr("Existing radio profiles are shown here.<br/>" \
+                                 "Create or edit profiles using the Companion application."));
+  QMapIterator<int, QString> pi(g.getActiveProfiles());
+  while (pi.hasNext()) {
+    pi.next();
+    cbProf->addItem(pi.value(), pi.key());
+    if (pi.key() == opts.profileId)
+      cbProf->setCurrentIndex(cbProf->count() - 1);
+  }
+  form->addRow(label, cbProf);
+
+  label = QObject::tr("Radio Type:");
+  QComboBox * cbType = new QComboBox();
+  cbType->setToolTip(QObject::tr("Existing radio simulators are shown here.<br/>" \
+                                 "The radio type specified in the selected profile is used by default."));
+  cbType->addItems(registered_simulators.keys());
+  cbType->setCurrentIndex(cbType->findText(opts.firmwareId));
+  form->addRow(label, cbType);
+
+  label = QObject::tr("EEPROM Image:");
+  QLineEdit * fwFile = new QLineEdit(opts.eepromFileName, dialog);
+  fwFile->setToolTip(QObject::tr("EEPROM image file to use. A new file with a default image will be created if necessary.<br />" \
+                                 "<b>NOTE</b>: any existing EEPROM data incompatible with the selected radio type may be overwritten!"));
+  QToolButton * fwBtn = new QToolButton(dialog);
+  fwBtn->setText("...");
+  fwBtn->setToolButtonStyle(Qt::ToolButtonTextOnly);
+  fwBtn->setToolTip(QObject::tr("Select EEPROM image file..."));
+  QWidget * fw = new QWidget(dialog);
+  QHBoxLayout * hl = new QHBoxLayout(fw);
+  hl->setContentsMargins(0, 0, 0, 0);
+  hl->setSpacing(2);
+  hl->addWidget(fwFile, 2);
+  hl->addWidget(fwBtn, 0);
+  form->addRow(label, fw);
+
+  QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, dialog);
+  form->addRow(&buttonBox);
+
+  dialog->resize(400, dialog->sizeHint().height());
+
+  QObject::connect(&buttonBox, SIGNAL(accepted()), dialog, SLOT(accept()));
+  QObject::connect(&buttonBox, SIGNAL(rejected()), dialog, SLOT(reject()));
+
+  // set new default radio type when profile choice changes
+  QObject::connect(cbProf, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [cbProf, cbType](int index) {
+    if (index < 0)
+      return;
+    SimulatorFactory * sf = getSimulatorFactory(g.profile[index].fwType());
+    if (sf) {
+      int i = cbType->findText(sf->name());
+      if (i > -1)
+        cbType->setCurrentIndex(i);
+    }
+  });
+
+  // set new default firmware file when radio type changes
+  QObject::connect(cbType, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), [cbType, fwFile](int index) {
+    if (index < 0)
+      return;
+    fwFile->setText(radioEepromFileName(cbType->currentText()));
+  });
+
+  // connect button to file selector dialog
+  QObject::connect(fwBtn, &QToolButton::clicked, [dialog, fwFile, cbType, opts](bool) {
+    QString filter = QObject::tr((cbType->currentText().contains("horus") ? OTX_FILES_FILTER : EEPROM_FILES_FILTER));
+    filter += QObject::tr("All files (*.*)");
+    QString file = QFileDialog::getSaveFileName(dialog, QObject::tr("Select EEPROM image"), opts.eepromFileName,
+                                                filter, NULL, QFileDialog::DontConfirmOverwrite);
+    if (!file.isEmpty())
+      fwFile->setText(file);
+  });
+
+  // go
+  if (dialog->exec() == QDialog::Accepted) {
+    opts.profileId = cbProf->currentData().toInt();
+    opts.firmwareId = cbType->currentText();
+    opts.eepromFileName = fwFile->text();
+    ret = true;
+  }
+
+  dialog->deleteLater();
+  return ret;
+}
+
+void sharedHelpText(QTextStream &stream)
+{
+  // list all available profiles
+  stream << endl << QObject::tr("Available profiles:") << endl;
+  QMapIterator<int, QString> pi(g.getActiveProfiles());
+  while (pi.hasNext()) {
+    pi.next();
+    stream << "\t" << QObject::tr("ID: ") << pi.key() << QObject::tr(" Name: ") << pi.value() << endl;
+  }
+  // list all available radios
+  stream << endl << QObject::tr("Available radios:") << endl;
+  foreach(QString name, registered_simulators.keys()) {
+    stream << "\t" << name << endl;
+  }
 }
 
 int main(int argc, char *argv[])
@@ -118,122 +265,144 @@ int main(int argc, char *argv[])
 #endif
 
   SimulatorDialog *dialog;
-  QString eepromFileName;
-  QDir eedir;
-  QFile file;
+  simulatorOptions_t simOptions;
+  QxtCommandOptions cliOptions;
+  bool cliOptsFound = false;
+
+  g_eepromDirectory = QDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+  if (!g_eepromDirectory.exists("OpenTX")) {
+    if (!g_eepromDirectory.mkpath("OpenTX")) {
+      showMessage(QObject::tr("WARNING: couldn't create directory for EEPROM:\n%1").arg(g_eepromDirectory.absoluteFilePath("OpenTX")), QMessageBox::Warning);
+    }
+  }
+  g_eepromDirectory.cd("OpenTX");
 
   registerSimulators();
   registerOpenTxFirmwares();
 
-  eedir = QDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
-  if (!eedir.exists("OpenTX")) {
-    if (!eedir.mkpath("OpenTX")) {
-      showMessage(QObject::tr("WARNING: couldn't create directory for EEPROM:\n%1").arg(eedir.absoluteFilePath("OpenTX")), QMessageBox::Warning);
-    }
-  }
-  eedir.cd("OpenTX");
-
-  QStringList firmwareIds;
-  int currentIdx = 0;
-  foreach(SimulatorFactory *factory, registered_simulators) {
-    firmwareIds << factory->name();
-    if (factory->name() == g.lastSimulator()) {
-      currentIdx = firmwareIds.size() - 1;
-    }
+  if (!registered_simulators.size()) {
+    showMessage(QObject::tr("ERROR: No simulator libraries available."), QMessageBox::Critical);
+    return finish(3);
   }
 
-  QxtCommandOptions options;
-  options.add("radio", "radio to simulate", QxtCommandOptions::ValueRequired);
-  options.alias("radio", "r");
-  options.add("help", "show this help text");
-  options.alias("help", "h");
-  options.parse(QCoreApplication::arguments());
-  if (options.count("help") || options.showUnrecognizedWarning()) {
+  cliOptions.add("profile", QObject::tr("Radio profile ID or Name to use for simulator."), QxtCommandOptions::ValueRequired);
+  cliOptions.alias("profile", "p");
+  cliOptions.add("radio", QObject::tr("Radio type to simulate (usually defined in profile)."), QxtCommandOptions::ValueRequired);
+  cliOptions.alias("radio", "r");
+  cliOptions.add("help", QObject::tr("show this help text"));
+  cliOptions.alias("help", "h");
+  cliOptions.parse(QCoreApplication::arguments());
+  if (cliOptions.count("help") || cliOptions.showUnrecognizedWarning()) {
     QString msg;
     QTextStream stream(&msg);
-    stream << "Usage: simulator [OPTION]... [EEPROM.BIN FILE] " << endl << endl;
-    stream << "Options:" << endl;
-    options.showUsage(false, stream);
-    // list all available radios
-    stream << endl << "Available radios:" << endl;
-    foreach(QString name, firmwareIds) {
-      stream << "\t" << name << endl;
-    }
+    stream << QObject::tr("Usage: simulator [OPTION]... [EEPROM.BIN FILE] ") << endl << endl;
+    stream << QObject::tr("Options:") << endl;
+    cliOptions.showUsage(false, stream);
+    sharedHelpText(stream);
     // display
     showMessage(msg, QMessageBox::Information);
-    return 1;
+    return finish(1);
   }
 
-
-  bool ok = false;
-  QString firmwareId;
-  if (options.count("radio") == 1) {
-    firmwareId = options.value("radio").toString();
-    if (firmwareIds.contains(firmwareId)) {
-      ok = true;
-    }
-  }
-  if (!ok) {
-    firmwareId = QInputDialog::getItem(0, QObject::tr("Radio type"),
-                                                QObject::tr("Which radio type do you want to simulate?"),
-                                                firmwareIds, currentIdx, false, &ok);
-  }
-  qDebug() << "firmwareId" << firmwareId;
-
-  if (ok && !firmwareId.isEmpty()) {
-    if (firmwareId != g.lastSimulator()) {
-      g.lastSimulator(firmwareId);
-    }
-    QString radioId;
-    int pos = firmwareId.indexOf("-");
-    if (pos > 0) {
-      radioId = firmwareId.mid(pos+1);
-      pos = radioId.lastIndexOf("-");
-      if (pos > 0) {
-        radioId = radioId.mid(0, pos);
-      }
-    }
-    qDebug() << "radioId" << radioId;
-    current_firmware_variant = GetFirmware(firmwareId);
-    qDebug() << "current_firmware_variant" << current_firmware_variant->getName();
-
-    if (options.positional().isEmpty()) {
-      eepromFileName = QString("eeprom-%1.bin").arg(radioId);
-      eepromFileName = eedir.filePath(eepromFileName.toLatin1());
-    }
-    else {
-      eepromFileName = options.positional()[0];
-    }
-    qDebug() << "eepromFileName" << eepromFileName;
-    // TODO display used eeprom filename somewhere
-
-    uint32_t flags = SIMULATOR_FLAGS_STANDALONE;
-
-    SimulatorFactory * factory = getSimulatorFactory(firmwareId);
-    if (!factory) {
-      showMessage(QObject::tr("ERROR: Simulator %1 not found").arg(firmwareId), QMessageBox::Critical);
-      return 2;
-    }
-    if (factory->type() == BOARD_HORUS)
-      dialog = new SimulatorDialogHorus(NULL, factory->create(), flags);
-    else if (factory->type() == BOARD_FLAMENCO)
-      dialog = new SimulatorDialogFlamenco(NULL, factory->create(), flags);
-    else if (factory->type() == BOARD_TARANIS_X9D || factory->type() == BOARD_TARANIS_X9DP || factory->type() == BOARD_TARANIS_X9E)
-      dialog = new SimulatorDialogTaranis(NULL, factory->create(), flags | SIMULATOR_FLAGS_S1 | SIMULATOR_FLAGS_S2);
-    else
-      dialog = new SimulatorDialog9X(NULL, factory->create(), flags);
+  if (cliOptions.count("radio") == 1) {
+    simOptions.firmwareId = cliOptions.value("radio").toString();
+    cliOptsFound = true;
   }
   else {
-    return 0;
+    simOptions.firmwareId = g.lastSimulator();
   }
 
-  dialog->show();
-  dialog->start(eepromFileName.toLatin1().constData());
+  if (cliOptions.count("profile") == 1) {
+    bool chk;
+    int pid = cliOptions.value("profile").toInt(&chk);
+    if (chk) {
+      simOptions.profileId = pid;
+    }
+    else {
+      simOptions.profileId = g.getActiveProfiles().key(cliOptions.value("profile").toString(), -1);
+    }
+    // load default radio for this profile if not already passed on command line
+    if (!cliOptsFound) {
+      SimulatorFactory * sf = getSimulatorFactory(g.profile[simOptions.profileId].fwType());
+      if (sf)
+        simOptions.firmwareId = sf->name();
+    }
+    cliOptsFound = true;
+  }
+  else if (g.simuLastProfId() != -1) {
+    simOptions.profileId = g.simuLastProfId();
+  }
+  else {
+    simOptions.profileId = g.id();
+  }
 
+  if (!cliOptions.positional().isEmpty()) {
+    simOptions.eepromFileName = cliOptions.positional()[0];
+    cliOptsFound = true;
+  }
+  else if (cliOptsFound || g.simuLastEepe().isEmpty()) {
+    simOptions.eepromFileName = radioEepromFileName(simOptions.firmwareId);
+  }
+  else {
+    simOptions.eepromFileName = g.simuLastEepe();
+  }
+
+  if (!cliOptsFound || simOptions.profileId == -1 || simOptions.firmwareId.isEmpty() || simOptions.eepromFileName.isEmpty()) {
+    if (!startupOptionsDialog(simOptions)) {
+      return finish(0);
+    }
+  }
+  qDebug() << "firmwareId" << simOptions.firmwareId << "profileId" << simOptions.profileId << "eepromFileName" << simOptions.eepromFileName;
+
+  if (simOptions.profileId < 0 || simOptions.firmwareId.isEmpty() || simOptions.eepromFileName.isEmpty()) {
+    showMessage(QObject::tr("ERROR: Couldn't start simulator, missing radio/profile/EEPROM file.\nProfile ID: [%1]; Radio ID: [%2]\nEEPROM File: [%3]")
+                .arg(simOptions.profileId).arg(simOptions.firmwareId).arg(simOptions.eepromFileName), QMessageBox::Critical);
+    return finish(1);
+  }
+  if (!g.getActiveProfiles().contains(simOptions.profileId) || !registered_simulators.keys().contains(simOptions.firmwareId)) {
+    QString msg;
+    QTextStream stream(&msg);
+    stream << QObject::tr("ERROR: Radio profile or simulator firmware not found.\nProfile ID: [%1]; Radio ID: [%2]")
+                    .arg(simOptions.profileId).arg(simOptions.firmwareId);
+    sharedHelpText(stream);
+    showMessage(msg, QMessageBox::Critical);
+    return finish(2);
+  }
+
+  SimulatorFactory * factory = getSimulatorFactory(simOptions.firmwareId);
+  if (!factory) {
+    showMessage(QObject::tr("ERROR: Simulator %1 not found").arg(simOptions.firmwareId), QMessageBox::Critical);
+    return finish(2);
+  }
+
+  g.simuLastProfId(simOptions.profileId);
+  g.lastSimulator(simOptions.firmwareId);
+  g.simuLastEepe(simOptions.eepromFileName);
+
+  uint32_t flags = SIMULATOR_FLAGS_STANDALONE;
+
+  if (factory->type() == BOARD_HORUS)
+    dialog = new SimulatorDialogHorus(NULL, factory->create(), flags);
+  else if (factory->type() == BOARD_FLAMENCO)
+    dialog = new SimulatorDialogFlamenco(NULL, factory->create(), flags);
+  else if (factory->type() == BOARD_TARANIS_X9D || factory->type() == BOARD_TARANIS_X9DP || factory->type() == BOARD_TARANIS_X9E)
+    dialog = new SimulatorDialogTaranis(NULL, factory->create(), flags | SIMULATOR_FLAGS_S1 | SIMULATOR_FLAGS_S2);
+  else
+    dialog = new SimulatorDialog9X(NULL, factory->create(), flags);
+
+  dialog->setRadioProfileId(simOptions.profileId);
+  dialog->start(simOptions.eepromFileName.toLatin1().constData());
+
+  dialog->show();
   int result = app.exec();
 
-  delete dialog;
+  dialog->deleteLater();
 
+  return finish(result);
+}
+
+int finish(int exitCode)
+{
   unregisterSimulators();
   unregisterOpenTxFirmwares();
 
@@ -244,5 +413,5 @@ int main(int argc, char *argv[])
   FreeConsole();
 #endif
 
-  return result;
+  return exitCode;
 }

--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
 #endif
 #if defined(WIN32) && defined(WIN_USE_CONSOLE_STDIO)
   AllocConsole();
+  SetConsoleTitle("Simulator Console");
   freopen("conin$", "r", stdin);
   freopen("conout$", "w", stdout);
   freopen("conout$", "w", stderr);
@@ -206,19 +207,21 @@ int main(int argc, char *argv[])
     qDebug() << "eepromFileName" << eepromFileName;
     // TODO display used eeprom filename somewhere
 
+    uint32_t flags = SIMULATOR_FLAGS_STANDALONE;
+
     SimulatorFactory * factory = getSimulatorFactory(firmwareId);
     if (!factory) {
       showMessage(QObject::tr("ERROR: Simulator %1 not found").arg(firmwareId), QMessageBox::Critical);
       return 2;
     }
     if (factory->type() == BOARD_HORUS)
-      dialog = new SimulatorDialogHorus(NULL, factory->create());
+      dialog = new SimulatorDialogHorus(NULL, factory->create(), flags);
     else if (factory->type() == BOARD_FLAMENCO)
-      dialog = new SimulatorDialogFlamenco(NULL, factory->create());
+      dialog = new SimulatorDialogFlamenco(NULL, factory->create(), flags);
     else if (factory->type() == BOARD_TARANIS_X9D || factory->type() == BOARD_TARANIS_X9DP || factory->type() == BOARD_TARANIS_X9E)
-      dialog = new SimulatorDialogTaranis(NULL, factory->create(), SIMULATOR_FLAGS_S1|SIMULATOR_FLAGS_S2);
+      dialog = new SimulatorDialogTaranis(NULL, factory->create(), flags | SIMULATOR_FLAGS_S1 | SIMULATOR_FLAGS_S2);
     else
-      dialog = new SimulatorDialog9X(NULL, factory->create());
+      dialog = new SimulatorDialog9X(NULL, factory->create(), flags);
   }
   else {
     return 0;

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -537,6 +537,7 @@ QString AppData::programmer()      { return _programmer;      }
 QString AppData::sambaLocation()   { return _sambaLocation;   }
 QString AppData::sambaPort()       { return _sambaPort;       }
 QString AppData::lastSimulator()   { return _lastSimulator;   }
+QString AppData::simuLastEepe()    { return _simuLastEepe;    }
 
 QString AppData::backupDir()       { return _backupDir;       }
 QString AppData::gePath()          { return _gePath;          }
@@ -567,6 +568,7 @@ int AppData::jsCtrl()              { return _jsCtrl;          }
 int AppData::id()                  { return _id;              }
 int AppData::theme()               { return _theme;           }
 int AppData::warningId()           { return _warningId;       }
+int AppData::simuLastProfId()      { return _simuLastProfId;  }
 
 // Set declarations
 void AppData::recentFiles     (const QStringList x) { store(x, _recentFiles,     "recentFileList"          );}
@@ -586,6 +588,7 @@ void AppData::programmer      (const QString     x) { store(x, _programmer,     
 void AppData::sambaLocation   (const QString     x) { store(x, _sambaLocation,   "samba_location"          );}
 void AppData::sambaPort       (const QString     x) { store(x, _sambaPort,       "samba_port"              );}
 void AppData::lastSimulator   (const QString     x) { store(x, _lastSimulator,   "last_simulator"          );}
+void AppData::simuLastEepe    (const QString     x) { store(x, _simuLastEepe,    "simuLastEepe"            );}
 
 void AppData::backupDir       (const QString     x) { store(x, _backupDir,       "backupPath"              );}
 void AppData::gePath          (const QString     x) { store(x, _gePath,          "gePath"                  );}
@@ -616,6 +619,7 @@ void AppData::jsCtrl          (const int         x) { store(x, _jsCtrl,         
 void AppData::id              (const int         x) { store(x, _id,              "profileId"               );}
 void AppData::theme           (const int         x) { store(x, _theme,           "theme"                   );}
 void AppData::warningId       (const int         x) { store(x, _warningId,       "warningId"               );}
+void AppData::simuLastProfId  (const int         x) { store(x, _simuLastProfId,  "simuLastProfId"          );}
 
 // Constructor
 AppData::AppData()
@@ -773,6 +777,7 @@ void AppData::init()
     getset( _sambaLocation,   "samba_location"          ,"" );
     getset( _sambaPort,       "samba_port"              ,"\\USBserial\\COM23" );
     getset( _lastSimulator,   "last_simulator"          ,"" );
+    getset( _simuLastEepe,    "simuLastEepe"            ,"" );
 
     getset( _backupDir,       "backupPath"              ,"" );
     getset( _gePath,          "gePath"                  ,"" );
@@ -811,4 +816,15 @@ void AppData::init()
     getset( _id,              "profileId"               ,0  );
     getset( _theme,           "theme"                   ,1  );
     getset( _warningId,       "warningId"               ,0  );
+    getset( _simuLastProfId,  "simuLastProfId"          ,-1 );
+}
+
+QMap<int, QString> AppData::getActiveProfiles()
+{
+  QMap<int, QString> active;
+  for (int i=0; i<MAX_PROFILES; i++) {
+    if (g.profile[i].existsOnDisk())
+      active.insert(i, g.profile[i].name());
+  }
+  return active;
 }

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -310,6 +310,8 @@ bool    Profile::renameFwFiles() const { return _renameFwFiles; }
 int     Profile::channelOrder()  const { return _channelOrder;  }
 int     Profile::defaultMode()   const { return _defaultMode;   }
 
+QByteArray Profile::simuWinGeo() const { return _simuWinGeo;    }
+
 QString Profile::beeper()        const { return _beeper;        }
 QString Profile::countryCode()   const { return _countryCode;   }
 QString Profile::display()       const { return _display;       }
@@ -342,6 +344,8 @@ void Profile::penableBackup (const bool    x) { store(x, _penableBackup, "penabl
 void Profile::channelOrder  (const int     x) { store(x, _channelOrder,  "default_channel_order" ,"Profiles", QString("profile%1").arg(index));}
 void Profile::defaultMode   (const int     x) { store(x, _defaultMode,   "default_mode"          ,"Profiles", QString("profile%1").arg(index));}
 
+void Profile::simuWinGeo    (const QByteArray x) { store(x, _simuWinGeo, "simuWindowGeometry"    ,"Profiles", QString("profile%1").arg(index));}
+
 void Profile::beeper        (const QString x) { store(x, _beeper,        "Beeper"                ,"Profiles", QString("profile%1").arg(index));}
 void Profile::countryCode   (const QString x) { store(x, _countryCode,   "countryCode"           ,"Profiles", QString("profile%1").arg(index));}
 void Profile::display       (const QString x) { store(x, _display,       "Display"               ,"Profiles", QString("profile%1").arg(index));}
@@ -352,10 +356,10 @@ void Profile::timeStamp     (const QString x) { store(x, _timeStamp,     "TimeSt
 void Profile::trainerCalib  (const QString x) { store(x, _trainerCalib,  "TrainerCalib"          ,"Profiles", QString("profile%1").arg(index));}
 void Profile::controlTypes  (const QString x) { store(x, _controlTypes,  "ControlTypes"          ,"Profiles", QString("profile%1").arg(index));}
 void Profile::controlNames  (const QString x) { store(x, _controlNames,  "ControlNames"          ,"Profiles", QString("profile%1").arg(index));}
-void Profile::txCurrentCalibration  (const int x) { store(x, _txCurrentCalibration, "currentCalib","Profiles", QString("profile%1").arg(index));}
+void Profile::txCurrentCalibration (const int x) { store(x, _txCurrentCalibration, "currentCalib","Profiles", QString("profile%1").arg(index));}
 void Profile::gsStickMode   (const int     x) { store(x, _gsStickMode,   "GSStickMode"           ,"Profiles", QString("profile%1").arg(index));}
 void Profile::ppmMultiplier (const int     x) { store(x, _ppmMultiplier, "PPM_Multiplier"        ,"Profiles", QString("profile%1").arg(index));}
-void Profile::txVoltageCalibration     (const int x) { store(x, _txVoltageCalibration, "VbatCalib","Profiles", QString("profile%1").arg(index));}
+void Profile::txVoltageCalibration (const int x) { store(x, _txVoltageCalibration, "VbatCalib","Profiles", QString("profile%1").arg(index));}
 void Profile::vBatWarn      (const int     x) { store(x, _vBatWarn,      "vBatWarn"              ,"Profiles", QString("profile%1").arg(index));}
 void Profile::vBatMin       (const int     x) { store(x, _vBatMin,       "VbatMin"               ,"Profiles", QString("profile%1").arg(index));}
 void Profile::vBatMax       (const int     x) { store(x, _vBatMax,       "VbatMax"               ,"Profiles", QString("profile%1").arg(index));}
@@ -464,6 +468,8 @@ void Profile::init(int newIndex)
     _channelOrder =  0;
     _defaultMode =   1;
 
+    _simuWinGeo = QByteArray();
+
     initFwVariables();
 
     // Do not write empty profiles to disk except the default (0) profile.
@@ -488,6 +494,8 @@ void Profile::flush()
     getset( _renameFwFiles, "rename_firmware_files" ,false  ,"Profiles", QString("profile%1").arg(index));
     getset( _channelOrder,  "default_channel_order" ,0      ,"Profiles", QString("profile%1").arg(index));
     getset( _defaultMode,   "default_mode"          ,1      ,"Profiles", QString("profile%1").arg(index));
+
+    getset( _simuWinGeo,    "simuWindowGeometry"    ,""     ,"Profiles", QString("profile%1").arg(index));
 
     getset( _beeper,        "Beeper"                ,""     ,"Profiles", QString("profile%1").arg(index));
     getset( _countryCode,   "countryCode"           ,""     ,"Profiles", QString("profile%1").arg(index));

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -122,6 +122,9 @@ class Profile: protected CompStoreObj
     int     _channelOrder;
     int     _defaultMode;
 
+    // Simulator variables
+    QByteArray _simuWinGeo;
+
     // Firmware Variables
     QString _beeper;
     QString _countryCode;
@@ -156,6 +159,8 @@ class Profile: protected CompStoreObj
     int     channelOrder() const;
     int     defaultMode() const;
 
+    QByteArray simuWinGeo() const;
+
     QString beeper() const;
     QString countryCode() const;
     QString display() const;
@@ -187,6 +192,8 @@ class Profile: protected CompStoreObj
     void penableBackup (const bool);
     void channelOrder  (const int);
     void defaultMode   (const int);
+
+    void simuWinGeo    (const QByteArray);
 
     void beeper        (const QString);
     void countryCode   (const QString);

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -262,6 +262,7 @@ class AppData: protected CompStoreObj
     QString _sambaLocation;
     QString _sambaPort;
     QString _lastSimulator;
+    QString _simuLastEepe;
 
     QString _backupDir;
     QString _gePath;
@@ -292,6 +293,7 @@ class AppData: protected CompStoreObj
     int _id;
     int _theme;
     int _warningId;
+    int _simuLastProfId;
 
   public:
     // All the get definitions
@@ -313,6 +315,7 @@ class AppData: protected CompStoreObj
     QString sambaLocation();
     QString sambaPort();
     QString lastSimulator();
+    QString simuLastEepe();
 
     QString backupDir();
     QString gePath();
@@ -343,6 +346,7 @@ class AppData: protected CompStoreObj
     int id();
     int theme();
     int warningId();
+    int simuLastProfId();
 
     // All the set definitions
     void recentFiles     (const QStringList x);
@@ -363,6 +367,7 @@ class AppData: protected CompStoreObj
     void sambaLocation   (const QString);
     void sambaPort       (const QString);
     void lastSimulator   (const QString);
+    void simuLastEepe    (const QString);
 
     void backupDir       (const QString);
     void gePath          (const QString);
@@ -394,10 +399,13 @@ class AppData: protected CompStoreObj
     void id              (const int);
     void theme           (const int);
     void warningId       (const int);
+    void simuLastProfId  (const int);
 
     // Constructor
     AppData();
     void init();
+
+    QMap<int, QString> getActiveProfiles();
 };
 
 extern AppData g;


### PR DESCRIPTION
- Radio profile used for standalone Simulator can now be separate from Companion;
- Allow selecting a radio profile and EEPROM image file (in addition to radio type) at startup via GUI and CLI;
- All startup settings are saved between uses.
- Save and restore Simulator window sizes and positions (based on selected radio profile).
- Set startup throttle stick lock in standalone sim based on default mode in selected radio profile (until we can read that from the model settings).

![simu_new_startup_linux](https://cloud.githubusercontent.com/assets/1366615/21471858/b9060252-ca8e-11e6-9644-861c2b632174.png)

So the biggest change here is that you no longer have to go into Companion to switch radio profiles before starting sim with different radios.  Especially handy for developers & testers.  You still use Companion to create/edit profiles, as  before.

Though I ended up changing a lot of `simulator.cpp` in the process (hopefully for the better, but the diff isn't easy to follow).

-Max

![simu-new-startup-help](https://cloud.githubusercontent.com/assets/1366615/21472196/8580df1c-ca9b-11e6-8dd7-b6c371315905.png)
