### PR TITLE
Re #4224 Add "rename" item to Category context menu in companion.

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -139,6 +139,8 @@ void MdiChild::showModelsListContextMenu(const QPoint & pos)
   else if (IS_HORUS(firmware->getBoard())) {
     if (modelsListModel->getCategoryIndex(modelIndex) >= 0) {
       contextMenu.addAction(CompanionIcon("add.png"), tr("&Add model"), this, SLOT(modelAdd()));
+      contextMenu.addSeparator();
+      contextMenu.addAction(CompanionIcon("rename.png"), tr("&Rename category"), this, SLOT(categoryRename()));
       contextMenu.addAction(CompanionIcon("delete.png"), tr("&Delete category"), this, SLOT(categoryDelete()));
     }
     else {
@@ -368,6 +370,19 @@ void MdiChild::categoryAdd()
   CategoryData category("New category");
   radioData.categories.push_back(category);
   setModified();
+}
+
+void MdiChild::categoryRename()
+{
+  QModelIndex modelIndex  = ui->modelsList->currentIndex();
+  int categoryIndex = modelsListModel->getCategoryIndex(modelIndex);
+  if (categoryIndex < 0 || categoryIndex >= (int)radioData.categories.size()) {
+    return;
+  }
+
+  // Not calling setModified() here because QAbstractItemView::edit will
+  // haandle it if the user actually makes a change
+  ui->modelsList->edit(modelIndex);
 }
 
 void MdiChild::categoryDelete()

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -54,7 +54,7 @@ class MdiChild : public QWidget
     int getCurrentRow() const;
     void refresh(bool expand=false);
     void keyPressEvent(QKeyEvent * event);
-  
+
   signals:
     void copyAvailable(bool val);
 
@@ -69,12 +69,13 @@ class MdiChild : public QWidget
     void on_radioSettings_clicked();
     void setDefault();
     void onFirmwareChanged();
-  
+
   public slots:
     void showModelsListContextMenu(const QPoint & pos);
     void checkAndInitModel(int row);
     void generalEdit();
     void categoryAdd();
+    void categoryRename();
     void categoryDelete();
     void modelAdd();
     void modelEdit();
@@ -84,7 +85,7 @@ class MdiChild : public QWidget
     void confirmDelete();
     void deleteSelectedModels();
     void onDataChanged(const QModelIndex & index);
-    
+
     void cut();
     void copy();
     void paste();
@@ -101,11 +102,11 @@ class MdiChild : public QWidget
     void doCopy(QByteArray * gmData);
     void doPaste(QByteArray * gmData, int index);
     void initModelsList();
-    
+
     MainWindow * parent;
     Ui::MdiChild * ui;
     TreeModel * modelsListModel;
-    
+
     QString curFile;
 
     Firmware * firmware;

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -321,7 +321,7 @@ ModelsListWidget::ModelsListWidget(QWidget * parent):
 {
   setColumnWidth(0, 50);
   setColumnWidth(2, 100);
-  
+
   active_highlight_color = palette().color(QPalette::Active, QPalette::Highlight);
 }
 
@@ -337,7 +337,7 @@ void ModelsListWidget::mouseMoveEvent(QMouseEvent *event)
 {
   if (!(event->buttons() & Qt::LeftButton))
     return;
-  
+
   if ((event->pos() - dragStartPosition).manhattanLength() < QApplication::startDragDistance())
     return;
 


### PR DESCRIPTION
- Adds "rename" to the context menu for categories, it uses the
same code path as the default dblClick handler for the base class.

- Added a separator so the context menu looks more like the one
for models

- Some whitespace changes in mdichild.h, my editor truncates
whitespace on blank lines. Let me know if you don't like this.
