### PR TITLE
X7 switch warning, take 2

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -511,7 +511,7 @@ void menuModelSetup(event_t event)
             div_t qr = div(current, 8);
             uint8_t swactive = !(g_model.switchWarningEnable & (1<<i));
             c = "\300-\301"[states & 0x03];
-            lcdDrawChar(MODEL_SETUP_2ND_COLUMN+qr.rem*(2*FW+1), y+FH*qr.quot, 'A'+i, line && (menuHorizontalPosition==current) ? INVERS : 0);
+            lcdDrawChar(MODEL_SETUP_2ND_COLUMN+qr.rem*(2*FW+1), y+FH*qr.quot, (i < 4 ? 'A'+i : 'B'+i), line && (menuHorizontalPosition==current) ? INVERS : 0);
             if (swactive) lcdDrawChar(lcdNextPos, y+FH*qr.quot, c);
             ++current;
           }

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -189,7 +189,7 @@ void menuModelSetup(event_t event)
   EXTRA_MODULE_ROWS
   TRAINER_MODULE_ROWS });
 #elif defined(CPUARM)
-  MENU_TAB({ HEADER_LINE_COLUMNS 0, TIMER_ROWS, TIMER_ROWS, TIMER_ROWS, 0, 1, 0, 0, 0, 0, 0, CASE_CPUARM(LABEL(PreflightCheck)) CASE_CPUARM(0) 0, NUM_SWITCHES-2, NUM_STICKS+NUM_POTS+NUM_SLIDERS+NUM_ROTARY_ENCODERS-1, 0,
+  MENU_TAB({ HEADER_LINE_COLUMNS 0, TIMER_ROWS, TIMER_ROWS, TIMER_ROWS, 0, 1, 0, 0, 0, 0, 0, CASE_CPUARM(LABEL(PreflightCheck)) CASE_CPUARM(0) 0, NUM_SWITCHES-1, NUM_STICKS+NUM_POTS+NUM_SLIDERS+NUM_ROTARY_ENCODERS-1, 0,
   LABEL(ExternalModule),
   EXTERNAL_MODULE_MODE_ROWS,
   MULTIMODULE_SUBTYPE_ROWS(EXTERNAL_MODULE)
@@ -459,7 +459,6 @@ void menuModelSetup(event_t event)
       {
         lcdDrawTextAlignedLeft(y, STR_SWITCHWARNING);
         swarnstate_t states = g_model.switchWarningState;
-
         char c;
         if (attr) {
           s_editMode = 0;
@@ -467,15 +466,37 @@ void menuModelSetup(event_t event)
             switch (event) {
               CASE_EVT_ROTARY_BREAK
               case EVT_KEY_BREAK(KEY_ENTER):
+#if defined(CPUM64)
                 g_model.switchWarningEnable ^= (1 << menuHorizontalPosition);
                 storageDirty(EE_MODEL);
+#else
+                if (menuHorizontalPosition < NUM_SWITCHES-1) {
+                  g_model.switchWarningEnable ^= (1 << menuHorizontalPosition);
+                  storageDirty(EE_MODEL);
+                }
+#endif
                 break;
 
               case EVT_KEY_LONG(KEY_ENTER):
+#if defined(CPUM64)
                 getMovedSwitch();
                 g_model.switchWarningState = switches_states;
                 AUDIO_WARNING1();
                 storageDirty(EE_MODEL);
+#elif defined(PCBX7)
+                getMovedSwitch();
+                g_model.switchWarningState = switches_states;
+                AUDIO_WARNING1();
+                storageDirty(EE_MODEL);
+#else
+                if (menuHorizontalPosition == NUM_SWITCHES-1) {
+                  START_NO_HIGHLIGHT();
+                  getMovedSwitch();
+                  g_model.switchWarningState = switches_states;
+                  AUDIO_WARNING1();
+                  storageDirty(EE_MODEL);
+                }
+#endif
                 killEvents(event);
                 break;
             }
@@ -483,7 +504,7 @@ void menuModelSetup(event_t event)
         }
 
         LcdFlags line = attr;
-#if defined(CPUM64)
+#if !defined(PCBX7)
         for (uint8_t i=0; i<NUM_SWITCHES-1/*not on TRN switch*/; i++) {
           uint8_t swactive = !(g_model.switchWarningEnable & 1 << i);
           attr = 0;
@@ -501,26 +522,28 @@ void menuModelSetup(event_t event)
           if (line && (menuHorizontalPosition == i)) {
             attr = BLINK | INVERS;
           }
+#if defined(CPUARM)
+          lcdDrawChar(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive) ? c : '-', attr);
+#else
           lcdDrawChar(MODEL_SETUP_2ND_COLUMN+i*FW, y, (swactive || (attr & BLINK)) ? c : '-', attr);
+#endif
+#if !defined(CPUM64)
           lcdDrawText(MODEL_SETUP_2ND_COLUMN+(NUM_SWITCHES*FW), y, PSTR("<]"), (menuHorizontalPosition == NUM_SWITCHES-1 && !NO_HIGHLIGHT()) ? line : 0);
+#endif
         }
-#else  // CPUM64
+#else // !PCBX7
         int current = 0;
         for (int i=0; i<NUM_SWITCHES-1; i++) {
           if (SWITCH_WARNING_ALLOWED(i)) {
-            div_t qr = div(current, 8);
             uint8_t swactive = !(g_model.switchWarningEnable & (1<<i));
             c = "\300-\301"[states & 0x03];
-            lcdDrawChar(MODEL_SETUP_2ND_COLUMN+qr.rem*(2*FW+1), y+FH*qr.quot, (i < 4 ? 'A'+i : 'B'+i), line && (menuHorizontalPosition==current) ? INVERS : 0);
-            if (swactive) lcdDrawChar(lcdNextPos, y+FH*qr.quot, c);
+            lcdDrawChar(MODEL_SETUP_2ND_COLUMN+(2*FW*i), y, (i < 4 ? 'A'+i : 'B'+i), line && (menuHorizontalPosition==current) ? INVERS : 0);
+            if (swactive) lcdDrawChar(lcdNextPos, y, c);
             ++current;
           }
           states >>= 2;
         }
-        if (attr && menuHorizontalPosition < 0) {
-          lcdDrawFilledRect(MODEL_SETUP_2ND_COLUMN-1, y-1, current*(2*FW+1), FH+1);
-        }
-#endif // CPUM64
+#endif // !PCBX7
         break;
       }
 


### PR DESCRIPTION
Using arrow a bit like x9, while keeping X7 menu behaviour.

ENT on a switch enables or disable that switch check (when anble, and arrow or - is played, when disabled, a blank space)

Long ENT while anywhere in that line stores the positions