### PR TITLE
Make lcd.clear() color aware on color screens

### DIFF
--- a/radio/sdcard/horus/S6R/S6R.lua
+++ b/radio/sdcard/horus/S6R/S6R.lua
@@ -108,7 +108,6 @@ end
 -- Redraw the current page
 local function redrawFieldsPage(event)
   lcd.clear()
-  lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, TEXT_BGCOLOR)
   drawScreenTitle("S6R", page, #pages)
 
   if refreshIndex < #fields then
@@ -276,7 +275,6 @@ local function runCalibrationPage(event)
     refreshIndex = 0
   end
   lcd.clear()
-  lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, TEXT_BGCOLOR)
   drawScreenTitle("S6R", page, #pages)
   if(calibrationStep < 6) then
     local position = calibrationPositions[1 + calibrationStep]

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -39,9 +39,11 @@ static int luaLcdRefresh(lua_State *L)
 }
 
 /*luadoc
-@function lcd.clear()
+@function lcd.clear([color])
 
 Clear the LCD screen
+
+@param color (only on color screens)
 
 @status current Introduced in 2.0.0
 
@@ -49,7 +51,14 @@ Clear the LCD screen
 */
 static int luaLcdClear(lua_State *L)
 {
-  if (luaLcdAllowed) lcdClear();
+  LcdFlags color = luaL_optunsigned(L, 1, TEXT_BGCOLOR);
+  if (luaLcdAllowed) {
+#if defined(COLORLCD)
+    lcd->clear(color);
+#else
+    lcdClear();
+#endif
+  }
   return 0;
 }
 

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -43,7 +43,7 @@ static int luaLcdRefresh(lua_State *L)
 
 Clear the LCD screen
 
-@param color (only on color screens)
+@param color (optionnal, only on color screens)
 
 @status current Introduced in 2.0.0
 
@@ -51,9 +51,9 @@ Clear the LCD screen
 */
 static int luaLcdClear(lua_State *L)
 {
-  LcdFlags color = luaL_optunsigned(L, 1, TEXT_BGCOLOR);
   if (luaLcdAllowed) {
 #if defined(COLORLCD)
+    LcdFlags color = luaL_optunsigned(L, 1, TEXT_BGCOLOR);
     lcd->clear(color);
 #else
     lcdClear();
@@ -61,7 +61,6 @@ static int luaLcdClear(lua_State *L)
   }
   return 0;
 }
-
 
 /*luadoc
 @function lcd.drawPoint(x, y)


### PR DESCRIPTION
Allows to specify a blanking color when using it on color screens