### PR TITLE
[Simulator] Add ability to update .otx files.

### DIFF
--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -824,22 +824,23 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
     }
 
     SimulatorMainWindow * dialog = new SimulatorMainWindow(parent, simulator, flags);
-    if (IS_HORUS(getCurrentBoard()) && !dialog->useTempDataPath(true)) {
-      QMessageBox::critical(NULL, QObject::tr("Data Load Error"), QObject::tr("Error: Could not create temporary directory in '%1'").arg(QDir::tempPath()));
+    if (!dialog->setRadioData(simuData)) {
+      QMessageBox::critical(NULL, QObject::tr("Data Load Error"), QObject::tr("Error occurred while starting simulator."));
       delete dialog;
       delete simuData;
       return;
     }
-    dialog->setRadioData(simuData);
+
     dialog->setWindowModality(Qt::ApplicationModal);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->start();
-    dialog->show();
 
     QObject::connect(dialog, &SimulatorMainWindow::destroyed, [simuData] (void) {
       // TODO simuData and Horus tmp directory is deleted on simulator close OR we could use it to get back data from the simulation
       delete simuData;
     });
+
+    dialog->show();
   }
   else {
     QMessageBox::warning(NULL,

--- a/companion/src/simulation/simulatordialog.h
+++ b/companion/src/simulation/simulatordialog.h
@@ -73,7 +73,7 @@ class SimulatorDialog : public QWidget
     bool setRadioData(RadioData * radioData);
     bool setOptions(SimulatorOptions & options, bool withSave = true);
     bool saveRadioData(RadioData * radioData, const QString & path = "", QString * error = NULL);
-    bool useTempDataPath(bool deleteOnClose = true, bool saveOnClose = false);
+    bool useTempDataPath(bool deleteOnClose = true);
     bool saveTempData();
     void deleteTempData();
     void saveState();

--- a/companion/src/simulation/simulatorinterface.h
+++ b/companion/src/simulation/simulatorinterface.h
@@ -62,7 +62,7 @@ class SimulatorInterface
 
     virtual ~SimulatorInterface() {}
 
-    virtual void setSdPath(const QString & sdPath = "", const QString & settingsPath = "") { };
+    virtual void setSdPath(const QString & sdPath = "", const QString & settingsPath = "") { }
 
     virtual void setVolumeGain(int value) { }
 
@@ -71,6 +71,8 @@ class SimulatorInterface
     virtual void start(const char * filename, bool tests=true) = 0;
 
     virtual void stop() = 0;
+
+    virtual void readEepromData(QByteArray & dest) = 0;
 
     virtual bool timer10ms() = 0;
 

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -217,9 +217,9 @@ bool SimulatorMainWindow::setRadioData(RadioData * radioData)
   return m_simulatorWidget->setRadioData(radioData);
 }
 
-bool SimulatorMainWindow::useTempDataPath(bool deleteOnClose, bool saveOnClose)
+bool SimulatorMainWindow::useTempDataPath(bool deleteOnClose)
 {
-  return m_simulatorWidget->useTempDataPath(deleteOnClose, saveOnClose);
+  return m_simulatorWidget->useTempDataPath(deleteOnClose);
 }
 
 bool SimulatorMainWindow::setOptions(SimulatorOptions & options, bool withSave)

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -52,7 +52,7 @@ class SimulatorMainWindow : public QMainWindow
     ~SimulatorMainWindow();
 
     bool setRadioData(RadioData * radioData);
-    bool useTempDataPath(bool deleteOnClose = true, bool saveOnClose = false);
+    bool useTempDataPath(bool deleteOnClose = true);
     bool setOptions(SimulatorOptions & options, bool withSave = true);
     QMenu * createPopupMenu();
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -116,6 +116,13 @@ void OpenTxSimulator::stop()
   StopEepromThread();
 }
 
+void OpenTxSimulator::readEepromData(QByteArray & dest)
+{
+#if defined(EEPROM_SIZE)
+  memcpy(dest.data(), eeprom, std::min<int>(EEPROM_SIZE, dest.size()));
+#endif
+}
+
 void OpenTxSimulator::getValues(TxOutputs &outputs)
 {
 #define GETVALUES_IMPORT

--- a/radio/src/targets/simu/opentxsimulator.h
+++ b/radio/src/targets/simu/opentxsimulator.h
@@ -46,6 +46,8 @@ class DLLEXPORT OpenTxSimulator : public SimulatorInterface {
 
     virtual void stop();
 
+    virtual void readEepromData(QByteArray & dest);
+
     virtual bool timer10ms();
 
     virtual uint8_t * getLcd();


### PR DESCRIPTION
This could use some testing to make sure all the various startup permutations are covered and data is properly updated.

- [ ] Non-Horus with existing old-school .bin|.eepe files.
- [ ] Non-Horus with existing .otx files.
- [ ] Non-Horus with new .bin file.
- [ ] Non-Horus with new .otx file.
- [ ] Non-Horus from within Companion (whole radio and model-only).
- [ ] Horus with existing .otx files.
- [ ] Horus with new .otx file.
- [ ] Horus with SD card path.
- [ ] Horus with existing data in separate folder from SD path.
- [ ] Horus with new data in separate folder.
- [ ] Horus from within Companion (whole radio and model-only).

(Did I miss any?)

Radio & model settings should be saved back to the file/data path in all cases except when launched from within Companion.

Also, I could not find an existing way to get radio data back from SimulatorInterface, so I created the new `readEepromData()` function.  But if I missed an existing method, or there's a better way to go about this, I'm all ears.

All `libsimulator` flavors need to be rebuilt after this change, the old versions WILL crash when launched with this Simulator/Companion.

Thanks,
-Max