### PR TITLE
Fix a regression that omitted filenames from allsrc.cpp

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -507,7 +507,7 @@ if(NOT MSVC)
     if (BASH AND NOT WIN32)
       add_custom_command(
         OUTPUT ${ALLSRC}
-        COMMAND ${BASH} -kc 'rm -f ${ALLSRC}\; for f in ${SRC}\; do echo "\\# 1 \"$$f\"" >> allsrc.cpp\; cat "$$f" >> ${ALLSRC}\; done'
+        COMMAND ${BASH} -kc 'rm -f ${ALLSRC}\; for f in ${SRC}\; do echo "\\# 1 \\\"$$f\\\"" >> ${ALLSRC}\; cat "$$f" >> ${ALLSRC}\; done'
         WORKING_DIRECTORY ${RADIO_SRC_DIRECTORY}
         DEPENDS ${SRC}
         )


### PR DESCRIPTION
Commit ab6f910 added filename markers to allsrc.cpp, those subsequently got broken at some point.
This PR fixed the regression.

Filename markers are helpful when trying to figure out which file contains compilation errors.