### PR TITLE
LUA drawline fix

### DIFF
--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -111,8 +111,8 @@ static int luaLcdDrawLine(lua_State *L)
   coord_t y1 = luaL_checkunsigned(L, 2);
   coord_t x2 = luaL_checkunsigned(L, 3);
   coord_t y2 = luaL_checkunsigned(L, 4);
-  int pat = luaL_checkinteger(L, 5);
-  int flags = luaL_checkinteger(L, 6);
+  uint8_t pat = luaL_checkunsigned(L, 5);
+  LcdFlags flags = luaL_checkunsigned(L, 6);
 
   if (x1 > LCD_W || y1 > LCD_H || x2 > LCD_W || y2 > LCD_H)
     return 0;

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -107,23 +107,23 @@ whole line will not be drawn (starting from OpenTX 2.1.5)
 static int luaLcdDrawLine(lua_State *L)
 {
   if (!luaLcdAllowed) return 0;
-  int x1 = luaL_checkinteger(L, 1);
-  int y1 = luaL_checkinteger(L, 2);
-  int x2 = luaL_checkinteger(L, 3);
-  int y2 = luaL_checkinteger(L, 4);
+  coord_t x1 = luaL_checkunsigned(L, 1);
+  coord_t y1 = luaL_checkunsigned(L, 2);
+  coord_t x2 = luaL_checkunsigned(L, 3);
+  coord_t y2 = luaL_checkunsigned(L, 4);
   int pat = luaL_checkinteger(L, 5);
   int flags = luaL_checkinteger(L, 6);
 
-  if (x1 < 0 || x1 >= LCD_W || y1 < 0 || y1 >= LCD_H || x2 < 0 || x2 >= LCD_W || y2 < 0 || y2 >= LCD_H)
+  if (x1 > LCD_W || y1 > LCD_H || x2 > LCD_W || y2 > LCD_H)
     return 0;
 
   if (pat == SOLID) {
     if (x1 == x2) {
-      lcdDrawSolidVerticalLine(x1, y2 >= y1 ? y1 : y1+1, y2 >= y1 ? y2-y1+1 : y2-y1-1, flags);
+      lcdDrawSolidVerticalLine(x1, y1<y2 ? y1 : y2,  y1<y2 ? y2-y1 : y1 - y2, flags);
       return 0;
     }
     else if (y1 == y2) {
-      lcdDrawSolidHorizontalLine(x2 >= x1 ? x1 : x1+1, y1, x2 >= x1 ? x2-x1+1 : x2-x1-1, flags);
+      lcdDrawSolidHorizontalLine(x1<x2 ? x1:x2, y1, x1<x2 ? x2-x1 : x1-x2, flags);
       return 0;
     }
   }


### PR DESCRIPTION
This fixes : #4567
Fix and simplify lcd.drawlines. Executing:
```
lcd.clear()
-- outward star
xc = LCD_W / 4
yc = LCD_H / 2
lcd.drawPoint(xc, yc)
lcd.drawLine(xc, yc, xc+10, yc, SOLID, 0)
lcd.drawLine(xc, yc, xc-10, yc, SOLID, 0)
lcd.drawLine(xc, yc, xc, yc+10, SOLID, 0)
lcd.drawLine(xc, yc, xc, yc-10, SOLID, 0)
lcd.drawLine(xc, yc, xc-10, yc - 10, SOLID, 0)
lcd.drawLine(xc, yc, xc+10, yc+10, SOLID, 0)
lcd.drawLine(xc, yc, xc+10, yc-10, SOLID, 0)
lcd.drawLine(xc, yc, xc-10, yc+10, SOLID, 0)

-- inward star
xc = xc + (LCD_W / 2)
lcd.drawPoint(xc, yc)
lcd.drawLine(xc-10, yc, xc, yc, SOLID, 0)
lcd.drawLine(xc+10, yc, xc, yc, SOLID, 0)
lcd.drawLine(xc, yc-10, xc, yc, SOLID, 0)
lcd.drawLine(xc, yc+10, xc, yc, SOLID, 0)
lcd.drawLine(xc-10, yc-10, xc, yc, SOLID, 0)
lcd.drawLine(xc+10, yc+10, xc, yc, SOLID, 0)
lcd.drawLine(xc-10, yc+10, xc, yc, SOLID, 0)
lcd.drawLine(xc+10, yc-10, xc, yc, SOLID, 0)
```
Produces:
![image](https://cloud.githubusercontent.com/assets/5167938/23748880/c4040f7a-04c5-11e7-9ce2-bf49990abd44.png)

![image](https://cloud.githubusercontent.com/assets/5167938/23748899/dcdc1290-04c5-11e7-8751-6d0b130befe7.png)

![image](https://cloud.githubusercontent.com/assets/5167938/23748923/f933ac64-04c5-11e7-8a55-2e18ecf5f307.png)
