### PR TITLE
Prevent Companion crash if input data is smaller than required

### DIFF
--- a/companion/src/eepromimportexport.h
+++ b/companion/src/eepromimportexport.h
@@ -68,6 +68,10 @@ class DataField {
     int Import(const QByteArray & input)
     {
       QBitArray bits = bytesToBits(input);
+      if ((unsigned int)bits.size() < size()) {
+        qDebug() << QString("Error importing %1: size to small %2/%3").arg(getName()).arg(input.size()).arg(size());
+        return -1;
+      }
       ImportBits(bits);
       return 0;
     }

--- a/companion/src/firmwares/opentx/opentxeeprom.h
+++ b/companion/src/firmwares/opentx/opentxeeprom.h
@@ -40,6 +40,8 @@ class OpenTxGeneralData: public TransformedField {
   public:
     OpenTxGeneralData(GeneralSettings & generalData, Board::Type board, unsigned int version, unsigned int variant=0);
 
+    virtual const char * getName() { return internalField.getName(); }
+
   protected:
     virtual void beforeExport();
     virtual void afterImport();
@@ -107,7 +109,7 @@ class OpenTxModelData: public TransformedField {
   public:
     OpenTxModelData(ModelData & modelData, Board::Type board, unsigned int version, unsigned int variant);
 
-    const char * getName() { return name; }
+    virtual const char * getName() { return internalField.getName(); }
 
   protected:
     virtual void beforeExport();

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -171,7 +171,9 @@ template <class T, class M>
 bool OpenTxEepromInterface::loadFromByteArray(T & dest, const QByteArray & data, uint8_t version, uint32_t variant)
 {
   M manager(dest, board, version, variant);
-  manager.Import(data);
+  if (manager.Import(data) != 0) {
+    return false;
+  }
   // manager.Dump(); // Dumps the structure so that it's easy to check with firmware datastructs.h
   return true;
 }


### PR DESCRIPTION
Loading a bad .otx resulted in segfault because input bits array was smaller then for example radio data array. 

Qt does assert when accessing QByteArray[n] with n >= size.
```
ASSERT: "i >= 0 && i < size()"
```
