### PR TITLE
[radio] Improve TRACEs

### DIFF
--- a/radio/src/debug.h
+++ b/radio/src/debug.h
@@ -57,8 +57,8 @@ uint8_t serial2TracesEnabled();
 }
 #endif
 
-#define TRACE_NOCRLF(...)     do { debugPrintf(__VA_ARGS__); } while(0)
-#define TRACE(...)            do { debugPrintf(__VA_ARGS__); debugPrintf("\r\n"); } while(0)
+#define TRACE_NOCRLF(...)     debugPrintf(__VA_ARGS__)
+#define TRACE(f_, ...)        debugPrintf((f_ "\r\n"), ##__VA_ARGS__)
 #define DUMP(data, size)      dump(data, size)
 #define TRACE_DEBUG(...)      debugPrintf("-D- " __VA_ARGS__)
 #define TRACE_DEBUG_WP(...)   debugPrintf(__VA_ARGS__)


### PR DESCRIPTION
I also propose we prefix TRACE with `-T- ` (or `-D- `) for easier filtering.  Important messages meant for end-users should be sent with `TRACE_[INFO|WARNING|ERROR]` (not sure if that's always the case now).

I also like Damjan's suggestion of prefixing the individual TRACE_module macros, like: https://github.com/opentx/opentx/pull/4458/files#diff-fbb61f947eba942385bf18e8b1e4a20dR72

I'm also wondering if we could reduce the flood of TRACE_SIMPGMSPACE messages at Horus startup somehow.  I realize it can be useful which is why I don't like disabling that trace entirely in the build, but ~500 lines at startup seems a bit much and becomes less useful in my opinion.

Thoughts?