### PR TITLE
[Companion] Add context-menu actions for moving a model between categories.

### DIFF
--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -66,6 +66,7 @@ class MdiChild : public QWidget
   protected slots:
     void documentWasModified();
     void on_simulateButton_clicked();
+    void onModelMoveToCategory();
     void on_radioSettings_clicked();
     void setDefault();
     void onFirmwareChanged();
@@ -80,6 +81,7 @@ class MdiChild : public QWidget
     void modelAdd();
     void modelEdit();
     void modelDuplicate();
+    void modelChangeCategory(int toCategoryId);
     void wizardEdit();
     void openModelEditWindow();
     bool loadBackup();


### PR DESCRIPTION
The new option is only shown if > 1 categories exist.
Ref. #4224 : Horus models cannot be moved from one category to another.

![model_move_cat](https://cloud.githubusercontent.com/assets/1366615/23583519/ca1e78b4-0114-11e7-86ad-91b3d5b148fa.png)
