### PR TITLE
Fix GPS display in telem screen for X9. 

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -1119,6 +1119,7 @@ void drawValueWithUnit(coord_t x, coord_t y, lcdint_t val, uint8_t unit, LcdFlag
 
 void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags att, bool seconds=true)
 {
+  att &= ~RIGHT & ~BOLD;
   uint32_t absvalue = abs(value);
   lcdDrawNumber(x, y, absvalue / 1000000, att); // ddd
   lcdDrawChar(lcdLastPos, y, '@', att);
@@ -1174,7 +1175,7 @@ void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 void drawGPSPosition(coord_t x, coord_t y, int32_t longitude, int32_t latitude, LcdFlags flags)
 {
   if (flags & DBLSIZE) {
-    x -= (g_eeGeneral.gpsFormat == 0 ? 54 : 51);
+    x -= (g_eeGeneral.gpsFormat == 0 ? 62 : 61);
     flags &= ~0x0F00; // TODO constant
     drawGPSCoord(x, y, latitude, "NS", flags);
     drawGPSCoord(x, y+FH, longitude, "EW", flags);

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -739,8 +739,8 @@ void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, L
     if (seconds) {
       absvalue %= 1000000;
       absvalue *= 60;
-      absvalue /= 100000;
-      lcdDrawNumber(lcdLastPos+2, y, absvalue, att|LEFT|PREC1);
+      absvalue /= 10000;
+      lcdDrawNumber(lcdLastPos+2, y, absvalue, att|LEFT|PREC2);
       lcdDrawSolidVerticalLine(lcdLastPos, y, 2);
       lcdDrawSolidVerticalLine(lcdLastPos+2, y, 2);
       lcdLastPos += 3;

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -726,9 +726,10 @@ void drawValueWithUnit(coord_t x, coord_t y, int32_t val, uint8_t unit, LcdFlags
 void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags att, bool seconds=true)
 {
   uint32_t absvalue = abs(value);
+  att &= ~RIGHT;
+  if (x > 10) x-=10;
   lcdDrawNumber(x, y, absvalue / 1000000, att); // ddd
   lcdDrawChar(lcdLastPos, y, '@', att);
-  att &= ~RIGHT;
   absvalue = absvalue % 1000000;
   absvalue *= 60;
   if (g_eeGeneral.gpsFormat == 0 || !seconds) {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -61,7 +61,7 @@ lcdint_t applyChannelRatio(source_t channel, lcdint_t val)
 #else
 #define IS_TELEMETRY_INTERNAL_MODULE (false)
 #endif
-#if defined(CPUARM)
+
 void processTelemetryData(uint8_t data)
 {
 #if defined(CROSSFIRE)
@@ -84,7 +84,6 @@ void processTelemetryData(uint8_t data)
 #endif
   processFrskyTelemetryData(data);
 }
-#endif
 
 void telemetryWakeup()
 {


### PR DESCRIPTION
With this fix, it is working fine, but maybe could be improved later by moving to right aligned

![image](https://cloud.githubusercontent.com/assets/5167938/22618787/38c7196e-eae6-11e6-9e43-7858c1a1aa9a.png)

X7:
![image](https://cloud.githubusercontent.com/assets/5167938/22618775/ce229ff2-eae5-11e6-8830-da0a7e51e6ce.png)

This closes #4382