### PR TITLE
Fix for #4222: On Horus GUI, can't edit X values for < 3-point curves.

### DIFF
--- a/radio/src/gui/480x272/model_curves.cpp
+++ b/radio/src/gui/480x272/model_curves.cpp
@@ -91,7 +91,13 @@ bool menuModelCurveOne(event_t event)
   lcdDrawSolidFilledRect(0, MENU_FOOTER_TOP, 250, MENU_FOOTER_HEIGHT, HEADER_BGCOLOR);
 
   if (crv.type==CURVE_TYPE_CUSTOM && menuVerticalPosition == ITEM_CURVE_COORDS1) {
-    if (menuHorizontalPosition == 0) {
+    if (crv.points <= -3) { // can't edit X values on custom curves with 2 points.
+      if (CURSOR_MOVED_RIGHT(event))
+        (menuHorizontalPosition = 0, menuVerticalPosition += 1);
+      else
+        menuVerticalPosition -= 1;
+    }
+    else if (menuHorizontalPosition == 0) {
       if (CURSOR_MOVED_RIGHT(event))
         menuHorizontalPosition = 1;
       else


### PR DESCRIPTION
After looking at the Taranis GUI code, I decided to emulate what that
does, which is just skip over the X coord line in the menu if when
curve type is custom and points is <= 2.

TESTING DONE:
Tested Horus in the simulator. Trying a variety of combinations of 2 and 3 point custom and standad curves while using the rotory dial to scroll thru the menu positions.