### PR TITLE
Allow HAPTIC to be defined for avr too

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -1013,7 +1013,7 @@ enum CountDownModes {
   COUNTDOWN_SILENT,
   COUNTDOWN_BEEPS,
   COUNTDOWN_VOICE,
-#if defined(CPUARM) && defined(HAPTIC)
+#if defined(HAPTIC)
   COUNTDOWN_HAPTIC,
 #endif
   COUNTDOWN_COUNT


### PR DESCRIPTION
We have several failed compilation on the server with this error:
audio_avr.cpp: In function 'void audioTimerCountdown(uint8_t, int)':
audio_avr.cpp:298:51: error: 'COUNTDOWN_HAPTIC' was not declared in this scope

Since there is code in avr that deal with it, I'm assuming that it should be ok to declare for avr too