### PR TITLE
[simulation] Fix some potential crashes & 26 memory leaks, improve LCD redraws.

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -124,7 +124,9 @@ add_subdirectory(thirdparty/qxtcommandoptions)
 set(common_SRCS
   appdebugmessagehandler.cpp
   boards.cpp
+  customdebug.cpp
   eeprominterface.cpp
+  helpers.cpp
   radiodata.cpp
   firmwares/er9x/er9xeeprom.cpp
   firmwares/er9x/er9xinterface.cpp
@@ -132,21 +134,25 @@ set(common_SRCS
   firmwares/ersky9x/ersky9xinterface.cpp
   firmwares/opentx/opentxeeprom.cpp
   firmwares/opentx/opentxinterface.cpp
+  modeledit/node.cpp  # used in simulator
+  modeledit/edge.cpp  # used by node
   )
 
 set(common_MOC_HDRS
   appdebugmessagehandler.h
+  helpers.h
+  modeledit/node.h
   )
 
 qt5_wrap_cpp(common_SRCS ${common_MOC_HDRS})
 
 add_library(common ${common_SRCS})
 qt5_use_modules(common Core Xml Widgets)
+target_link_libraries(common simulation)
 
 ############# Companion ###############
 
 set(companion_SRCS
-  helpers.cpp
   helpers_html.cpp
   mdichild.cpp
   modelslist.cpp
@@ -206,7 +212,6 @@ set(companion_MOC_HDRS
   mdichild.h
   mainwindow.h
   radionotfound.h
-  helpers.h
   wizarddialog.h
   modelprinter.h
   multimodelprinter.h
@@ -259,9 +264,9 @@ qt5_wrap_ui(companion_SRCS ${companion_UIS})
 qt5_wrap_cpp(companion_SRCS ${companion_MOC_HDRS})
 qt5_add_translation(companion_QM ${companion_TS})
 qt5_add_resources(companion_RCC ${companion_RESOURCES})
-add_custom_target(gen_qrc DEPENDS ${companion_RCC})
+add_custom_target(gen_qrc DEPENDS ${companion_RCC} ${companion_QM})
 
-add_executable(${COMPANION_NAME} MACOSX_BUNDLE ${WIN_EXECUTABLE_TYPE} ${companion_SRCS} ${companion_RCC} ${companion_QM})
+add_executable(${COMPANION_NAME} MACOSX_BUNDLE ${WIN_EXECUTABLE_TYPE} ${companion_SRCS} ${companion_RCC})
 
 add_dependencies(${COMPANION_NAME} gen_qrc)
 qt5_use_modules(${COMPANION_NAME} Core Widgets Network)
@@ -272,19 +277,7 @@ PrintTargetReport("${COMPANION_NAME}")
 
 ############# Standalone simulator ###############
 
-set(simu_SRCS
-  modeledit/node.cpp
-  modeledit/edge.cpp
-  helpers.cpp
-  simulator.cpp
-  )
-
-set(simu_MOC_HDRS
-  modeledit/node.h
-  helpers.h
-  )
-
-qt5_wrap_cpp(simu_SRCS ${simu_MOC_HDRS} )
+set(simu_SRCS simulator.cpp )
 
 if(WIN32)
   list(APPEND simu_SRCS icon.rc)
@@ -293,7 +286,7 @@ endif()
 add_executable(${SIMULATOR_NAME} MACOSX_BUNDLE ${WIN_EXECUTABLE_TYPE} ${simu_SRCS} ${companion_RCC})
 add_dependencies(${SIMULATOR_NAME} gen_qrc)
 
-target_link_libraries(${SIMULATOR_NAME} PRIVATE simulation common shared storage qxtcommandoptions ${PTHREAD_LIBRARY} ${SDL_LIBRARY} ${WIN_LINK_LIBRARIES})
+target_link_libraries(${SIMULATOR_NAME} PRIVATE simulation common storage qxtcommandoptions ${PTHREAD_LIBRARY} ${SDL_LIBRARY} ${WIN_LINK_LIBRARIES})
 
 ############# Translations ####################
 

--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "appdebugmessagehandler.h"
+#include "customdebug.h"
 #include "mainwindow.h"
 #include "version.h"
 #include "appdata.h"
@@ -64,6 +65,8 @@ int main(int argc, char *argv[])
 
   if (AppDebugMessageHandler::instance())
     AppDebugMessageHandler::instance()->installAppMessageHandler();
+
+  CustomDebug::setFilterRules();
 
   g.init();
 
@@ -134,7 +137,7 @@ int main(int argc, char *argv[])
 
   unregisterSimulators();
   unregisterOpenTxFirmwares();
-  unregisterEEpromInterfaces();
+  unregisterStorageFactories();
 
 #if defined(JOYSTICKS) || defined(SIMU_AUDIO)
   SDL_Quit();

--- a/companion/src/customdebug.cpp
+++ b/companion/src/customdebug.cpp
@@ -18,13 +18,19 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MACROS_H_
-#define _MACROS_H_
+#include "customdebug.h"
 
-#include <iterator>
+Q_LOGGING_CATEGORY(eepromImport, "eeprom.import")
 
-// #define DIM(arr) (sizeof((arr))/sizeof((arr)[0]))
-// new way for c++11
-#define DIM(arr__)   ((size_t)(std::end((arr__)) - std::begin((arr__))))
+void CustomDebug::setFilterRules()
+{
+  QString rules;
+  rules.append("eeprom.import=");
+#if defined(DEBUG_STORAGE_IMPORT)
+  rules.append("true");
+#else
+  rules.append("false");
+#endif
 
-#endif // _MACROS_H_
+  QLoggingCategory::setFilterRules(rules);
+}

--- a/companion/src/customdebug.h
+++ b/companion/src/customdebug.h
@@ -21,15 +21,15 @@
 #ifndef _CUSTOMDEBUG_H_
 #define _CUSTOMDEBUG_H_
 
-#include <QDebug>
+#include <QLoggingCategory>
 
 // Controls the generation of debug output for EEPROM import
-#if defined(DEBUG_STORAGE_IMPORT)
-  inline QDebug eepromImportDebug() { return QDebug(QtDebugMsg); }
-#else
-  #undef eepromImportDebug
-  inline QNoDebug eepromImportDebug() { return QNoDebug(); }
-#endif
+Q_DECLARE_LOGGING_CATEGORY(eepromImport)
 
+class CustomDebug
+{
+  public:
+    static void setFilterRules();
+};
 
 #endif // _CUSTOMDEBUG_H_

--- a/companion/src/eepromimportexport.h
+++ b/companion/src/eepromimportexport.h
@@ -181,7 +181,7 @@ class BaseUnsignedField: public DataField {
         if (input[i])
           field |= ((container)1<<i);
       }
-      eepromImportDebug() << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
+      qCDebug(eepromImport) << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
     }
 
     virtual unsigned int size()
@@ -238,7 +238,7 @@ class BoolField: public DataField {
     virtual void ImportBits(const QBitArray & input)
     {
       field = input[0] ? true : false;
-      eepromImportDebug() << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
+      qCDebug(eepromImport) << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
     }
 
     virtual unsigned int size()
@@ -308,7 +308,7 @@ class SignedField: public DataField {
       }
 
       field = (int)value;
-      eepromImportDebug() << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
+      qCDebug(eepromImport) << QString("\timported %1<%2>: 0x%3(%4)").arg(name).arg(N).arg(field, 0, 16).arg(field);
     }
 
     virtual unsigned int size()
@@ -369,7 +369,7 @@ class CharField: public DataField {
         }
         field[i] = idx;
       }
-      eepromImportDebug() << QString("\timported %1<%2>: '%3'").arg(name).arg(N).arg(field);
+      qCDebug(eepromImport) << QString("\timported %1<%2>: '%3'").arg(name).arg(N).arg(field);
     }
 
     virtual unsigned int size()
