### PR TITLE
[Companion] Move SwitchType enum to RadioData GeneralSettings

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1055,17 +1055,17 @@ bool GeneralSettings::switchPositionAllowedTaranis(int index) const
   if (index == 0)
     return true;
   SwitchInfo info = switchInfoFromSwitchPositionTaranis(abs(index));
-  if (index < 0 && switchConfig[info.index] != Firmware::SWITCH_3POS)
+  if (index < 0 && switchConfig[info.index] != GeneralSettings::SWITCH_3POS)
     return false;
   else if (info.position == 1)
-    return switchConfig[info.index] == Firmware::SWITCH_3POS;
+    return switchConfig[info.index] == GeneralSettings::SWITCH_3POS;
   else
-    return switchConfig[info.index] != Firmware::SWITCH_NONE;
+    return switchConfig[info.index] != GeneralSettings::SWITCH_NONE;
 }
 
 bool GeneralSettings::switchSourceAllowedTaranis(int index) const
 {
-  return switchConfig[index] != Firmware::SWITCH_NONE;
+  return switchConfig[index] != GeneralSettings::SWITCH_NONE;
 }
 
 bool GeneralSettings::isPotAvailable(int index) const

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -196,7 +196,7 @@ class EEPROMInterface
     virtual unsigned long load(RadioData &radioData, const uint8_t * eeprom, int size) = 0;
 
     virtual unsigned long loadBackup(RadioData & radioData, const uint8_t * eeprom, int esize, int index) = 0;
-    
+
     virtual int save(uint8_t * eeprom, const RadioData & radioData, uint8_t version=0, uint32_t variant=0) = 0;
 
     virtual int getSize(const ModelData &) = 0;
