### PR TITLE
Add firmware update tools location for FreeBSD

### DIFF
--- a/companion/src/burnconfigdialog.cpp
+++ b/companion/src/burnconfigdialog.cpp
@@ -125,6 +125,11 @@ void burnConfigDialog::getSettings()
       sambaLoc = "/usr/local/bin/sam-ba";
     if ( dfuLoc.isEmpty())
       dfuLoc = QFileInfo(QApplication::applicationDirPath() + "/../Resources/dfu-util").absoluteFilePath();
+#elif defined __FreeBSD__
+    if (avrLoc.isEmpty())
+      avrLoc = "/usr/local/bin/avrdude";
+    if (dfuLoc.isEmpty())
+      dfuLoc = "/usr/local/bin/dfu-util";
 #else
     if ( avrLoc.isEmpty())
       avrLoc = "/usr/bin/avrdude";


### PR DESCRIPTION
  Add paths for avrdude and dfu-util programs under FreeBSD. SAM-BA does
not exist yet in the FreeBSD port collection.
