### PR TITLE
Move antenna switch to module switches

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -340,6 +340,7 @@ void ModulePanel::update()
   // Antenna slection on Horus
   ui->label_antenna->setVisible(mask & MASK_ANTENNA);
   ui->antennaMode->setVisible(mask & MASK_ANTENNA);
+  ui->antennaMode->setCurrentIndex(module.ppm.pulsePol);
 
   // Multi settings fields
   ui->label_multiProtocol->setVisible(mask & MASK_MULTIMODULE);


### PR DESCRIPTION
Fix display when module is OFF

This fixes "Horus: Internal/external antenna choice showing up even if internal module is OFF (should be in modulePanel too)" in #4224