### PR TITLE
Update GCS_MAVLink sync script to work with updated mavlink repo

### DIFF
--- a/radio/src/thirdparty/GCS_MAVLink/sync
+++ b/radio/src/thirdparty/GCS_MAVLink/sync
@@ -2,13 +2,13 @@
 branch="master" 
 trap exit ERR
 rm -rf _tmp
-git clone git://github.com/mavlink/mavlink.git -b $branch _tmp
+git clone --recursive --depth 1 git://github.com/mavlink/mavlink.git -b $branch _tmp
 rm -rf _tmp/.git
 rsync -av _tmp/message_definitions/v1.0/* ./message_definitions_v1.0/
 rm -rf include_v1.0
 WD=`pwd`
 OUT_DIR="$WD/include_v1.0"
 IN_FILE="$WD/message_definitions_v1.0/ardupilotmega.xml"
-CMD="./_tmp/pymavlink/generator/mavgen.py --lang=C -o $OUT_DIR $IN_FILE"
+CMD="./_tmp/pymavlink/tools/mavgen.py --lang=C -o $OUT_DIR $IN_FILE"
 $CMD
 rm -rf _tmp


### PR DESCRIPTION
Updated GCS_MAVLink sync script that was broken on current mavlink master due to directory structure changes and submodules added to mavlink repo https://github.com/mavlink/mavlink.
Current version of protocol definitions in GCS_MAVLink dir is 3 years old and is missing RC_CHANNELS message  that contains RSSI in PX4 mavlink implementation.
This missing definition prevents adding support for PX4 RSSI to mavlink telemetry code.

Prerequisites: `sudo pip install future` or `sudo apt install python-future`
This script DOES NOT run automatically during build, so no immediate impact on build process.
Updated headers (after running the script manually) need a one-line source change to mavlink.cpp, provided here: https://github.com/alteman/opentx/commit/57167df663889bd8fbf9abf0a96a4d85c65f9595.

I'm going to submit a PR with header changes made by this script (+build fix) next.
Here's a preview: https://github.com/alteman/opentx/commit/732640d8c9504a4de3057650d0f2b27bb56d683f