### PR TITLE
Add support for PX4 RSSI

### DIFF
--- a/radio/src/telemetry/mavlink.cpp
+++ b/radio/src/telemetry/mavlink.cpp
@@ -117,7 +117,15 @@ static inline void REC_MAVLINK_MSG_ID_SYS_STATUS(const mavlink_message_t* msg) {
 #endif
 }
 
-/*!	\brief Recive rc channels
+/*!	\brief Receive rc channels
+ *
+ */
+static inline void REC_MAVLINK_MSG_ID_RC_CHANNELS(const mavlink_message_t* msg) {
+	uint8_t temp_scale = 5 + g_model.mavlink.rc_rssi_scale;
+	telemetry_data.rc_rssi =  mavlink_msg_rc_channels_get_rssi(msg) * 20 / temp_scale;
+}
+
+/*!	\brief Receive raw rc channels
  *
  */
 static inline void REC_MAVLINK_MSG_ID_RC_CHANNELS_RAW(const mavlink_message_t* msg) {
@@ -368,6 +376,9 @@ static inline void handleMessage(mavlink_message_t* p_rxmsg) {
 		break;
 	case MAVLINK_MSG_ID_SYS_STATUS:
 		REC_MAVLINK_MSG_ID_SYS_STATUS(p_rxmsg);
+		break;
+	case MAVLINK_MSG_ID_RC_CHANNELS:
+		REC_MAVLINK_MSG_ID_RC_CHANNELS(p_rxmsg);
 		break;
 	case MAVLINK_MSG_ID_RC_CHANNELS_RAW:
 		REC_MAVLINK_MSG_ID_RC_CHANNELS_RAW(p_rxmsg);


### PR DESCRIPTION
Add support for displaying Mavlink RSSI from PX4 firmware.
Note that scaling from 255 to 100 in REC_MAVLINK_MSG_ID_RC_CHANNELS_RAW is not up to Mavlink spec https://pixhawk.ethz.ch/mavlink/#RC_CHANNELS
> rssi	uint8_t	Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.