### PR TITLE
Issue #4224: Implement "duplicate model" in Companion

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -128,7 +128,7 @@ void MdiChild::showModelsListContextMenu(const QPoint & pos)
     contextMenu.addAction(CompanionIcon("copy.png"), tr("&Copy"), this, SLOT(copy()), tr("Ctrl+C"));
     contextMenu.addAction(CompanionIcon("cut.png"), tr("&Cut"), this, SLOT(cut()), tr("Ctrl+X"));
     contextMenu.addAction(CompanionIcon("paste.png"), tr("&Paste"), this, SLOT(paste()), tr("Ctrl+V"))->setEnabled(hasData);
-    contextMenu.addAction(CompanionIcon("duplicate.png"), tr("D&uplicate"), this, SLOT(duplicate()), tr("Ctrl+U"));
+    contextMenu.addAction(CompanionIcon("duplicate.png"), tr("D&uplicate"), this, SLOT(modelDuplicate()), tr("Ctrl+U"));
     contextMenu.addSeparator();
     contextMenu.addAction(CompanionIcon("currentmodel.png"), tr("&Use as default"), this, SLOT(setDefault()));
     contextMenu.addSeparator();
@@ -438,10 +438,15 @@ void MdiChild::modelAdd()
   ModelData model;
   model.category = categoryIndex;
   model.used = true;
-  sprintf(model.filename, "model%lu.bin", (long unsigned)radioData.models.size()+1);
+  strcpy(model.filename, radioData.getNextModelFilename().toStdString().c_str());
   strcpy(model.name, qPrintable(tr("New model")));
   radioData.models.push_back(model);
-  radioData.setCurrentModel(radioData.models.size() - 1);
+
+  // Only set the default model if we just added the first one.
+  int newModelIndex = radioData.models.size() - 1;
+  if (newModelIndex == 0) {
+    radioData.setCurrentModel(newModelIndex);
+  }
   setModified();
 }
 
@@ -461,6 +466,19 @@ void MdiChild::modelEdit()
   t->show();
   QApplication::restoreOverrideCursor();
   gStopwatch.report("ModelEdit shown");
+}
+
+void MdiChild::modelDuplicate()
+{
+  int srcModelIndex = getCurrentRow();
+  if (srcModelIndex < 0) {
+    return;
+  }
+
+  ModelData model(radioData.models[srcModelIndex]);
+  strcpy(model.filename, radioData.getNextModelFilename().toStdString().c_str());
+  radioData.models.push_back(model);
+  setModified();
 }
 
 void MdiChild::setDefault()

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -79,6 +79,7 @@ class MdiChild : public QWidget
     void categoryDelete();
     void modelAdd();
     void modelEdit();
+    void modelDuplicate();
     void wizardEdit();
     void openModelEditWindow();
     bool loadBackup();


### PR DESCRIPTION
Just what it says in the title, implement the "duplicate model" action in
Companion's context menu. This isn't actually listed in #4224, but it
feels like something that would be and I couldn't find a separate issue
for this.

Also, fixed "modelAdd" so that it only sets the default model if it just
added the first one. Previously, the newly added model would become the
default, which seemed like the wrong thing. 