@@ -367,15 +367,8 @@ class Firmware {
 
     virtual int getCapability(Capability) = 0;
 
-    enum SwitchType {
-      SWITCH_NONE,
-      SWITCH_TOGGLE,
-      SWITCH_2POS,
-      SWITCH_3POS
-    };
-
     struct Switch {
-      SwitchType type;
+      GeneralSettings::SwitchConfig type;
       const char * name;
     };
 

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -820,44 +820,45 @@ QString OpenTxFirmware::getAnalogInputName(unsigned int index)
 
 Firmware::Switch OpenTxFirmware::getSwitch(unsigned int index)
 {
+  typedef GeneralSettings::SwitchConfig sc;
   if (board == BOARD_TARANIS_X7) {
-    const Switch switches[] = {{SWITCH_3POS,   "SA"},
-                               {SWITCH_3POS,   "SB"},
-                               {SWITCH_3POS,   "SC"},
-                               {SWITCH_3POS,   "SD"},
-                               {SWITCH_2POS,   "SF"},
-                               {SWITCH_TOGGLE, "SH"}};
+    const Switch switches[] = {{sc::SWITCH_3POS,   "SA"},
+                               {sc::SWITCH_3POS,   "SB"},
+                               {sc::SWITCH_3POS,   "SC"},
+                               {sc::SWITCH_3POS,   "SD"},
+                               {sc::SWITCH_2POS,   "SF"},
+                               {sc::SWITCH_TOGGLE, "SH"}};
     return switches[index];
   }
   else if (IS_HORUS_OR_TARANIS(board)) {
-    const Switch switches[] = {{SWITCH_3POS,   "SA"},
-                               {SWITCH_3POS,   "SB"},
-                               {SWITCH_3POS,   "SC"},
-                               {SWITCH_3POS,   "SD"},
-                               {SWITCH_3POS,   "SE"},
-                               {SWITCH_2POS,   "SF"},
-                               {SWITCH_3POS,   "SG"},
-                               {SWITCH_TOGGLE, "SH"},
-                               {SWITCH_3POS,   "SI"},
-                               {SWITCH_3POS,   "SJ"},
-                               {SWITCH_3POS,   "SK"},
-                               {SWITCH_3POS,   "SL"},
-                               {SWITCH_3POS,   "SM"},
-                               {SWITCH_3POS,   "SN"},
-                               {SWITCH_3POS,   "SO"},
-                               {SWITCH_3POS,   "SP"},
-                               {SWITCH_3POS,   "SQ"},
-                               {SWITCH_3POS,   "SR"}};
+    const Switch switches[] = {{sc::SWITCH_3POS,   "SA"},
+                               {sc::SWITCH_3POS,   "SB"},
+                               {sc::SWITCH_3POS,   "SC"},
+                               {sc::SWITCH_3POS,   "SD"},
+                               {sc::SWITCH_3POS,   "SE"},
+                               {sc::SWITCH_2POS,   "SF"},
+                               {sc::SWITCH_3POS,   "SG"},
+                               {sc::SWITCH_TOGGLE, "SH"},
+                               {sc::SWITCH_3POS,   "SI"},
+                               {sc::SWITCH_3POS,   "SJ"},
+                               {sc::SWITCH_3POS,   "SK"},
+                               {sc::SWITCH_3POS,   "SL"},
+                               {sc::SWITCH_3POS,   "SM"},
+                               {sc::SWITCH_3POS,   "SN"},
+                               {sc::SWITCH_3POS,   "SO"},
+                               {sc::SWITCH_3POS,   "SP"},
+                               {sc::SWITCH_3POS,   "SQ"},
+                               {sc::SWITCH_3POS,   "SR"}};
     return switches[index];
   }
   else {
-    const Switch switches[] = {{SWITCH_3POS,   "3POS"},
-                               {SWITCH_2POS,   "THR"},
-                               {SWITCH_2POS,   "RUD"},
-                               {SWITCH_2POS,   "ELE"},
-                               {SWITCH_2POS,   "AIL"},
-                               {SWITCH_2POS,   "GEA"},
-                               {SWITCH_TOGGLE, "SH"}};
+    const Switch switches[] = {{sc::SWITCH_3POS,   "3POS"},
+                               {sc::SWITCH_2POS,   "THR"},
+                               {sc::SWITCH_2POS,   "RUD"},
+                               {sc::SWITCH_2POS,   "ELE"},
+                               {sc::SWITCH_2POS,   "AIL"},
+                               {sc::SWITCH_2POS,   "GEA"},
+                               {sc::SWITCH_TOGGLE, "SH"}};
     return switches[index];
   }
 }

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -24,11 +24,11 @@
 void HardwarePanel::setupSwitchConfig(int index, QLabel *label, AutoLineEdit *name, AutoComboBox *type, bool threePos = true)
 {
   if (IS_STM32(firmware->getBoard()) && index < firmware->getCapability(Switches)) {
-    type->addItem(tr("None"), Firmware::SWITCH_NONE);
-    type->addItem(tr("2 Positions Toggle"), Firmware::SWITCH_TOGGLE);
-    type->addItem(tr("2 Positions"), Firmware::SWITCH_2POS);
+    type->addItem(tr("None"), GeneralSettings::SWITCH_NONE);
+    type->addItem(tr("2 Positions Toggle"), GeneralSettings::SWITCH_TOGGLE);
+    type->addItem(tr("2 Positions"), GeneralSettings::SWITCH_2POS);
     if (threePos)
-      type->addItem(tr("3 Positions"), Firmware::SWITCH_3POS);
+      type->addItem(tr("3 Positions"), GeneralSettings::SWITCH_3POS);
     name->setField(generalSettings.switchName[index], 3, this);
     type->setField(generalSettings.switchConfig[index], this);
   }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -676,9 +676,9 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   for (int i=0; i<firmware->getCapability(Switches); i++) {
     Firmware::Switch sw = firmware->getSwitch(i);
     if (IS_HORUS_OR_TARANIS(board)) {
-      sw.type = Firmware::SwitchType(generalSettings.switchConfig[i]);
+      sw.type = GeneralSettings::SwitchConfig(generalSettings.switchConfig[i]);
     }
-    if (sw.type == Firmware::SWITCH_NONE || sw.type == Firmware::SWITCH_TOGGLE) {
+    if (sw.type == GeneralSettings::SWITCH_NONE || sw.type == GeneralSettings::SWITCH_TOGGLE) {
       continue;
     }
     QLabel * label = new QLabel(this);
@@ -695,7 +695,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
     slider->setPageStep(1);
     slider->setTickInterval(1);
     label->setText(sw.name);
-    slider->setMaximum(sw.type == Firmware::SWITCH_3POS ? 2 : 1);
+    slider->setMaximum(sw.type == GeneralSettings::SWITCH_3POS ? 2 : 1);
     cb->setProperty("index", i);
     ui->switchesStartupLayout->addWidget(label, 0, i+1);
     ui->switchesStartupLayout->setAlignment(label, Qt::AlignCenter);
@@ -917,7 +917,7 @@ void SetupPanel::updateStartupSwitches()
     bool enabled = !(model->switchWarningEnable & (1 << index));
     if (IS_TARANIS(GetEepromInterface()->getBoard())) {
       value = (switchStates >> 2*index) & 0x03;
-      if (generalSettings.switchConfig[index] != Firmware::SWITCH_3POS && value == 2) {
+      if (generalSettings.switchConfig[index] != GeneralSettings::SWITCH_3POS && value == 2) {
         value = 1;
       }
     }
@@ -956,7 +956,7 @@ void SetupPanel::startupSwitchEdited(int value)
 
     model->switchWarningStates &= ~mask;
 
-    if (IS_TARANIS(GetEepromInterface()->getBoard()) && generalSettings.switchConfig[index] != Firmware::SWITCH_3POS) {
+    if (IS_TARANIS(GetEepromInterface()->getBoard()) && generalSettings.switchConfig[index] != GeneralSettings::SWITCH_3POS) {
       if (value == 1) {
         value = 2;
       }

--- a/companion/src/radiodata.h
+++ b/companion/src/radiodata.h
@@ -7,7 +7,7 @@
 
 enum Switches {
   SWITCH_NONE,
-  
+
   SWITCH_THR = SWITCH_NONE+1,
   SWITCH_RUD,
   SWITCH_ELE,
@@ -17,7 +17,7 @@ enum Switches {
   SWITCH_AIL,
   SWITCH_GEA,
   SWITCH_TRN,
-  
+
   SWITCH_SA0 = SWITCH_NONE+1,
   SWITCH_SA1,
   SWITCH_SA2,
@@ -46,7 +46,7 @@ enum Switches {
   SWITCH_SJ2,
   SWITCH_SK0,
   SWITCH_SK2,
-  
+
 };
 
 enum TimerModes {
@@ -188,9 +188,9 @@ class RawSourceRange
       offset(0.0)
     {
     }
-    
+
     float getValue(int value);
-    
+
     int decimals;
     double min;
     double max;
@@ -210,40 +210,40 @@ class RawSource {
       index(0)
     {
     }
-    
+
     explicit RawSource(int value):
       type(RawSourceType(abs(value)/65536)),
       index(value >= 0 ? abs(value)%65536 : -(abs(value)%65536))
     {
     }
-    
+
     RawSource(RawSourceType type, int index=0):
       type(type),
       index(index)
     {
     }
-    
+
     inline const int toValue() const
     {
       return index >= 0 ? (type * 65536 + index) : -(type * 65536 - index);
     }
-    
+
     QString toString(const ModelData * model = NULL) const;
-    
+
     RawSourceRange getRange(const ModelData * model, const GeneralSettings & settings, unsigned int flags=0) const;
-    
+
     bool operator == ( const RawSource & other) {
       return (this->type == other.type) && (this->index == other.index);
     }
-    
+
     bool operator != ( const RawSource & other) {
       return (this->type != other.type) || (this->index != other.index);
     }
-    
+
     bool isTimeBased() const;
     bool isPot() const;
     bool isSlider() const;
-    
+
     RawSourceType type;
     int index;
 };
@@ -269,34 +269,34 @@ class RawSwitch {
       index(0)
     {
     }
-    
+
     explicit RawSwitch(int value):
       type(RawSwitchType(abs(value)/256)),
       index(value >= 0 ? abs(value)%256 : -(abs(value)%256))
     {
     }
-    
+
     RawSwitch(RawSwitchType type, int index=0):
       type(type),
       index(index)
     {
     }
-    
+
     inline const int toValue() const
     {
       return index >= 0 ? (type * 256 + index) : -(type * 256 - index);
     }
-    
+
     QString toString() const;
-    
+
     bool operator== ( const RawSwitch& other) {
       return (this->type == other.type) && (this->index == other.index);
     }
-    
+
     bool operator!= ( const RawSwitch& other) {
       return (this->type != other.type) || (this->index != other.index);
     }
-    
+
     RawSwitchType type;
     int index;
 };
@@ -309,20 +309,20 @@ class CurveReference {
       CURVE_REF_FUNC,
       CURVE_REF_CUSTOM
     };
-    
+
     CurveReference() { clear(); }
-    
+
     CurveReference(CurveRefType type, int value):
       type(type),
       value(value)
     {
     }
-    
+
     void clear() { memset(this, 0, sizeof(CurveReference)); }
-    
+
     CurveRefType type;
     int value;
-    
+
     QString toString() const;
 };
 
@@ -363,7 +363,7 @@ class CurveData {
       CURVE_TYPE_CUSTOM,
       CURVE_TYPE_LAST = CURVE_TYPE_CUSTOM
     };
-    
+
     CurveData();
     void clear(int count);
     bool isEmpty() const;
@@ -419,7 +419,7 @@ class MixData {
     unsigned int flightModes;             // -5=!FP4, 0=normal, 5=FP4
     int    sOffset;
     char   name[MIXDATA_NAME_LEN+1];
-    
+
     void clear() { memset(this, 0, sizeof(MixData)); }
 };
 
@@ -539,11 +539,11 @@ class CustomFunctionData { // Function Switches data
     QString paramToString(const ModelData * model) const;
     QString repeatToString() const;
     QString enabledToString() const;
-    
+
     static void populateResetParams(const ModelData * model, QComboBox * b, unsigned int value);
     static void populatePlaySoundParams(QStringList & qs);
     static void populateHapticParams(QStringList & qs);
-  
+
 };
 
 class FlightModeData {
@@ -581,7 +581,7 @@ class FrSkyAlarmData {
     unsigned int   level;               // 0=none, 1=Yellow, 2=Orange, 3=Red
     unsigned int   greater;             // 0=LT(<), 1=GT(>)
     unsigned int value;               // 0.1V steps EG. 6.6 Volts = 66. 25.1V = 251, etc.
-    
+
     void clear() { memset(this, 0, sizeof(FrSkyAlarmData)); }
 };
 
@@ -601,7 +601,7 @@ class FrSkyChannelData {
     int   offset;
     unsigned int multiplier;
     FrSkyAlarmData alarms[2];
-    
+
     float getRatio() const;
     RawSourceRange getRange() const;
     void clear() { memset(this, 0, sizeof(FrSkyChannelData)); }
@@ -631,16 +631,16 @@ enum TelemetryScreenEnum {
 class FrSkyScreenData {
   public:
     FrSkyScreenData() { clear(); }
-    
+
     typedef struct {
       FrSkyBarData bars[4];
       FrSkyLineData lines[4];
       TelemetryScriptData script;
     } FrSkyScreenBody;
-    
+
     unsigned int type;
     FrSkyScreenBody body;
-    
+
     void clear();
 };
 
@@ -708,7 +708,7 @@ class FrSkyData {
     unsigned int storedMah;
     int fasOffset;
     bool ignoreSensorIds;
-    
+
     void clear();
 };
 
@@ -816,15 +816,15 @@ class ModuleData {
     int          channelsCount; // 0=8 channels
     unsigned int failsafeMode;
     int          failsafeChannels[CPN_MAX_CHNOUT];
-    
-    
+
+
     struct {
       int delay;
       bool pulsePol;           // false = positive
       bool outputType;         // false = open drain, true = push pull
       int frameLength;
     } ppm;
-    
+
     struct {
       unsigned int rfProtocol;
       bool autoBindMode;
@@ -832,9 +832,9 @@ class ModuleData {
       bool customProto;
       int optionValue;
     } multi;
-    
-    
-    
+
+
+
     void clear() { memset(this, 0, sizeof(ModuleData)); }
     QString polarityToString() const { return ppm.pulsePol ? QObject::tr("Positive") : QObject::tr("Negative"); } // TODO ModelPrinter
 };
@@ -852,15 +852,15 @@ class ScriptData {
 
 #define CPN_MAX_SENSORS       32
 class SensorData {
-  
+
   public:
-    
+
     enum
     {
       TELEM_TYPE_CUSTOM,
       TELEM_TYPE_CALCULATED
     };
-    
+
     enum
     {
       TELEM_FORMULA_ADD,
@@ -874,7 +874,7 @@ class SensorData {
       TELEM_FORMULA_DIST,
       TELEM_FORMULA_LAST = TELEM_FORMULA_DIST
     };
-    
+
     enum {
       TELEM_CELL_INDEX_LOWEST,
       TELEM_CELL_INDEX_1,
@@ -886,7 +886,7 @@ class SensorData {
       TELEM_CELL_INDEX_HIGHEST,
       TELEM_CELL_INDEX_DELTA,
     };
-    
+
     enum
     {
       UNIT_RAW,
@@ -930,7 +930,7 @@ class SensorData {
       UNIT_DATETIME_HOUR_MIN,
       UNIT_DATETIME_SEC
     };
-    
+
     SensorData() { clear(); }
     unsigned int type; // custom / formula
     unsigned int id;
@@ -946,25 +946,25 @@ class SensorData {
     bool logs;
     bool persistent;
     bool onlyPositive;
-    
+
     // for custom sensors
     unsigned int ratio;
     int offset;
-    
+
     // for consumption
     unsigned int amps;
-    
+
     // for cell
     unsigned int source;
     unsigned int index;
-    
+
     // for calculations
     int sources[4];
-    
+
     // for GPS dist
     unsigned int gps;
     unsigned int alt;
-    
+
     bool isAvailable() const { return strlen(label) > 0; }
     void updateUnit();
     QString unitString() const;
@@ -1004,17 +1004,17 @@ class ModelData {
     ModelData();
     ModelData(const ModelData & src);
     ModelData & operator = (const ModelData & src);
-    
+
     ExpoData * insertInput(const int idx);
     void removeInput(const int idx);
-    
+
     bool isInputValid(const unsigned int idx) const;
     bool hasExpos(uint8_t inputIdx) const;
     bool hasMixes(uint8_t output) const;
-    
+
     QVector<const ExpoData *> expos(int input) const;
     QVector<const MixData *> mixes(int channel) const;
-    
+
     bool      used;
     int       category;
     char      name[15+1];
@@ -1025,19 +1025,19 @@ class ModelData {
     int       trimInc;            // Trim Increments
     unsigned int trimsDisplay;
     bool      disableThrottleWarning;
-    
+
     unsigned int beepANACenter;      // 1<<0->A1.. 1<<6->A7
-    
+
     bool      extendedLimits; // TODO xml
     bool      extendedTrims;
     bool      throttleReversed;
     FlightModeData flightModeData[CPN_MAX_FLIGHT_MODES];
     MixData   mixData[CPN_MAX_MIXERS];
     LimitData limitData[CPN_MAX_CHNOUT];
-    
+
     char      inputNames[CPN_MAX_INPUTS][4+1];
     ExpoData  expoData[CPN_MAX_EXPOS];
-    
+
     CurveData curves[CPN_MAX_CURVES];
     LogicalSwitchData  logicalSw[CPN_MAX_CSW];
     CustomFunctionData customFn[CPN_MAX_CUSTOM_FUNCTIONS];
@@ -1055,42 +1055,42 @@ class ModelData {
     MavlinkData mavlink;
     unsigned int telemetryProtocol;
     FrSkyData frsky;
-    
+
     char bitmap[10+1];
-    
+
     unsigned int trainerMode;
-    
+
     ModuleData moduleData[CPN_MAX_MODULES+1/*trainer*/];
-    
+
     ScriptData scriptData[CPN_MAX_SCRIPTS];
-    
+
     SensorData sensorData[CPN_MAX_SENSORS];
-    
+
     unsigned int toplcdTimer;
-    
+
     CustomScreenData customScreenData[5];
-    
+
     TopbarData topbarData;
-    
+
     void clear();
     bool isEmpty() const;
     void setDefaultInputs(const GeneralSettings & settings);
     void setDefaultMixes(const GeneralSettings & settings);
     void setDefaultValues(unsigned int id, const GeneralSettings & settings);
-    
+
     int getTrimValue(int phaseIdx, int trimIdx);
     void setTrimValue(int phaseIdx, int trimIdx, int value);
-    
+
     bool isGVarLinked(int phaseIdx, int gvarIdx);
     int getGVarFieldValue(int phaseIdx, int gvarIdx);
-    
+
     ModelData removeGlobalVars();
-    
+
     void clearMixes();
     void clearInputs();
-    
+
     int getChannelsMax(bool forceExtendedLimits=false) const;
-  
+
   protected:
     void removeGlobalVar(int & var);
 };
@@ -1116,32 +1116,39 @@ class TrainerData {
 
 class GeneralSettings {
   public:
-    
+
     enum BeeperMode {
       BEEPER_QUIET = -2,
       BEEPER_ALARMS_ONLY = -1,
       BEEPER_NOKEYS = 0,
       BEEPER_ALL = 1
     };
-    
+
     enum PotConfig {
       POT_NONE,
       POT_WITH_DETENT,
       POT_MULTIPOS_SWITCH,
       POT_WITHOUT_DETENT
     };
-    
+
     enum SliderConfig {
       SLIDER_NONE,
       SLIDER_WITH_DETENT
     };
-    
+
+    enum SwitchConfig {
+      SWITCH_NONE,
+      SWITCH_TOGGLE,
+      SWITCH_2POS,
+      SWITCH_3POS
+    };
+
     GeneralSettings();
-    
+
     int getDefaultStick(unsigned int channel) const;
     RawSource getDefaultSource(unsigned int channel) const;
     int getDefaultChannel(unsigned int stick) const;
-    
+
     unsigned int version;
     unsigned int variant;
     int   calibMid[CPN_MAX_STICKS+CPN_MAX_POTS+CPN_MAX_MOUSE_ANALOGS];
@@ -1226,11 +1233,11 @@ class GeneralSettings {
     unsigned int potConfig[4];
     char sliderName[4][3+1];
     unsigned int sliderConfig[4];
-    
+
     char themeName[8+1];
     typedef uint8_t ThemeOptionData[8+1];
     ThemeOptionData themeOptionValue[5];
-    
+
     struct SwitchInfo {
       SwitchInfo(unsigned int index, unsigned int position):
         index(index),
@@ -1240,7 +1247,7 @@ class GeneralSettings {
       unsigned int index;
       unsigned int position;
     };
-    
+
     static SwitchInfo switchInfoFromSwitchPositionTaranis(unsigned int index);
     bool switchPositionAllowedTaranis(int index) const;
     bool switchSourceAllowedTaranis(int index) const;
@@ -1259,17 +1266,17 @@ class CategoryData {
 class RadioData {
   public:
     RadioData();
-    
+
     GeneralSettings generalSettings;
     std::vector<CategoryData> categories;
     std::vector<ModelData> models;
-    
+
     void setCurrentModel(unsigned int index)
     {
       generalSettings.currModelIndex = index;
       strcpy(generalSettings.currModelFilename, models[index].filename);
     }
-    
+
     void fixModelFilename(unsigned int index)
     {
       ModelData & model = models[index];
@@ -1292,14 +1299,14 @@ class RadioData {
         sprintf(model.filename, "model%d.bin", index+1);
       }
     }
-    
+
     void fixModelFilenames()
     {
       for (unsigned int i=0; i<models.size(); i++) {
         fixModelFilename(i);
       }
     }
-    
+
     QString getNextModelFilename()
     {
       char filename[sizeof(ModelData::filename)];


### PR DESCRIPTION
For consistency with the other enums defined there.  On the radio side those same "nnConfig" enums are also defined in one place ([myeeprom.h](https://github.com/opentx/opentx/blob/next/radio/src/myeeprom.h#L138)).  :)    This also helps with some simulator stuff I'm working on.

The `SWITCH_` prefix here is a bit awkward because it conflicts with the `Switches` enum defined in [radiodata.h](https://github.com/opentx/opentx/blob/next/companion/src/radiodata.h#L8) .  But I understand it matches with the same enum names on radio side, which I guess helps semantically.  (Also that name `Switches` in global conflicts with something else... I forget what now.)

Though it does beg the question... is some shared place these enums could be better centralized?