### PR TITLE
[TravisCI] Set up for parallel Travis builds and use Qt5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,32 +11,36 @@ python:
 
 env:
   global:
-     # - QT_BASE=53
-     # - QT_BASE=54
-     # - QT_BASE=55
-     # - QT_BASE=56
-     - QT_BASE=57
-     #- GCC_ARM=/opt/gcc-arm-none-eabi/bin
+    # - QT_BASE=53
+    # - QT_BASE=54
+    # - QT_BASE=55
+    # - QT_BASE=56
+    - QT_BASE=57
+    #- GCC_ARM=/opt/gcc-arm-none-eabi/bin
+    - AVR_FLAVORS="AVR9X 9X GRUVIN9X MEGA2560"
   matrix:
-     # - FLAVOR=ALL
-     - FLAVOR=DEFAULT
-     - FLAVOR=AVR9X
-     # - FLAVOR=9X
-     # - FLAVOR=GRUVIN9X
-     # - FLAVOR=MEGA2560
-     - FLAVOR=ARM9X
-     # - FLAVOR=AR9X
-     # - FLAVOR=SKY9X
-     # - FLAVOR=9XRPRO
-     # - FLAVOR=TARANIS
-     - FLAVOR=X7
-     - FLAVOR=X9
-     # - FLAVOR=X9D
-     # - FLAVOR=X9D+
-     # - FLAVOR=X9E
-     - FLAVOR=HORUS
-     # - FLAVOR=X12Sr10
-     # - FLAVOR=X12S
+    #
+    # ALL will build every individual board & DEFAULT, sequentially.
+    # DEFAULT is "make all" (including Companion & Simulator), with default settings
+    #
+    # - FLAVOR=ALL
+    - FLAVOR=DEFAULT
+    - FLAVOR=AVR9X
+    # - FLAVOR=9X
+    # - FLAVOR=GRUVIN9X
+    # - FLAVOR=MEGA2560
+    - FLAVOR=ARM9X
+    # - FLAVOR=AR9X
+    # - FLAVOR=SKY9X
+    # - FLAVOR=9XRPRO
+    - FLAVOR=X7
+    - FLAVOR=X9
+    # - FLAVOR=X9D
+    # - FLAVOR=X9D+
+    # - FLAVOR=X9E
+    - FLAVOR=X12
+    # - FLAVOR=X12Sr10
+    # - FLAVOR=X12S
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-sdk-team/ppa --yes
@@ -52,13 +56,15 @@ before_install:
 install:
   - sudo apt-get --yes --force-yes install python3-pyqt5 curl libmpfr4 libmpc3 libfox-1.6-dev libgtest-dev
   - |
-    if [[ ${FLAVOR} == "ALL" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "9X" || ${FLAVOR} == "GRUVIN9X" || ${FLAVOR} == "MEGA2560" ]]; then
+    if [[ " ${AVR_FLAVORS} " =~ " ${FLAVOR} " || ${FLAVOR} == "ALL" ]]; then
       wget --quiet https://launchpad.net/ubuntu/+source/gcc-avr/1:4.9.2+Atmel3.5.0-1/+build/8403710/+files/gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb
       wget --quiet https://launchpad.net/ubuntu/+source/avr-libc/1:1.8.0+Atmel3.5.0-1/+build/8435473/+files/avr-libc_1.8.0+Atmel3.5.0-1_all.deb
       wget --quiet https://launchpad.net/ubuntu/+source/binutils-avr/2.25+Atmel3.5.0-2/+build/8435474/+files/binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
       sudo dpkg --install gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb avr-libc_1.8.0+Atmel3.5.0-1_all.deb binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
-    else
+    fi
+    if [[ ! " ${AVR_FLAVORS} " =~ " ${FLAVOR} " || ${FLAVOR} == "ALL" ]]; then
       sudo apt-get --yes --force-yes install gcc-arm-none-eabi
+      # Trying to build with gcc-arm 4.7 isn't working because it can't find the compiler, despite adding to PATH (in commit-tests.sh) by defining GCC_ARM above 
       # - wget --quiet https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/+download/gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2
       # - tar xjf gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2
       # - mv gcc-arm-none-eabi-4_7-2013q3 /opt/gcc-arm-none-eabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 dist: trusty
 language: python
+compiler: gcc
 
 virtualenv:
   system_site_packages: true
@@ -8,18 +9,61 @@ virtualenv:
 python:
   - 3.4
 
