### PR TITLE
Proper skipping of hidden menu lines, old code accessed mstate_tab[] …

### DIFF
--- a/radio/src/gui/128x64/model_display.cpp
+++ b/radio/src/gui/128x64/model_display.cpp
@@ -82,6 +82,24 @@ void onTelemetryScriptFileSelectionMenu(const char *result)
 }
 #endif
 
+
+int skipHiddenLines(int noRows, const uint8_t * mstate_tab, int Row)
+{
+  for(int i=0; i<noRows; ++i) {
+    if (mstate_tab[i] != HIDDEN_ROW) {
+      if (Row == 0) {
+        // TRACE("%d -> %d", Row, i);
+        return i;
+      }
+      --Row;
+    }
+  }
+  return -1;
+}
+
+// #define SKIP_HIDDEN_MENU_ROWS(row)    row = skipHiddenLines((int)DIM(mstate_tab), mstate_tab, row); if (row < 0) return;
+#define SKIP_HIDDEN_MENU_ROWS(row)    if ((row = skipHiddenLines((int)DIM(mstate_tab), mstate_tab, row)) < 0) return;
+
 void menuModelDisplay(event_t event)
 {
   MENU(STR_MENU_DISPLAY, menuTabModel, MENU_MODEL_DISPLAY, HEADER_LINE + ITEM_DISPLAY_MAX, { HEADER_LINE_COLUMNS TELEMETRY_SCREEN_ROWS(0), TELEMETRY_SCREEN_ROWS(1), TELEMETRY_SCREEN_ROWS(2), TELEMETRY_SCREEN_ROWS(3) });
@@ -91,11 +109,7 @@ void menuModelDisplay(event_t event)
   for (uint8_t i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;
     int k = i + menuVerticalOffset;
-    for (int j=0; j<=k; j++) {
-      if (mstate_tab[j+HEADER_LINE] == HIDDEN_ROW) {
-        k++;
-      }
-    }
+    SKIP_HIDDEN_MENU_ROWS(k);
 
     LcdFlags blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
     LcdFlags attr = (sub == k ? blink : 0);


### PR DESCRIPTION
This is just an example. Several more places in code where this issues occurs. The `mstate_tab[]` gets accessed with index out of bounds. 

The new code (function and macro) should be moved to `menu.h`

The problem was discovered with `valgrind ./simu`
```
==16889== Conditional jump or move depends on uninitialised value(s)
==16889==    at 0x44B69E: menuModelDisplay(unsigned short) (in opentx/build-x7/simu)
==16889==    by 0x42B3DD: handleGui(unsigned short) (in opentx/build-x7/simu)
==16889==    by 0x42B548: guiMain(unsigned short) (in opentx/build-x7/simu)
==16889==    by 0x42B5FA: perMain() (in opentx/build-x7/simu)
==16889==    by 0x42B8E4: menusTask(void*) (in opentx/build-x7/simu)
==16889==    by 0x46D28E: start_routine(void*) (in opentx/build-x7/simu)
==16889==    by 0x53B66B9: start_thread (pthread_create.c:333)
==16889==    by 0x5F0382C: clone (clone.S:109)
```