### PR TITLE
Fixes #4136 Reset logical switch fields when changing function type

### DIFF
--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -11,7 +11,7 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   ModelPanel(parent, model, generalSettings, firmware),
   selectedSwitch(0)
 {
-  Stopwatch s1("LogicalSwitchesPanel"); 
+  Stopwatch s1("LogicalSwitchesPanel");
 
   int channelsMax = model.getChannelsMax(true);
 
@@ -199,23 +199,14 @@ void LogicalSwitchesPanel::edited()
     CSFunctionFamily newFuncFamily = model->logicalSw[i].getFunctionFamily();
 
     if (oldFuncFamily != newFuncFamily) {
+      model->logicalSw[i].clear();
+      model->logicalSw[i].func = csw[i]->itemData(csw[i]->currentIndex()).toInt();
       if (newFuncFamily == LS_FAMILY_TIMER) {
         model->logicalSw[i].val1 = -119;
         model->logicalSw[i].val2 = -119;
       }
       else if (newFuncFamily == LS_FAMILY_EDGE) {
-        model->logicalSw[i].val1 = 0;
         model->logicalSw[i].val2 = -129;
-        model->logicalSw[i].val3 = 0;
-      }
-      else if (newFuncFamily == LS_FAMILY_STICKY) {
-        model->logicalSw[i].val1 = 0;
-        model->logicalSw[i].val2 = 0;
-        model->logicalSw[i].delay = 0;
-      }
-      else {
-        model->logicalSw[i].val1 = 0;
-        model->logicalSw[i].val2 = 0;
       }
       setSwitchWidgetVisibility(i);
     }
@@ -229,7 +220,7 @@ void LogicalSwitchesPanel::edited()
         source = RawSource(model->logicalSw[i].val1);
         RawSourceRange range = source.getRange(model, generalSettings, model->logicalSw[i].getRangeFlags());
         double value = source.isTimeBased() ? QTimeS(cswitchTOffset[i]->time()).seconds() : cswitchOffset[i]->value();
-        model->logicalSw[i].val2 = round((value-range.offset)/range.step);;
+        model->logicalSw[i].val2 = round((value-range.offset)/range.step);
         value = model->logicalSw[i].val2*range.step + range.offset;
         if (source.isTimeBased())
           cswitchTOffset[i]->setTime(QTimeS(round(value)));

--- a/radio/src/gui/9X/menu_model_logical_switches.cpp
+++ b/radio/src/gui/9X/menu_model_logical_switches.cpp
@@ -516,18 +516,16 @@ void menuModelLogicalSwitches(uint8_t event)
 #endif
           uint8_t new_cstate = lswFamily(cs->func);
           if (cstate != new_cstate) {
-#if defined(CPUARM)
+            unsigned int save_func = cs->func;
+            memset(cs, 0, sizeof(LogicalSwitchData));
+            cs->func = save_func;
             if (new_cstate == LS_FAMILY_TIMER) {
               cs->v1 = cs->v2 = -119;
             }
-            else if (new_cstate == LS_FAMILY_EDGE) {
-              cs->v1 = 0; cs->v2 = -129; cs->v3 = 0;
+#if defined(CPUARM)
+            if (new_cstate == LS_FAMILY_EDGE) {
+              cs->v2 = -129;
             }
-            else {
-              cs->v1 = cs->v2 = 0;
-            }
-#else
-            cs->v1 = cs->v2 = (new_cstate==LS_FAMILY_TIMER ? -119/*1.0*/ : 0);
 #endif
           }
           break;

--- a/radio/src/gui/Taranis/menu_model_logical_switches.cpp
+++ b/radio/src/gui/Taranis/menu_model_logical_switches.cpp
@@ -232,14 +232,14 @@ void menuModelLogicalSwitches(uint8_t event)
           cs->func = checkIncDec(event, cs->func, 0, LS_FUNC_MAX, EE_MODEL, isLogicalSwitchFunctionAvailable);
           uint8_t new_cstate = lswFamily(cs->func);
           if (cstate != new_cstate) {
+            unsigned int save_func = cs->func;
+            memset(cs, 0, sizeof(LogicalSwitchData));
+            cs->func = save_func;
             if (new_cstate == LS_FAMILY_TIMER) {
               cs->v1 = cs->v2 = -119;
             }
             else if (new_cstate == LS_FAMILY_EDGE) {
-              cs->v1 = 0; cs->v2 = -129; cs->v3 = 0;
-            }
-            else {
-              cs->v1 = cs->v2 = 0;
+              cs->v2 = -129;
             }
           }
           break;


### PR DESCRIPTION
Fixes #4136 for Companion and radios where not all fields were being reset.
For a logical switch on change of function family clear all fields and set family defaults.
OFF function is unable to act as an enable/disable switch for most functions as it is a member of a function family.

If and when this PR is merged I will port to next and create another PR.
