### PR TITLE
Removed const modifer to Widget::update in the 480x272 GUI.

### DIFF
--- a/radio/src/gui/480x272/screens_setup.cpp
+++ b/radio/src/gui/480x272/screens_setup.cpp
@@ -174,7 +174,7 @@ int getOptionsCount(const ZoneOption * options)
 }
 
 template <class T>
-bool menuSettings(const char * title, const T * object, uint32_t i_flags, event_t event)
+bool menuSettings(const char * title, T * object, uint32_t i_flags, event_t event)
 {
 
   if (object->getErrorMessage()) {

--- a/radio/src/gui/480x272/widget.h
+++ b/radio/src/gui/480x272/widget.h
@@ -45,7 +45,7 @@ class Widget
     {
     }
 
-    virtual void update() const
+    virtual void update()
     {
     }
 


### PR DESCRIPTION
When compiling on OSX with px4/px4/gcc-arm-none-eabi: stable 20160928, I was getting const errors with a recent gcc. 

So I removed the const modifer to Widget::update in the 480x272 GUI. This caused menu_settings.cpp menuSettings() to complain, because it was being passed a param called
'object' of type pointer to a const T, and then called object->update(),
which is not a const function.

However, the one call site I found to menuSettings() (menu_settings.cpp:224)
is passing currentWidget, which is of type Widget*. 

'currentWidget' is a static though, and I don't have the full picture on this code yet, so maybe there's a problem with multithreaded use that the const-ness was trying to solve?


