### PR TITLE
[simu][horus] Replace 2nd knob/pot with functional 6-pos switch

### DIFF
--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -117,8 +117,17 @@ Open9xSim::Open9xSim(FXApp* a):
 
   for(int i=0; i<NUM_POTS+NUM_SLIDERS; i++){
     knobs[i]= new FXKnob(hf11,NULL,0,KNOB_TICKS|LAYOUT_LEFT);
-    knobs[i]->setRange(-1024, 1024);
     knobs[i]->setValue(0);
+
+#if defined(PCBHORUS)
+    if (i == 1) {  // 6-pos switch
+      knobs[i]->setRange(0, 2048);
+      knobs[i]->setIncrement(2048 / 5);
+      knobs[i]->setTickDelta(2048 / 5);
+      continue;
+    }
+#endif
+    knobs[i]->setRange(-1024, 1024);
   }
 
   bmf = new FXImageFrame(this,bmp);


### PR DESCRIPTION
As with Simulator, the pot must be "calibrated."  This is because the current [radio code](https://github.com/opentx/opentx/blob/mpaperno/simu_6pos/radio/src/switches.cpp#L253) won't even try to read the switch/pot positions w/out at least some valid calibration data ( 👍 ).

This is just hard-coding the 6-pos switch with yet another `#ifdef`... open to better ideas or if anyone thinks the 6-pos should be added to other radio(s) also.

![simu-horus-6pos](https://cloud.githubusercontent.com/assets/1366615/23582111/1436d8f2-00f1-11e7-9b50-d1b59a93d4e5.png)
