### PR TITLE
Issue #4375, fix pasting multiple items in Companion.

### DIFF
--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -101,7 +101,7 @@ class MdiChild : public QWidget
     bool maybeSave();
     void setCurrentFile(const QString & fileName);
     void doCopy(QByteArray * gmData);
-    void doPaste(QByteArray * gmData, int modelIdx, int categoryIdx);
+    void doPaste(QByteArray * gmData, QModelIndex row);
     void initModelsList();
 
     MainWindow * parent;

--- a/companion/src/modelslist.h
+++ b/companion/src/modelslist.h
@@ -98,6 +98,9 @@ class TreeModel : public QAbstractItemModel
       return getItem(index)->getCategoryIndex();
     }
 
+    int rowNumber(const QModelIndex & index = QModelIndex()) const {
+      return getItem(index)->childNumber();
+    }
   private:
     TreeItem * getItem(const QModelIndex & index) const;
     TreeItem * rootItem;


### PR DESCRIPTION
Fixes issue #4375.

With category-capable radio profiles, finding the next row to paste into mean following the UI rows rather than just getting the next model in radioData. Also, we have to account for possibly pasting "off-the-end" of the category. In that case, the extra models in the paste data will end added to the same category. 

For non-category capable models, the same code works (I tested on Taranis profile!)  because the UI layout appears sort of like one big category. 