@@ -427,7 +427,7 @@ class ZCharField: public DataField {
         else
           break;
       }
-      eepromImportDebug() << QString("\timported %1<%2>: '%3'").arg(name).arg(N).arg(field);
+      qCDebug(eepromImport) << QString("\timported %1<%2>: '%3'").arg(name).arg(N).arg(field);
     }
 
     virtual unsigned int size()
@@ -453,7 +453,7 @@ class StructField: public DataField {
     }
 
     inline void Append(DataField * field) {
-      //eepromImportDebug() << QString("StructField(%1) appending field: %2").arg(name).arg(field->getName());
+      //qCDebug(eepromImport) << QString("StructField(%1) appending field: %2").arg(name).arg(field->getName());
       fields.append(field);
     }
 
@@ -471,7 +471,7 @@ class StructField: public DataField {
 
     virtual void ImportBits(const QBitArray & input)
     {
-      eepromImportDebug() << QString("\timporting %1[%2]:").arg(name).arg(fields.size());
+      qCDebug(eepromImport) << QString("\timporting %1[%2]:").arg(name).arg(fields.size());
       int offset = 0;
       foreach(DataField *field, fields) {
         unsigned int size = field->size();
@@ -526,7 +526,7 @@ class TransformedField: public DataField {
 
     virtual void ImportBits(const QBitArray & input)
     {
-      eepromImportDebug() << QString("\timporting TransformedField %1:").arg(field.getName());
+      qCDebug(eepromImport) << QString("\timporting TransformedField %1:").arg(field.getName());
       field.ImportBits(input);
       afterImport();
     }
@@ -564,7 +564,7 @@ class ConversionTable {
       after = 0;
 
       for (std::list<ConversionTuple>::iterator it=exportTable.begin(); it!=exportTable.end(); it++) {
-        ConversionTuple tuple = *it;
+        ConversionTuple & tuple = *it;
         if (before == tuple.a) {
           after = tuple.b;
           return true;
@@ -579,7 +579,7 @@ class ConversionTable {
       after = 0;
 
       for (std::list<ConversionTuple>::iterator it=importTable.begin(); it!=importTable.end(); it++) {
-        ConversionTuple tuple = *it;
+        ConversionTuple & tuple = *it;
         if (before == tuple.b) {
           after = tuple.a;
           return true;
@@ -756,7 +756,7 @@ class ConversionField: public TransformedField {
       if (scale) {
         field *= scale;
       }
-      eepromImportDebug() << QString("\timported ConversionField<%1>:").arg(internalField.getName()) << QString(" before: %1, after: %2").arg(_field).arg(field);
+      qCDebug(eepromImport) << QString("\timported ConversionField<%1>:").arg(internalField.getName()) << QString(" before: %1, after: %2").arg(_field).arg(field);
     }
 
   protected:

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -160,6 +160,7 @@ class SwitchesConversionTable: public ConversionTable {
       }
     }
 
+
   protected:
 
     void addConversion(const RawSwitch & sw, const int b)
@@ -199,7 +200,7 @@ class SwitchesConversionTable: public ConversionTable {
     static SwitchesConversionTable * getInstance(Board::Type board, unsigned int version, unsigned long flags=0)
     {
       for (std::list<Cache>::iterator it=internalCache.begin(); it!=internalCache.end(); it++) {
-        Cache element = *it;
+        Cache & element = *it;
         if (element.board == board && element.version == version && element.flags == flags)
           return element.table;
       }
@@ -211,8 +212,9 @@ class SwitchesConversionTable: public ConversionTable {
     static void Cleanup()
     {
       for (std::list<Cache>::iterator it=internalCache.begin(); it!=internalCache.end(); it++) {
-        Cache element = *it;
-        delete element.table;
+        Cache & element = *it;
+        if (element.table)
+          delete element.table;
       }
       internalCache.clear();
     }
@@ -386,7 +388,7 @@ class SourcesConversionTable: public ConversionTable {
     static SourcesConversionTable * getInstance(Board::Type board, unsigned int version, unsigned int variant, unsigned long flags=0)
     {
       for (std::list<Cache>::iterator it=internalCache.begin(); it!=internalCache.end(); it++) {
-        Cache element = *it;
+        Cache & element = *it;
         if (element.board == board && element.version == version && element.variant == variant && element.flags == flags)
           return element.table;
       }
@@ -398,8 +400,9 @@ class SourcesConversionTable: public ConversionTable {
     static void Cleanup()
     {
       for (std::list<Cache>::iterator it=internalCache.begin(); it!=internalCache.end(); it++) {
-        Cache element = *it;
-        delete element.table;
+        Cache & element = *it;
+        if (element.table)
+          delete element.table;
       }
       internalCache.clear();
     }
@@ -439,7 +442,7 @@ class SwitchField: public ConversionField< SignedField<N> > {
     {
       ConversionField< SignedField<N> >::afterImport();
       sw = RawSwitch(_switch);
-      eepromImportDebug() << QString("imported %1: %2").arg(ConversionField< SignedField<N> >::internalField.getName()).arg(sw.toString(board));
+      qCDebug(eepromImport) << QString("imported %1: %2").arg(ConversionField< SignedField<N> >::internalField.getName()).arg(sw.toString(board));
     }
 
   protected:
@@ -565,7 +568,7 @@ class TelemetrySourceField: public ConversionField< UnsignedField<N> > {
     {
       ConversionField< UnsignedField<N> >::afterImport();
       source = (_source == 0 ? RawSource(0) : RawSource(SOURCE_TYPE_TELEMETRY, _source-1));
-      eepromImportDebug() << QString("imported %1: %2").arg(ConversionField< UnsignedField<N> >::internalField.getName()).arg(source.toString());
+      qCDebug(eepromImport) << QString("imported %1: %2").arg(ConversionField< UnsignedField<N> >::internalField.getName()).arg(source.toString());
     }
 
   protected:
@@ -601,7 +604,7 @@ class SourceField: public ConversionField< UnsignedField<N> > {
     {
       ConversionField< UnsignedField<N> >::afterImport();
       source = RawSource(_source);
-      eepromImportDebug() << QString("imported %1: %2").arg(ConversionField< UnsignedField<N> >::internalField.getName()).arg(source.toString());
+      qCDebug(eepromImport) << QString("imported %1: %2").arg(ConversionField< UnsignedField<N> >::internalField.getName()).arg(source.toString());
     }
 
   protected:
@@ -760,7 +763,7 @@ class CurveReferenceField: public TransformedField {
     {
       curve.type = (CurveReference::CurveRefType)_curve_type;
       curve.value = smallGvarToC9x(_curve_value);
-      eepromImportDebug() << QString("imported CurveReference(%1)").arg(curve.toString());
+      qCDebug(eepromImport) << QString("imported CurveReference(%1)").arg(curve.toString());
     }
 
   protected:
@@ -942,7 +945,7 @@ class FlightModeField: public TransformedField {
           }
         }
       }
-      eepromImportDebug() << QString("imported %1: '%2'").arg(internalField.getName()).arg(phase.name);
+      qCDebug(eepromImport) << QString("imported %1: '%2'").arg(internalField.getName()).arg(phase.name);
     }
 
   protected:
@@ -1231,7 +1234,7 @@ class MixField: public TransformedField {
         }
         if (mix.carryTrim < 0) mix.carryTrim = 0;
       }
-      eepromImportDebug() << QString("imported %1: ch %2, name '%3'").arg(internalField.getName()).arg(mix.destCh).arg(mix.name);
+      qCDebug(eepromImport) << QString("imported %1: ch %2, name '%3'").arg(internalField.getName()).arg(mix.destCh).arg(mix.name);
     }
 
   protected:
@@ -1412,7 +1415,7 @@ class InputField: public TransformedField {
         else
           expo.curve = CurveReference(CurveReference::CURVE_REF_FUNC, _curveParam);
       }
-      eepromImportDebug() << QString("imported %1: ch %2 name '%3'").arg(internalField.getName()).arg(expo.chn).arg(expo.name);
+      qCDebug(eepromImport) << QString("imported %1: ch %2 name '%3'").arg(internalField.getName()).arg(expo.chn).arg(expo.name);
     }
 
   protected:
@@ -1626,7 +1629,7 @@ class CurvesField: public TransformedField {
           for (int j=0; j<curve->count; j++)
             curve->points[j].x = -100 + (200*i) / (curve->count-1);
         }
-        eepromImportDebug() << QString("imported curve: %3 points").arg(curve->count);
+        qCDebug(eepromImport) << QString("imported curve: %3 points").arg(curve->count);
       }
     }
 
@@ -1955,7 +1958,7 @@ class LogicalSwitchField: public TransformedField {
           }
         }
       }
-      eepromImportDebug() << QString("imported %1: %2").arg(internalField.getName()).arg(csw.funcToString());
+      qCDebug(eepromImport) << QString("imported %1: %2").arg(internalField.getName()).arg(csw.funcToString());
     }
 
   protected:
@@ -2115,7 +2118,7 @@ class SwitchesWarningField: public TransformedField {
       else {
         sw = _sw;
       }
-      eepromImportDebug() << QString("imported %1").arg(internalField.getName());
+      qCDebug(eepromImport) << QString("imported %1").arg(internalField.getName());
     }
 
   protected:
@@ -2350,7 +2353,7 @@ class ArmCustomFunctionField: public TransformedField {
       else {
         fn.param = value;
       }
-      eepromImportDebug() << QString("imported %1").arg(internalField.getName());
+      qCDebug(eepromImport) << QString("imported %1").arg(internalField.getName());
     }
 
   protected:
@@ -2539,7 +2542,7 @@ class AvrCustomFunctionField: public TransformedField {
         else if (version >= 213)
           fn.repeatParam = _active * 10;
       }
-      eepromImportDebug() << QString("imported %1").arg(internalField.getName());
+      qCDebug(eepromImport) << QString("imported %1").arg(internalField.getName());
     }
 
   protected:
@@ -2634,7 +2637,7 @@ class FrskyScreenField: public DataField {
 
     virtual void ImportBits(const QBitArray & input)
     {
-      eepromImportDebug() << QString("importing %1: type: %2").arg(name).arg(screen.type);
+      qCDebug(eepromImport) << QString("importing %1: type: %2").arg(name).arg(screen.type);
 
       // NOTA: screen.type should have been imported first!
       if (IS_ARM(board) && version >= 217) {
@@ -3007,7 +3010,7 @@ class SensorField: public TransformedField {
           sensor.unit++;
       }
 
-      eepromImportDebug() << QString("imported %1").arg(internalField.getName());
+      qCDebug(eepromImport) << QString("imported %1").arg(internalField.getName());
     }
 
   protected:
@@ -3041,7 +3044,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
 {
   sprintf(name, "Model %s", modelData.name);
 
-  eepromImportDebug() << QString("OpenTxModelData::OpenTxModelData(name: %1, board: %2, ver: %3, var: %4)").arg(name).arg(board).arg(version).arg(variant);
+  qCDebug(eepromImport) << QString("OpenTxModelData::OpenTxModelData(name: %1, board: %2, ver: %3, var: %4)").arg(name).arg(board).arg(version).arg(variant);
 
   if (IS_HORUS(board))
     internalField.Append(new ZCharField<15>(this, modelData.name, "Model name"));
@@ -3452,7 +3455,7 @@ void OpenTxModelData::beforeExport()
 
 void OpenTxModelData::afterImport()
 {
-  eepromImportDebug() << QString("OpenTxModelData::afterImport()") << modelData.name;
+  qCDebug(eepromImport) << QString("OpenTxModelData::afterImport()") << modelData.name;
 
   if (IS_TARANIS(board) && version < 216) {
     for (unsigned int i=0; i<CPN_MAX_STICKS; i++) {
@@ -3520,7 +3523,7 @@ OpenTxGeneralData::OpenTxGeneralData(GeneralSettings & generalData, Board::Type 
   version(version),
   inputsCount(CPN_MAX_STICKS+MAX_POTS(board, version)+MAX_SLIDERS(board)+MAX_MOUSE_ANALOGS(board))
 {
-  eepromImportDebug() << QString("OpenTxGeneralData::OpenTxGeneralData(board: %1, version:%2, variant:%3)").arg(board).arg(version).arg(variant);
+  qCDebug(eepromImport) << QString("OpenTxGeneralData::OpenTxGeneralData(board: %1, version:%2, variant:%3)").arg(board).arg(version).arg(variant);
 
   generalData.version = version;
   generalData.variant = variant;

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1517,6 +1517,7 @@ void unregisterOpenTxFirmwares()
   foreach (Firmware * f, firmwares) {
     delete f;
   }
+  unregisterEEpromInterfaces();
 }
 
 template <class T, class M>

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -31,9 +31,11 @@
 
 #include "appdata.h"
 #include "helpers.h"
-#include "modeledit/modeledit.h"
 #include "simulatormainwindow.h"
 #include "storage/sdcard.h"
+
+#include <QLabel>
+#include <QMessageBox>
 
 Stopwatch gStopwatch("global");
 
@@ -126,7 +128,11 @@ void populatePhasesCB(QComboBox *b, int value)
   b->setCurrentIndex(value + getCurrentFirmware()->getCapability(FlightModes));
 }
 
-GVarGroup::GVarGroup(QCheckBox * weightGV, QAbstractSpinBox * weightSB, QComboBox * weightCB, int & weight, const ModelData & model, const int deflt, const int mini, const int maxi, const double step, bool allowGvars, ModelPanel * panel):
+/*
+ * GVarGroup
+*/
+
+GVarGroup::GVarGroup(QCheckBox * weightGV, QAbstractSpinBox * weightSB, QComboBox * weightCB, int & weight, const ModelData & model, const int deflt, const int mini, const int maxi, const double step, bool allowGvars):
   QObject(),
   weightGV(weightGV),
   weightSB(weightSB),
@@ -135,8 +141,7 @@ GVarGroup::GVarGroup(QCheckBox * weightGV, QAbstractSpinBox * weightSB, QComboBo
   weightCB(weightCB),
   weight(weight),
   step(step),
-  lock(true),
-  panel(panel)
+  lock(true)
 {
   if (allowGvars && getCurrentFirmware()->getCapability(Gvars)) {
     populateGVCB(*weightCB, weight, model);
@@ -200,11 +205,14 @@ void GVarGroup::valuesChanged()
       weight = sb->value();
     else
       weight = round(dsb->value()/step);
-    if (panel)
-      emit panel->modified();
 
+    emit valueChanged();
   }
 }
+
+/*
+ * CurveGroup
+*/
 
 CurveGroup::CurveGroup(QComboBox * curveTypeCB, QCheckBox * curveGVarCB, QComboBox * curveValueCB, QSpinBox * curveValueSB, CurveReference & curve, const ModelData & model, unsigned int flags):
   QObject(),
@@ -363,6 +371,10 @@ void CurveGroup::valuesChanged()
     update();
   }
 }
+
+/*
+ * Helpers
+*/
 
 void populateGvarUseCB(QComboBox *b, unsigned int phase)
 {

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -22,7 +22,6 @@
 #define _HELPERS_H_
 
 #include "eeprominterface.h"
-#include "modeledit/modeledit.h"
 #include <QCheckBox>
 #include <QSpinBox>
 #include <QTableWidget>
@@ -69,7 +68,10 @@ class GVarGroup: public QObject {
   Q_OBJECT
 
   public:
-    GVarGroup(QCheckBox * weightGV, QAbstractSpinBox * weightSB, QComboBox * weightCB, int & weight, const ModelData & model, const int deflt, const int mini, const int maxi, const double step=1.0, bool allowGVars=true, ModelPanel * panel=NULL);
+    GVarGroup(QCheckBox * weightGV, QAbstractSpinBox * weightSB, QComboBox * weightCB, int & weight, const ModelData & model, const int deflt, const int mini, const int maxi, const double step=1.0, bool allowGVars=true);
+
+  signals:
+    void valueChanged();
 
   protected slots:
     void gvarCBChanged(int);
@@ -84,7 +86,6 @@ class GVarGroup: public QObject {
     int & weight;
     double step;
     bool lock;
-    ModelPanel * panel;
 };
 
 #define HIDE_DIFF             0x01
@@ -156,26 +157,6 @@ QString getFrSkyMeasure(int units);
 QString getFrSkySrc(int index);
 
 void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx);
-
-template <class T>
-QVector<T> findWidgets(QObject * object, const QString & name)
-{
-  QVector<T> result;
-  QRegExp rx(name.arg("([0-9]+)"));
-  QList<T> children = object->findChildren<T>();
-  foreach(T child, children) {
-    int pos = rx.indexIn(child->objectName());
-    if (pos >= 0) {
-      QStringList list = rx.capturedTexts();
-      int index = list[1].toInt();
-      if (result.size() <= index) {
-        result.resize(index+1);
-      }
-      result[index] = child;
-    }
-  }
-  return result;
-}
 
 // Format a pixmap to fit on the current firmware
 QPixmap makePixMap(const QImage & image);
@@ -249,13 +230,13 @@ public:
 
   void resizeColumnsToContents();
   void setColumnWidth(int col, int width);
-  void pushRowsUp(int row); 
+  void pushRowsUp(int row);
 
 private:
 #if defined(TABLE_LAYOUT)
-  QTableWidget * tableWidget; 
+  QTableWidget * tableWidget;
 #else
-  QGridLayout * gridWidget; 
+  QGridLayout * gridWidget;
 #endif
 };
 

--- a/companion/src/modeledit/CMakeLists.txt
+++ b/companion/src/modeledit/CMakeLists.txt
@@ -23,8 +23,8 @@ set(modeledit_SRCS
   customfunctions.cpp
   # templates.cpp
   mixerslistwidget.cpp
-  node.cpp
-  edge.cpp
+  # node.cpp  ## node and edge are built in common lib because also used by simulator
+  # edge.cpp  ## commenting them here avoids a "duplicate target" warning eg. from ninja
 )
 
 set(modeledit_HDRS
@@ -36,7 +36,7 @@ set(modeledit_HDRS
   customfunctions.h
   # templates.h
   mixerslistwidget.h
-  node.h
+  # node.h
 )
 
 set(modeledit_UIS
@@ -53,7 +53,7 @@ foreach(name ${modeledit_NAMES})
   set(modeledit_HDRS ${modeledit_HDRS} ${name}.h)
   set(modeledit_UIS  ${modeledit_UIS}  ${name}.ui)
 endforeach()
- 
+
 qt5_wrap_ui(modeledit_SRCS ${modeledit_UIS})
 qt5_wrap_cpp(modeledit_SRCS ${modeledit_HDRS})
 

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -64,7 +64,8 @@ LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout * tableLayout, int row
   horizontalLayout->addWidget(cb);
   horizontalLayout->addWidget(spinbox);
   tableLayout->addLayout(row, col, horizontalLayout);
-  gvarGroup = new GVarGroup(gv, spinbox, cb, value, model, deflt, min, max, displayStep, allowGVars, panel);
+  gvarGroup = new GVarGroup(gv, spinbox, cb, value, model, deflt, min, max, displayStep, allowGVars);
+  QObject::connect(gvarGroup, &GVarGroup::valueChanged, panel, &ModelPanel::modified);
 }
 
 LimitsGroup::~LimitsGroup()
@@ -227,7 +228,7 @@ void Channels::refreshExtendedLimits()
     group->updateMinMax(10*channelMax);
   }
 
-  emit modified(); 
+  emit modified();
 }
 
 void Channels::invEdited()

--- a/companion/src/simulation/debugoutput.cpp
+++ b/companion/src/simulation/debugoutput.cpp
@@ -174,17 +174,18 @@ void DebugOutput::restoreState()
 
 void DebugOutput::processBytesReceived()
 {
+  static char buf[512];
   const QTextCursor savedCursor(ui->console->textCursor());
   const int sbValue = ui->console->verticalScrollBar()->value();
   const bool sbAtBottom = (sbValue == ui->console->verticalScrollBar()->maximum());
   qint64 len;
+  QString text;
 
-  while (m_dataBufferDevice && (len = m_dataBufferDevice->bytesAvailable()) > 0) {
-    QByteArray ba(qMin(len, qint64(512)), 0);
-    int ret = m_dataBufferDevice->read(ba.data(), ba.size());
-    if (ret <= 0)
+  while (m_dataBufferDevice && m_dataBufferDevice->bytesAvailable() > 0) {
+    len = m_dataBufferDevice->read(buf, sizeof(buf));
+    if (len <= 0)
       break;
-    QString text(ba);
+    text = QString::fromLocal8Bit(buf, len);
     ui->console->moveCursor(QTextCursor::End);
     ui->console->textCursor().insertText(text);
     if (sbAtBottom) {

--- a/companion/src/simulation/debugoutput.h
+++ b/companion/src/simulation/debugoutput.h
@@ -101,6 +101,8 @@ class DebugOutputFilterValidator : public QValidator
 class DeleteComboBoxItemEventFilter : public QObject
 {
   Q_OBJECT
+  public:
+    DeleteComboBoxItemEventFilter(QObject *parent = Q_NULLPTR) : QObject(parent) { }
   protected:
     bool eventFilter(QObject *obj, QEvent *event);
 };

--- a/companion/src/simulation/debugoutput.h
+++ b/companion/src/simulation/debugoutput.h
@@ -29,14 +29,15 @@
 #include <QValidator>
 #include <QWidget>
 
-// NOTE : The buffer sizes need to be large enough to handle the flood of data when X12/X10 simulator starts up (almost 40K!).
+// NOTE : The buffer sizes need to be large enough to handle the flood of data when X12/X10 simulator starts up with TRACE_SIMPGMSPACE=1 (> 40K!).
+// These are maximum sizes, not necessarily allocated sizes.
 #ifndef DEBUG_OUTPUT_WIDGET_OUT_BUFF_SIZE
   // This buffer holds received and processed data until it can be printed to our console.
-  #define DEBUG_OUTPUT_WIDGET_OUT_BUFF_SIZE    (40 * 1024)  // [bytes]
+  #define DEBUG_OUTPUT_WIDGET_OUT_BUFF_SIZE    (50 * 1024)  // [bytes]
 #endif
 #ifndef DEBUG_OUTPUT_WIDGET_INP_BUFF_SIZE
   // This buffer is active if line filter is enabled and holds received data until it can be filtered and placed in output buffer.
-  #define DEBUG_OUTPUT_WIDGET_INP_BUFF_SIZE    (30 * 1024)  // [bytes]
+  #define DEBUG_OUTPUT_WIDGET_INP_BUFF_SIZE    (50 * 1024)  // [bytes]
 #endif
 
 namespace Ui {

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -33,6 +33,8 @@
 #endif
 
 #include <QDebug>
+#include <QLabel>
+#include <QMessageBox>
 
 extern AppData g;  // ensure what "g" means
 

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -38,6 +38,7 @@
 #endif
 
 #include <QFile>
+#include <QMessageBox>
 #include <iostream>
 
 SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface *simulator, quint8 flags):

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -100,6 +100,7 @@ SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface *simulator
     keymapHelp.append(item);
 
   ui->radioUiWidget->layout()->removeItem(ui->radioUiTempSpacer);
+  delete ui->radioUiTempSpacer;
   ui->radioUiWidget->layout()->addWidget(radioUiWidget);
   radioUiWidget->setFocusPolicy(Qt::WheelFocus);
   radioUiWidget->setFocus();

--- a/companion/src/simulation/simulatorwidget.h
+++ b/companion/src/simulation/simulatorwidget.h
@@ -26,6 +26,7 @@
 #include "radiodata.h"
 #include "simulator.h"
 
+#include <QTimer>
 #include <QWidget>
 #include <QVector>
 

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -49,9 +49,9 @@ class TelemetrySimulator : public QWidget
   protected slots:
 
     virtual void closeEvent(QCloseEvent *event);
-    virtual void showEvent(QShowEvent *event);
+    void setupDataFields();
     void onSimulateToggled(bool isChecked);
-    void onTimerEvent();
+    void generateTelemetryFrame();
     void onLogTimerEvent();
     void onLoadLogFile();
     void onPlay();
@@ -65,10 +65,9 @@ class TelemetrySimulator : public QWidget
   protected:
 
     Ui::TelemetrySimulator * ui;
-    QTimer * timer;
-    QTimer * logTimer;
+    QTimer timer;
+    QTimer logTimer;
     SimulatorInterface *simulator;
-    void generateTelemetryFrame();
 
   // protected classes follow
 

--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -34,6 +34,7 @@
 #include "appdata.h"
 #include "appdebugmessagehandler.h"
 #include "constants.h"
+#include "customdebug.h"
 #include "eeprominterface.h"
 #include "simulator.h"
 #include "simulatormainwindow.h"
@@ -94,6 +95,8 @@ int main(int argc, char *argv[])
 
   if (AppDebugMessageHandler::instance())
     AppDebugMessageHandler::instance()->installAppMessageHandler();
+
+  CustomDebug::setFilterRules();
 
   g.init();
 
@@ -257,6 +260,7 @@ int finish(int exitCode)
   qDebug() << "SIMULATOR EXIT" << exitCode;
   unregisterSimulators();
   unregisterOpenTxFirmwares();
+  unregisterStorageFactories();
 
 #if defined(JOYSTICKS) || defined(SIMU_AUDIO)
   SDL_Quit();

--- a/companion/src/storage/firmwareinterface.cpp
+++ b/companion/src/storage/firmwareinterface.cpp
@@ -24,6 +24,8 @@
 #include "helpers.h"
 #include "storage.h"
 
+#include <QFile>
+
 #define FW_MARK     "FW"
 #define VERS_MARK   "VERS"
 #define DATE_MARK   "DATE"

--- a/companion/src/storage/storage.cpp
+++ b/companion/src/storage/storage.cpp
@@ -64,6 +64,12 @@ void registerStorageFactories()
   registerStorageFactory(new SdcardStorageFactory());
 }
 
+void unregisterStorageFactories()
+{
+  foreach (StorageFactory * factory, registeredStorageFactories)
+    delete factory;
+}
+
 bool Storage::load(RadioData & radioData)
 {
   QFile file(filename);
@@ -71,30 +77,37 @@ bool Storage::load(RadioData & radioData)
     setError(QObject::tr("Unable to find file %1!").arg(filename));
     return false;
   }
-  
+
+  bool ret = false;
   foreach(StorageFactory * factory, registeredStorageFactories) {
     StorageFormat * format = factory->instance(filename);
     if (format->load(radioData)) {
       board = format->getBoard();
       setWarning(format->warning());
-      return true;
+      ret = true;
+      break;
     }
     else {
       setError(format->error());
     }
+    delete format;
   }
 
-  return false;
+  return ret;
 }
 
 bool Storage::write(const RadioData & radioData)
 {
+  bool ret = false;
   foreach(StorageFactory * factory, registeredStorageFactories) {
     if (factory->probe(filename)) {
-      return factory->instance(filename)->write(radioData);
+      StorageFormat * format = factory->instance(filename);
+      ret = format->write(radioData);
+      delete format;
+      break;
     }
   }
-  return false;
+  return ret;
 }
 
 bool convertEEprom(const QString & sourceEEprom, const QString & destinationEEprom, const QString & firmwareFilename)
@@ -102,26 +115,26 @@ bool convertEEprom(const QString & sourceEEprom, const QString & destinationEEpr
   FirmwareInterface firmware(firmwareFilename);
   if (!firmware.isValid())
     return false;
-  
+
   uint8_t version = firmware.getEEpromVersion();
   unsigned int variant = firmware.getEEpromVariant();
-  
+
   QSharedPointer<RadioData> radioData = QSharedPointer<RadioData>(new RadioData());
   Storage storage(sourceEEprom);
   if (!storage.load(*radioData))
     return false;
-  
+
   QByteArray eeprom(EESIZE_MAX, 0);
   int size = getCurrentEEpromInterface()->save((uint8_t *)eeprom.data(), *radioData, version, variant);
   if (size == 0) {
     return false;
   }
-  
+
   QFile destinationFile(destinationEEprom);
   if (!destinationFile.open(QIODevice::WriteOnly)) {
     return false;
   }
-  
+
   int result = destinationFile.write(eeprom.constData(), size);
   destinationFile.close();
   return (result == size);
@@ -131,7 +144,7 @@ bool convertEEprom(const QString & sourceEEprom, const QString & destinationEEpr
 unsigned long LoadBackup(RadioData & radioData, uint8_t * eeprom, int size, int index)
 {
   std::bitset<NUM_ERRORS> errors;
-    
+
     foreach(EEPROMInterface *eepromInterface, eepromInterfaces) {
       std::bitset<NUM_ERRORS> result((unsigned long long)eepromInterface->loadBackup(radioData, eeprom, size, index));
       if (result.test(ALL_OK)) {
@@ -141,7 +154,7 @@ unsigned long LoadBackup(RadioData & radioData, uint8_t * eeprom, int size, int 
         errors |= result;
       }
     }
-  
+
   if (errors.none()) {
     errors.set(UNKNOWN_ERROR);
   }
@@ -152,7 +165,7 @@ unsigned long LoadBackup(RadioData & radioData, uint8_t * eeprom, int size, int 
 unsigned long LoadEepromXml(RadioData & radioData, QDomDocument & doc)
 {
   std::bitset<NUM_ERRORS> errors;
-    
+
     foreach(EEPROMInterface *eepromInterface, eepromInterfaces) {
       std::bitset<NUM_ERRORS> result((unsigned long long)eepromInterface->loadxml(radioData, doc));
       if (result.test(ALL_OK)) {
@@ -162,7 +175,7 @@ unsigned long LoadEepromXml(RadioData & radioData, QDomDocument & doc)
         errors |= result;
       }
     }
-  
+
   if (errors.none()) {
     errors.set(UNKNOWN_ERROR);
   }

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -48,14 +48,14 @@ class StorageFormat
       board(Board::BOARD_UNKNOWN)
     {
     }
-    virtual ~StorageFormat() { }
+    virtual ~StorageFormat() {}
     virtual bool load(RadioData & radioData) = 0;
     virtual bool write(const RadioData & radioData) = 0;
 
     QString error() {
       return _error;
     }
-    
+
     QString warning() {
       return _warning;
     }
@@ -84,13 +84,13 @@ class StorageFormat
       qDebug() << qPrintable(QString("[%1] error: %2").arg(name()).arg(error));
       _error = error;
     }
-    
+
     void setWarning(const QString & warning)
     {
       qDebug() << qPrintable(QString("[%1] warning: %2").arg(name()).arg(warning));
       _warning = warning;
     }
-    
+
     QString filename;
     uint8_t version;
     QString _error;
@@ -119,22 +119,22 @@ class DefaultStorageFactory : public StorageFactory
       _name(name)
     {
     }
-    
+
     virtual QString name()
     {
       return _name;
     }
-    
+
     virtual bool probe(const QString & filename)
     {
       return filename.toLower().endsWith("." + _name);
     }
-    
+
     virtual StorageFormat * instance(const QString & filename)
     {
       return new T(filename);
     }
-    
+
     QString _name;
 };
 
@@ -145,19 +145,19 @@ class Storage : public StorageFormat
       StorageFormat(filename)
     {
     }
-    
+
     virtual QString name() { return "storage"; }
-    
+
     void setError(const QString & error)
     {
       _error = error;
     }
-    
+
     void setWarning(const QString & warning)
     {
       _warning = warning;
     }
-    
+
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
 };

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -48,7 +48,7 @@ class StorageFormat
       board(Board::BOARD_UNKNOWN)
     {
     }
-    
+    virtual ~StorageFormat() { }
     virtual bool load(RadioData & radioData) = 0;
     virtual bool write(const RadioData & radioData) = 0;
 
@@ -104,6 +104,7 @@ class StorageFactory
     StorageFactory()
     {
     }
+    virtual ~StorageFactory() {}
     virtual QString name() = 0;
     virtual bool probe(const QString & filename) = 0;
     virtual StorageFormat * instance(const QString & filename) = 0;
@@ -145,7 +146,7 @@ class Storage : public StorageFormat
     {
     }
     
-    virtual QString name() { return "storage"; };
+    virtual QString name() { return "storage"; }
     
     void setError(const QString & error)
     {
@@ -162,6 +163,7 @@ class Storage : public StorageFormat
 };
 
 void registerStorageFactories();
+void unregisterStorageFactories();
 
 #if 0
 unsigned long LoadBackup(RadioData &radioData, uint8_t *eeprom, int esize, int index);

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -40,19 +40,6 @@ uint8_t getStickMode()
   return limit<uint8_t>(0, g_eeGeneral.stickMode, 3);
 }
 
-#if defined(PCBTARANIS)
-void resetTrims()
-{
-  TRIMS_GPIO_REG_RVD |= TRIMS_GPIO_PIN_RVD;
-  TRIMS_GPIO_REG_RVU |= TRIMS_GPIO_PIN_RVU;
-  TRIMS_GPIO_REG_RHL |= TRIMS_GPIO_PIN_RHL;
-  TRIMS_GPIO_REG_RHR |= TRIMS_GPIO_PIN_RHR;
-  TRIMS_GPIO_REG_LVD |= TRIMS_GPIO_PIN_LVD;
-  TRIMS_GPIO_REG_LVU |= TRIMS_GPIO_PIN_LVU;
-  TRIMS_GPIO_REG_LHL |= TRIMS_GPIO_PIN_LHL;
-  TRIMS_GPIO_REG_LHR |= TRIMS_GPIO_PIN_LHR;
-}
-#endif
 
 OpenTxSimulator::OpenTxSimulator()
 {
@@ -96,11 +83,8 @@ void OpenTxSimulator::start(QByteArray & ee, bool tests)
 
 void OpenTxSimulator::start(const char * filename, bool tests)
 {
-#if defined(ROTARY_ENCODER_NAVIGATION)
-  for (uint8_t i=0; i<DIM(rotencValue); i++) {
-    rotencValue[i] = 0;
-  }
-#endif
+  if (main_thread_running)
+    return;
 
   StartEepromThread(filename);
   StartAudioThread(volumeGain);
@@ -109,6 +93,9 @@ void OpenTxSimulator::start(const char * filename, bool tests)
 
 void OpenTxSimulator::stop()
 {
+  if (!main_thread_running)
+    return;
+
   StopSimu();
 #if defined(CPUARM)
   StopAudioThread();

--- a/radio/src/targets/simu/simufatfs.cpp
+++ b/radio/src/targets/simu/simufatfs.cpp
@@ -97,8 +97,8 @@ void simuFatfsSetPaths(const char * sdPath, const char * settingsPath)
   if (settingsPath) {
     simuSettingsDirectory = removeTrailingPathDelimiter(fixPathDelimiters(settingsPath));
   }
-  TRACE_SIMPGMSPACE("simuFatfsSetPaths(): simuSdDirectory: \"\"", simuSdDirectory.c_str());
-  TRACE_SIMPGMSPACE("simuFatfsSetPaths(): simuSettingsDirectory: \"\"", simuSettingsDirectory.c_str());
+  TRACE_SIMPGMSPACE("simuFatfsSetPaths(): simuSdDirectory: \"%s\"", simuSdDirectory.c_str());
+  TRACE_SIMPGMSPACE("simuFatfsSetPaths(): simuSettingsDirectory: \"%s\"", simuSettingsDirectory.c_str());
 }
 
 bool startsWith(const char *path, const char * start)


### PR DESCRIPTION
A bunch "small" fixes all bunched together... pre-squashed, if you will (I cold break them up but if they'll be squashed anyway... this was easier).  These should probably be included in next 2.2 RC.

  * [simpgmspace] Init trims; Make sure `REa` is really defined (to match board files).
  * [simpgmspace][opentxsimulator] Verify current running state before start/stop; Move rotary enc. init.
  * [simpgmspace][LcdWidget] Improve performance by moving LCD content change check to lcdRefresh() & limiting LcdWidget refresh time to 60 fps max; Ensure thread safety with shared LCD buffer.
  * [simueeprom] Ensure thread could be started, set default running state to false.
  * [simufatfs] Fix paths report trace.
  * [eepromimportexport] Fix memory leaks resulting from import debugging scheme being used.
  * [customdebug] Introduce new scheme for custom debug output in compliance with Qt recommendations (see [docs for QLoggingCategory](http://doc.qt.io/qt-5/qloggingcategory.html)).
  * [opentxeeprom] Fix extra conversion table cache elements being created and also not properly deleted (and hence leaking).
  * [opentxinterface] Unregister EEpromInterfaces in unregisterOpenTxFirmwares();
  * [storage] Unregister storage factories on exit (fixes leak); create virtual StorageFormat/StorageFactory destructors (prevents warnings).
  * [helpers] GVarGroup now emits own signal, no need to pass ModelPanel pointer (removes dependency on modeledit.h)
  * [DebugOutput] Clear simulator trace hook before exiting (prevent possible issues); Fix leak and possible bad QString allocations when reading from buffer; Fix leak with combo box event filter.
  * [TelemetrySimulator] Fix leak by deleting LogPlaybackController object on exit; Only set up data fields once; convert timers to static.
  * [build] Consolidate all Companion/Simulator shared items in `common` library to reduce build time/etc (node & edge still remain awkward).

The leak fixes are result of running standalone Simulator (not Companion) through valgrind & gdb on Linux gcc 4.9.  Moral of this story... don't just automatically blame Qt for memory leaks.  :) 