+env:
+  global:
+     # - QT_BASE=53
+     # - QT_BASE=54
+     # - QT_BASE=55
+     # - QT_BASE=56
+     - QT_BASE=57
+     #- GCC_ARM=/opt/gcc-arm-none-eabi/bin
+  matrix:
+     # - FLAVOR=ALL
+     - FLAVOR=AVR9X
+     # - FLAVOR=9X
+     # - FLAVOR=GRUVIN9X
+     # - FLAVOR=MEGA2560
+     - FLAVOR=ARM9X
+     # - FLAVOR=AR9X
+     # - FLAVOR=SKY9X
+     # - FLAVOR=9XRPRO
+     # - FLAVOR=TARANIS
+     - FLAVOR=X7
+     - FLAVOR=X9
+     # - FLAVOR=X9D
+     # - FLAVOR=X9D+
+     # - FLAVOR=X9E
+     - FLAVOR=HORUS
+     # - FLAVOR=X12Sr10
+     # - FLAVOR=X12S
+     - FLAVOR=COMPANION
+
 before_install:
   - sudo add-apt-repository ppa:ubuntu-sdk-team/ppa --yes
   - sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded --yes
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes
+  - if [ "$QT_BASE" = "53" ]; then sudo add-apt-repository ppa:beineri/opt-qt532-trusty -y; fi
+  - if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt542-trusty -y; fi
+  - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y; fi
+  - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
+  - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get --yes --force-yes install qtbase5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools python3-pyqt5 curl gcc-arm-none-eabi libmpfr4 libmpc3 libfox-1.6-dev libgtest-dev
-  - wget --quiet https://launchpad.net/ubuntu/+source/gcc-avr/1:4.9.2+Atmel3.5.0-1/+build/8403710/+files/gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb
-  - wget --quiet https://launchpad.net/ubuntu/+source/avr-libc/1:1.8.0+Atmel3.5.0-1/+build/8435473/+files/avr-libc_1.8.0+Atmel3.5.0-1_all.deb
-  - wget --quiet https://launchpad.net/ubuntu/+source/binutils-avr/2.25+Atmel3.5.0-2/+build/8435474/+files/binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
-  - sudo dpkg --install gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb avr-libc_1.8.0+Atmel3.5.0-1_all.deb binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
+  - sudo apt-get --yes --force-yes install python3-pyqt5 curl libmpfr4 libmpc3 libfox-1.6-dev libgtest-dev
+  - |
+    if [[ ${FLAVOR} == "ALL" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "9X" || ${FLAVOR} == "GRUVIN9X" || ${FLAVOR} == "MEGA2560" ]]; then
+      wget --quiet https://launchpad.net/ubuntu/+source/gcc-avr/1:4.9.2+Atmel3.5.0-1/+build/8403710/+files/gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb
+      wget --quiet https://launchpad.net/ubuntu/+source/avr-libc/1:1.8.0+Atmel3.5.0-1/+build/8435473/+files/avr-libc_1.8.0+Atmel3.5.0-1_all.deb
+      wget --quiet https://launchpad.net/ubuntu/+source/binutils-avr/2.25+Atmel3.5.0-2/+build/8435474/+files/binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
+      sudo dpkg --install gcc-avr_4.9.2+Atmel3.5.0-1_amd64.deb avr-libc_1.8.0+Atmel3.5.0-1_all.deb binutils-avr_2.25+Atmel3.5.0-2_amd64.deb
+    else
+      sudo apt-get --yes --force-yes install gcc-arm-none-eabi
+      # - wget --quiet https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/+download/gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2
+      # - tar xjf gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2
+      # - mv gcc-arm-none-eabi-4_7-2013q3 /opt/gcc-arm-none-eabi
+    fi
+  - sudo apt-get install -qq qt${QT_BASE}base qt${QT_BASE}multimedia qt${QT_BASE}tools; source /opt/qt${QT_BASE}/bin/qt${QT_BASE}-env.sh
 
 script:
   - ./tools/commit-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
      #- GCC_ARM=/opt/gcc-arm-none-eabi/bin
   matrix:
      # - FLAVOR=ALL
+     - FLAVOR=DEFAULT
      - FLAVOR=AVR9X
      # - FLAVOR=9X
      # - FLAVOR=GRUVIN9X
@@ -36,7 +37,6 @@ env:
      - FLAVOR=HORUS
      # - FLAVOR=X12Sr10
      # - FLAVOR=X12S
-     - FLAVOR=COMPANION
 
 before_install:
   - sudo add-apt-repository ppa:ubuntu-sdk-team/ppa --yes

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -55,7 +55,7 @@ if (( $WERROR )); then COMMON_OPTIONS+=" -DWARNINGS_AS_ERRORS=YES"; fi
 mkdir build || true
 cd build
 
