### PR TITLE
Fixes #3683: Display trainer icon in master mode when IS_TRAINER_INPU…

### DIFF
--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -260,15 +260,15 @@ void displayTopBar()
     x -= 12;
   }
 
-  if (TRAINER_CONNECTED()) {
-    if (SLAVE_MODE()) {
+  if (SLAVE_MODE()) {
+    if (TRAINER_CONNECTED()) {
       LCD_NOTIF_ICON(x, ICON_TRAINEE);
       x -= 12;
     }
-    else if (IS_TRAINER_INPUT_VALID()) {
-      LCD_NOTIF_ICON(x, ICON_TRAINER);
-      x -= 12;
-    }
+  }
+  else if (IS_TRAINER_INPUT_VALID()) {
+    LCD_NOTIF_ICON(x, ICON_TRAINER);
+    x -= 12;
   }
 
   if (isFunctionActive(FUNCTION_LOGS)) {


### PR DESCRIPTION
…T_VALID() is true, don't rely on trainer jack connected detection.

Closes #3683.