### PR TITLE
Allow datestamp for ARM 128x64 model backups

### DIFF
--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -332,7 +332,7 @@ void menuModelSelect(event_t event)
   if (event) reusableBuffer.modelsel.eepromfree = EeFsGetFree();
   lcdDrawNumber(17*FW, 0, reusableBuffer.modelsel.eepromfree, RIGHT);
 #endif
-  
+
 #if defined(PCBX7)
   drawScreenIndex(MENU_MODEL_SELECT, DIM(menuTabModel), 0);
 #elif defined(ROTARY_ENCODER_NAVIGATION)

--- a/radio/src/gui/128x64/popups.h
+++ b/radio/src/gui/128x64/popups.h
@@ -76,11 +76,7 @@ extern uint8_t warningInfoFlags;
   #define POPUP_MENU_START(func)       do { popupMenuHandler = (func); AUDIO_KEY_PRESS(); } while (0)
   #define POPUP_MENU_MAX_LINES         12
   #define MENU_MAX_DISPLAY_LINES       6
-#if defined(PCBX7)
   #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+12)
-#else
-  #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+1)
-#endif
   #define POPUP_MENU_SET_BSS_FLAG()
   #define POPUP_MENU_UNSET_BSS_FLAG()
   enum {

--- a/radio/src/gui/128x64/popups.h
+++ b/radio/src/gui/128x64/popups.h
@@ -76,7 +76,11 @@ extern uint8_t warningInfoFlags;
   #define POPUP_MENU_START(func)       do { popupMenuHandler = (func); AUDIO_KEY_PRESS(); } while (0)
   #define POPUP_MENU_MAX_LINES         12
   #define MENU_MAX_DISPLAY_LINES       6
+#if defined(PCBX7)
+  #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+12)
+#else
   #define MENU_LINE_LENGTH             (LEN_MODEL_NAME+1)
+#endif
   #define POPUP_MENU_SET_BSS_FLAG()
   #define POPUP_MENU_UNSET_BSS_FLAG()
   enum {

--- a/radio/src/storage/eeprom_rlc.cpp
+++ b/radio/src/storage/eeprom_rlc.cpp
@@ -519,7 +519,7 @@ const pm_char * eeBackupModel(uint8_t i_fileSrc)
     len = sizeof(MODELS_PATH) + PSIZE(TR_MODEL) + 2;
   }
 
-#if defined(RTCLOCK) && (LCD_W >= 212 || defined(PCBX7))
+#if defined(RTCLOCK)
   char * tmp = strAppendDate(&buf[len]);
   len = tmp - buf;
 #endif

--- a/radio/src/storage/eeprom_rlc.cpp
+++ b/radio/src/storage/eeprom_rlc.cpp
@@ -519,7 +519,7 @@ const pm_char * eeBackupModel(uint8_t i_fileSrc)
     len = sizeof(MODELS_PATH) + PSIZE(TR_MODEL) + 2;
   }
 
-#if defined(RTCLOCK) && LCD_W >= 212
+#if defined(RTCLOCK) && (LCD_W >= 212 || defined(PCBX7))
   char * tmp = strAppendDate(&buf[len]);
   len = tmp - buf;
 #endif


### PR DESCRIPTION
To allow restore, I've had to increase MENU_LINE_LENGTH, could not find adverse effect, but want to warn about it

This fixes #4511 