### PR TITLE
[firmware][gui] Extended limits fixes, issue #4447

### DIFF
--- a/radio/src/gui/128x64/view_channels.cpp
+++ b/radio/src/gui/128x64/view_channels.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -101,11 +101,11 @@ void menuChannelsView(event_t event)
 #endif
 
       // Gauge
-// #ifdef MIXERS_MONITOR
-//       uint16_t lim = mixersView ? 512*2*2 : (g_model.extendedLimits ? 640*2 : 512*2);
-// #else
-//       uint16_t lim = g_model.extendedLimits ? 640*2 : 512*2;
-// #endif
+//      uint16_t lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
+//#ifdef MIXERS_MONITOR
+//      if (mixersView)
+//        lim = 512 * 2 * 2;
+//#endif
       // TODO ? drawGauge(x+LCD_W/2-3-wbar-ofs, y, wbar, 6, val, lim);
 
       ch++;

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -495,7 +495,7 @@ void menuMainView(event_t event)
           x0 = i<4 ? LCD_W/4+2 : LCD_W*3/4-2;
           y0 = 38+(i%4)*5;
 
-          uint16_t lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
+          const uint16_t lim = (g_model.extendedLimits ? 512 * uint8_t(LIMIT_EXT_PERCENT / 100) : 512) * 2;
           int8_t len = (abs(val) * WBAR2 + lim/2) / lim;
 
           if (len>WBAR2)

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -495,10 +495,11 @@ void menuMainView(event_t event)
           x0 = i<4 ? LCD_W/4+2 : LCD_W*3/4-2;
           y0 = 38+(i%4)*5;
 
-          uint16_t lim = g_model.extendedLimits ? 640*2 : 512*2;
+          uint16_t lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
           int8_t len = (abs(val) * WBAR2 + lim/2) / lim;
 
-          if (len>WBAR2) len = WBAR2; // prevent bars from going over the end - comment for debugging
+          if (len>WBAR2)
+            len = WBAR2; // prevent bars from going over the end - comment for debugging
           lcdDrawHorizontalLine(x0-WBAR2, y0, WBAR2*2+1, DOTTED);
           lcdDrawSolidVerticalLine(x0, y0-2,5 );
           if (val > 0)

--- a/radio/src/gui/212x64/view_channels.cpp
+++ b/radio/src/gui/212x64/view_channels.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -101,10 +101,10 @@ void menuChannelsView(event_t event)
 #endif
 
       // Gauge
+      uint16_t lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
 #ifdef MIXERS_MONITOR
-      uint16_t lim = mixersView ? 512*2*2 : (g_model.extendedLimits ? 640*2 : 512*2);
-#else
-      uint16_t lim = g_model.extendedLimits ? 640*2 : 512*2;
+      if (mixersView)
+        lim = 512 * 2 * 2;
 #endif
       drawGauge(x+LCD_W/2-3-wbar-ofs, y, wbar, 6, val, lim);
 

