### PR TITLE
Some memory leaks and out of bounds array access fixed

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -116,6 +116,7 @@ int cliLs(const char ** argv)
       if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
       serialPrint(fno.fname);
     }
+    f_closedir(&dir);
   }
   else {
     serialPrint("%s: Invalid directory \"%s\"", argv[0], argv[1]);

--- a/radio/src/gui/480x272/radio_sdmanager.cpp
+++ b/radio/src/gui/480x272/radio_sdmanager.cpp
@@ -323,6 +323,7 @@ bool menuRadioSdManager(event_t _event)
           }
         }
       }
+      f_closedir(&dir);
     }
   }
 

--- a/radio/src/gui/480x272/widgets.cpp
+++ b/radio/src/gui/480x272/widgets.cpp
@@ -370,6 +370,7 @@ void drawSleepBitmap()
   const BitmapBuffer * bitmap = BitmapBuffer::load(getThemePath("sleep.bmp"));
   if (bitmap) {
     lcd->drawBitmap((LCD_W-bitmap->getWidth())/2, (LCD_H-bitmap->getHeight())/2, bitmap);
+    delete bitmap;
   }
   lcdRefresh();
 }

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -384,6 +384,7 @@ void menuRadioSdManager(event_t _event)
           }
         }
       }
+      f_closedir(&dir);
     }
   }
 

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -362,6 +362,7 @@ bool sdListFiles(const char * path, const char * extension, const uint8_t maxlen
         }
       }
     }
+    f_closedir(&dir);
   }
 
   if (popupMenuOffset > 0)

--- a/radio/src/storage/eeprom_rlc.cpp
+++ b/radio/src/storage/eeprom_rlc.cpp
@@ -678,44 +678,43 @@ void RlcFile::nextRlcWriteStep()
     return;
   }
 
-  bool run0 = (m_rlc_buf[0] == 0);
+  if (m_rlc_len>0) {
 
-  if (m_rlc_len==0) goto close;
+    bool run0 = (m_rlc_buf[0] == 0);
 
-  for (i=1; 1; i++) { // !! laeuft ein byte zu weit !!
-    bool cur0 = m_rlc_buf[i] == 0;
-    if (cur0 != run0 || cnt==0x3f || (cnt0 && cnt==0x0f) || i==m_rlc_len) {
-      if (run0) {
-        assert(cnt0==0);
-        if (cnt<8 && i!=m_rlc_len)
-          cnt0 = cnt; //aufbew fuer spaeter
+    for (i=1; 1; i++) { // !! laeuft ein byte zu weit !!
+      bool cur0 = (i<m_rlc_len) ? (m_rlc_buf[i] == 0) : false;
+      if (cur0 != run0 || cnt==0x3f || (cnt0 && cnt==0x0f) || i==m_rlc_len) {
+        if (run0) {
+          assert(cnt0==0);
+          if (cnt<8 && i!=m_rlc_len)
+            cnt0 = cnt; //aufbew fuer spaeter
+          else {
+            m_rlc_buf+=cnt;
+            m_rlc_len-=cnt;
+            write1(cnt|0x40);
+            return;
+          }
+        }
         else {
-          m_rlc_buf+=cnt;
-          m_rlc_len-=cnt;
-          write1(cnt|0x40);
+          m_rlc_buf+=cnt0;
+          m_rlc_len-=cnt0+cnt;
+          m_cur_rlc_len=cnt;
+          if(cnt0){
+            write1(0x80 | (cnt0<<4) | cnt);
+          }
+          else{
+            write1(cnt);
+          }
           return;
         }
+        cnt=0;
+        if (i==m_rlc_len) break;
+        run0 = cur0;
       }
-      else {
-        m_rlc_buf+=cnt0;
-        m_rlc_len-=cnt0+cnt;
-        m_cur_rlc_len=cnt;
-        if(cnt0){
-          write1(0x80 | (cnt0<<4) | cnt);
-        }
-        else{
-          write1(cnt);
-        }
-        return;
-      }
-      cnt=0;
-      if (i==m_rlc_len) break;
-      run0 = cur0;
+      cnt++;
     }
-    cnt++;
   }
-
-  close:
 
   switch(m_write_step) {
     case WRITE_START_STEP: {

--- a/radio/src/storage/rlc.cpp
+++ b/radio/src/storage/rlc.cpp
@@ -36,7 +36,7 @@ unsigned int compress(uint8_t * dst, unsigned int dstsize, const uint8_t * src, 
   uint8_t cnt0   = 0;
 
   for (unsigned int i=1; 1; i++) {
-    bool cur0 = (src[i] == 0);
+    bool cur0 = (i < srcsize) ? (src[i] == 0) : false;
     if (i==srcsize || cur0!=run0 || cnt==0x3f || (cnt0 && cnt==0xf)) {
       if (run0) {
         assert(cnt0==0);


### PR DESCRIPTION
A couple of problems were found using `-DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize=leak"` and then running `simu`.

More reading https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer and https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html

Example error before this fix:
```
==13966==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000000735e52 at pc 0x00000044bf9c bp 0x7f419aa7ec40 sp 0x7f419aa7ec30
READ of size 1 at 0x000000735e52 thread T6
    #0 0x44bf9b in RlcFile::nextRlcWriteStep() /radio/src/storage/eeprom_rlc.cpp:681
    #1 0x44a9c3 in RlcFile::nextWriteStep() /radio/src/storage/eeprom_rlc.cpp:430
    #2 0x4356ee in eepromWriteProcess() (/build-x7/simu+0x4356ee)
    #3 0x434e06 in checkEeprom() /radio/src/main_arm.cpp:72
    #4 0x435566 in perMain() /radio/src/main_arm.cpp:384
    #5 0x435b7f in menusTask(void*) /radio/src/tasks_arm.cpp:220
    #6 0x4c742a in start_routine(void*) /radio/src/targets/simu/simpgmspace.cpp:678
    #7 0x7f41a7c1b6b9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76b9)
    #8 0x7f41a712082c in clone (/lib/x86_64-linux-gnu/libc.so.6+0x10682c)

0x000000735e52 is located 0 bytes to the right of global variable 'g_eeGeneral' defined in '/radio/src/opentx.cpp:23:12' (0x735b00) of size 850
0x000000735e52 is located 46 bytes to the left of global variable 'g_model' defined in '/radio/src/opentx.cpp:24:12' (0x735e80) of size 6025
SUMMARY: AddressSanitizer: global-buffer-overflow /radio/src/storage/eeprom_rlc.cpp:681 RlcFile::nextRlcWriteStep()
```

**I did not actually test if my fix broke RLC or not**!

