### PR TITLE
[Companion] Improve handling of non-supported splash image (Horus) in radio profile settings page.

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -77,7 +77,7 @@ void AppPreferencesDialog::writeValues()
   g.enableBackup(ui->backupEnable->isChecked());
 
   if (ui->joystickChkB ->isChecked() && ui->joystickCB->isEnabled()) {
-    g.jsSupport(ui->joystickChkB ->isChecked());  
+    g.jsSupport(ui->joystickChkB ->isChecked());
     g.jsCtrl(ui->joystickCB ->currentIndex());
   }
   else {
@@ -193,7 +193,7 @@ void AppPreferencesDialog::initSettings()
     ui->joystickCB->setDisabled(true);
     ui->joystickcalButton->setDisabled(true);
   }
-#endif  
+#endif
   //  Profile Tab Inits
   ui->channelorderCB->setCurrentIndex(g.profile[g.id()].channelOrder());
   ui->stickmodeCB->setCurrentIndex(g.profile[g.id()].defaultMode());
@@ -213,7 +213,6 @@ void AppPreferencesDialog::initSettings()
   }
 
   ui->profileNameLE->setText(g.profile[g.id()].name());
-  ui->SplashFileName->setText(g.profile[g.id()].splashFile());
 
   QString hwSettings;
   if (g.profile[g.id()].stickPotCalib() == "" ) {
@@ -229,30 +228,13 @@ void AppPreferencesDialog::initSettings()
   ui->lblGeneralSettings->setText(hwSettings);
 
   Firmware * current_firmware = getCurrentFirmware();
-  
-  if (!IS_HORUS(current_firmware->getBoard())) {
-    displayImage(g.profile[g.id()].splashFile());
-  }
-  // TODO: Remove once splash replacement supported on Horus
-  // NOTE: 480x272 image causes issues on screens <800px high, needs a solution like scrolling once reinstated
-  else {
-    ui->imageLabel->hide();
-    ui->splashLabel->hide();
-    ui->SplashFileName->hide();
-    ui->SplashSelect->hide();
-    ui->SplashSelect->setEnabled(false);
-    ui->clearImageButton->hide();
-    ui->clearImageButton->setEnabled(false);
-    ui->splashSeparator->hide();
-  }
-
   foreach(Firmware * firmware, firmwares) {
     ui->downloadVerCB->addItem(firmware->getName(), firmware->getId());
     if (current_firmware->getFirmwareBase() == firmware) {
       ui->downloadVerCB->setCurrentIndex(ui->downloadVerCB->count() - 1);
     }
   }
-  
+
   baseFirmwareChanged();
 }
 
@@ -306,7 +288,7 @@ void AppPreferencesDialog::on_ge_pathButton_clicked()
     ui->ge_lineedit->setText(fileName);
   }
 }
- 
+
 #if defined(JOYSTICKS)
 void AppPreferencesDialog::on_joystickChkB_clicked() {
   if (ui->joystickChkB->isChecked()) {
@@ -367,10 +349,13 @@ bool AppPreferencesDialog::displayImage(const QString & fileName)
   // Start by clearing the label
   ui->imageLabel->clear();
 
-  QImage image(fileName);
-  if (image.isNull()) 
+  if (fileName.isEmpty())
     return false;
-  
+
+  QImage image(fileName);
+  if (image.isNull())
+    return false;
+
   ui->imageLabel->setPixmap(makePixMap(image));
   ui->imageLabel->setFixedSize(getCurrentFirmware()->getCapability(LcdWidth), getCurrentFirmware()->getCapability(LcdHeight));
   return true;
@@ -388,7 +373,7 @@ void AppPreferencesDialog::on_SplashSelect_clicked()
 
   if (!fileName.isEmpty()){
     g.imagesDir(QFileInfo(fileName).dir().absolutePath());
-   
+
     displayImage(fileName);
     ui->SplashFileName->setText(fileName);
   }
@@ -478,7 +463,7 @@ void AppPreferencesDialog::firmwareOptionChanged(bool state)
         }
       }
     }
-  } 
+  }
 }
 
 void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
@@ -541,6 +526,18 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
   }
 
   showVoice(voice && voice->isChecked());
+
+  // TODO: Remove once splash replacement supported on Horus
+  // NOTE: 480x272 image causes issues on screens <800px high, needs a solution like scrolling once reinstated
+  if (IS_HORUS(parent->getBoard())) {
+    ui->widget_splashImage->hide();
+    ui->SplashFileName->setText("");
+  }
+  else {
+    ui->widget_splashImage->show();
+    ui->SplashFileName->setText(g.profile[g.id()].splashFile());
+    displayImage(g.profile[g.id()].splashFile());
+  }
 
   updateLock = false;
   QTimer::singleShot(0, this, SLOT(shrink()));

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -45,7 +45,139 @@
       <attribute name="title">
        <string>Radio Profile</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,0">
