### PR TITLE
Fix for issue #4590

### DIFF
--- a/companion/src/storage/firmwareinterface.cpp
+++ b/companion/src/storage/firmwareinterface.cpp
@@ -126,6 +126,8 @@ QString FirmwareInterface::getFlavour() const
     return "opentx-x9d+";
   else if (flavour == "opentx-taranis")
     return "opentx-x9d";
+  else if (flavour == "opentx-horus")
+    return "opentx-x12s";
   else
     return flavour;
 }


### PR DESCRIPTION
Fix for companion firmware compatibility check failing under new firmware names (opentx-x12s, was previously opentx-horus)