### PR TITLE
Define multi subtype strings in the same way as all other strings

### DIFF
--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -607,45 +607,45 @@ int getFirstAvailable(int min, int max, IsValueAvailable isValueAvailable)
 // we don't need the special eeprom/flash string handling, just define them as
 // local strings
 
-static const char* STR_SUBTYPE_FLYSKY   =   "\004""Std\0""V9x9""V6x6""V912""CX20";
+const pm_char STR_SUBTYPE_FLYSKY[] PROGMEM =     "\004""Std\0""V9x9""V6x6""V912""CX20";
 
-static const char* STR_SUBTYPE_AFHDS2A =    "\010""PWM,IBUS""PPM,IBUS""PWM,SBUS""PPM,SBUS";
+const pm_char STR_SUBTYPE_AFHDS2A[] PROGMEM =    "\010""PWM,IBUS""PPM,IBUS""PWM,SBUS""PPM,SBUS";
 
-static const char* STR_SUBTYPE_FRSKY =      "\007""D16\0   ""D8\0    ""D16 8ch""V8\0    ""LBT(EU)""LBT 8ch";
+const pm_char STR_SUBTYPE_FRSKY[] PROGMEM =      "\007""D16\0   ""D8\0    ""D16 8ch""V8\0    ""LBT(EU)""LBT 8ch";
 
-static const char* STR_SUBTYPE_HISKY =      "\005""HiSky""HK310";
+const pm_char STR_SUBTYPE_HISKY[] PROGMEM =      "\005""HiSky""HK310";
 
-static const char* STR_SUBTYPE_DSM =        "\006""2 22ms""2 11ms""X 22ms""X 11ms";
+const pm_char STR_SUBTYPE_DSM[] PROGMEM =        "\006""2 22ms""2 11ms""X 22ms""X 11ms";
 
-static const char* STR_SUBTYPE_YD717 =      "\007""YD717\0 ""SKYWLKR""Syma X2""XINXUN\0""NIHUI\0  ";
+const pm_char STR_SUBTYPE_YD717[] PROGMEM =      "\007""YD717\0 ""SKYWLKR""Syma X2""XINXUN\0""NIHUI\0  ";
 
-static const char* STR_SUBTYPE_SYMAX =      "\003""Std""5c\0";
+const pm_char STR_SUBTYPE_SYMAX[] PROGMEM =      "\003""Std""5c\0";
 
-static const char* STR_SUBTYPE_SLT =        "\005""SLT\0 ""Vista";
+const pm_char STR_SUBTYPE_SLT[] PROGMEM =        "\005""SLT\0 ""Vista";
 
-static const char* STR_SUBTYPE_CX10 =       "\007""Green\0 ""Blue\0  ""DM007\0 ""-\0     ""JC3015a""JC3015b""MK33041""Q242\0  ";
+const pm_char STR_SUBTYPE_CX10[] PROGMEM =       "\007""Green\0 ""Blue\0  ""DM007\0 ""-\0     ""JC3015a""JC3015b""MK33041""Q242\0  ";
 
-static const char* STR_SUBTYPE_CG023 =      "\005""CG023""YD829""H3 3d";
+const pm_char STR_SUBTYPE_CG023[] PROGMEM =      "\005""CG023""YD829""H3 3d";
 
-static const char* STR_SUBTYPE_KN =         "\006""WLtoys""FeiLun";
+const pm_char STR_SUBTYPE_KN[] PROGMEM =         "\006""WLtoys""FeiLun";
 
-static const char* STR_SUBTYPE_MT99 =       "\005""MT99\0""H7\0  ""YZ\0  ""LS\0  ""FY805";
+const pm_char STR_SUBTYPE_MT99[] PROGMEM =       "\005""MT99\0""H7\0  ""YZ\0  ""LS\0  ""FY805";
 
-static const char* STR_SUBTYPE_MJXQ =       "\005""WLH08""X600\0""X800\0""H26D\0""E010\0""H26WH";
+const pm_char STR_SUBTYPE_MJXQ[] PROGMEM =       "\005""WLH08""X600\0""X800\0""H26D\0""E010\0""H26WH";
 
-static const char* STR_SUBTYPE_HONTAI=      "\007""Std\0   ""JJRC X1""X5C1cln";
+const pm_char STR_SUBTYPE_HONTAI[] PROGMEM =     "\007""Std\0   ""JJRC X1""X5C1cln";
 
-static const char* STR_SUBTYPE_Q2X2 =       "\004""Q222""Q242""Q282";
+const pm_char STR_SUBTYPE_Q2X2[] PROGMEM =       "\004""Q222""Q242""Q282";
 
-static const char* STR_SUBTYPE_Q303 =       "\006""Q303\0 ""CX35\0 ""CX10D\0""CX10WD";
+const pm_char STR_SUBTYPE_Q303[] PROGMEM =       "\006""Q303\0 ""CX35\0 ""CX10D\0""CX10WD";
 
-static const char* STR_SUBTYPE_WK2x01 =     "\006""WK2801""WK2401""W6_5_1""W6_6_1""W6_Hel""W6_HeI";
+const pm_char STR_SUBTYPE_WK2x01[] PROGMEM =     "\006""WK2801""WK2401""W6_5_1""W6_6_1""W6_Hel""W6_HeI";
 
-static const char* STR_SUBTYPE_V2X2 =       "\006""V2x2\0 ""JXD506";
+const pm_char STR_SUBTYPE_V2X2[] PROGMEM =       "\006""V2x2\0 ""JXD506";
 
-static const char* STR_SUBTYPE_BAYANG =     "\006""Bayang""H8S3D";
+const pm_char STR_SUBTYPE_BAYANG[] PROGMEM =     "\006""Bayang""H8S3D";
 
-static const char* STR_SUBTYPE_FY326 =      "\005""FY326""FY319";
+const pm_char STR_SUBTYPE_FY326[] PROGMEM =      "\005""FY326""FY319";
 
 const mm_protocol_definition multi_protocols[] = {
   { MM_RF_PROTO_FLYSKY,     STR_SUBTYPE_FLYSKY,   4,  nullptr             },
@@ -671,7 +671,7 @@ const mm_protocol_definition multi_protocols[] = {
   { MM_RF_PROTO_Q2X2,       STR_SUBTYPE_Q2X2,     2,  nullptr             },
   { MM_RF_PROTO_WK_2X01,    STR_SUBTYPE_WK2x01,   5,  nullptr             },
   { MM_RF_PROTO_Q303,       STR_SUBTYPE_Q303,     3,  nullptr             },
-  { MM_RF_PROTO_GW08,       NO_SUBTYPE,           0,   nullptr             },
+  { MM_RF_PROTO_GW08,       NO_SUBTYPE,           0,  nullptr             },
   { MM_RF_CUSTOM_SELECTED,  NO_SUBTYPE,           7,  STR_MULTI_OPTION    },
 
   //Sential and default for protocols not listed above (MM_RF_CUSTOM is 0xff()


### PR DESCRIPTION
The removal of the static might fix #4641 if there is some linking problem. Anyway even if it does not fix the bug, the increased consistency is nice.