### PR TITLE
[Companion][Horus] Add joystick axes (JSx & JSy) and trims T5 & T6 as usable sources.

### DIFF
--- a/companion/src/boards.cpp
+++ b/companion/src/boards.cpp
@@ -123,6 +123,11 @@ int getBoardCapability(Board::Type board, Board::Capability capability)
         return 2;
       else
         return 0;
+    case Joysticks:
+      if (IS_HORUS(board))
+        return 2;
+      else
+        return 0;
     case FactoryInstalledSwitches:
       if (IS_TARANIS_X9E(board))
         return 8;

--- a/companion/src/boards.cpp
+++ b/companion/src/boards.cpp
@@ -52,45 +52,51 @@ int getEEpromSize(Board::Type board)
 Board::SwitchInfo getSwitchInfo(Board::Type board, unsigned index)
 {
   if (IS_TARANIS_X7(board)) {
-    const Board::SwitchInfo switches[] = {{Board::SWITCH_3POS,   "SA"},
-                                          {Board::SWITCH_3POS,   "SB"},
-                                          {Board::SWITCH_3POS,   "SC"},
-                                          {Board::SWITCH_3POS,   "SD"},
-                                          {Board::SWITCH_2POS,   "SF"},
-                                          {Board::SWITCH_TOGGLE, "SH"}};
+    const Board::SwitchInfo switches[] = {
+      {Board::SWITCH_3POS,   "SA"},
+      {Board::SWITCH_3POS,   "SB"},
+      {Board::SWITCH_3POS,   "SC"},
+      {Board::SWITCH_3POS,   "SD"},
+      {Board::SWITCH_2POS,   "SF"},
+      {Board::SWITCH_TOGGLE, "SH"}
+    };
     if (index < DIM(switches))
       return switches[index];
   }
   else if (IS_HORUS_OR_TARANIS(board)) {
-    const Board::SwitchInfo switches[] = {{Board::SWITCH_3POS,   "SA"},
-                                          {Board::SWITCH_3POS,   "SB"},
-                                          {Board::SWITCH_3POS,   "SC"},
-                                          {Board::SWITCH_3POS,   "SD"},
-                                          {Board::SWITCH_3POS,   "SE"},
-                                          {Board::SWITCH_2POS,   "SF"},
-                                          {Board::SWITCH_3POS,   "SG"},
-                                          {Board::SWITCH_TOGGLE, "SH"},
-                                          {Board::SWITCH_3POS,   "SI"},
-                                          {Board::SWITCH_3POS,   "SJ"},
-                                          {Board::SWITCH_3POS,   "SK"},
-                                          {Board::SWITCH_3POS,   "SL"},
-                                          {Board::SWITCH_3POS,   "SM"},
-                                          {Board::SWITCH_3POS,   "SN"},
-                                          {Board::SWITCH_3POS,   "SO"},
-                                          {Board::SWITCH_3POS,   "SP"},
-                                          {Board::SWITCH_3POS,   "SQ"},
-                                          {Board::SWITCH_3POS,   "SR"}};
+    const Board::SwitchInfo switches[] = {
+      {Board::SWITCH_3POS,   "SA"},
+      {Board::SWITCH_3POS,   "SB"},
+      {Board::SWITCH_3POS,   "SC"},
+      {Board::SWITCH_3POS,   "SD"},
+      {Board::SWITCH_3POS,   "SE"},
+      {Board::SWITCH_2POS,   "SF"},
+      {Board::SWITCH_3POS,   "SG"},
+      {Board::SWITCH_TOGGLE, "SH"},
+      {Board::SWITCH_3POS,   "SI"},
+      {Board::SWITCH_3POS,   "SJ"},
+      {Board::SWITCH_3POS,   "SK"},
+      {Board::SWITCH_3POS,   "SL"},
+      {Board::SWITCH_3POS,   "SM"},
+      {Board::SWITCH_3POS,   "SN"},
+      {Board::SWITCH_3POS,   "SO"},
+      {Board::SWITCH_3POS,   "SP"},
+      {Board::SWITCH_3POS,   "SQ"},
+      {Board::SWITCH_3POS,   "SR"}
+    };
     if (index < DIM(switches))
       return switches[index];
   }
   else {
-    const Board::SwitchInfo switches[] = {{Board::SWITCH_2POS,   "THR"},
-                                          {Board::SWITCH_2POS,   "RUD"},
-                                          {Board::SWITCH_2POS,   "ELE"},
-                                          {Board::SWITCH_3POS,   "3POS"},
-                                          {Board::SWITCH_2POS,   "AIL"},
-                                          {Board::SWITCH_2POS,   "GEA"},
-                                          {Board::SWITCH_TOGGLE, "TRN"}};
+    const Board::SwitchInfo switches[] = {
+      {Board::SWITCH_2POS,   "THR"},
+      {Board::SWITCH_2POS,   "RUD"},
+      {Board::SWITCH_2POS,   "ELE"},
+      {Board::SWITCH_3POS,   "3POS"},
+      {Board::SWITCH_2POS,   "AIL"},
+      {Board::SWITCH_2POS,   "GEA"},
+      {Board::SWITCH_TOGGLE, "TRN"}
+    };
     if (index < DIM(switches))
       return switches[index];
   }
@@ -123,7 +129,7 @@ int getBoardCapability(Board::Type board, Board::Capability capability)
         return 2;
       else
         return 0;
-    case Joysticks:
+    case MouseAnalogs:
       if (IS_HORUS(board))
         return 2;
       else
@@ -141,6 +147,13 @@ int getBoardCapability(Board::Type board, Board::Capability capability)
         return 8;
       else
         return 7;
+    case NumTrims:
+      if (IS_HORUS(board))
+        return 6;
+      else
+        return 4;
+    case NumTrimSwitches:
+      return getBoardCapability(board, NumTrims) * 2;
   }
 
   return 0;

