### PR TITLE
Menu updates handling cat/models for Horus

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -871,14 +871,14 @@ void MainWindow::about()
 void MainWindow::updateMenus()
 {
   bool hasMdiChild = (activeMdiChild() != 0);
-  bool hasSelection = (activeMdiChild() && activeMdiChild()->hasSelection());
+  bool hasModelSelected = (activeMdiChild() && activeMdiChild()->hasModelSelected());
 
   newAct->setEnabled(true);
   openAct->setEnabled(true);
   saveAct->setEnabled(hasMdiChild);
   saveAsAct->setEnabled(hasMdiChild);
-  cutAct->setEnabled(hasSelection);
-  copyAct->setEnabled(hasSelection);
+  cutAct->setEnabled(hasModelSelected);
+  copyAct->setEnabled(hasModelSelected);
   pasteAct->setEnabled(hasMdiChild ? activeMdiChild()->hasPasteData() : false);
   writeEepromAct->setEnabled(hasMdiChild);
   readEepromAct->setEnabled(true);
@@ -889,7 +889,7 @@ void MainWindow::updateMenus()
   }
   separatorAct->setVisible(hasMdiChild);
   simulateAct->setEnabled(hasMdiChild);
-  printAct->setEnabled(hasSelection);
+  printAct->setEnabled(hasModelSelected);
   loadbackupAct->setEnabled(hasMdiChild);
   compareAct->setEnabled(activeMdiChild());
   updateRecentFileActions();

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -870,7 +870,6 @@ void MainWindow::about()
 
 void MainWindow::updateMenus()
 {
-  qDebug() << QString("UPDATING MENU");
   bool hasMdiChild = (activeMdiChild() != 0);
   bool hasSelection = (activeMdiChild() && activeMdiChild()->hasSelection());
 

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -870,6 +870,7 @@ void MainWindow::about()
 
 void MainWindow::updateMenus()
 {
+  qDebug() << QString("UPDATING MENU");
   bool hasMdiChild = (activeMdiChild() != 0);
   bool hasSelection = (activeMdiChild() && activeMdiChild()->hasSelection());
 
@@ -888,7 +889,7 @@ void MainWindow::updateMenus()
     recentFileActs[i]->setEnabled(true);
   }
   separatorAct->setVisible(hasMdiChild);
-  simulateAct->setEnabled(hasSelection);
+  simulateAct->setEnabled(hasMdiChild);
   printAct->setEnabled(hasSelection);
   loadbackupAct->setEnabled(hasMdiChild);
   compareAct->setEnabled(activeMdiChild());

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -340,8 +340,7 @@ bool MdiChild::hasPasteData() const
 
 bool MdiChild::hasModelSelected()
 {
-  QModelIndex modelIndex  = ui->modelsList->currentIndex();
-  return isModel(modelIndex);
+  return isModel(ui->modelsList->currentIndex());
 }
 
 void MdiChild::updateTitle()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -764,11 +764,6 @@ void MdiChild::print(int model, const QString & filename)
   }
 }
 
-void MdiChild::viableModelSelected(bool viable)
-{
-  emit copyAvailable(viable);
-}
-
 int MdiChild::getCurrentModel() const
 {
   return modelsListModel->getModelIndex(ui->modelsList->currentIndex());

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -56,9 +56,9 @@ MdiChild::MdiChild(MainWindow * parent):
   initModelsList();
   connect(parent, SIGNAL(FirmwareChanged()), this, SLOT(onFirmwareChanged()));
   connect(ui->modelsList, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(openModelEditWindow()));
+  connect(ui->modelsList, SIGNAL(activated(QModelIndex)), this, SLOT(openModelEditWindow()));
   connect(ui->modelsList, SIGNAL(pressed(QModelIndex)), this, SLOT(onItemSelected(QModelIndex)));
   connect(ui->modelsList, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(showModelsListContextMenu(const QPoint &)));
-  connect(ui->modelsList, SIGNAL(activated(QModelIndex)), this, SLOT(openModelEditWindow()));
   // connect(ui->modelsList, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this, SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
 
   ui->modelsList->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -101,8 +101,12 @@ bool MdiChild::isModel(QModelIndex idx)
 
 bool MdiChild::isCategory(QModelIndex idx)
 {
-  if (isModel(idx)) return false;
-  else return (modelsListModel->getCategoryIndex(idx) >= 0 ? true : false);
+  if (isModel(idx)) {
+    return false;
+  }
+  else {
+    return (modelsListModel->getCategoryIndex(idx) >= 0);
+  }
 }
 
 void MdiChild::confirmDelete()
@@ -408,6 +412,7 @@ void MdiChild::categoryAdd()
   CategoryData category("New category");
   radioData.categories.push_back(category);
   setModified();
+  emit copyAvailable(false); // workaround : nothing is selected after model creation
 }
 
 void MdiChild::categoryRename()
