### PR TITLE
Fix non overlapping text

### DIFF
--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -231,7 +231,7 @@ void displayMixInfos(coord_t y, MixData * md)
 void displayMixLine(coord_t y, MixData * md, bool active)
 {
   if(active && md->name[0]) {
-    lcdDrawSizedText(FW*sizeof(TR_MIXER), 0, md->name, sizeof(md->name), ZCHAR);
+    lcdDrawSizedText(FW*sizeof(TR_MIXER)+FW/2, 0, md->name, sizeof(md->name), ZCHAR);
     if (!md->flightModes || ((md->curve.value || md->swtch) && ((get_tmr10ms() / 200) & 1)))
       displayMixInfos(y, md);
     else


### PR DESCRIPTION
If three is a mixer name, it is displayed, but on active row, the name is moved to title bar, and data is displayed instead

This fixes #4690 

For reference : #4281 