-if [[ ${FLAVOR} == "9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " 9X AVR9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on 9X stock with FrSky telemetry
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
@@ -74,7 +74,7 @@ if [[ ${FLAVOR} == "9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
   make -j${CORES} ${FIRMARE_TARGET}
 fi
 
-if [[ ${FLAVOR} == "MEGA2560" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " MEGA2560 AVR9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Mega2560
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
@@ -90,7 +90,7 @@ if [[ ${FLAVOR} == "MEGA2560" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ;
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "GRUVIN9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " GRUVIN9X AVR9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on gruvin9x board
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
@@ -99,7 +99,7 @@ if [[ ${FLAVOR} == "GRUVIN9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ;
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "SKY9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " SKY9X ARM9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Sky9x
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
@@ -108,7 +108,7 @@ if [[ ${FLAVOR} == "SKY9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; th
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "AR9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " AR9X ARM9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on AR9X
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
@@ -117,7 +117,7 @@ if [[ ${FLAVOR} == "AR9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; the
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "9XRPRO" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " 9XRPRO ARM9X ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Sky9x
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=9XRPRO -DHELI=YES ${SRCDIR}
@@ -126,7 +126,7 @@ if [[ ${FLAVOR} == "9XRPRO" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; t
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X7" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X7 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on X7
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=X7 -DHELI=YES ${SRCDIR}
@@ -135,7 +135,7 @@ if [[ ${FLAVOR} == "X7" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; the
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X9D" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X9D X9 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on X9D
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
@@ -144,7 +144,7 @@ if [[ ${FLAVOR} == "X9D" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLA
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X9D+" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X9D+ X9 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on X9D+
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=X9D+ -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
@@ -153,7 +153,7 @@ if [[ ${FLAVOR} == "X9D+" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FL
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X9E" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X9E X9 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Taranis X9E
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DGVARS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
@@ -162,7 +162,7 @@ if [[ ${FLAVOR} == "X9E" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLA
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X12Sr10" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X12Sr10 X12 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Horus beta boards
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
@@ -171,7 +171,7 @@ if [[ ${FLAVOR} == "X12Sr10" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; 
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "X12S" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " X12S X12 ALL " =~ " ${FLAVOR} " ]] ; then
   # OpenTX on Horus
   rm -rf *
   cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
@@ -180,7 +180,7 @@ if [[ ${FLAVOR} == "X12S" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; the
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "DEFAULT" || ${FLAVOR} == "ALL" ]] ; then
+if [[ " DEFAULT ALL " =~ " ${FLAVOR} " ]] ; then
   # Companion
   rm -rf *
   cmake ${COMMON_OPTIONS} ${SRCDIR}

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -180,7 +180,7 @@ if [[ ${FLAVOR} == "X12S" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; the
   make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 fi
 
-if [[ ${FLAVOR} == "COMPANION" || ${FLAVOR} == "ALL" ]] ; then
+if [[ ${FLAVOR} == "DEFAULT" || ${FLAVOR} == "ALL" ]] ; then
   # Companion
   rm -rf *
   cmake ${COMMON_OPTIONS} ${SRCDIR}

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -5,9 +5,12 @@ set -e
 set -x
 
 # Allow variable core usage, default uses two cores, to set 8 cores for example : commit-tests.sh -j8
+: ${CORES:=2}
 # Default build treats warnings as errors, set -Wno-error to override, e.g.: commit-tests.sh -Wno-error
-CORES=2
-WERROR=1
+: ${WERROR:=1}
+# A board name to build for, or ALL 
+: ${FLAVOR:=ALL}
+
 for i in "$@"
 do
 case $i in
@@ -23,6 +26,10 @@ case $i in
       WERROR=0
       shift
       ;;
+    -b*)
+      FLAVOR="${i#*b}"
+      shift
+      ;;
 esac
 done
 
@@ -31,110 +38,151 @@ if [ "$(uname)" = "Darwin" ]; then
 else
     SCRIPT=$(readlink -f "$0")
 fi
+#export CMAKE_PREFIX_PATH=/opt/qt${QT_BASE}
+if [[ ! -z ${GCC_ARM} ]] ; then
+  export PATH=${GCC_ARM}:$PATH
+fi
 
-SRCDIR=$(dirname "$SCRIPT")/..
-COMMON_OPTIONS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/opt/qt55 -DTRACE_SIMPGMSPACE=NO -DVERBOSE_CMAKELISTS=YES -DCMAKE_RULE_MESSAGES=OFF -Wno-dev"
+: ${SRCDIR:=$(dirname "$SCRIPT")/..}
+
+: ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=Debug -DTRACE_SIMPGMSPACE=NO -DVERBOSE_CMAKELISTS=YES -DCMAKE_RULE_MESSAGES=OFF -Wno-dev"}
 if (( $WERROR )); then COMMON_OPTIONS+=" -DWARNINGS_AS_ERRORS=YES"; fi
-FIRMARE_TARGET="firmware-size"
+
+: ${TEST_OPTIONS:="--gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure"}
+
+: ${FIRMARE_TARGET:="firmware-size"}
 
 mkdir build || true
 cd build
 
-# OpenTX on 9X stock with FrSky telemetry
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on 9X stock with FrSky telemetry
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=FRSKY ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 
-# OpenTX on 9X stock with Ardupilot telemetry
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
+  # OpenTX on 9X stock with Ardupilot telemetry
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=ARDUPILOT ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
 
-# OpenTX on 9X stock with JETI telemetry
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
+  # OpenTX on 9X stock with JETI telemetry
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=9X -DHELI=YES -DTEMPLATES=YES -DTELEMETRY=JETI ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+fi
 
-# OpenTX on Mega2560
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "MEGA2560" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Mega2560
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTEMPLATES=YES -DHELI=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
 
-# OpenTX on Mega2560 with Mavlink telemetry
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+  # OpenTX on Mega2560 with Mavlink telemetry
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=MEGA2560 -DTELEMETRY=MAVLINK -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on gruvin9x board
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "GRUVIN9X" || ${FLAVOR} == "AVR9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on gruvin9x board
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=GRUVIN9X -DHELI=YES -DTEMPLATES=YES -DAUDIO=YES -DVOICE=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on Sky9x
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "SKY9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Sky9x
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=SKY9X -DHELI=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on AR9X
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "AR9X" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on AR9X
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=AR9X -DHELI=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on X7
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=X7 -DHELI=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "9XRPRO" || ${FLAVOR} == "ARM9X" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Sky9x
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=9XRPRO -DHELI=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on X9D
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "X7" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on X7
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=X7 -DHELI=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on X9D+
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=X9D+ -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "X9D" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on X9D
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=X9D -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on Taranis X9E
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DGVARS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "X9D+" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on X9D+
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=X9D+ -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on Horus beta boards
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "X9E" || ${FLAVOR} == "X9" || ${FLAVOR} == "TARANIS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Taranis X9E
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=X9E -DHELI=YES -DLUA=YES -DGVARS=YES -DPPM_UNIT=PERCENT_PREC1 ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# OpenTX on Horus
-rm -rf *
-cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
-make -j${CORES} ${FIRMARE_TARGET}
-make -j${CORES} simu
-make -j${CORES} gtests ; ./gtests --gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure
+if [[ ${FLAVOR} == "X12Sr10" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Horus beta boards
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=HORUS -DPCBREV=10 -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
 
-# Companion
-rm -rf *
-cmake ${COMMON_OPTIONS} ${SRCDIR}
-make -j${CORES}
+if [[ ${FLAVOR} == "X12S" || ${FLAVOR} == "HORUS" || ${FLAVOR} == "ALL" ]] ; then
+  # OpenTX on Horus
+  rm -rf *
+  cmake ${COMMON_OPTIONS} -DPCB=HORUS -DHELI=YES -DLUA=YES -DGVARS=YES ${SRCDIR}
+  make -j${CORES} ${FIRMARE_TARGET}
+  make -j${CORES} simu
+  make -j${CORES} gtests ; ./gtests ${TEST_OPTIONS}
+fi
+
+if [[ ${FLAVOR} == "COMPANION" || ${FLAVOR} == "ALL" ]] ; then
+  # Companion
+  rm -rf *
+  cmake ${COMMON_OPTIONS} ${SRCDIR}
+  make -j${CORES}
+fi


### PR DESCRIPTION
Check out the build times on the parallel builds vs. one single one... ~11-16min vs. 23+. Plus I added one more board (9XRPRO, not sure it's needed).  Plus you get to see results quicker, if one set of targets fails you still get tests on the others, and the logs are much shorter/easier to view.

Note that the [build summary](https://travis-ci.org/opentx/opentx/builds) page at Travis shows the total time for all the builds together.  You have to click through to the details to see the actual time.  The key point here is that the "sub-builds" run in parallel as slots become available.

Looks like Travis gives us up to 5 parallel builds across the whole repo (so that includes any other builds in progress).  So I have 6 now and the X7 build finishes quickly to open up a slot.  It could of course be split up any other way. 

I tried getting gcc-arm 5.7 working (to sync with production build server), but failed... it couldn't find the arm-none-eabi-g++ no matter what I tried (setting PATH every which way).  The code is still in `.travis.yml` if someone wants to give it a shot (obviously copied from the Docker setup).

-Max