@@ -486,6 +491,7 @@ void MdiChild::modelAdd()
     radioData.setCurrentModel(newModelIndex);
   }
   setModified();
+  emit copyAvailable(false); // workaround : nothing is selected after model creation
 }
 
 void MdiChild::modelEdit()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -90,13 +90,7 @@ void MdiChild::refresh(bool expand)
 
 void MdiChild::updateMenu(QModelIndex idx)
 {
-
-  if (modelsListModel->getModelIndex(idx) >= 0) {
-    emit copyAvailable(true);
-  }
-  else if (modelsListModel->getCategoryIndex(idx) >= 0) {
-    emit copyAvailable(false);
-  }
+  emit copyAvailable(modelsListModel->getModelIndex(idx) >= 0 ? true : false);
 }
 
 void MdiChild::confirmDelete()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -56,6 +56,7 @@ MdiChild::MdiChild(MainWindow * parent):
   initModelsList();
   connect(parent, SIGNAL(FirmwareChanged()), this, SLOT(onFirmwareChanged()));
   connect(ui->modelsList, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(openModelEditWindow()));
+  connect(ui->modelsList, SIGNAL(clicked(QModelIndex)), this, SLOT(updateMenu(QModelIndex)));
   connect(ui->modelsList, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(showModelsListContextMenu(const QPoint &)));
   // connect(ui->modelsList, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this, SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
 
@@ -85,6 +86,17 @@ void MdiChild::refresh(bool expand)
   }
   ui->simulateButton->setEnabled(firmware->getCapability(Simulation));
   updateTitle();
+}
+
+void MdiChild::updateMenu(QModelIndex idx)
+{
+
+  if (modelsListModel->getModelIndex(idx) >= 0) {
+    emit copyAvailable(true);
+  }
+  else if (modelsListModel->getCategoryIndex(idx) >= 0) {
+    emit copyAvailable(false);
+  }
 }
 
 void MdiChild::confirmDelete()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -54,11 +54,11 @@ MdiChild::MdiChild(MainWindow * parent):
   ui->simulateButton->setIcon(CompanionIcon("simulate.png"));
   setAttribute(Qt::WA_DeleteOnClose);
   initModelsList();
-  connect(parent, SIGNAL(FirmwareChanged()), this, SLOT(onFirmwareChanged()));
-  connect(ui->modelsList, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(openModelEditWindow()));
-  connect(ui->modelsList, SIGNAL(activated(QModelIndex)), this, SLOT(openModelEditWindow()));
-  connect(ui->modelsList, SIGNAL(pressed(QModelIndex)), this, SLOT(onItemSelected(QModelIndex)));
-  connect(ui->modelsList, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(showModelsListContextMenu(const QPoint &)));
+  connect(parent, &MainWindow::FirmwareChanged, this, &MdiChild::onFirmwareChanged);
+  connect(ui->modelsList, &QTreeView::doubleClicked, this, &MdiChild::openModelEditWindow);
+  connect(ui->modelsList, &QTreeView::activated, this, &MdiChild::openModelEditWindow);
+  connect(ui->modelsList, &QTreeView::pressed, this, &MdiChild::onItemSelected);
+  connect(ui->modelsList, &QTreeView::customContextMenuRequested, this, &MdiChild::showModelsListContextMenu);
   // connect(ui->modelsList, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this, SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
 
   ui->modelsList->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -210,7 +210,7 @@ void MdiChild::initModelsList()
 
   delete modelsListModel;
   modelsListModel = new TreeModel(&radioData, this);
