### PR TITLE
Instead of copying current profile, start from a blank one

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1403,15 +1403,12 @@ void MainWindow::updateProfilesActions()
 
 void MainWindow::copyProfile()
 {
-  int i;
-  for (i=0; i<MAX_PROFILES && g.profile[i].existsOnDisk(); i++);
-  if (i==MAX_PROFILES)  //Failed to find free slot
+  int previous = g.id();
+
+  createProfile();
+  if (g.id() == previous) //Failed to find free slot
     return;
-
-  g.profile[i] = g.profile[g.id()];
-  g.profile[i].name(tr("New Radio"));
-
-  g.id(i);
+  g.profile[g.id()] = g.profile[previous];
   updateMenus();
 }
 

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1405,8 +1405,7 @@ void MainWindow::createProfile()
   if (i==MAX_PROFILES)  //Failed to find free slot
     return;
 
-  // Copy current profile to new and give it a new name
-  g.profile[i] = g.profile[g.id()];
+  g.profile[i].init(i);
   g.profile[i].name(tr("New Radio"));
 
   g.id(i);

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1059,6 +1059,7 @@ void MainWindow::createActions()
   readFlashAct =       addAct("read_flash.png",    tr("Read Firmware from Radio"),tr("Read firmware from Radio"),           SLOT(readFlash()));
   writeFlashAct =      addAct("write_flash.png",   tr("Write Firmware to Radio"), tr("Write firmware to Radio"),            SLOT(writeFlash()));
   createProfileAct =   addAct("",                  tr("Add Radio Profile"),       tr("Create a new Radio Setting Profile"), SLOT(createProfile()));
+  copyProfileAct =     addAct("",                  tr("Copy Current Radio Profile"), tr("Duplicate current Radio Setting Profile"), SLOT(copyProfile()));
   openDocURLAct =      addAct("",                  tr("Manuals and other Documents"),      tr("Open the OpenTX document page in a web browser"), SLOT(openDocURL()));
   writeEepromAct =     addAct("write_eeprom.png",  tr("Write Models and Settings To Radio"),  tr("Write Models and Settings to Radio"),       SLOT(writeEeprom()));
   readEepromAct =      addAct("read_eeprom.png",   tr("Read Models and Settings From Radio"), tr("Read Models and Settings from Radio"),      SLOT(readEeprom()));
@@ -1218,6 +1219,7 @@ QMenu *MainWindow::createProfilesMenu()
   profilesMenu->addSeparator();
 
   profilesMenu->addAction(createProfileAct);
+  profilesMenu->addAction(copyProfileAct);
   profilesMenu->setIcon(CompanionIcon("profiles.png"));
   return profilesMenu;
 }
@@ -1396,6 +1398,21 @@ void MainWindow::updateProfilesActions()
       profileActs[i]->setVisible(false);
     }
   }
+}
+
+
+void MainWindow::copyProfile()
+{
+  int i;
+  for (i=0; i<MAX_PROFILES && g.profile[i].existsOnDisk(); i++);
+  if (i==MAX_PROFILES)  //Failed to find free slot
+    return;
+
+  g.profile[i] = g.profile[g.id()];
+  g.profile[i].name(tr("New Radio"));
+
+  g.id(i);
+  updateMenus();
 }
 
 void MainWindow::createProfile()

--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -123,6 +123,7 @@ class MainWindow : public QMainWindow
     void fwPrefs();
     void updateMenus();
     void createProfile();
+    void copyProfile();
     void setActiveSubWindow(QWidget *window);
     void autoClose();
 
@@ -213,6 +214,7 @@ class MainWindow : public QMainWindow
     QAction *recentFileActs[MAX_RECENT];
     QAction *profileActs[MAX_PROFILES];
     QAction *createProfileAct;
+    QAction *copyProfileAct;
     QAction *openDocURLAct;
 };
 


### PR DESCRIPTION
Thix fix #4686 

Thix changes current behaviour of copying current profile when creating a new one. Given the differences in radio capabilities and working principles, this protects from carrying not relevant, sometime incompatible data