### PR TITLE
[Simulator] UI tweaks for last major update.

### DIFF
--- a/companion/src/simulation/debugoutput.cpp
+++ b/companion/src/simulation/debugoutput.cpp
@@ -67,7 +67,7 @@ DebugOutput::DebugOutput(QWidget * parent, SimulatorInterface *simulator):
   QStringList stockFilters;
   stockFilters << "^lua[A-Z].*";
   stockFilters << "/(error|warning|-(E|W)-)/i";
-  stockFilters << "!^(GC Use|(play|load|write|find(True)?)File|convert(To|From)Simu|\\tfound( in map)?:|eeprom |f_[a-z]+\\(|(push|(p|P)op(up)?|chain)? ?Menu( .+ display)?|RamBackup).+$";
+  stockFilters << "!^(GC Use|(play|load|write|find(True)?)File|convert(To|From)Simu|\\t(not )?found( in map)?:?|eeprom |f_[a-z]+\\(|(push|(p|P)op(up)?|chain)? ?Menu( .+ display)?|RamBackup).+$";
 
   foreach (const QString & fltr, stockFilters)
     ui->filterText->addItem(fltr, "no_delete");
@@ -267,9 +267,9 @@ void DebugOutput::on_actionClearScr_triggered()
 void DebugOutput::on_actionShowFilterHelp_triggered()
 {
   // TODO : find some place better for this.
-  QString help = \
-    "<html><head><style>kbd {background-color: ghostwhite; font-size: large; white-space: nowrap;}</style></head><body>"
-    "<p>The filter supports two syntax types: basic matching with common wildcards and well as full Perl-style (<code>pcre</code>) Regular Expressions.</p>"
+  QString help = tr( \
+    "<html><head><style>kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}</style></head><body>"
+    "<p>The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (<code>pcre</code>) Regular Expressions.</p>"
     "<p>By default a filter will only show lines which match (<b>inclusive</b>). To make an <b>exclusive</b> filter which removes matching lines, "
       "prefix the filter expression with a <kbd>!</kbd> (exclamation mark).</p>"
     "<p>To use <b>Regular Expressions</b> (RegEx), prefix the filter text with a <kbd>/</kbd> (slash) or <kbd>^</kbd> (up caret). "
@@ -280,8 +280,9 @@ void DebugOutput::on_actionShowFilterHelp_triggered()
       "<li>If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.</li>"
       "<li>A useful resource for testing REs (with a full reference) can be found at <a href=\"http://www.regexr.com/\">http://www.regexr.com/</a></li>"
     "</ul></p>"
-    "<p>To use <b>basic matching</b> just type any text. Wildcards <kbd>*</kbd> (asterisk) matches any text and <kbd>?</kbd> (question mark) matches any single character."
+    "<p>To use <b>basic matching</b> just type any text."
     "<ul>"
+      "<li>Wildcards: <kbd>*</kbd> (asterisk) matches zero or more of any character(s), and <kbd>?</kbd> (question mark) matches any single character.</li>"
       "<li>The match is always case-insensitive.</li>"
       "<li>The match always starts from the beginning of a log line. To ignore characters at the start, use a leading <kbd>*</kbd> wildcard.</li>"
       "<li>A trailing <kbd>*</kbd> is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.</li>"
@@ -291,7 +292,7 @@ void DebugOutput::on_actionShowFilterHelp_triggered()
     "<p>To <b>remove an entry</b> from the filter selector list, first choose it, and while in the line editor press <kbd>Shift-Delete</kbd> (or <kbd>Shift-Backspace</kbd>) key combination. "
       "The default filters cannot be removed. Up to 50 filters are stored.</p>"
     "</body></html>"
-  ;
+  );
   QMessageBox * msgbox = new QMessageBox(QMessageBox::NoIcon, tr("Debug Console Filter Help"), help, QMessageBox::Ok, this);
   msgbox->exec();
 }
