### PR TITLE
Simulator key/mouse mapping improvements

### DIFF
--- a/companion/src/simulation/simulatordialog-horus.ui
+++ b/companion/src/simulation/simulatordialog-horus.ui
@@ -134,6 +134,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -208,6 +211,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -248,6 +254,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -286,6 +295,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">
@@ -396,6 +408,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -434,6 +449,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">
@@ -477,7 +495,7 @@
             <bool>true</bool>
            </property>
            <property name="invertedControls">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
@@ -551,6 +569,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">

--- a/companion/src/simulation/simulatordialog-taranis.ui
+++ b/companion/src/simulation/simulatordialog-taranis.ui
@@ -446,6 +446,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -500,7 +503,7 @@
             <bool>true</bool>
            </property>
            <property name="invertedControls">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
@@ -561,6 +564,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -601,6 +607,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -639,6 +648,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">
@@ -684,6 +696,9 @@
            <property name="invertedAppearance">
             <bool>true</bool>
            </property>
+           <property name="invertedControls">
+            <bool>true</bool>
+           </property>
            <property name="tickPosition">
             <enum>QSlider::TicksBothSides</enum>
            </property>
@@ -722,6 +737,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">
@@ -805,6 +823,9 @@
             <enum>Qt::Vertical</enum>
            </property>
            <property name="invertedAppearance">
+            <bool>true</bool>
+           </property>
+           <property name="invertedControls">
             <bool>true</bool>
            </property>
            <property name="tickPosition">

--- a/companion/src/simulation/simulatordialog.h
+++ b/companion/src/simulation/simulatordialog.h
@@ -77,6 +77,7 @@ class SimulatorDialog : public QDialog
     virtual void traceCallback(const char * text);
 
   protected:
+    typedef QPair<QString, QString> keymapHelp_t;
     template <class T> void initUi(T * ui);
     virtual void setLightOn(bool enable) { }
     virtual void updateBeepButton() { }
@@ -98,6 +99,7 @@ class SimulatorDialog : public QDialog
     VirtualJoystickWidget *vJoyRight;
     QTimer *timer;
     QString windowName;
+    QVector<keymapHelp_t> keymapHelp;
     unsigned int backLight;
     bool lightOn;
     int switches;
@@ -164,6 +166,7 @@ class SimulatorDialog : public QDialog
     void openDebugOutput();
     void onDebugOutputClose();
     void luaReload();
+    void showHelp();
 
 #ifdef JOYSTICKS
     void onjoystickAxisValueChanged(int axis, int value);

--- a/companion/src/simulation/simulatordialog9x.cpp
+++ b/companion/src/simulation/simulatordialog9x.cpp
@@ -18,7 +18,10 @@
  * GNU General Public License for more details.
  */
 
+#include "simulatordialog.h"
 #include "ui_simulatordialog-9x.h"
+#include "helpers.h"
+
 
 uint32_t SimulatorDialog9X::switchstatus = 0;
 
