### PR TITLE
remove src/radio/stamp.h from the gitignore (make cmake idempotent)

### DIFF
--- a/radio/src/.gitignore
+++ b/radio/src/.gitignore
@@ -1,4 +1,3 @@
-/stamp.h
 /opentx.elf
 /simu
 /opentx.map


### PR DESCRIPTION
without this, i get:

```
CMake Error at CMakeLists.txt:88 (message):
  Source directory contains files leftover from a OpenTX 2.1 build.  Please
  run `git clean -f` in source directory (Careful: Will remove any extra
  files) or do a new clean git checkout
```

but `git clean -f` does not remove `stamp.h`