### PR TITLE
[Simulator] Fix timing issues in all AVR simulators on Windows (MSVC)

### DIFF
--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -88,7 +88,7 @@ U64 microsTimer(void)
   static QElapsedTimer ticker;
   if (!ticker.isValid())
     ticker.start();
-  return ticker.nsecsElapsed();
+  return ticker.nsecsElapsed() / 1000;
 
 #elif defined(_MSC_VER)
 


### PR DESCRIPTION
Fix 2MHz and 16KHz timers on MSVC builds.  Fixes LCD/key/switch response delay on all AVR simulators.  Apparently has been broken for quite some time...

Tested on MSVC2015, MinGW 5.3, Linux GCC 4.8 & 4.9, OS X clang 8.

Also introduce experimental use of Qt to possibly simplify x-platform code in future (disabled by default).