@@ -74,6 +77,14 @@ SimulatorDialog9X::SimulatorDialog9X(QWidget * parent, SimulatorInterface *simul
   //restore switches
   if (g.simuSW())
     restoreSwitches();
+
+  keymapHelp.append(keymapHelp_t(tr("UP/PG-UP"),         tr("[ UP ]")));
+  keymapHelp.append(keymapHelp_t(tr("DN/PG-DN"),         tr("[ DN ]")));
+  keymapHelp.append(keymapHelp_t(tr("LEFT/+"),           tr("[ + ]")));
+  keymapHelp.append(keymapHelp_t(tr("RIGHT/-"),          tr("[ - ]")));
+  keymapHelp.append(keymapHelp_t(tr("ENTER/MOUSE-MID"),  tr("[ MENU ]")));
+  keymapHelp.append(keymapHelp_t(tr("DEL/BKSP/ESC"),     tr("[ EXIT ]")));
+  keymapHelp.append(keymapHelp_t(tr("WHEEL/PAD SCRL"),   tr("[ UP ]/[ DN ] or Rotary Sel.")));
 
   for (int i=0; i<pots.count(); i++) {
     pots[i]->setProperty("index", i);
@@ -154,12 +165,12 @@ void SimulatorDialog9X::getValues()
     },
 
     {
-      buttonPressed == Qt::Key_Enter,
+      buttonPressed == Qt::Key_Enter || middleButtonPressed,
       buttonPressed == Qt::Key_Escape,
-      buttonPressed == Qt::Key_Down,
-      buttonPressed == Qt::Key_Up,
-      buttonPressed == Qt::Key_Right,
-      buttonPressed == Qt::Key_Left,
+      buttonPressed == Qt::Key_Down || buttonPressed == Qt::Key_PageDown,
+      buttonPressed == Qt::Key_Up || buttonPressed == Qt::Key_PageUp,
+      buttonPressed == Qt::Key_Right || buttonPressed == Qt::Key_Plus,
+      buttonPressed == Qt::Key_Left || buttonPressed == Qt::Key_Minus,
     },
 
     middleButtonPressed,

--- a/companion/src/simulation/simulatordialoghorus.cpp
+++ b/companion/src/simulation/simulatordialoghorus.cpp
@@ -49,7 +49,7 @@ SimulatorDialogHorus::SimulatorDialogHorus(QWidget * parent, SimulatorInterface 
   polygon.setPoints(19, 29,232, 23,225, 19,218, 16,210, 14,200, 13,190, 14,179, 17,170, 20,162, 25,155, 30,149, 43,164, 37,172, 34,181, 33,190, 34,200, 37,209, 41,215, 44,219);
   ui->leftbuttons->addArea(polygon, Qt::Key_PageUp, "Horus/left_btn1.png");
   polygon.setPoints(22, 32,234, 46,220, 52,225, 59,228, 68,230, 75,230, 83,229, 90,227, 95,224, 101,220, 114,234, 109,239, 103,242, 98,245, 91,248, 84,249, 77,250, 69,250, 60,249, 51,247, 44,243, 38,239);
-  ui->leftbuttons->addArea(polygon, Qt::Key_Escape, "Horus/left_btn2.png");
+  ui->leftbuttons->addArea(polygon, Qt::Key_PageDown, "Horus/left_btn2.png");
   ui->leftbuttons->addArea(9, 259, 34, 282, Qt::Key_Print, "Horus/left_scrnsht.png");
 
   // install simulator TRACE hook
@@ -62,6 +62,17 @@ SimulatorDialogHorus::SimulatorDialogHorus(QWidget * parent, SimulatorInterface 
   //restore switches
   if (g.simuSW())
     restoreSwitches();
+
+  keymapHelp.append(keymapHelp_t(tr("PG-UP"),           tr("[ PgUp ]")));
+  keymapHelp.append(keymapHelp_t(tr("PG-DN"),           tr("[ PgDn ]")));
+  keymapHelp.append(keymapHelp_t(tr("UP"),              tr("[ MDL ]")));
+  keymapHelp.append(keymapHelp_t(tr("DN/DEL/BKSP"),     tr("[ RTN ]")));
+  keymapHelp.append(keymapHelp_t(tr("LEFT"),            tr("[ SYS ]")));
+  keymapHelp.append(keymapHelp_t(tr("RIGHT"),           tr("[ TELE ]")));
+  keymapHelp.append(keymapHelp_t(tr("WHEEL/PAD SCRL"),  tr("Rotary Selector")));
+  keymapHelp.append(keymapHelp_t(tr("-/X"),             tr("Rotary UP")));
+  keymapHelp.append(keymapHelp_t(tr("+/C"),             tr("Rotary DOWN")));
+  keymapHelp.append(keymapHelp_t(tr("ENTER/MOUSE-MID"), tr("Selector Press")));
 
   connect(ui->leftbuttons, SIGNAL(buttonPressed(int)), this, SLOT(onButtonPressed(int)));
   connect(ui->rightbuttons, SIGNAL(buttonPressed(int)), this, SLOT(onButtonPressed(int)));
@@ -118,10 +129,10 @@ void SimulatorDialogHorus::getValues()
 
     {
       buttonPressed == Qt::Key_PageUp,
-      buttonPressed == Qt::Key_Escape,
+      buttonPressed == Qt::Key_PageDown,
       buttonPressed == Qt::Key_Enter || middleButtonPressed,
       buttonPressed == Qt::Key_Up,
-      buttonPressed == Qt::Key_Down,
+      buttonPressed == Qt::Key_Down || buttonPressed == Qt::Key_Escape,
       buttonPressed == Qt::Key_Right,
       buttonPressed == Qt::Key_Left
     },
@@ -146,6 +157,15 @@ void SimulatorDialogHorus::getValues()
   };
 
   simulator->setValues(inputs);
+
+  if (buttonPressed == Qt::Key_Plus || buttonPressed == Qt::Key_C) {
+    simulator->wheelEvent(1);
+    buttonPressed = 0;  // debounce, important
+  }
+  else if (buttonPressed == Qt::Key_Minus || buttonPressed == Qt::Key_X) {
+    simulator->wheelEvent(-1);
+    buttonPressed = 0;  // debounce, important
+  }
 }
 
 void SimulatorDialogHorus::saveSwitches(void)

--- a/companion/src/simulation/simulatordialogtaranis.cpp
+++ b/companion/src/simulation/simulatordialogtaranis.cpp
@@ -18,7 +18,10 @@
  * GNU General Public License for more details.
  */
 
+#include "simulatordialog.h"
 #include "ui_simulatordialog-taranis.h"
+#include "helpers.h"
+
 
 uint32_t SimulatorDialogTaranis::switchstatus = 0;
 
@@ -69,6 +72,14 @@ SimulatorDialogTaranis::SimulatorDialogTaranis(QWidget * parent, SimulatorInterf
       potLabels[i]->hide();
     }
   }
