### PR TITLE
X7 switch warning setup

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -519,7 +519,11 @@ void menuModelSetup(event_t event)
             if (swactive)
               attr |= INVERS;
           }
+#if defined(CPUARM)
+          lcdDrawChar(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive) ? c : '-', attr);
+#else
           lcdDrawChar(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive || (attr & BLINK)) ? c : '-', attr);
+#endif
 #if !defined(CPUM64)
           lcdDrawText(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (menuHorizontalPosition == NUM_SWITCHES-1 && !NO_HIGHLIGHT()) ? line : 0);
 #endif

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -515,9 +515,7 @@ void menuModelSetup(event_t event)
             states >>= 1;
           }
           if (line && (menuHorizontalPosition == i)) {
-            attr = BLINK;
-            if (swactive)
-              attr |= INVERS;
+            attr = BLINK | INVERS; 
           }
 #if defined(CPUARM)
           lcdDrawChar(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive) ? c : '-', attr);


### PR DESCRIPTION
With this version, the switch been edited is both blinking and inversed, which seemed most natural to me when editing. Another version (https://github.com/opentx/opentx/tree/3djc/X7-sw-warning) has those blinking for editing, and  blinking+invers for editing activated

This closes #4401