### PR TITLE
Revert : Changes to allow Linux companion to be compiled with qt5.7 (#4262)

### DIFF
--- a/radio/util/Dockerfile
+++ b/radio/util/Dockerfile
@@ -1,6 +1,6 @@
 # An Debian image for compiling OpenTX 2.2
 
-FROM ubuntu:16.04
+FROM debian:jessie
 
 RUN apt-get update && \
     apt-get install -y \
@@ -9,20 +9,18 @@ RUN apt-get update && \
       cmake \
       gcc \
       git \
-      libgtest-dev \
       lib32ncurses5 \
       lib32z1 \
       libfox-1.6-dev \
       libsdl1.2-dev \
       python-qt4 \
+      qt5-default \
+      qtmultimedia5-dev \
+      qttools5-dev \
+      qttools5-dev-tools \
       software-properties-common \
       wget \
       zip
-
-RUN add-apt-repository ppa:beineri/opt-qt571-xenial -y && \
-    apt-get update && \
-    apt-get install -qq qt57base qt57multimedia qt57tools && \
-   /opt/qt57/bin/qt57-env.sh
 
 RUN wget -q https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/+download/gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2 && \
     tar xjf gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2 && \
@@ -39,4 +37,4 @@ VOLUME ["/opentx"]
 ENV PATH $PATH:/opt/gcc-arm-none-eabi/bin:/opentx/code/radio/util
 ARG OPENTX_VERSION_SUFFIX=
 ENV OPENTX_VERSION_SUFFIX ${OPENTX_VERSION_SUFFIX}
-ENV CMAKE_PREFIX_PATH /opt/qt57
+

--- a/tools/nightly22/build-nightly.sh
+++ b/tools/nightly22/build-nightly.sh
@@ -57,3 +57,4 @@ cd $output/companion/macosx
 wget -qO- http://opentx.blinkt.de:8080/~opentx/build-opentx.py?branch=${branch}\&suffix=${suffix}
 wget -O opentx-companion-${version}${suffix}.dmg http://opentx.blinkt.de:8080/~opentx/builds/opentx-companion-${version}${suffix}.dmg
 chmod -Rf g+w opentx-companion-${version}${suffix}.dmg
+


### PR DESCRIPTION
After lengthy discussion and many test, we feel we have to back down on this one, and offer a more mainstream and usable version.

We will continue to investigate ways to distribute more versions