@@ -341,7 +342,6 @@ QRegularExpression DebugOutput::makeRegEx(const QString & input, bool * isExlusi
     reFlags |= QRegularExpression::CaseInsensitiveOption;
     re.setPattern(output);
   }
-  // TODO : user option?
   re.setPatternOptions(reFlags);
   return re;
 }

--- a/companion/src/simulation/radiooutputswidget.h
+++ b/companion/src/simulation/radiooutputswidget.h
@@ -63,7 +63,7 @@ class RadioOutputsWidget : public QWidget
     void setupChannelsDisplay();
     void setupLsDisplay();
     void setupGVarsDisplay();
-    QWidget * createLogicalSwitch(QWidget * parent, int switchNo, QLabel * label);
+    QWidget * createLogicalSwitch(QWidget * parent, int switchNo);
 
     SimulatorInterface * m_simulator;
     Firmware * m_firmware;

--- a/companion/src/simulation/simulatordialog.ui
+++ b/companion/src/simulation/simulatordialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -20,7 +20,7 @@
    <string>Companion Simulator</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../companion.qrc">
+   <iconset>
     <normaloff>:/icon.png</normaloff>:/icon.png</iconset>
   </property>
   <property name="styleSheet">
@@ -307,8 +307,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../companion.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -57,15 +57,22 @@ class SimulatorMainWindow : public QMainWindow
     QMenu * createPopupMenu();
 
   public slots:
+    virtual void show();
     void start();
-    void showRadioTitlebar(bool show);
-    void toggleMenuBar(bool show);
+    void showMenuBar(bool show);
+    void showRadioFixedSize(Qt::Orientation orientation, bool fixed);
+    void showRadioFixedWidth(bool fixed);
+    void showRadioFixedHeight(bool fixed);
+    void showRadioDocked(bool dock);
 
   protected slots:
     virtual void closeEvent(QCloseEvent *);
     virtual void changeEvent(QEvent *e);
     void restoreUiState();
     void saveUiState();
+    void toggleMenuBar(bool show);
+    void setRadioSizePolicy(int fixType);
+    void toggleRadioDocked(bool dock);
     void luaReload(bool);
     void openJoystickDialog(bool);
     void showHelp(bool show);
@@ -89,8 +96,9 @@ class SimulatorMainWindow : public QMainWindow
 
     QVector<keymapHelp_t> m_keymapHelp;
     int m_radioProfileId;
+    int m_radioSizeConstraint;
     bool m_firstShow;
-    bool m_showRadioTitlebar;
+    bool m_showRadioDocked;
     bool m_showMenubar;
 
     const static quint16 m_savedUiStateVersion;

--- a/companion/src/simulation/simulatormainwindow.ui
+++ b/companion/src/simulation/simulatormainwindow.ui
@@ -14,7 +14,7 @@
    <string>OpenTx Simulator</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../companion.qrc">
     <normaloff>:/icon.png</normaloff>:/icon.png</iconset>
   </property>
   <property name="dockNestingEnabled">
@@ -23,7 +23,14 @@
   <property name="dockOptions">
    <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
   </property>
-  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QWidget" name="centralwidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
@@ -40,6 +47,16 @@
     <property name="title">
      <string>View</string>
     </property>
+    <widget class="QMenu" name="menuRadio_Window">
+     <property name="title">
+      <string>Radio Window</string>
+     </property>
+     <addaction name="actionFixedRadioWidth"/>
+     <addaction name="actionFixedRadioHeight"/>
+     <addaction name="actionDockRadio"/>
+    </widget>
+    <addaction name="actionToggleMenuBar"/>
+    <addaction name="menuRadio_Window"/>
    </widget>
    <widget class="QMenu" name="menuReload">
     <property name="title">
@@ -79,7 +96,7 @@
   </widget>
   <action name="actionReloadLua">
    <property name="icon">
