### PR TITLE
Shorten GVx to Gx on 128x64 radios, where screen estate is a real issue

### DIFF
--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -760,7 +760,7 @@
 #define TR_SLOWUP              TR3("Zpomalení(+)", "Zpomal(\176)", "Zpomalení(\176)")
 #define TR_MIXER               "MIXER"
 #define TR_CV                  "K"
-#define TR_GV                  "GP"
+#define TR_GV                  TR("G", "GP")
 #define TR_ACHANNEL            "A\004Kanál"
 #define TR_RANGE               INDENT"Rozsah"
 #define TR_CENTER              INDENT "Střed"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -758,7 +758,7 @@
 #define TR_SLOWUP              "Langs.Up"
 #define TR_MIXER               "MISCHER"
 #define TR_CV                  "KV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            TR("A\004gemessen", "A\004Kanal gemessen =>") //9XR-Pro
 #define TR_RANGE               TR(INDENT "Bereich", INDENT "Variobereich m/s") // 9XR-Pro
 #define TR_CENTER              TR(INDENT "Mitte m/s", INDENT "Variomitte     m/s")

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -733,7 +733,7 @@
 #define TR_SLOWUP                      "Slow  up"
 #define TR_MIXER                       "MIXER"
 #define TR_CV                          "CV"
-#define TR_GV                          "GV"
+#define TR_GV                          TR("G", "GV")
 #define TR_ACHANNEL                    "A\004channel"
 #define TR_RANGE                       INDENT "Range"
 #define TR_CENTER                      INDENT "Center"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -717,7 +717,7 @@
 #define TR_SLOWUP              "Slow  Up"
 #define TR_MIXER               "Mezclas"
 #define TR_CV                  "CV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\004canal"
 #define TR_RANGE               INDENT"Alcance"
 #define TR_CENTER              INDENT "Center"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -717,7 +717,7 @@
 #define TR_SLOWUP              "Slow  Up"
 #define TR_MIXER               "MIXER"
 #define TR_CV                  "CV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\004channel"
 #define TR_RANGE               INDENT"Range"
 #define TR_CENTER              INDENT "Center"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -745,7 +745,7 @@
 #define TR_SLOWUP              "Ralenti haut"
 #define TR_MIXER               "MIXEUR"
 #define TR_CV                  "CB"
-#define TR_GV                  "VG"
+#define TR_GV                  TR("G", "VG")
 #define TR_ACHANNEL            "A"
 #define TR_RANGE               INDENT "Plage"
 #define TR_CENTER              INDENT "Centre"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -743,7 +743,7 @@
 #define TR_SLOWUP              "Rall.Sù"
 #define TR_MIXER               "MIXER"
 #define TR_CV                  "CV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\002ingresso"
 #define TR_RANGE               TR(INDENT"Inter.", INDENT"Intervallo")
 #define TR_CENTER              INDENT "Centro"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -729,7 +729,7 @@
 #define TR_SLOWUP              "Langz.Up"
 #define TR_MIXER               "MIXER"
 #define TR_CV                  "CV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\004kanaal"
 #define TR_RANGE               INDENT "Bereik"
 #define TR_CENTER              INDENT "Centreer"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -745,7 +745,7 @@
 #define TR_SLOWUP              "Spowoln.(+)"
 #define TR_MIXER               "MIKSERY"
 #define TR_CV                  "Kr"
-#define TR_GV                  "ZG"
+#define TR_GV                  TR("G", "ZG")
 #define TR_ACHANNEL            "A\004Kanał"
 #define TR_RANGE               INDENT "Zakres"
 #define TR_CENTER              INDENT "Środek"

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -712,7 +712,7 @@
 #define TR_SLOWUP              "Lento  Up"
 #define TR_MIXER               "MIXAGENS"
 #define TR_CV                  "CV"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\004Canal"
 #define TR_RANGE               INDENT"Range"
 #define TR_CENTER              INDENT "Center"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -756,7 +756,7 @@
 #define TR_SLOWUP              "Trög Upp"
 #define TR_MIXER               "MIXAR"
 #define TR_CV                  "KU"
-#define TR_GV                  "GV"
+#define TR_GV                  TR("G", "GV")
 #define TR_ACHANNEL            "A\004kanal  "
 #define TR_RANGE               INDENT"MinMax"
 #define TR_CENTER              INDENT "Center"


### PR DESCRIPTION
It is a proposal to gain some space on busy 128x64 screens. Bellow are some example on how it looks.

![image](https://cloud.githubusercontent.com/assets/5167938/22255452/b4c90b0e-e257-11e6-9fed-2e154a312395.png)

![image](https://cloud.githubusercontent.com/assets/5167938/22255471/beb4da26-e257-11e6-88cc-bada7897ee48.png)