-  connect(modelsListModel, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this, SLOT(onDataChanged(const QModelIndex &)));
+  connect(modelsListModel, &QAbstractItemModel::dataChanged, this, &MdiChild::onDataChanged);
   ui->modelsList->setModel(modelsListModel);
   ui->modelsList->header()->setVisible(!IS_HORUS(board));
   if (IS_HORUS(board)) {
@@ -403,7 +403,7 @@ void MdiChild::checkAndInitModel(int row)
 void MdiChild::generalEdit()
 {
   GeneralEdit * t = new GeneralEdit(this, radioData, firmware);
-  connect(t, SIGNAL(modified()), this, SLOT(setModified()));
+  connect(t, &GeneralEdit::modified, this, &MdiChild::setModified);
   t->show();
 }
 
@@ -505,7 +505,7 @@ void MdiChild::modelEdit()
   ModelEdit * t = new ModelEdit(this, radioData, (row), firmware);
   gStopwatch.report("ModelEdit created");
   t->setWindowTitle(tr("Editing model %1: ").arg(row+1) + model.name);
-  connect(t, SIGNAL(modified()), this, SLOT(setModified()));
+  connect(t, &ModelEdit::modified, this, &MdiChild::setModified);
   gStopwatch.report("STARTING MODEL EDIT");
   t->show();
   QApplication::restoreOverrideCursor();

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -56,8 +56,9 @@ MdiChild::MdiChild(MainWindow * parent):
   initModelsList();
   connect(parent, SIGNAL(FirmwareChanged()), this, SLOT(onFirmwareChanged()));
   connect(ui->modelsList, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(openModelEditWindow()));
-  connect(ui->modelsList, SIGNAL(clicked(QModelIndex)), this, SLOT(updateMenu(QModelIndex)));
+  connect(ui->modelsList, SIGNAL(pressed(QModelIndex)), this, SLOT(onItemSelected(QModelIndex)));
   connect(ui->modelsList, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(showModelsListContextMenu(const QPoint &)));
+  connect(ui->modelsList, SIGNAL(activated(QModelIndex)), this, SLOT(openModelEditWindow()));
   // connect(ui->modelsList, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)), this, SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
 
   ui->modelsList->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -88,9 +89,20 @@ void MdiChild::refresh(bool expand)
   updateTitle();
 }
 
-void MdiChild::updateMenu(QModelIndex idx)
+void MdiChild::onItemSelected(QModelIndex idx)
 {
-  emit copyAvailable(modelsListModel->getModelIndex(idx) >= 0 ? true : false);
+  emit copyAvailable(isModel(idx) ? true : false);
+}
+
+bool MdiChild::isModel(QModelIndex idx)
+{
+  return (modelsListModel->getModelIndex(idx) >= 0 ? true : false);
+}
+
+bool MdiChild::isCategory(QModelIndex idx)
+{
+  if (isModel(idx)) return false;
+  else return (modelsListModel->getCategoryIndex(idx) >= 0 ? true : false);
 }
 
 void MdiChild::confirmDelete()
@@ -326,9 +338,10 @@ bool MdiChild::hasPasteData() const
   return mimeData->hasFormat("application/x-companion");
 }
 
-bool MdiChild::hasSelection() const
+bool MdiChild::hasModelSelected()
 {
-  return ui->modelsList->selectionModel()->hasSelection();
+  QModelIndex modelIndex  = ui->modelsList->currentIndex();
+  return isModel(modelIndex);
 }
 
 void MdiChild::updateTitle()

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -46,7 +46,7 @@ class MdiChild : public QWidget
     bool save();
     bool saveAs(bool isNew=false);
     bool saveFile(const QString & fileName, bool setCurrent=true);
-    bool hasSelection() const;
+    bool hasModelSelected();
     bool hasPasteData() const;
     QString userFriendlyCurrentFile() const;
     QString currentFile() const { return curFile; }
@@ -97,7 +97,9 @@ class MdiChild : public QWidget
     void print(int model=-1, const QString & filename="");
     void setModified();
     void updateTitle();
-    void updateMenu(QModelIndex);
+    void onItemSelected(QModelIndex);
+    bool isModel(QModelIndex);
+    bool isCategory(QModelIndex);
 
   private:
     bool maybeSave();

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -50,7 +50,6 @@ class MdiChild : public QWidget
     bool hasPasteData() const;
     QString userFriendlyCurrentFile() const;
     QString currentFile() const { return curFile; }
-    void viableModelSelected(bool viable);
     int getCurrentModel() const;
     int getCurrentCategory() const;
     void refresh(bool expand=false);

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -97,6 +97,7 @@ class MdiChild : public QWidget
     void print(int model=-1, const QString & filename="");
     void setModified();
     void updateTitle();
+    void updateMenu(QModelIndex);
 
   private:
     bool maybeSave();


### PR DESCRIPTION
Fixes Alt-S not always activated when needed
Fixes edit menu for Horus (activated for models, not category)

This fixes #4349