-    <iconset>
+    <iconset resource="../companion.qrc">
      <normaloff>:/images/simulator/icons/svg/reload_script.svg</normaloff>:/images/simulator/icons/svg/reload_script.svg</iconset>
    </property>
    <property name="text">
@@ -94,7 +111,7 @@
   </action>
   <action name="actionReloadRadioData">
    <property name="icon">
-    <iconset>
+    <iconset resource="../companion.qrc">
      <normaloff>:/images/simulator/icons/svg/restart.svg</normaloff>:/images/simulator/icons/svg/restart.svg</iconset>
    </property>
    <property name="text">
@@ -109,7 +126,7 @@
   </action>
   <action name="actionShowKeymap">
    <property name="icon">
-    <iconset>
+    <iconset resource="../companion.qrc">
      <normaloff>:/images/simulator/icons/svg/info.svg</normaloff>:/images/simulator/icons/svg/info.svg</iconset>
    </property>
    <property name="text">
@@ -124,7 +141,7 @@
   </action>
   <action name="actionJoystickSettings">
    <property name="icon">
-    <iconset>
+    <iconset resource="../companion.qrc">
      <normaloff>:/images/simulator/icons/svg/joystick_settings.svg</normaloff>:/images/simulator/icons/svg/joystick_settings.svg</iconset>
    </property>
    <property name="text">
@@ -139,7 +156,7 @@
   </action>
   <action name="actionScreenshot">
    <property name="icon">
-    <iconset>
+    <iconset resource="../companion.qrc">
      <normaloff>:/images/simulator/icons/svg/camera.svg</normaloff>:/images/simulator/icons/svg/camera.svg</iconset>
    </property>
    <property name="text">
@@ -152,15 +169,15 @@
     <string>F8</string>
    </property>
   </action>
-  <action name="actionToggleRadioTitle">
+  <action name="actionDockRadio">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Radio Titlebar</string>
+    <string>Dock In Main Window</string>
    </property>
    <property name="toolTip">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The title bar on the main radio window allows you to undock it or move it around separately from the other windows. Hiding the title makes a more compact and streamlined appearance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <string>Show the radio in the main window or as a separate &quot;floating&quot; window.</string>
    </property>
   </action>
   <action name="actionToggleMenuBar">
@@ -177,7 +194,31 @@
     <string>Alt+M</string>
    </property>
   </action>
+  <action name="actionFixedRadioWidth">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Constrain Width</string>
+   </property>
+   <property name="toolTip">
+    <string>Set radio widget width to be a fixed size.</string>
+   </property>
+  </action>
+  <action name="actionFixedRadioHeight">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Constrain Height</string>
+   </property>
+   <property name="toolTip">
+    <string>Set radio widget height to be a fixed size.</string>
+   </property>
+  </action>
  </widget>
- <resources/>
+ <resources>
+  <include location="../companion.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Main  window:
 * Fix floating dock widgets appearing behind other applications on Linux (https://github.com/opentx/opentx/issues/4403#issuecomment-277510273);
  * Fix previously-unused floating dock widgets appearing in top-left corner upon subsequent launches of application (https://github.com/opentx/opentx/pull/4385#issuecomment-277315158);
  * Fix various anomalies due to not using a "central widget" in QMainWindow (extra separators appearing, vertical resize not working in some cases (https://github.com/opentx/opentx/pull/4385#issuecomment-277315158)), radio widget is now central by default;
  * Add (keep) option to float the radio widget separate from main window, though this may cause the minor visual anomalies mentioned above;
  * Add options to disable radio widget size constraints while docked.

Debug output
 * Adjust exclusion filter, help text \<kbd\> background color (#4403) , fix help text typos;

Radio Outputs: 
  * Fix wrong FM highlighted (#4408) and current FM not highlighted until switched once; 
  * Change highlight color role of active LS/FM so it is always shown (#4393) ;
  * Active LSs now much more obvious (bold font & sunken frame);
