### PR TITLE
X9e bootfix

### DIFF
--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -115,11 +115,13 @@ tmr10ms_t lastLogTime = 0;
 
 void logsClose()
 {
-  if (f_close(&g_oLogFile) != FR_OK) {
-    // close failed, forget file
-    g_oLogFile.obj.fs = 0;
+  if (sdMounted()) {
+    if (f_close(&g_oLogFile) != FR_OK) {
+      // close failed, forget file
+      g_oLogFile.obj.fs = 0;
+    }
+    lastLogTime = 0;
   }
-  lastLogTime = 0;
 }
 
 #if !defined(CPUARM)
@@ -391,6 +393,3 @@ void logsWrite()
     }
   }
 }
-
-
-


### PR DESCRIPTION
Since https://github.com/opentx/opentx/commit/86ee89990577449775d7b700d8aed008ff2824a8, my x9e doesn't boot anymore.

What is happening is that deep inside storageReadAll(), there is a logsClose() call. And that function crash on some taranis (at least on mine !) if called before sdinit

This fixes the issue