### PR TITLE
Force different file name after conversion

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -168,7 +168,7 @@ void MdiChild::onFirmwareChanged()
 
 void MdiChild::convertStorage(BoardEnum from, BoardEnum to)
 {
-  QMessageBox::warning(this, "Companion", tr("Models and settings will be automatically converted"), QMessageBox::Ok);
+  QMessageBox::warning(this, "Companion", tr("Models and settings will be automatically converted.\nIf that is not what you intended, please close the file\nand choose the correct radio type/profile before reopening it."), QMessageBox::Ok);
   radioData.convert(from, to);
   forceNewFilename("_converted", ".otx");
   initModelsList();

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -152,10 +152,10 @@ void MdiChild::showModelsListContextMenu(const QPoint & pos)
   contextMenu.exec(globalPos);
 }
 
-void MdiChild::setCurrentFileExtension(const QString & ext)
+void MdiChild::forceNewFilename(const QString & suffix, const QString & ext)
 {
   QFileInfo info(curFile);
-  curFile = info.path() + "/" + info.baseName() + ext;
+  curFile = info.path() + "/" + info.baseName() + suffix + ext;
 }
 
 void MdiChild::onFirmwareChanged()
@@ -170,9 +170,10 @@ void MdiChild::convertStorage(BoardEnum from, BoardEnum to)
 {
   QMessageBox::warning(this, "Companion", tr("Models and settings will be automatically converted"), QMessageBox::Ok);
   radioData.convert(from, to);
-  setCurrentFileExtension(".otx");
+  forceNewFilename("_converted", ".otx");
   initModelsList();
   fileChanged = true;
+  isUntitled = true;
   documentWasModified();
 }
 

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -60,7 +60,7 @@ class MdiChild : public QWidget
 
   protected:
     void convertStorage(BoardEnum from, BoardEnum to);
-    void setCurrentFileExtension(const QString & ext);
+    void forceNewFilename(const QString & suffix, const QString & ext);
     void closeEvent(QCloseEvent * event);
 
   protected slots:


### PR DESCRIPTION
If we're ok to do that, should we not also automatically change every bin and hex file to .otx when opened?

Anything that might break or is storage type well decoupled from the extension now? 