### PR TITLE
3djc/x7 mixer screen rework

### DIFF
--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -228,12 +228,23 @@ void displayMixInfos(coord_t y, MixData * md)
   lcdDrawChar(MIX_LINE_DELAY_POS, y, cs);
 }
 
-void displayMixLine(coord_t y, MixData * md)
+void displayMixLine(coord_t y, MixData * md, bool active)
 {
-  if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
-    displayMixInfos(y, md);
-  else
-    displayFlightModes(MIX_LINE_FM_POS, y, md->flightModes);
+  if(active && md->name[0]) {
+    lcdDrawSizedText(FW*sizeof(TR_MIXER), 0, md->name, sizeof(md->name), ZCHAR);
+    if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
+      displayMixInfos(y, md);
+    else
+      displayFlightModes(MIX_LINE_FM_POS, y, md->flightModes);
+  }
+  else {
+    if (md->name[0])
+      lcdDrawSizedText(MIX_LINE_NAME_POS, y, md->name, sizeof(md->name), ZCHAR);
+    else if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
+      displayMixInfos(y, md);
+    else
+      displayFlightModes(MIX_LINE_FM_POS, y, md->flightModes);
+  }
 }
 #endif // LCD_W >= 212
 
@@ -426,16 +437,13 @@ void menuModelMixAll(event_t event)
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           LcdFlags attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
 
-          if (cur == sub && md->name[0])
-              lcdDrawSizedText(FW*sizeof(TR_MIXER), 0, md->name, sizeof(md->name), ZCHAR);
-
           if (mixCnt > 0) lcdDrawTextAtIndex(FW, y, STR_VMLTPX2, md->mltpx, 0);
 
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
           gvarWeightItem(MIX_LINE_WEIGHT_POS, y, md, RIGHT | attr | (isMixActive(i) ? BOLD : 0), 0);
 
-          displayMixLine(y, md);
+          displayMixLine(y, md, (sub == cur));
 
           if (s_copyMode) {
             if ((s_copyMode==COPY_MODE || s_copyTgtOfs == 0) && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -195,12 +195,12 @@ void displayMixLine(coord_t y, MixData * md)
     cs = (cs == 'S' ? '*' : 'D');
   lcdDrawChar(MIX_LINE_DELAY_POS, y, cs);
 }
-#else
+#else // LCD_W >= 212
 #define MIX_LINE_WEIGHT_POS            6*FW+8
 #define MIX_LINE_SRC_POS               7*FW+3
-#define MIX_LINE_CURVE_POS             12*FW
-#define MIX_LINE_SWITCH_POS            16*FW+4
-#define MIX_LINE_FM_POS                13*FW+3
+#define MIX_LINE_CURVE_POS             12*FW+3
+#define MIX_LINE_SWITCH_POS            16*FW+5
+#define MIX_LINE_FM_POS                19*FW
 #define MIX_LINE_DELAY_POS             20*FW+2
 #define MIX_LINE_NAME_POS              LCD_W-LEN_EXPOMIX_NAME*FW
 
@@ -230,14 +230,12 @@ void displayMixInfos(coord_t y, MixData * md)
 
 void displayMixLine(coord_t y, MixData * md)
 {
-  if (md->name[0])
-    lcdDrawSizedText(MIX_LINE_NAME_POS, y, md->name, sizeof(md->name), ZCHAR);
-  else if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
+  if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
     displayMixInfos(y, md);
   else
     displayFlightModes(MIX_LINE_FM_POS, y, md->flightModes);
 }
-#endif
+#endif // LCD_W >= 212
 
 void menuModelMixAll(event_t event)
 {
@@ -427,6 +425,9 @@ void menuModelMixAll(event_t event)
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           LcdFlags attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
+
+          if (cur == sub && md->name[0])
+              lcdDrawSizedText(FW*sizeof(TR_MIXER), 0, md->name, sizeof(md->name), ZCHAR);
 
           if (mixCnt > 0) lcdDrawTextAtIndex(FW, y, STR_VMLTPX2, md->mltpx, 0);
 

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -442,8 +442,11 @@ void menuModelMixAll(event_t event)
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
           gvarWeightItem(MIX_LINE_WEIGHT_POS, y, md, RIGHT | attr | (isMixActive(i) ? BOLD : 0), 0);
-
+#if LCD_W >= 212
+          displayMixLine(y, md);
+#else
           displayMixLine(y, md, (sub == cur));
+#endif
 
           if (s_copyMode) {
             if ((s_copyMode==COPY_MODE || s_copyTgtOfs == 0) && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {


### PR DESCRIPTION
Please review thoroughly

- fix FM display that was completely off

Introduce a way to see more details on a mixer quickly without having to got to details when there is a mix name defined.

Currently : if there is a name, it is displayed
Proposed : if the is a name, it is displayed, but on active row, the name is moved to title bar, and data is displayed instead