--- a/companion/src/boards.h
+++ b/companion/src/boards.h
@@ -85,6 +85,7 @@ namespace Board {
   enum Capability {
     Pots,
     Sliders,
+    Joysticks,
     Switches,
     FactoryInstalledSwitches
   };

--- a/companion/src/boards.h
+++ b/companion/src/boards.h
@@ -85,9 +85,11 @@ namespace Board {
   enum Capability {
     Pots,
     Sliders,
-    Joysticks,
+    MouseAnalogs,
     Switches,
-    FactoryInstalledSwitches
+    FactoryInstalledSwitches,
+    NumTrims,
+    NumTrimSwitches
   };
 }
 

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -503,7 +503,7 @@ QString RotaryEncoderString(int index)
 QString RawSource::toString(const ModelData * model) const
 {
   static const QString trims[] = {
-    QObject::tr("TrmR"), QObject::tr("TrmE"), QObject::tr("TrmT"), QObject::tr("TrmA")
+    QObject::tr("TrmR"), QObject::tr("TrmE"), QObject::tr("TrmT"), QObject::tr("TrmA"), QObject::tr("Trm5"), QObject::tr("Trm6")
   };
 
   static const QString special[] = {
@@ -617,7 +617,9 @@ QString RawSwitch::toString(Board::Type board) const
     QObject::tr("RudTrim Left"), QObject::tr("RudTrim Right"),
     QObject::tr("EleTrim Down"), QObject::tr("EleTrim Up"),
     QObject::tr("ThrTrim Down"), QObject::tr("ThrTrim Up"),
-    QObject::tr("AilTrim Left"), QObject::tr("AilTrim Right")
+    QObject::tr("AilTrim Left"), QObject::tr("AilTrim Right"),
+    QObject::tr("Trim 5 Down"), QObject::tr("Trim 5 Up"),
+    QObject::tr("Trim 6 Down"), QObject::tr("Trim 6 Up")
   };
 
   static const QString rotaryEncoders[] = {

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -52,7 +52,6 @@ enum Capability {
   MultiLangVoice,
   ModelImage,
   SwitchesPositions,
-  NumTrimSwitches,
   CustomFunctions,
   SafetyChannelCustomFunction,
   LogicalSwitches,
@@ -277,7 +276,7 @@ class Firmware {
     {
       return base ? base : this;
     }
-    
+
     virtual Firmware * getFirmwareVariant(const QString & id) { return NULL; }
 
     unsigned int getVariantNumber();
@@ -300,12 +299,12 @@ class Firmware {
     {
       return board;
     }
-    
+
     void setEEpromInterface(EEPROMInterface * eeprom)
     {
       eepromInterface = eeprom;
     }
-    
+
     EEPROMInterface * getEEpromInterface()
     {
       return eepromInterface;

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -517,11 +517,6 @@ int OpenTxFirmware::getCapability(::Capability capability)
         return getBoardCapability(board, Board::Switches) * 3;
       else
         return 9;
-    case NumTrimSwitches:
-      if (IS_HORUS(board))
-        return 12;
-      else
-        return 8;
     case CustomFunctions:
       if (IS_ARM(board))
         return 64;

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -735,48 +735,60 @@ int OpenTxFirmware::getCapability(::Capability capability)
 QString OpenTxFirmware::getAnalogInputName(unsigned int index)
 {
   if (index < 4) {
-    const QString sticks[] = { QObject::tr("Rud"),
-                               QObject::tr("Ele"),
-                               QObject::tr("Thr"),
-                               QObject::tr("Ail") };
+    const QString sticks[] = {
+      QObject::tr("Rud"),
+      QObject::tr("Ele"),
+      QObject::tr("Thr"),
+      QObject::tr("Ail")
+    };
     return sticks[index];
   }
 
   index -= 4;
 
   if (IS_9X(board) || IS_2560(board) || IS_SKY9X(board)) {
-    const QString pots[]  = { QObject::tr("P1"),
-                              QObject::tr("P2"),
-                              QObject::tr("P3") };
+    const QString pots[] = {
+      QObject::tr("P1"),
+      QObject::tr("P2"),
+      QObject::tr("P3")
+    };
     return CHECK_IN_ARRAY(pots, index);
   }
   else if (IS_TARANIS_X9E(board)) {
-    const QString pots[] = { QObject::tr("F1"),
-                             QObject::tr("F2"),
-                             QObject::tr("F3"),
-                             QObject::tr("F4"),
-                             QObject::tr("S1"),
-                             QObject::tr("S2"),
-                             QObject::tr("LS"),
-                             QObject::tr("RS") };
+    const QString pots[] = {
+      QObject::tr("F1"),
+      QObject::tr("F2"),
+      QObject::tr("F3"),
+      QObject::tr("F4"),
+      QObject::tr("S1"),
+      QObject::tr("S2"),
+      QObject::tr("LS"),
+      QObject::tr("RS")
+    };
     return CHECK_IN_ARRAY(pots, index);
   }
   else if (IS_TARANIS(board)) {
-    const QString pots[] = {QObject::tr("S1"),
-                            QObject::tr("S2"),
-                            QObject::tr("S3"),
-                            QObject::tr("LS"),
-                            QObject::tr("RS")};
+    const QString pots[] = {
+      QObject::tr("S1"),
+      QObject::tr("S2"),
+      QObject::tr("S3"),
+      QObject::tr("LS"),
+      QObject::tr("RS")
+    };
     return CHECK_IN_ARRAY(pots, index);
   }
   else if (IS_HORUS(board)) {
-    const QString pots[] = {QObject::tr("S1"),
-                            QObject::tr("6P"),
-                            QObject::tr("S2"),
-                            QObject::tr("L1"),
-                            QObject::tr("L2"),
-                            QObject::tr("LS"),
-                            QObject::tr("RS")};
+    const QString pots[] = {
+      QObject::tr("S1"),
+      QObject::tr("6P"),
+      QObject::tr("S2"),
+      QObject::tr("L1"),
+      QObject::tr("L2"),
+      QObject::tr("LS"),
+      QObject::tr("RS"),
+      QObject::tr("JSx"),
+      QObject::tr("JSy")
+    };
     return CHECK_IN_ARRAY(pots, index);
   }
   else {
@@ -1238,7 +1250,7 @@ void registerOpenTxFirmwares()
   addOpenTxFrskyOptions(firmware);
   firmware->addOption("pcbdev", QObject::tr("Use ONLY with first DEV pcb version"));
   registerOpenTxFirmware(firmware);
-  
+
 
   /* FrSky X10 board */
 /* Disabled for now

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -387,7 +387,6 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       for (int i=-getCurrentFirmware()->getCapability(FlightModes); i<0; i++) {
         item = RawSwitch(SWITCH_TYPE_FLIGHT_MODE, i);
         b->addItem(item.toString(), item.toValue());
-        if (item == value) b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -396,20 +395,17 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
     for (int i=-getCurrentFirmware()->getCapability(LogicalSwitches); i<0; i++) {
       item = RawSwitch(SWITCH_TYPE_VIRTUAL, i);
       b->addItem(item.toString(), item.toValue());
-      if (item == value) b->setCurrentIndex(b->count()-1);
     }
   }
 
   for (int i=-getCurrentFirmware()->getCapability(RotaryEncoders); i<0; i++) {
     item = RawSwitch(SWITCH_TYPE_ROTARY_ENCODER, i);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
-  for (int i=-8; i<0; i++) {
+  for (int i = -getBoardCapability(board, Board::NumTrimSwitches); i < 0; i++) {
     item = RawSwitch(SWITCH_TYPE_TRIM, i);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   for (int i=getCurrentFirmware()->getCapability(MultiposPots)-1; i>=0; i--) {
@@ -417,7 +413,6 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       for (int j=-getCurrentFirmware()->getCapability(MultiposPotsPositions); j<0; j++) {
         item = RawSwitch(SWITCH_TYPE_MULTIPOS_POT, -i*getCurrentFirmware()->getCapability(MultiposPotsPositions)+j);
         b->addItem(item.toString(), item.toValue());
-        if (item == value) b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -428,20 +423,17 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       continue;
     }
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   if (context == TimersContext) {
     for (int i=0; i<5; i++) {
       item = RawSwitch(SWITCH_TYPE_TIMER_MODE, i);
       b->addItem(item.toString(), item.toValue());
-      if (item == value) b->setCurrentIndex(b->count()-1);
     }
   }
   else {
     item = RawSwitch(SWITCH_TYPE_NONE);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   for (int i=1; i<=getCurrentFirmware()->getCapability(SwitchesPositions); i++) {
@@ -450,7 +442,6 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       continue;
     }
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   for (int i=0; i<getCurrentFirmware()->getCapability(MultiposPots); i++) {
@@ -458,28 +449,24 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       for (int j=1; j<=getCurrentFirmware()->getCapability(MultiposPotsPositions); j++) {
         item = RawSwitch(SWITCH_TYPE_MULTIPOS_POT, i*getCurrentFirmware()->getCapability(MultiposPotsPositions)+j);
         b->addItem(item.toString(), item.toValue());
-        if (item == value) b->setCurrentIndex(b->count()-1);
       }
     }
   }
 
-  for (int i=1; i<=8; i++) {
+  for (int i=1; i <= getBoardCapability(board, Board::NumTrimSwitches); i++) {
     item = RawSwitch(SWITCH_TYPE_TRIM, i);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   for (int i=1; i<=getCurrentFirmware()->getCapability(RotaryEncoders); i++) {
     item = RawSwitch(SWITCH_TYPE_ROTARY_ENCODER, i);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   if (context != GlobalFunctionsContext) {
     for (int i=1; i<=getCurrentFirmware()->getCapability(LogicalSwitches); i++) {
       item = RawSwitch(SWITCH_TYPE_VIRTUAL, i);
       b->addItem(item.toString(), item.toValue());
-      if (item == value) b->setCurrentIndex(b->count()-1);
     }
   }
 
@@ -487,11 +474,9 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
     // ON
     item = RawSwitch(SWITCH_TYPE_ON);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
     // One
     item = RawSwitch(SWITCH_TYPE_ONE, 1);
     b->addItem(item.toString(), item.toValue());
-    if (item == value) b->setCurrentIndex(b->count()-1);
   }
 
   // FMx
@@ -500,8 +485,14 @@ void populateSwitchCB(QComboBox * b, const RawSwitch & value, const GeneralSetti
       for (int i=1; i<=getCurrentFirmware()->getCapability(FlightModes); i++) {
         item = RawSwitch(SWITCH_TYPE_FLIGHT_MODE, i);
         b->addItem(item.toString(), item.toValue());
-        if (item == value) b->setCurrentIndex(b->count()-1);
       }
+    }
+  }
+
+  for (int i=0; i < b->count(); ++i) {
+    if (RawSwitch(b->itemData(i).toInt()) == value) {
+      b->setCurrentIndex(i);
+      break;
     }
   }
 
@@ -554,8 +545,6 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
   if (flags & POPULATE_NONE) {
     item = RawSource(SOURCE_TYPE_NONE);
     b->addItem(item.toString(model), item.toValue());
-    if (item == source)
-      b->setCurrentIndex(b->count()-1);
   }
 
   if (flags & POPULATE_SCRIPT_OUTPUTS) {
@@ -563,8 +552,6 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
       for (int j=0; j<getCurrentFirmware()->getCapability(LuaOutputsPerScript); j++) {
         item = RawSource(SOURCE_TYPE_LUA_OUTPUT, i*16+j);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source)
-          b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -575,14 +562,12 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
       if (model->isInputValid(i)) {
         item = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source)
-          b->setCurrentIndex(b->count()-1);
       }
     }
   }
 
   if (flags & POPULATE_SOURCES) {
-    int totalSources = CPN_MAX_STICKS + getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders) + getBoardCapability(board, Board::Joysticks);
+    int totalSources = CPN_MAX_STICKS + getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders) + getBoardCapability(board, Board::MouseAnalogs);
     for (int i=0; i < totalSources; i++) {
       item = RawSource(SOURCE_TYPE_STICK, i);
       // skip unavailable pots and sliders
@@ -592,31 +577,23 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
         continue;
 
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
     for (int i=0; i<getCurrentFirmware()->getCapability(RotaryEncoders); i++) {
       item = RawSource(SOURCE_TYPE_ROTARY_ENCODER, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
   }
 
   if (flags & POPULATE_TRIMS) {
-    for (int i=0; i<4; i++) {
+    for (int i=0; i < getBoardCapability(board, Board::NumTrims); i++) {
       item = RawSource(SOURCE_TYPE_TRIM, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
   }
 
   if (flags & POPULATE_SOURCES) {
     item = RawSource(SOURCE_TYPE_MAX);
     b->addItem(item.toString(model), item.toValue());
-    if (item == source)
-      b->setCurrentIndex(b->count()-1);
   }
 
   if (flags & POPULATE_SWITCHES) {
@@ -628,15 +605,11 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
         QVariant v(0);
         b->model()->setData(index, v, Qt::UserRole - 1);
       }
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(LogicalSwitches); i++) {
       item = RawSource(SOURCE_TYPE_CUSTOM_SWITCH, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
   }
 
@@ -644,22 +617,16 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
     for (int i=0; i<CPN_MAX_CYC; i++) {
       item = RawSource(SOURCE_TYPE_CYC, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(TrainerInputs); i++) {
       item = RawSource(SOURCE_TYPE_PPM, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(Outputs); i++) {
       item = RawSource(SOURCE_TYPE_CH, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
     }
   }
 
@@ -668,8 +635,6 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
       for (int i=0; i<5; ++i) {
         item = RawSource(SOURCE_TYPE_SPECIAL, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source)
-          b->setCurrentIndex(b->count()-1);
       }
       for (int i=0; i<CPN_MAX_SENSORS; ++i) {
         if (model && model->sensorData[i].isAvailable()) {    //this conditon must be false if we populate Global Functions where model = 0
@@ -677,8 +642,6 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
             item = RawSource(SOURCE_TYPE_TELEMETRY, 3*i+j);
             b->addItem(item.toString(model), item.toValue());
             // qDebug() << item.toString(model) << source.toString(model);
-            if (item == source)
-              b->setCurrentIndex(b->count()-1);
           }
         }
       }
@@ -693,8 +656,6 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
           continue;
         item = RawSource(SOURCE_TYPE_TELEMETRY, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source)
-          b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -703,8 +664,13 @@ void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSett
     for (int i=0; i<getCurrentFirmware()->getCapability(Gvars); i++) {
       item = RawSource(SOURCE_TYPE_GVAR, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source)
-        b->setCurrentIndex(b->count()-1);
+    }
+  }
+
+  for (int i=0; i < b->count(); ++i) {
+    if (RawSource(b->itemData(i).toInt()) == source) {
+      b->setCurrentIndex(i);
+      break;
     }
   }
 

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -544,7 +544,7 @@ void populateGVCB(QComboBox & b, int value, const ModelData & model)
   }
 }
 
-void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSettings generalSettings, const ModelData * model, unsigned int flags)
+void populateSourceCB(QComboBox * b, const RawSource & source, const GeneralSettings generalSettings, const ModelData * model, unsigned int flags)
 {
   Board::Type board = getCurrentBoard();
   RawSource item;
@@ -554,7 +554,8 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
   if (flags & POPULATE_NONE) {
     item = RawSource(SOURCE_TYPE_NONE);
     b->addItem(item.toString(model), item.toValue());
-    if (item == source) b->setCurrentIndex(b->count()-1);
+    if (item == source)
+      b->setCurrentIndex(b->count()-1);
   }
 
   if (flags & POPULATE_SCRIPT_OUTPUTS) {
@@ -562,7 +563,8 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
       for (int j=0; j<getCurrentFirmware()->getCapability(LuaOutputsPerScript); j++) {
         item = RawSource(SOURCE_TYPE_LUA_OUTPUT, i*16+j);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source) b->setCurrentIndex(b->count()-1);
+        if (item == source)
+          b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -573,24 +575,31 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
       if (model->isInputValid(i)) {
         item = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source) b->setCurrentIndex(b->count()-1);
+        if (item == source)
+          b->setCurrentIndex(b->count()-1);
       }
     }
   }
 
   if (flags & POPULATE_SOURCES) {
-    for (int i=0; i<CPN_MAX_STICKS+getBoardCapability(getCurrentBoard(), Board::Pots)+getBoardCapability(getCurrentBoard(), Board::Sliders); i++) {
+    int totalSources = CPN_MAX_STICKS + getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders) + getBoardCapability(board, Board::Joysticks);
+    for (int i=0; i < totalSources; i++) {
       item = RawSource(SOURCE_TYPE_STICK, i);
       // skip unavailable pots and sliders
-      if (item.isPot() && !generalSettings.isPotAvailable(i-CPN_MAX_STICKS)) continue;
-      if (item.isSlider() && !generalSettings.isSliderAvailable(i-CPN_MAX_STICKS-getBoardCapability(getCurrentBoard(), Board::Pots))) continue;
+      if (item.isPot() && !generalSettings.isPotAvailable(i-CPN_MAX_STICKS))
+        continue;
+      if (item.isSlider() && !generalSettings.isSliderAvailable(i-CPN_MAX_STICKS-getBoardCapability(board, Board::Pots)))
+        continue;
+
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
     for (int i=0; i<getCurrentFirmware()->getCapability(RotaryEncoders); i++) {
       item = RawSource(SOURCE_TYPE_ROTARY_ENCODER, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
   }
 
@@ -598,14 +607,16 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
     for (int i=0; i<4; i++) {
       item = RawSource(SOURCE_TYPE_TRIM, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
   }
 
   if (flags & POPULATE_SOURCES) {
     item = RawSource(SOURCE_TYPE_MAX);
     b->addItem(item.toString(model), item.toValue());
-    if (item == source) b->setCurrentIndex(b->count()-1);
+    if (item == source)
+      b->setCurrentIndex(b->count()-1);
   }
 
   if (flags & POPULATE_SWITCHES) {
@@ -617,13 +628,15 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
         QVariant v(0);
         b->model()->setData(index, v, Qt::UserRole - 1);
       }
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(LogicalSwitches); i++) {
       item = RawSource(SOURCE_TYPE_CUSTOM_SWITCH, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
   }
 
@@ -631,28 +644,32 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
     for (int i=0; i<CPN_MAX_CYC; i++) {
       item = RawSource(SOURCE_TYPE_CYC, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(TrainerInputs); i++) {
       item = RawSource(SOURCE_TYPE_PPM, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
 
     for (int i=0; i<getCurrentFirmware()->getCapability(Outputs); i++) {
       item = RawSource(SOURCE_TYPE_CH, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
   }
 
   if (flags & POPULATE_TELEMETRY) {
-    if (IS_ARM(getCurrentBoard())) {
+    if (IS_ARM(board)) {
       for (int i=0; i<5; ++i) {
         item = RawSource(SOURCE_TYPE_SPECIAL, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source) b->setCurrentIndex(b->count()-1);
+        if (item == source)
+          b->setCurrentIndex(b->count()-1);
       }
       for (int i=0; i<CPN_MAX_SENSORS; ++i) {
         if (model && model->sensorData[i].isAvailable()) {    //this conditon must be false if we populate Global Functions where model = 0
@@ -660,7 +677,8 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
             item = RawSource(SOURCE_TYPE_TELEMETRY, 3*i+j);
             b->addItem(item.toString(model), item.toValue());
             // qDebug() << item.toString(model) << source.toString(model);
-            if (item == source) b->setCurrentIndex(b->count()-1);
+            if (item == source)
+              b->setCurrentIndex(b->count()-1);
           }
         }
       }
@@ -675,7 +693,8 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
           continue;
         item = RawSource(SOURCE_TYPE_TELEMETRY, i);
         b->addItem(item.toString(model), item.toValue());
-        if (item == source) b->setCurrentIndex(b->count()-1);
+        if (item == source)
+          b->setCurrentIndex(b->count()-1);
       }
     }
   }
@@ -684,7 +703,8 @@ void populateSourceCB(QComboBox *b, const RawSource & source, const GeneralSetti
     for (int i=0; i<getCurrentFirmware()->getCapability(Gvars); i++) {
       item = RawSource(SOURCE_TYPE_GVAR, i);
       b->addItem(item.toString(model), item.toValue());
-      if (item == source) b->setCurrentIndex(b->count()-1);
+      if (item == source)
+        b->setCurrentIndex(b->count()-1);
     }
   }
 

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -105,8 +105,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->trimCB->hide();
   }
 
-  for(int i=0; i < CPN_MAX_STICKS; i++) {
-    ui->trimCB->addItem(firmware->getAnalogInputName(i), i+1);
+  for(int i=0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
+    ui->trimCB->addItem(RawSource(SOURCE_TYPE_TRIM, i).toString(), i+1);
   }
   ui->trimCB->setCurrentIndex(1 - ed->carryTrim);
 

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -717,7 +717,7 @@ void SimulatorWidget::setValues()
 // "get" values from this UI and send them to the firmware simulator.
 void SimulatorWidget::getValues()
 {
-  static const int numTrims  = firmware->getCapability(NumTrimSwitches);
+  static const int numTrims  = getBoardCapability(m_board, Board::NumTrimSwitches);
   int i;
 
   TxInputs inp;


### PR DESCRIPTION
 Fixes bug in #4336.  JSx/JSy are available in the same lists which now show pots/sliders.

![horus-js-source](https://cloud.githubusercontent.com/assets/1366615/23578413/6a30c3c8-00a4-11e7-9d64-098789e590ab.png)
