### PR TITLE
3djc/x7 custom scripts

### DIFF
--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -333,8 +333,6 @@ void editSingleName(coord_t x, coord_t y, const pm_char * label, char * name, ui
 uint8_t editDelay(coord_t y, event_t event, uint8_t attr, const pm_char * str, uint8_t delay);
 #define EDIT_DELAY(x, y, event, attr, str, delay) editDelay(y, event, attr, str, delay)
 
-void copySelection(char * dst, const char * src, uint8_t size);
-
 #define WARNING_TYPE_ASTERISK          0
 #define WARNING_TYPE_CONFIRM           1
 #define WARNING_TYPE_INPUT             2

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -311,7 +311,7 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min, int
 #endif
 
 void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event);
-  
+
 #if defined(GVARS)
 #define displayGVar(x, y, v, min, max) GVAR_MENU_ITEM(x, y, v, min, max, 0, 0, 0)
 #else
@@ -332,6 +332,8 @@ void editSingleName(coord_t x, coord_t y, const pm_char * label, char * name, ui
 
 uint8_t editDelay(coord_t y, event_t event, uint8_t attr, const pm_char * str, uint8_t delay);
 #define EDIT_DELAY(x, y, event, attr, str, delay) editDelay(y, event, attr, str, delay)
+
+void copySelection(char * dst, const char * src, uint8_t size);
 
 #define WARNING_TYPE_ASTERISK          0
 #define WARNING_TYPE_CONFIRM           1
@@ -426,7 +428,7 @@ uint8_t getMixesCount();
 void insertMix(uint8_t idx);
 void deleteMix(uint8_t idx);
 #endif
-  
+
 typedef int (*FnFuncP) (int x);
 void drawFunction(FnFuncP fn, uint8_t offset=0);
 

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -312,7 +312,7 @@ void lcdDrawSizedText(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdF
   const uint8_t orig_len = len;
   uint32_t fontsize = FONTSIZE(flags);
 #endif
-  
+
 #if defined(CPUARM) && !defined(BOOT)
   uint8_t width = 0;
   if (flags & RIGHT) {
@@ -320,7 +320,7 @@ void lcdDrawSizedText(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdF
     x -= width;
   }
 #endif
-  
+
   bool setx = false;
   while (len--) {
     unsigned char c;
@@ -337,7 +337,7 @@ void lcdDrawSizedText(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdF
         c = pgm_read_byte(s);
         break;
     }
-    
+
     if (setx) {
       x = c;
       setx = false;
@@ -358,7 +358,7 @@ void lcdDrawSizedText(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdF
 #endif
       x = orig_x;
       y += FH;
-#if defined(CPUARM)      
+#if defined(CPUARM)
       if (fontsize == DBLSIZE)
         y += FH;
       else if (fontsize == MIDSIZE)
@@ -368,7 +368,7 @@ void lcdDrawSizedText(coord_t x, coord_t y, const pm_char * s, uint8_t len, LcdF
 #endif
       if (y >= LCD_H) break;
     }
-#if defined(CPUARM)      
+#if defined(CPUARM)
     else if (c == 0x1D) {  // TAB
       x |= 0x3F;
       x += 1;
@@ -461,7 +461,7 @@ void lcdDrawNumber(coord_t x, coord_t y, lcdint_t val, LcdFlags flags, uint8_t l
   uint8_t fw = FWNUM;
   int8_t mode = MODE(flags);
   flags &= ~LEADING0;
-  
+
 #if defined(CPUARM)
   uint32_t fontsize = FONTSIZE(flags);
   bool dblsize = (fontsize == DBLSIZE);
@@ -719,14 +719,14 @@ void lcdDrawVerticalLine(coord_t x, scoord_t y, scoord_t h, uint8_t pat, LcdFlag
   // should never happen on 9X
   if (y >= LCD_H) return;
 #endif
-  
+
   if (h<0) { y+=h; h=-h; }
   if (y<0) { h+=y; y=0; }
   if (y+h > LCD_H) { h = LCD_H - y; }
-  
+
   if (pat==DOTTED && !(y%2))
     pat = ~pat;
-  
+
   uint8_t *p  = &displayBuf[ y / 8 * LCD_W + x ];
   y = (y & 0x07);
   if (y) {
@@ -879,7 +879,7 @@ void drawSource(coord_t x, coord_t y, uint32_t idx, LcdFlags att)
 #if defined(LUA_MODEL_SCRIPTS)
     if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
       lcdDrawChar(x+2, y+1, '1'+qr.quot, TINSIZE);
-      lcdDrawFilledRect(x, y, 7, 7);
+      lcdDrawFilledRect(x, y, 7, 7, 0);
       lcdDrawSizedText(x+8, y, scriptInputsOutputs[qr.quot].outputs[qr.rem].name, att & STREXPANDED ? 9 : 4, att);
     }
     else
@@ -1527,7 +1527,7 @@ LCD_IMG_FUNCTION(lcd_img, const pm_uchar *, pgm_read_byte)
 void lcdMaskPoint(uint8_t * p, uint8_t mask, LcdFlags att)
 {
   ASSERT_IN_DISPLAY(p);
-  
+
   if (att & FORCE)
     *p |= mask;
   else if (att & ERASE)
@@ -1557,7 +1557,7 @@ void lcdDrawHorizontalLine(coord_t x, coord_t y, coord_t w, uint8_t pat, LcdFlag
 {
   if (y >= LCD_H) return;
   if (x+w > LCD_W) { w = LCD_W - x; }
-  
+
   uint8_t *p  = &displayBuf[ y / 8 * LCD_W + x ];
   uint8_t msk = BITMASK(y%8);
   while (w--) {

--- a/radio/src/gui/128x64/menus.h
+++ b/radio/src/gui/128x64/menus.h
@@ -119,6 +119,9 @@ enum MenuModelIndexes {
   CASE_CURVES(MENU_MODEL_CURVES)
   MENU_MODEL_LOGICAL_SWITCHES,
   MENU_MODEL_SPECIAL_FUNCTIONS,
+#if defined(LUA_MODEL_SCRIPTS)
+  MENU_MODEL_CUSTOM_SCRIPTS,
+#endif
   CASE_FRSKY(MENU_MODEL_TELEMETRY_FRSKY)
   CASE_MAVLINK(MENU_MODEL_TELEMETRY_MAVLINK)
   CASE_CPUARM(MENU_MODEL_DISPLAY)
@@ -140,6 +143,7 @@ void menuModelCurveOne(event_t event);
 void menuModelGVars(event_t event);
 void menuModelLogicalSwitches(event_t event);
 void menuModelSpecialFunctions(event_t event);
+void menuModelCustomScripts(event_t event);
 void menuModelTelemetryFrsky(event_t event);
 void menuModelTelemetryMavlink(event_t event);
 void menuModelDisplay(event_t event);
@@ -156,6 +160,9 @@ static const MenuHandlerFunc menuTabModel[] PROGMEM = {
   CASE_CURVES(menuModelCurvesAll)
   menuModelLogicalSwitches,
   menuModelSpecialFunctions,
+#if defined(LUA_MODEL_SCRIPTS)
+  menuModelCustomScripts,
+#endif
   CASE_FRSKY(menuModelTelemetryFrsky)
   CASE_MAVLINK(menuModelTelemetryMavlink)
   CASE_CPUARM(menuModelDisplay)

--- a/radio/src/gui/128x64/model_custom_scripts.cpp
+++ b/radio/src/gui/128x64/model_custom_scripts.cpp
@@ -44,7 +44,7 @@ enum menuModelCustomScriptItems {
   ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL,
 };
 
-#define SCRIPT_ONE_2ND_COLUMN_POS  (4*FW-1)
+#define SCRIPT_ONE_2ND_COLUMN_POS  (8*FW)
 #define SCRIPT_ONE_3RD_COLUMN_POS  (15*FW-3)
 
 void menuModelCustomScriptOne(event_t event)
@@ -54,7 +54,7 @@ void menuModelCustomScriptOne(event_t event)
   drawStringWithIndex(PSIZE(TR_MENUCUSTOMSCRIPTS)*FW+FW, 0, "LUA", s_currIdx+1, 0);
   lcdDrawFilledRect(0, 0, LCD_W, FH, SOLID, 0);
 
-  SUBMENU(STR_MENUCUSTOMSCRIPTS, 3+scriptInputsOutputs[s_currIdx].inputsCount, { 0, 0, LABEL(inputs), 0/*repeated*/ });
+  SUBMENU(STR_MENUCUSTOMSCRIPTS, 3+scriptInputsOutputs[s_currIdx].inputsCount+scriptInputsOutputs[s_currIdx].outputsCount, { 0, 0, LABEL(inputs), 0/*repeated*/ });
 
   int8_t sub = menuVerticalPosition;
 
@@ -66,7 +66,7 @@ void menuModelCustomScriptOne(event_t event)
     if (i == ITEM_MODEL_CUSTOMSCRIPT_FILE) {
       lcdDrawTextAlignedLeft(y, STR_SCRIPT);
       if (ZEXIST(sd.file))
-        lcdDrawSizedText(SCRIPT_ONE_2ND_COLUMN_POS+10, y, sd.file, sizeof(sd.file), attr);
+        lcdDrawSizedText(SCRIPT_ONE_2ND_COLUMN_POS, y, sd.file, sizeof(sd.file), attr);
       else
         lcdDrawTextAtIndex(SCRIPT_ONE_2ND_COLUMN_POS, y, STR_VCSWFUNC, 0, attr);
       if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && !READ_ONLY()) {
@@ -103,15 +103,13 @@ void menuModelCustomScriptOne(event_t event)
         }
       }
     }
-  }
-
-  if (scriptInputsOutputs[s_currIdx].outputsCount > 0) {
-    lcdDrawSolidVerticalLine(SCRIPT_ONE_3RD_COLUMN_POS-4, FH+1, LCD_H-FH-1);
-    lcdDrawText(SCRIPT_ONE_3RD_COLUMN_POS, FH+1, STR_OUTPUTS);
-
-    for (int i=0; i<scriptInputsOutputs[s_currIdx].outputsCount; i++) {
-      drawSource(SCRIPT_ONE_3RD_COLUMN_POS+INDENT_WIDTH, FH+1+FH+i*FH, MIXSRC_FIRST_LUA+(s_currIdx*MAX_SCRIPT_OUTPUTS)+i, 0);
-      lcdDrawNumber(SCRIPT_ONE_3RD_COLUMN_POS+11*FW+3, FH+1+FH+i*FH, calcRESXto1000(scriptInputsOutputs[s_currIdx].outputs[i].value), PREC1|RIGHT);
+    else if (i == ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount+1) {
+      lcdDrawTextAlignedLeft(y, STR_OUTPUTS);
+    }
+    else if (i <= ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount+scriptInputsOutputs[s_currIdx].outputsCount) {
+      int outputIdx = i-(ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount)-2;
+      lcdDrawSizedText(INDENT_WIDTH, y, scriptInputsOutputs[s_currIdx].outputs[outputIdx].name, 10, 0);
+      lcdDrawNumber(SCRIPT_ONE_2ND_COLUMN_POS, y, calcRESXto1000(scriptInputsOutputs[s_currIdx].outputs[i].value), PREC1|RIGHT);
     }
   }
 }

--- a/radio/src/gui/128x64/model_custom_scripts.cpp
+++ b/radio/src/gui/128x64/model_custom_scripts.cpp
@@ -106,10 +106,10 @@ void menuModelCustomScriptOne(event_t event)
     else if (i == ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount+1) {
       lcdDrawTextAlignedLeft(y, STR_OUTPUTS);
     }
-    else if (i <= ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount+scriptInputsOutputs[s_currIdx].outputsCount) {
+    else if (i <= ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount+scriptInputsOutputs[s_currIdx].outputsCount+1) {
       int outputIdx = i-(ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount)-2;
       lcdDrawSizedText(INDENT_WIDTH, y, scriptInputsOutputs[s_currIdx].outputs[outputIdx].name, 10, 0);
-      lcdDrawNumber(SCRIPT_ONE_2ND_COLUMN_POS, y, calcRESXto1000(scriptInputsOutputs[s_currIdx].outputs[i].value), PREC1|RIGHT);
+      lcdDrawNumber(SCRIPT_ONE_2ND_COLUMN_POS, y, calcRESXto1000(scriptInputsOutputs[s_currIdx].outputs[outputIdx].value), PREC1|RIGHT);
     }
   }
 }

--- a/radio/src/gui/128x64/model_custom_scripts.cpp
+++ b/radio/src/gui/128x64/model_custom_scripts.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "opentx.h"
+
+void onModelCustomScriptMenu(const char *result)
+{
+  ScriptData &sd = g_model.scriptsData[s_currIdx];
+
+  if (result == STR_UPDATE_LIST) {
+    if (!sdListFiles(SCRIPTS_MIXES_PATH, SCRIPTS_EXT, sizeof(sd.file), NULL)) {
+      POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
+    }
+  }
+  else {
+    // The user choosed a lua file in the list
+    copySelection(sd.file, result, sizeof(sd.file));
+    memset(sd.inputs, 0, sizeof(sd.inputs));
+    storageDirty(EE_MODEL);
+    LUA_LOAD_MODEL_SCRIPT(s_currIdx);
+  }
+}
+
+enum menuModelCustomScriptItems {
+  ITEM_MODEL_CUSTOMSCRIPT_FILE,
+  ITEM_MODEL_CUSTOMSCRIPT_NAME,
+  ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL,
+};
+
+#define SCRIPT_ONE_2ND_COLUMN_POS  (4*FW-1)
+#define SCRIPT_ONE_3RD_COLUMN_POS  (15*FW-3)
+
+void menuModelCustomScriptOne(event_t event)
+{
+  ScriptData & sd = g_model.scriptsData[s_currIdx];
+
+  drawStringWithIndex(PSIZE(TR_MENUCUSTOMSCRIPTS)*FW+FW, 0, "LUA", s_currIdx+1, 0);
+  lcdDrawFilledRect(0, 0, LCD_W, FH, SOLID, 0);
+
+  SUBMENU(STR_MENUCUSTOMSCRIPTS, 3+scriptInputsOutputs[s_currIdx].inputsCount, { 0, 0, LABEL(inputs), 0/*repeated*/ });
+
+  int8_t sub = menuVerticalPosition;
+
+  for (int k=0; k<LCD_LINES-1; k++) {
+    coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
+    int i = k + menuVerticalOffset;
+    LcdFlags attr = (sub==i ? (s_editMode>0 ? BLINK|INVERS : INVERS) : 0);
+
+    if (i == ITEM_MODEL_CUSTOMSCRIPT_FILE) {
+      lcdDrawTextAlignedLeft(y, STR_SCRIPT);
+      if (ZEXIST(sd.file))
+        lcdDrawSizedText(SCRIPT_ONE_2ND_COLUMN_POS+10, y, sd.file, sizeof(sd.file), attr);
+      else
+        lcdDrawTextAtIndex(SCRIPT_ONE_2ND_COLUMN_POS, y, STR_VCSWFUNC, 0, attr);
+      if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && !READ_ONLY()) {
+        s_editMode = 0;
+        if (sdListFiles(SCRIPTS_MIXES_PATH, SCRIPTS_EXT, sizeof(sd.file), sd.file, LIST_NONE_SD_FILE)) {
+          POPUP_MENU_START(onModelCustomScriptMenu);
+        }
+        else {
+          POPUP_WARNING(STR_NO_SCRIPTS_ON_SD);
+        }
+      }
+    }
+    else if (i == ITEM_MODEL_CUSTOMSCRIPT_NAME) {
+      lcdDrawTextAlignedLeft(y, TR_NAME);
+      editName(SCRIPT_ONE_2ND_COLUMN_POS, y, sd.name, sizeof(sd.name), event, attr);
+    }
+    else if (i == ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL) {
+      lcdDrawTextAlignedLeft(y, STR_INPUTS);
+    }
+    else if (i <= ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL+scriptInputsOutputs[s_currIdx].inputsCount) {
+      int inputIdx = i-ITEM_MODEL_CUSTOMSCRIPT_PARAMS_LABEL-1;
+      lcdDrawSizedText(INDENT_WIDTH, y, scriptInputsOutputs[s_currIdx].inputs[inputIdx].name, 10, 0);
+      if (scriptInputsOutputs[s_currIdx].inputs[inputIdx].type == 0) {
+        lcdDrawNumber(SCRIPT_ONE_2ND_COLUMN_POS, y, g_model.scriptsData[s_currIdx].inputs[inputIdx]+scriptInputsOutputs[s_currIdx].inputs[inputIdx].def, attr|LEFT);
+        if (attr) {
+          CHECK_INCDEC_MODELVAR(event, g_model.scriptsData[s_currIdx].inputs[inputIdx], scriptInputsOutputs[s_currIdx].inputs[inputIdx].min-scriptInputsOutputs[s_currIdx].inputs[inputIdx].def, scriptInputsOutputs[s_currIdx].inputs[inputIdx].max-scriptInputsOutputs[s_currIdx].inputs[inputIdx].def);
+        }
+      }
+      else {
+        uint8_t *source = (uint8_t *)&g_model.scriptsData[s_currIdx].inputs[inputIdx];
+        drawSource(SCRIPT_ONE_2ND_COLUMN_POS, y, *source + scriptInputsOutputs[s_currIdx].inputs[inputIdx].def, attr);
+        if (attr) {
+          CHECK_INCDEC_MODELSOURCE(event, *source, scriptInputsOutputs[s_currIdx].inputs[inputIdx].min-scriptInputsOutputs[s_currIdx].inputs[inputIdx].def, scriptInputsOutputs[s_currIdx].inputs[inputIdx].max-scriptInputsOutputs[s_currIdx].inputs[inputIdx].def);
+        }
+      }
+    }
+  }
+
+  if (scriptInputsOutputs[s_currIdx].outputsCount > 0) {
+    lcdDrawSolidVerticalLine(SCRIPT_ONE_3RD_COLUMN_POS-4, FH+1, LCD_H-FH-1);
+    lcdDrawText(SCRIPT_ONE_3RD_COLUMN_POS, FH+1, STR_OUTPUTS);
+
+    for (int i=0; i<scriptInputsOutputs[s_currIdx].outputsCount; i++) {
+      drawSource(SCRIPT_ONE_3RD_COLUMN_POS+INDENT_WIDTH, FH+1+FH+i*FH, MIXSRC_FIRST_LUA+(s_currIdx*MAX_SCRIPT_OUTPUTS)+i, 0);
+      lcdDrawNumber(SCRIPT_ONE_3RD_COLUMN_POS+11*FW+3, FH+1+FH+i*FH, calcRESXto1000(scriptInputsOutputs[s_currIdx].outputs[i].value), PREC1|RIGHT);
+    }
+  }
+}
+
+void menuModelCustomScripts(event_t event)
+{
+
+  MENU(STR_MENUCUSTOMSCRIPTS, menuTabModel, MENU_MODEL_CUSTOM_SCRIPTS, MAX_SCRIPTS, { NAVIGATION_LINE_BY_LINE|4/*repeated*/ });
+
+  coord_t y;
+  int8_t  sub = menuVerticalPosition;
+
+  if (event == EVT_KEY_FIRST(KEY_ENTER)) {
+    s_currIdx = sub;
+    pushMenu(menuModelCustomScriptOne);
+  }
+
+  for (int i=0, scriptIndex=0; i<MAX_SCRIPTS; i++) {
+    y = 1 + (i+1)*FH;
+
+    ScriptData &sd = g_model.scriptsData[i];
+
+    // LUAx header
+    drawStringWithIndex(0, y, "LUA", i+1, sub==i ? INVERS : 0);
+
+    // LUA script
+    if (ZEXIST(sd.file)) {
+      lcdDrawSizedText(5*FW, y, sd.file, sizeof(sd.file), 0);
+      switch (scriptInternalData[scriptIndex].state) {
+        case SCRIPT_SYNTAX_ERROR:
+          lcdDrawText(30*FW+2, y, "(error)");
+          break;
+        case SCRIPT_KILLED:
+          lcdDrawText(29*FW+2, y, "(killed)");
+          break;
+        default:
+          lcdDrawNumber(34*FW, y, luaGetCpuUsed(scriptIndex), RIGHT);
+          lcdDrawChar(34*FW, y, '%');
+          break;
+      }
+      scriptIndex++;
+    }
+    else {
+      lcdDrawTextAtIndex(5*FW, y, STR_VCSWFUNC, 0, 0);
+    }
+
+    // Script name
+    lcdDrawSizedText(16*FW, y, sd.name, sizeof(sd.name), ZCHAR);
+  }
+}

--- a/radio/src/gui/128x64/model_custom_scripts.cpp
+++ b/radio/src/gui/128x64/model_custom_scripts.cpp
@@ -20,6 +20,14 @@
 
 #include "opentx.h"
 
+void copySelection(char * dst, const char * src, uint8_t size)
+{
+  if (memcmp(src, "---", 3) == 0)
+    memset(dst, 0, size);
+  else
+    memcpy(dst, src, size);
+}
+
 void onModelCustomScriptMenu(const char *result)
 {
   ScriptData &sd = g_model.scriptsData[s_currIdx];

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -168,14 +168,6 @@ enum MenuModelSetupItems {
   #define MODEL_SETUP_MAX_LINES          ((IS_PPM_PROTOCOL(protocol)||IS_DSM2_PROTOCOL(protocol)||IS_PXX_PROTOCOL(protocol)) ? HEADER_LINE+ITEM_MODEL_SETUP_MAX : HEADER_LINE+ITEM_MODEL_SETUP_MAX-1)
 #endif
 
-void copySelection(char * dst, const char * src, uint8_t size)
-{
-  if (memcmp(src, "---", 3) == 0)
-    memset(dst, 0, size);
-  else
-    memcpy(dst, src, size);
-}
-
 void menuModelSetup(event_t event)
 {
 #if defined(PCBX7)

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -167,6 +167,14 @@ enum MenuModelSetupItems {
   #define CURSOR_ON_CELL                 (true)
   #define MODEL_SETUP_MAX_LINES          ((IS_PPM_PROTOCOL(protocol)||IS_DSM2_PROTOCOL(protocol)||IS_PXX_PROTOCOL(protocol)) ? HEADER_LINE+ITEM_MODEL_SETUP_MAX : HEADER_LINE+ITEM_MODEL_SETUP_MAX-1)
 #endif
+
+void copySelection(char * dst, const char * src, uint8_t size)
+{
+  if (memcmp(src, "---", 3) == 0)
+    memset(dst, 0, size);
+  else
+    memcpy(dst, src, size);
+}
 
 void menuModelSetup(event_t event)
 {
@@ -557,7 +565,7 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_INTERNAL_MODULE_LABEL:
         lcdDrawTextAlignedLeft(y, TR_INTERNALRF);
         break;
-        
+
       case ITEM_MODEL_INTERNAL_MODULE_MODE:
         lcdDrawTextAlignedLeft(y, STR_MODE);
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_XJT_PROTOCOLS, 1+g_model.moduleData[0].rfProtocol, attr);
@@ -680,7 +688,7 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_TRAINER_LABEL:
         lcdDrawTextAlignedLeft(y, STR_TRAINER);
         break;
-        
+
       case ITEM_MODEL_TRAINER_MODE:
         lcdDrawTextAlignedLeft(y, STR_MODE);
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_VTRAINERMODES, g_model.trainerMode, attr);


### PR DESCRIPTION
Adds CUSTOM SCRIPTS screen to X7 when selecting LUA=YES

Due to reduced screen size, the display of a detailed LUA script is now only on one column for X7

![image](https://cloud.githubusercontent.com/assets/5167938/21680594/f2d5d178-d34a-11e6-9fa5-d289828713ea.png)