+
+  keymapHelp.append(keymapHelp_t(tr("PG-UP"),           tr("[ MENU ]")));
+  keymapHelp.append(keymapHelp_t(tr("PG-DN"),           tr("[ PAGE ]")));
+  keymapHelp.append(keymapHelp_t(tr("DEL/BKSP/ESC"),    tr("[ EXIT ]")));
+  keymapHelp.append(keymapHelp_t(tr("+/UP"),            tr("[ + ]")));
+  keymapHelp.append(keymapHelp_t(tr("-/DN"),            tr("[ - ]")));
+  keymapHelp.append(keymapHelp_t(tr("ENTER/MOUSE-MID"), tr("[ ENT ]")));
+  keymapHelp.append(keymapHelp_t(tr("WHEEL/PAD SCRL"),  tr("[ + ]/[ - ] or Rotary Sel.")));
 
   connect(ui->leftbuttons, SIGNAL(buttonPressed(int)), this, SLOT(onButtonPressed(int)));
   connect(ui->rightbuttons, SIGNAL(buttonPressed(int)), this, SLOT(onButtonPressed(int)));
@@ -134,10 +145,10 @@ void SimulatorDialogTaranis::getValues()
     {
       buttonPressed == Qt::Key_PageUp,
       buttonPressed == Qt::Key_Escape,
-      buttonPressed == Qt::Key_Enter,
+      buttonPressed == Qt::Key_Enter || middleButtonPressed,
       buttonPressed == Qt::Key_PageDown,
-      buttonPressed == Qt::Key_Plus,
-      buttonPressed == Qt::Key_Minus
+      buttonPressed == Qt::Key_Plus || buttonPressed == Qt::Key_Up,
+      buttonPressed == Qt::Key_Minus || buttonPressed == Qt::Key_Down
     },
 
     middleButtonPressed,

--- a/radio/src/targets/common/avr/board_avr.h
+++ b/radio/src/targets/common/avr/board_avr.h
@@ -56,7 +56,9 @@ enum EnumKeys
   KEY_ENTER=KEY_MENU,
   KEY_EXIT,
   KEY_DOWN,
+  KEY_MINUS = KEY_DOWN,
   KEY_UP,
+  KEY_PLUS = KEY_UP,
   KEY_RIGHT,
   KEY_LEFT,
   

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -158,6 +158,11 @@ void OpenTxSimulator::wheelEvent(int steps)
 {
 #if defined(ROTARY_ENCODER_NAVIGATION)
   ROTARY_ENCODER_NAVIGATION_VALUE += steps * ROTARY_ENCODER_GRANULARITY;
+#else
+  if (steps > 0)
+    simuSetKey(KEY_MINUS, 1);
+  else if (steps < 0)
+    simuSetKey(KEY_PLUS, 1);
 #endif
 }
 

--- a/radio/src/targets/sky9x/board.h
+++ b/radio/src/targets/sky9x/board.h
@@ -55,7 +55,9 @@ enum EnumKeys
   KEY_ENTER=KEY_MENU,
   KEY_EXIT,
   KEY_DOWN,
+  KEY_MINUS = KEY_DOWN,
   KEY_UP,
+  KEY_PLUS = KEY_UP,
   KEY_RIGHT,
   KEY_LEFT,
   


### PR DESCRIPTION
 - Make key/mouse navigation more consistent between radios and ensure keyboard events are always properly detected (eg. after clicking on a control);
- Fix mouse wheel direction for rotary encoder emulation (fixes #4160);
- Fix page up/down buttons on Horus (closes #4160);
- Horus rotary encoder can now be controlled with +/- keys (also keeps X/C keys, otherwise supersedes #4087 and fixes key repeat issue);
- DEL key now another alternative for ESC/BKSP (brings all controls to number pad);
- "=" key now acts same as "+" key (+ requires SHIFT in main row on most US keyboards);
- Fix controls direction when using mouse wheel over RC switches;
- Add help text showing keyboard mappings for each radio type (activate on F1 key -- a button will be added in future changes).
- Enable mouse wheel scrolling on radios w/out a rotary encoder (acts as +/- keys on X9D, PU/DN keys on 9X).

Full help text and 9X keymap:
![simu-keys-9x](https://cloud.githubusercontent.com/assets/1366615/21571945/34ff7c46-cea2-11e6-862f-f65098746a7f.png)
X9 keymap
![simu-keys-x9_crop](https://cloud.githubusercontent.com/assets/1366615/21572005/ae7e1f0a-cea2-11e6-98c9-9d77167e01e0.png)
Horus keymap:
![simu-keys-horus_crop](https://cloud.githubusercontent.com/assets/1366615/21572010/b30474ac-cea2-11e6-8e9e-0e97fb969d89.png)