--- a/radio/src/gui/212x64/view_channels.cpp
+++ b/radio/src/gui/212x64/view_channels.cpp
@@ -23,12 +23,11 @@
 void menuChannelsView(event_t event)
 {
   static bool longNames = false;
-  bool newLongNames = false;
   static bool secondPage = false;
-#ifdef MIXERS_MONITOR
   static bool mixersView = false;
-#endif
-  uint8_t ch;
+  uint8_t ch = 0;
+  uint8_t wbar = (longNames ? 54 : 64);
+  int16_t limits = 512 * 2;
 
   switch(event)
   {
@@ -48,69 +47,56 @@ void menuChannelsView(event_t event)
 
   if (secondPage)
     ch = 16;
-  else
-    ch = 0;
 
-#ifdef MIXERS_MONITOR
   if (mixersView)
-  lcdDrawTextAlignedCenter(0*FH, MIXERS_MONITOR);
+    limits *= 2;  // this could be handled nicer, but slower, by checking actual range for this mixer
+  else if (g_model.extendedLimits)
+    limits *= LIMIT_EXT_PERCENT / 100;
+
+  if (mixersView)
+    lcdDrawTextAlignedCenter(0, MIXERS_MONITOR);
   else
-#endif
-  lcdDrawTextAlignedCenter(0*FH, CHANNELS_MONITOR);
+    lcdDrawTextAlignedCenter(0, CHANNELS_MONITOR);
 
   lcdInvertLine(0);
 
   // Column separator
   lcdDrawSolidVerticalLine(LCD_W/2, FH, LCD_H-FH);
 
-  for (uint8_t col=0; col<2; col++) {
-
-    uint8_t x = col*LCD_W/2+1;
+  for (uint8_t col=0; col < 2; col++) {
+    const uint8_t x = col * LCD_W / 2 + 1;
+    const uint8_t ofs = (col ? 0 : 1);
 
     // Channels
-    for (uint8_t line=0; line<8; line++) {
-      uint8_t y = 9+line*7;
-#ifdef MIXERS_MONITOR
-      int32_t val = (mixersView) ? ex_chans[ch] : channelOutputs[ch];
-#else
-      int32_t val = channelOutputs[ch];
-#endif
-      uint8_t ofs = (col ? 0 : 1);
+    for (uint8_t line=0; line < 8; line++) {
+      const uint8_t y = 9 + line * 7;
+      const int32_t val = mixersView ? ex_chans[ch] : channelOutputs[ch];
+      const uint8_t lenLabel = ZLEN(g_model.limitData[ch].name);
 
       // Channel name if present, number if not
-      uint8_t lenLabel = ZLEN(g_model.limitData[ch].name);
-      if (lenLabel > 4) {
-        newLongNames = longNames = true;
-      }
-
-      if (lenLabel > 0)
+      if (lenLabel > 0) {
+        if (lenLabel > 4)
+          longNames = true;
         lcdDrawSizedText(x+1-ofs, y, g_model.limitData[ch].name, sizeof(g_model.limitData[ch].name), ZCHAR | SMLSIZE);
-      else
+      }
+      else {
         putsChn(x+1-ofs, y, ch+1, SMLSIZE);
+      }
 
       // Value
 #if defined(PPM_UNIT_US)
-      uint8_t wbar = (longNames ? 54 : 64);
       lcdDrawNumber(x+LCD_W/2-3-wbar-ofs, y+1, PPM_CH_CENTER(ch)+val/2, TINSIZE|RIGHT);
 #elif defined(PPM_UNIT_PERCENT_PREC1)
-      uint8_t wbar = (longNames ? 48 : 58);
+      wbar -= 6;
       lcdDrawNumber(x+LCD_W/2-3-wbar-ofs, y+1, calcRESXto1000(val), PREC1|TINSIZE|RIGHT);
 #else
-      uint8_t wbar = (longNames ? 54 : 64);
       lcdDrawNumber(x+LCD_W/2-3-wbar-ofs, y+1, calcRESXto1000(val)/10, TINSIZE|RIGHT);
 #endif
 
       // Gauge
-      uint16_t lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
-#ifdef MIXERS_MONITOR
-      if (mixersView)
-        lim = 512 * 2 * 2;
-#endif
-      drawGauge(x+LCD_W/2-3-wbar-ofs, y, wbar, 6, val, lim);
+      drawGauge(x+LCD_W/2-3-wbar-ofs, y, wbar, 6, val, limits);
 
-      ch++;
+      ++ch;
     }
   }
-
-  longNames = newLongNames;
 }

--- a/radio/src/gui/480x272/model_mixes.cpp
+++ b/radio/src/gui/480x272/model_mixes.cpp
@@ -284,14 +284,14 @@ bool menuModelMixOne(event_t event)
 #define MIX_LINE_NAME_FM_POS    390
 #define MIX_LINE_SELECT_POS     50
 #define MIX_LINE_SELECT_WIDTH   (LCD_W-MIX_LINE_SELECT_POS-15)
-#define MIX_STATUS_MARGIN_LEFT  MENUS_MARGIN_LEFT + 45
-#define MIX_STATUS_ICON_MIXER   MENUS_MARGIN_LEFT + 185
-#define MIX_STATUS_ICON_TO      MENUS_MARGIN_LEFT + 205
-#define MIX_STATUS_ICON_OUTPUT  MENUS_MARGIN_LEFT + 240
-#define MIX_STATUS_OUT_NAME     MENUS_MARGIN_LEFT + 265
-#define MIX_STATUS_OUT_BAR      MENUS_MARGIN_LEFT + 320
 #define MIX_STATUS_BAR_W        130
 #define MIX_STATUS_BAR_H        13
+#define MIX_STATUS_CHAN_BAR     MENUS_MARGIN_LEFT + 45
+#define MIX_STATUS_ICON_MIXER   MIX_STATUS_CHAN_BAR + 140
+#define MIX_STATUS_ICON_TO      MIX_STATUS_ICON_MIXER + 20
+#define MIX_STATUS_ICON_OUTPUT  MIX_STATUS_ICON_TO + 35
+#define MIX_STATUS_OUT_NAME     MIX_STATUS_ICON_OUTPUT + 25
+#define MIX_STATUS_OUT_BAR      LCD_W - MENUS_MARGIN_LEFT - MIX_STATUS_BAR_W
 
 void lineMixSurround(coord_t y, LcdFlags flags=CURVE_AXIS_COLOR)
 {
@@ -372,13 +372,16 @@ void displayMixLine(coord_t y, MixData *md)
 void displayMixStatus(uint8_t channel)
 {
   lcdDrawNumber(MENUS_MARGIN_LEFT, MENU_FOOTER_TOP, channel + 1, MENU_TITLE_COLOR, 0, "CH", NULL);
-  drawSingleMixerBar(MIX_STATUS_MARGIN_LEFT, MENU_FOOTER_TOP + 4, MIX_STATUS_BAR_W, MIX_STATUS_BAR_H, channel);
+  drawSingleMixerBar(MIX_STATUS_CHAN_BAR, MENU_FOOTER_TOP + 4, MIX_STATUS_BAR_W, MIX_STATUS_BAR_H, channel);
 
   lcd->drawBitmap(MIX_STATUS_ICON_MIXER, MENU_FOOTER_TOP, mixerSetupMixerBitmap);
   lcd->drawBitmap(MIX_STATUS_ICON_TO, MENU_FOOTER_TOP, mixerSetupToBitmap);
   lcd->drawBitmap(MIX_STATUS_ICON_OUTPUT, MENU_FOOTER_TOP, mixerSetupOutputBitmap);
 
-  lcdDrawSizedText(MIX_STATUS_OUT_NAME, MENU_FOOTER_TOP, g_model.limitData[channel].name, sizeof(g_model.limitData[channel].name), MENU_TITLE_COLOR | LEFT | ZCHAR);
+  if (g_model.limitData[channel].name[0] == '\0')
+    lcdDrawNumber(MIX_STATUS_OUT_NAME, MENU_FOOTER_TOP, channel + 1, MENU_TITLE_COLOR, 0, "CH", NULL);
+  else
+    lcdDrawSizedText(MIX_STATUS_OUT_NAME, MENU_FOOTER_TOP, g_model.limitData[channel].name, sizeof(g_model.limitData[channel].name), MENU_TITLE_COLOR | LEFT | ZCHAR);
   drawSingleOutputBar(MIX_STATUS_OUT_BAR, MENU_FOOTER_TOP + 4, MIX_STATUS_BAR_W, MIX_STATUS_BAR_H, channel);
 }
 

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -904,7 +904,9 @@ bool menuModelSetup(event_t event)
 bool menuModelFailsafe(event_t event)
 {
   uint8_t ch = 0;
-  uint8_t channelStart = g_model.moduleData[g_moduleIdx].channelsStart;
+  const uint8_t channelStart = g_model.moduleData[g_moduleIdx].channelsStart;
+  const int lim = (g_model.extendedLimits ? (512 * LIMIT_EXT_PERCENT / 100) : 512) * 2;
+  const uint8_t SLIDER_W = 128;
 
   if (event == EVT_KEY_LONG(KEY_ENTER)) {
     killEvents(event);
@@ -933,82 +935,71 @@ bool menuModelFailsafe(event_t event)
   SIMPLE_SUBMENU_WITH_OPTIONS("FAILSAFE", ICON_STATS_ANALOGS, NUM_CHANNELS(g_moduleIdx), OPTION_MENU_NO_SCROLLBAR);
   drawStringWithIndex(50, 3+FH, "Module", g_moduleIdx+1, MENU_TITLE_COLOR);
 
-  #define COL_W   (LCD_W/2)
-  const uint8_t SLIDER_W = 128;
-
-  unsigned int lim = g_model.extendedLimits ? 640*2 : 512*2;
-
   for (uint8_t col=0; col<2; col++) {
     for (uint8_t line=0; line<8; line++) {
       coord_t x = col*(LCD_W/2);
-      coord_t y = MENU_CONTENT_TOP - FH + line*(FH+4);
-      int32_t channelValue = channelOutputs[ch+channelStart];
-      int32_t failsafeValue = 0;
-      bool failsafeEditable = false;
+      const coord_t y = MENU_CONTENT_TOP - FH + line*(FH+4);
+      const int32_t channelValue = channelOutputs[ch+channelStart];
+      int32_t failsafeValue = g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line];
 
-      if (ch < NUM_CHANNELS(g_moduleIdx)) {
-        failsafeValue = g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line];
-        failsafeEditable = true;
+      // Channel name if present, number if not
+      if (ZLEN(g_model.limitData[ch+channelStart].name) > 0) {
+        putsChn(x+MENUS_MARGIN_LEFT, y-3, ch+1, TINSIZE);
+        lcdDrawSizedText(x+MENUS_MARGIN_LEFT, y+5, g_model.limitData[ch+channelStart].name, sizeof(g_model.limitData[ch+channelStart].name), ZCHAR|SMLSIZE);
+      }
+      else {
+        putsChn(x+MENUS_MARGIN_LEFT, y, ch+1, 0);
       }
 
-      if (failsafeEditable) {
-        // Channel name if present, number if not
-        uint8_t lenLabel = ZLEN(g_model.limitData[ch+channelStart].name);
-        if (lenLabel > 0) {
-          putsChn(x+MENUS_MARGIN_LEFT, y-3, ch+1, TINSIZE);
-          lcdDrawSizedText(x+MENUS_MARGIN_LEFT, y+5, g_model.limitData[ch+channelStart].name, sizeof(g_model.limitData[ch+channelStart].name), ZCHAR|SMLSIZE);
-        }
-        else {
-          putsChn(x+MENUS_MARGIN_LEFT, y, ch+1, 0);
-        }
-
-        // Value
-        LcdFlags flags = RIGHT;
-        if (menuVerticalPosition == ch) {
-          flags |= INVERS;
-          if (s_editMode) {
-            if (failsafeValue == FAILSAFE_CHANNEL_HOLD || failsafeValue == FAILSAFE_CHANNEL_NOPULSE) {
-              s_editMode = 0;
-            }
-            else {
-              flags |= BLINK;
-              CHECK_INCDEC_MODELVAR(event, g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line], -lim, +lim);
-            }
+      // Value
+      LcdFlags flags = RIGHT;
+      if (menuVerticalPosition == ch) {
+        flags |= INVERS;
+        if (s_editMode) {
+          if (failsafeValue == FAILSAFE_CHANNEL_HOLD || failsafeValue == FAILSAFE_CHANNEL_NOPULSE) {
+            s_editMode = 0;
+          }
+          else {
+            flags |= BLINK;
+            CHECK_INCDEC_MODELVAR(event, g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line], -lim, +lim);
           }
         }
-
-        x += COL_W-4-MENUS_MARGIN_LEFT-SLIDER_W;
-
-        if (failsafeValue == FAILSAFE_CHANNEL_HOLD) {
-          lcdDrawText(x, y+2, "HOLD", flags|SMLSIZE);
-          failsafeValue = 0;
-        }
-        else if (failsafeValue == FAILSAFE_CHANNEL_NOPULSE) {
-          lcdDrawText(x, y+2, "NONE", flags|SMLSIZE);
-          failsafeValue = 0;
-        }
-        else {
-#if defined(PPM_UNIT_US)
-          lcdDrawNumber(x, y, PPM_CH_CENTER(ch)+failsafeValue/2, flags);
-#elif defined(PPM_UNIT_PERCENT_PREC1)
-          lcdDrawNumber(x, y, calcRESXto1000(failsafeValue), PREC1|flags);
-#else
-          lcdDrawNumber(x, y, calcRESXto1000(failsafeValue)/10, flags);
-#endif
-        }
-
-        // Gauge
-        x += 4;
-        lcdDrawRect(x, y+3, SLIDER_W+1, 12);
-        unsigned int lenChannel = limit((uint8_t)1, uint8_t((abs(channelValue) * SLIDER_W/2 + lim/2) / lim), uint8_t(SLIDER_W/2));
-        unsigned int lenFailsafe = limit((uint8_t)1, uint8_t((abs(failsafeValue) * SLIDER_W/2 + lim/2) / lim), uint8_t(SLIDER_W/2));
-        x += SLIDER_W/2;
-        coord_t xChannel = (channelValue>0) ? x : x+1-lenChannel;
-        coord_t xFailsafe = (failsafeValue>0) ? x : x+1-lenFailsafe;
-        lcdDrawSolidFilledRect(xChannel, y+4, lenChannel, 5, TEXT_COLOR);
-        lcdDrawSolidFilledRect(xFailsafe, y+9, lenFailsafe, 5, ALARM_COLOR);
       }
-      ch++;
+
+      x += (LCD_W/2)-4-MENUS_MARGIN_LEFT-SLIDER_W;
+
+      if (failsafeValue == FAILSAFE_CHANNEL_HOLD) {
+        lcdDrawText(x, y+2, "HOLD", flags|SMLSIZE);
+        failsafeValue = 0;
+      }
+      else if (failsafeValue == FAILSAFE_CHANNEL_NOPULSE) {
+        lcdDrawText(x, y+2, "NONE", flags|SMLSIZE);
+        failsafeValue = 0;
+      }
+      else {
+#if defined(PPM_UNIT_US)
+        lcdDrawNumber(x, y, PPM_CH_CENTER(ch)+failsafeValue/2, flags);
+#elif defined(PPM_UNIT_PERCENT_PREC1)
+        lcdDrawNumber(x, y, calcRESXto1000(failsafeValue), PREC1|flags);
+#else
+        lcdDrawNumber(x, y, calcRESXto1000(failsafeValue)/10, flags);
+#endif
+      }
+
+      // Gauge
+      x += 4;
+      lcdDrawRect(x, y+3, SLIDER_W+1, 12);
+      const coord_t lenChannel = limit((uint8_t)1, uint8_t((abs(channelValue) * SLIDER_W/2 + lim/2) / lim), uint8_t(SLIDER_W/2));
+      const coord_t lenFailsafe = limit((uint8_t)1, uint8_t((abs(failsafeValue) * SLIDER_W/2 + lim/2) / lim), uint8_t(SLIDER_W/2));
+      x += SLIDER_W/2;
+      const coord_t xChannel = (channelValue>0) ? x : x+1-lenChannel;
+      const coord_t xFailsafe = (failsafeValue>0) ? x : x+1-lenFailsafe;
+      lcdDrawSolidFilledRect(xChannel, y+4, lenChannel, 5, TEXT_COLOR);
+      lcdDrawSolidFilledRect(xFailsafe, y+9, lenFailsafe, 5, ALARM_COLOR);
+
+      if (++ch >= NUM_CHANNELS(g_moduleIdx))
+        break;
+
     }
   }
 

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -943,7 +943,7 @@ bool menuModelFailsafe(event_t event)
       int32_t failsafeValue = g_model.moduleData[g_moduleIdx].failsafeChannels[8*col+line];
 
       // Channel name if present, number if not
-      if (ZLEN(g_model.limitData[ch+channelStart].name) > 0) {
+      if (g_model.limitData[ch+channelStart].name[0] != '\0') {
         putsChn(x+MENUS_MARGIN_LEFT, y-3, ch+1, TINSIZE);
         lcdDrawSizedText(x+MENUS_MARGIN_LEFT, y+5, g_model.limitData[ch+channelStart].name, sizeof(g_model.limitData[ch+channelStart].name), ZCHAR|SMLSIZE);
       }

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -161,12 +161,12 @@ void onMixesMenu(const char * result)
 #define MIX_LINE_FM_POS                13*FW+3
 #define MIX_LINE_DELAY_POS             24*FW+3
 #define MIX_LINE_NAME_POS              LCD_W-LEN_EXPOMIX_NAME*FW-MENUS_SCROLLBAR_WIDTH
+#define MIX_HDR_GAUGE_POS_X            127
 
 void displayHeaderChannelName(uint8_t ch)
 {
-  uint8_t len = zlen(g_model.limitData[ch].name, sizeof(g_model.limitData[ch].name));
-  if (len) {
-    lcdDrawSizedText(80, 1, g_model.limitData[ch].name, len, ZCHAR|SMLSIZE);
+  if (g_model.limitData[ch].name[0] != '\0') {
+    lcdDrawSizedText(MIX_HDR_GAUGE_POS_X - FWNUM * 5 - 1, 1, g_model.limitData[ch].name, ZLEN(g_model.limitData[ch].name), ZCHAR|SMLSIZE|RIGHT);
   }
 }
 
@@ -393,7 +393,7 @@ void menuModelMixAll(event_t event)
   if (!s_currCh) {
     displayHeaderChannelName(index);
 #if LCD_W >= 212
-    lcdDrawNumber(127, 2, calcRESXto1000(ex_chans[index]), PREC1|TINSIZE|RIGHT);
+    lcdDrawNumber(MIX_HDR_GAUGE_POS_X, 2, calcRESXto1000(ex_chans[index]), PREC1|TINSIZE|RIGHT);
 #endif
   }
 
@@ -402,7 +402,7 @@ void menuModelMixAll(event_t event)
 #if LCD_W >= 212
   // Gauge
   if (!s_currCh) {
-    drawGauge(127, 1, 58, 6, ex_chans[index], 1024);
+    drawGauge(MIX_HDR_GAUGE_POS_X, 1, 58, 6, ex_chans[index], 2048);
   }
 #endif
 


### PR DESCRIPTION
 * Adjust custom failsafe (and some channel display) ranges for proper extended limits (fixes #4447).  
 * Fix some display issues in x64 GUIs when adjusting failsafe settings, and cleans up code in those functions.
 * Fix 480x272 channel output progress bars to show full extended limits.
 * Fix alignment issues on 212x & 480x gui mixes screens with long custom channel names.
 * Streamline some channel outputs display code.