+      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
+       <item row="0" column="2" colspan="2">
+        <widget class="QPushButton" name="removeProfileButton">
+         <property name="text">
+          <string>Remove Profile</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="2" colspan="2">
+        <widget class="QPushButton" name="sdPathButton">
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="2" colspan="2">
+        <widget class="QPushButton" name="ProfilebackupPathButton">
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="4">
+        <widget class="QWidget" name="widget_splashImage" native="true">
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="splashLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Splash Screen</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="SplashFileName">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="SplashSelect">
+            <property name="text">
+             <string>Select Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="imageLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>128</width>
+              <height>64</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>212</width>
+              <height>64</height>
+             </size>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <property name="lineWidth">
+             <number>1</number>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="clearImageButton">
+            <property name="text">
+             <string>Clear Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="Line" name="line_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_2">
          <property name="font">
@@ -183,80 +315,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="splashLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Splash Screen</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QLineEdit" name="SplashFileName">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="readOnly">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QLabel" name="imageLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>128</width>
-           <height>64</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>212</width>
-           <height>64</height>
-          </size>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Plain</enum>
-         </property>
-         <property name="lineWidth">
-          <number>1</number>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="scaledContents">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0" colspan="4">
-        <widget class="Line" name="line_6">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label">
          <property name="font">
           <font>
@@ -269,7 +328,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="sdPathLabel">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -285,7 +344,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="8" column="1">
         <widget class="QLineEdit" name="sdPath">
          <property name="enabled">
           <bool>true</bool>
@@ -298,7 +357,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="profilebackupPathLabel">
          <property name="toolTip">
           <string>The profile specific folder,  if set, will override general Backup folder</string>
@@ -308,7 +367,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="9" column="1">
         <widget class="QLineEdit" name="profilebackupPath">
          <property name="toolTip">
           <string>If set it will override the application general setting</string>
@@ -318,7 +377,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="10" column="1">
         <widget class="QCheckBox" name="pbackupEnable">
          <property name="toolTip">
           <string>if set, will override general backup enable</string>
@@ -328,14 +387,14 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>General Settings</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="11" column="1">
         <widget class="QLabel" name="lblGeneralSettings">
          <property name="enabled">
           <bool>true</bool>
@@ -345,7 +404,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="label_14">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -358,7 +417,7 @@ May be different from firmware language</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="12" column="1">
         <widget class="QComboBox" name="stickmodeCB">
          <property name="maximumSize">
           <size>
@@ -412,7 +471,7 @@ Mode 4:
          </item>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_13">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
@@ -428,7 +487,7 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="13" column="1">
         <widget class="QComboBox" name="channelorderCB">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -576,21 +635,21 @@ Mode 4:
          </item>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="14" column="1">
         <widget class="QCheckBox" name="renameFirmware">
          <property name="text">
           <string>Append version number to FW file name</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="15" column="1">
         <widget class="QCheckBox" name="burnFirmware">
          <property name="text">
           <string>Offer to write FW to Tx after download</string>
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="16" column="1">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -602,44 +661,6 @@ Mode 4:
           </size>
          </property>
         </spacer>
-       </item>
-       <item row="7" column="2" colspan="2">
-        <widget class="QPushButton" name="clearImageButton">
-         <property name="text">
-          <string>Clear Image</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="2" colspan="2">
-        <widget class="QPushButton" name="SplashSelect">
-         <property name="text">
-          <string>Select Image</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2" colspan="2">
-        <widget class="QPushButton" name="removeProfileButton">
-         <property name="text">
-          <string>Remove Profile</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="2" colspan="2">
-        <widget class="QPushButton" name="sdPathButton">
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="2" colspan="2">
-        <widget class="QPushButton" name="ProfilebackupPathButton">
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -1111,9 +1132,6 @@ Mode 4:
   <tabstop>downloadVerCB</tabstop>
   <tabstop>langCombo</tabstop>
   <tabstop>voiceCombo</tabstop>
-  <tabstop>SplashFileName</tabstop>
-  <tabstop>SplashSelect</tabstop>
-  <tabstop>clearImageButton</tabstop>
   <tabstop>sdPath</tabstop>
   <tabstop>sdPathButton</tabstop>
   <tabstop>profilebackupPath</tabstop>
@@ -1147,9 +1165,7 @@ Mode 4:
   <tabstop>volumeGain</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
- <resources>
-  <include location="companion.qrc"/>
- </resources>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
Re: #4686

(Didn't test that the actual flashing works now, but it does wipe the splash image name correctly from profile settings when Horus radio type is selected).