### PR TITLE
Horus : limit model bitmaps filemane to 6 chars

### DIFF
--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -269,7 +269,7 @@ bool menuModelSetup(event_t event)
           lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_VCSWFUNC, 0, attr);
         if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
           s_editMode = 0;
-          if (sdListFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap)-BITMAPS_EXT_LEN, g_model.header.bitmap, LIST_NONE_SD_FILE | LIST_SD_FILE_EXT)) {
+          if (sdListFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap)-LEN_BITMAPS_EXT, g_model.header.bitmap, LIST_NONE_SD_FILE | LIST_SD_FILE_EXT)) {
             POPUP_MENU_START(onModelSetupBitmapMenu);
           }
           else {

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -269,7 +269,7 @@ bool menuModelSetup(event_t event)
           lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_VCSWFUNC, 0, attr);
         if (attr && event==EVT_KEY_BREAK(KEY_ENTER) && READ_ONLY_UNLOCKED()) {
           s_editMode = 0;
-          if (sdListFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap), g_model.header.bitmap, LIST_NONE_SD_FILE | LIST_SD_FILE_EXT)) {
+          if (sdListFiles(BITMAPS_PATH, BITMAPS_EXT, sizeof(g_model.header.bitmap)-BITMAPS_EXT_LEN, g_model.header.bitmap, LIST_NONE_SD_FILE | LIST_SD_FILE_EXT)) {
             POPUP_MENU_START(onModelSetupBitmapMenu);
           }
           else {

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -69,7 +69,7 @@ const char RADIO_SETTINGS_PATH[] = RADIO_PATH "/radio.bin";
 
 #if defined(PCBHORUS)
 #define BITMAPS_EXT         BMP_EXT JPG_EXT PNG_EXT
-#define BITMAPS_EXT_LEN     4
+#define LEN_BITMAPS_EXT     4
 #else
 #define BITMAPS_EXT         BMP_EXT
 #endif

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -69,6 +69,7 @@ const char RADIO_SETTINGS_PATH[] = RADIO_PATH "/radio.bin";
 
 #if defined(PCBHORUS)
 #define BITMAPS_EXT         BMP_EXT JPG_EXT PNG_EXT
+#define BITMAPS_EXT_LEN     4
 #else
 #define BITMAPS_EXT         BMP_EXT
 #endif


### PR DESCRIPTION
Limit filename to 6 as sdcardfilelist controls size without extension (and size with ext was sent).

This closes #4415