### PR TITLE
Several Lua improvements for stability

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -418,9 +418,15 @@ int cliMemoryInfo(const char ** argv)
 
 #if defined(LUA)
   serialPrint("\nLua:");
-  serialPrint("\tScripts %d", luaGetMemUsed(lsScripts));
-#if defined(PCBHORUS)
-  serialPrint("\tWidgets %d", luaGetMemUsed(lsWidgets));
+  uint32_t s = luaGetMemUsed(lsScripts);
+  serialPrint("\tScripts %u", s);
+#if defined(COLORLCD)
+  uint32_t w = luaGetMemUsed(lsWidgets);
+  uint32_t e = luaExtraMemoryUsage;
+  serialPrint("\tWidgets %u", w);
+  serialPrint("\tExtra   %u", e);
+  serialPrint("------------");
+  serialPrint("\tTotal   %u", s + w + e);
 #endif
 #endif
   return 0;

--- a/radio/src/gui/480x272/bitmapbuffer.h
+++ b/radio/src/gui/480x272/bitmapbuffer.h
@@ -79,6 +79,11 @@ class BitmapBufferBase
       return data;
     }
 
+    uint32_t getDataSize() const
+    {
+      return width * height * sizeof(T);
+    }
+
     inline const display_t * getPixelPtr(coord_t x, coord_t y) const
     {
 #if defined(PCBX10)

--- a/radio/src/gui/480x272/screens_setup.cpp
+++ b/radio/src/gui/480x272/screens_setup.cpp
@@ -176,6 +176,23 @@ int getOptionsCount(const ZoneOption * options)
 template <class T>
 bool menuSettings(const char * title, const T * object, uint32_t i_flags, event_t event)
 {
+
+  if (object->getErrorMessage()) {
+    // display error instead of widget settings
+    // TODO nicer display (proper word-wrap)
+    SIMPLE_SUBMENU("Widget Error", ICON_MODEL_LUA_SCRIPTS, 1);
+    int len = strlen(object->getErrorMessage());
+    int y = 3*FH;
+    const char * p = object->getErrorMessage();
+    while (len > 0) {
+      lcdDrawSizedText(MENUS_MARGIN_LEFT, y, p, 30);
+      p += 30;
+      y += FH;
+      len -= 30;
+    }
+    return true;
+  }
+
   const ZoneOption * options = object->getOptions();
   linesCount = getOptionsCount(options);
   uint8_t mstate_tab[MAX_WIDGET_OPTIONS];

--- a/radio/src/gui/480x272/view_statistics.cpp
+++ b/radio/src/gui/480x272/view_statistics.cpp
@@ -139,6 +139,16 @@ bool menuStatsDebug(event_t event)
   lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP+line*FH, "Lua interval");
   lcdDrawNumber(MENU_STATS_COLUMN1, MENU_CONTENT_TOP+line*FH, 10*maxLuaInterval, LEFT, 0, NULL, "ms");
   ++line;
+
+  lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP+line*FH, "Lua memory");
+  lcdDrawText(MENU_STATS_COLUMN1, MENU_CONTENT_TOP+line*FH+1, "[S]", HEADER_COLOR|SMLSIZE);
+  lcdDrawNumber(lcdNextPos+5, MENU_CONTENT_TOP+line*FH, luaGetMemUsed(lsScripts), LEFT);
+  lcdDrawText(lcdNextPos+20, MENU_CONTENT_TOP+line*FH+1, "[W]", HEADER_COLOR|SMLSIZE);
+  lcdDrawNumber(lcdNextPos+5, MENU_CONTENT_TOP+line*FH, luaGetMemUsed(lsWidgets), LEFT);
+  lcdDrawText(lcdNextPos+20, MENU_CONTENT_TOP+line*FH+1, "[B]", HEADER_COLOR|SMLSIZE);
+  lcdDrawNumber(lcdNextPos+5, MENU_CONTENT_TOP+line*FH, luaExtraMemoryUsage, LEFT);
+  ++line;
+
 #endif
 
   lcdDrawText(LCD_W/2, MENU_FOOTER_TOP+2, STR_MENUTORESET, CENTERED);

--- a/radio/src/gui/480x272/widget.h
+++ b/radio/src/gui/480x272/widget.h
@@ -56,6 +56,11 @@ class Widget
 
     inline const ZoneOption * getOptions() const;
 
+    virtual const char * getErrorMessage() const
+    {
+      return NULL;
+    }
+
     inline ZoneOptionValue * getOptionValue(unsigned int index) const
     {
       return &persistentData->options[index];

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include "opentx.h"
 #include "stamp.h"
-#include "lua/lua_api.h"
+#include "lua_api.h"
 #include "telemetry/frsky.h"
 
 #if defined(PCBX12S)

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -21,13 +21,13 @@
 #include <ctype.h>
 #include <stdio.h>
 #include "opentx.h"
-#include "lua/lua_api.h"
+#include "lua_api.h"
 #include "timers.h"
 
 /*luadoc
 @function model.getInfo()
 
-Get current Model information 
+Get current Model information
 
 @retval table model information:
  * `name` (string) model name

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -44,6 +44,9 @@ extern "C" {
 extern lua_State * lsScripts;
 extern lua_State * lsWidgets;
 extern bool luaLcdAllowed;
+#if defined(COLORLCD)
+extern uint32_t luaExtraMemoryUsage;
+#endif
 
 void luaInit();
 void luaInitThemesAndWidgets();
@@ -116,8 +119,9 @@ extern ScriptInputsOutputs scriptInputsOutputs[MAX_SCRIPTS];
 void luaClose(lua_State ** L);
 bool luaTask(event_t evt, uint8_t scriptType, bool allowLcdUsage);
 void luaExec(const char * filename);
+void luaDoGc(lua_State * L, bool full);
 void luaError(lua_State * L, uint8_t error, bool acknowledge=true);
-int luaGetMemUsed(lua_State * L);
+uint32_t luaGetMemUsed(lua_State * L);
 void luaGetValueAndPush(lua_State * L, int src);
 #define luaGetCpuUsed(idx) scriptInternalData[idx].instructions
 uint8_t isTelemetryScriptAvailable(uint8_t index);


### PR DESCRIPTION
Lua: Use incremental GC and also call it for Widgets
Fixes #3885: Error in Lua Widget options handled better (does not disable entire Lua state)
Disable Lua Widget if any of its functions has error.

This is a rough concept:
 * if a widget has Lua erorr, remember error and disable offending widget (it is still availabe in factory, should it be removed from there also?)
 * show widget error to user in widget settings screen   (very rough, should be improved visually)
 * I thought GC was running in Lua automagically, looks like it is not, lua_gc() call is needed, this commit also fixes this. The Scripts are also not GC so aggressively now (was always full GC). Needs testing and tuning (amount of work for incremental GC can be tuned).
 * Added a variable that keeps the total value of memory used by bitmaps that were loaded from withing Lua. This will enable Lua script memory usage limiting. See #4284 

Further ideas for this PR:
 * add Lua debug buffer (Horus only) which would store last N lua outputs (errors from interpreter and print()), Create a new screen that will display this buffer and allow user to scroll trough it. Options: save to file, clear.
 * Implement #4284