### PR TITLE
[Companion] Fix/improve setting radio module custom failsafe values.

### DIFF
--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -54,25 +54,22 @@ class TimerPanel : public ModelPanel
 
 class ModulePanel : public ModelPanel
 {
-  static const int maxChannels = 16;
-
-  struct ChannelFailsafeWidgetsGroup {
-    QComboBox * combo;
-    QDoubleSpinBox * spinbox;
-    QLabel * label;
-  };
-
-    Q_OBJECT
+  Q_OBJECT
 
   public:
     ModulePanel(QWidget *parent, ModelData & model, ModuleData & module, GeneralSettings & generalSettings, Firmware * firmware, int moduleIdx);
     virtual ~ModulePanel();
     virtual void update();
+    bool moduleHasFailsafes();
 
-  protected:
-    void updateFailsafe(int channel);
+  public slots:
+    void onExtendedLimitsToggled();
+
+  signals:
+    void channelsRangeChanged();
 
   private slots:
+    void setupFailsafes();
     void on_trainerMode_currentIndexChanged(int index);
     void on_protocol_currentIndexChanged(int index);
     void on_ppmDelay_editingFinished();
@@ -84,18 +81,32 @@ class ModulePanel : public ModelPanel
     void on_antennaMode_currentIndexChanged(int index);
     void on_rxNumber_editingFinished();
     void on_failsafeMode_currentIndexChanged(int value);
-    void onFailsafeComboIndexChanged(int index);
-    void onFailsafeSpinChanged(double value);
     void on_multiProtocol_currentIndexChanged(int index);
     void on_multiSubType_currentIndexChanged(int index);
     void on_autoBind_stateChanged(int state);
     void on_lowPower_stateChanged(int state);
+    void setChannelFailsafeValue(const int channel, const int value, quint8 updtSb = 0);
+    void onFailsafeComboIndexChanged(int index);
+    void onFailsafeUsecChanged(int value);
+    void onFailsafePercentChanged(double value);
+    void onFailsafesDisplayValueTypeChanged(int type);
+    void updateFailsafe(int channel);
 
   private:
+    enum FailsafeValueDisplayTypes { FAILSAFE_DISPLAY_PERCENT = 1, FAILSAFE_DISPLAY_USEC = 2 };
+
+    struct ChannelFailsafeWidgetsGroup {
+        QLabel * label;
+        QComboBox * combo;
+        QSpinBox * sbUsec;
+        QDoubleSpinBox * sbPercent;
+    };
+
     ModuleData & module;
     int moduleIdx;
     Ui::Module *ui;
-    ChannelFailsafeWidgetsGroup failsafeGroups[maxChannels];
+    QMap<int, ChannelFailsafeWidgetsGroup> failsafeGroupsMap;
+    static quint8 failsafesValueDisplayType;  // FailsafeValueDisplayTypes
 };
 
 class SetupPanel : public ModelPanel

--- a/companion/src/modeledit/setup_module.ui
+++ b/companion/src/modeledit/setup_module.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>674</width>
-    <height>205</height>
+    <height>229</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -657,6 +657,10 @@
       </item>
       <item row="1" column="0" colspan="3">
        <widget class="QGroupBox" name="failsafesGroupBox">
+        <property name="styleSheet">
+         <string notr="true">QGroupBox {padding-top: -10px; margin-top: 5px;}
+QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; padding-left: 10px; padding-right: 10px; }</string>
+        </property>
         <property name="title">
          <string>Failsafe Positions</string>
         </property>
@@ -676,6 +680,60 @@
          <property name="bottomMargin">
           <number>4</number>
          </property>
+         <item alignment="Qt::AlignRight">
+          <widget class="QWidget" name="widgetValueType" native="true">
+           <property name="autoFillBackground">
+            <bool>true</bool>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="spacing">
+             <number>5</number>
+            </property>
+            <property name="leftMargin">
+             <number>12</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>12</number>
+            </property>
+            <property name="bottomMargin">
+             <number>2</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Show values in:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="optPercent">
+              <property name="text">
+               <string extracomment="abbreviation for percent">%</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">btnGrpValueType</string>
+              </attribute>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="optUs">
+              <property name="text">
+               <string extracomment="abbreviation for microseconds">μs</string>
+              </property>
+              <attribute name="buttonGroup">
+               <string notr="true">btnGrpValueType</string>
+              </attribute>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
          <item>
           <layout class="QGridLayout" name="failsafesLayout">
            <property name="spacing">
@@ -725,4 +783,7 @@
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="btnGrpValueType"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
  * Properly set limits based on model's Extended Limits setting;
  * Fix rounding issues between percentile display and underlying value in μs;
  * Add ability to display values in μs or percent.
  * Channels numbering & count is responsive to module's defined start/end channels.

Fixes #4443

Please give this a good test first... I'm a bit rushed on final testing, and may be not be available for a few days for quick fixes.  I did give it a good workout, but you never know.  Thanks!
