### PR TITLE
Fixes telemetry stream confusion

### DIFF
--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -139,6 +139,8 @@
 #define RBOX_STATE_LAST_ID        0x0b2f
 #define RBOX_CNSP_FIRST_ID        0x0b30
 #define RBOX_CNSP_LAST_ID         0x0b3f
+#define DIY_FIRST_ID              0x5100
+#define DIY_LAST_ID               0x52ff
 #define DIY_STREAM_FIRST_ID       0x5100
 #define DIY_STREAM_LAST_ID        0x51ff
 #define RSSI_ID                   0xf101

--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -139,8 +139,8 @@
 #define RBOX_STATE_LAST_ID        0x0b2f
 #define RBOX_CNSP_FIRST_ID        0x0b30
 #define RBOX_CNSP_LAST_ID         0x0b3f
-#define DIY_FIRST_ID              0x5000
-#define DIY_LAST_ID               0x52ff
+#define DIY_STREAM_FIRST_ID       0x5100
+#define DIY_STREAM_LAST_ID        0x51ff
 #define RSSI_ID                   0xf101
 #define ADC1_ID                   0xf102
 #define ADC2_ID                   0xf103

--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -139,10 +139,10 @@
 #define RBOX_STATE_LAST_ID        0x0b2f
 #define RBOX_CNSP_FIRST_ID        0x0b30
 #define RBOX_CNSP_LAST_ID         0x0b3f
-#define DIY_FIRST_ID              0x5100
+#define DIY_FIRST_ID              0x5000
 #define DIY_LAST_ID               0x52ff
-#define DIY_STREAM_FIRST_ID       0x5100
-#define DIY_STREAM_LAST_ID        0x51ff
+#define DIY_STREAM_FIRST_ID       0x5000
+#define DIY_STREAM_LAST_ID        0x50ff
 #define RSSI_ID                   0xf101
 #define ADC1_ID                   0xf102
 #define ADC2_ID                   0xf103

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -210,7 +210,7 @@ void sportProcessTelemetryPacket(const uint8_t * packet)
           sportProcessTelemetryPacket(id, 0, instance, servosState);
           sportProcessTelemetryPacket(id, 1, instance, rboxState);
         }
-        else if (id >= DIY_FIRST_ID && id <= DIY_LAST_ID) {
+        else if (id >= DIY_STREAM_FIRST_ID && id <= DIY_STREAM_LAST_ID) {
 #if defined(LUA)
           if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(sizeof(SportTelemetryPacket))) {
             SportTelemetryPacket luaPacket;


### PR DESCRIPTION
Fixes telemetry stream confusion. 
0x5100 to 0x51ff is DIY stream data, 
0x5200 to 0x52ff is diy sensor data and is treated the same as any other telemetry packet.