### PR TITLE
Issue #4368. Don't duplicate categories in OTX's models.txt

### DIFF
--- a/companion/src/storage/categorized.cpp
+++ b/companion/src/storage/categorized.cpp
@@ -125,7 +125,7 @@ bool CategorizedStorageFormat::write(const RadioData & radioData)
     return false;
   }
 
-  for (unsigned int m=0; m<numModels; m++) {
+  for (size_t m=0; m<numModels; m++) {
     const ModelData & model = radioData.models[m];
     if (model.isEmpty()) continue;
 
@@ -151,10 +151,10 @@ bool CategorizedStorageFormat::write(const RadioData & radioData)
   }
 
   if (getCurrentFirmware()->getCapability(HasModelCategories)) {
-    for (int c= 0; c<numCategories; c++) {
+    for (size_t c=0; c<numCategories; c++) {
       modelsList.append(QString().sprintf("[%s]\n", radioData.categories[c].name));
       numModels = sortedModels[c].size();
-      for (unsigned int m=0; m<numModels; m++) {
+      for (size_t m=0; m<numModels; m++) {
         modelsList.append(sortedModels[c][m]);
       }
     }


### PR DESCRIPTION
The previous code  didn't account for this situations where the models vector
contained models from category 1, followed by models from category 2,
followed by models from category 1. In this situaion, models.txt would have
two categories named "category 1". 

The overall problem is that we need to output models to models.txt sorted first by category index than by model index.  I'm not really happy with the approach here, but I this is what came to mind:

- Create a map: of category indices to a vector of model indices 
- While running thru the models vector writing .bin files, store indices to models and categories in sortedModels. For category-less models, store them with map key '-1' 
- When done, iterate over known category indices in the map, outputting the category line followed by the model lines 

I tested this in Companion on OSX with both the Horus and Taranis radio profiles, converting back and forth, testing edge cases like empty categories etc. It all seems work. But, the code doesn't feel very readable to me, it's a bit too opaque. So, I'm hoping for suggestions. Some approaches I thought about but discarded:

- Leave existing code, but do std:stable_sort on radioData.models before iterating over it. Use a comparison function that sorted by category index. This feels like the best solution, but given how new I am to the codebase, I was worried sorting the models vector or adding move constructors would had side effects I couldn't see. 

- Forget the "map of indices" data structure and just brute force it. This would be something like and outer loop over categories, then an inner loop over models looking for the current category index. It's m*n time, but maybe we don't care? It would probably leave cleaner looking code.

- Store something more straightforward in the map, like the actual category and model strings to be outputted to models.txt. This doesn't quite work because it should be  have two different categories with the same name, so this would end up actually a little more complicated than what I had

Hopefully someone has a better idea.