### PR TITLE
[Companion] Change simulator startup from ModelEdit panel.

### DIFF
--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -38,8 +38,7 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   QDialog(parent),
   ui(new Ui::ModelEdit),
   modelId(modelId),
-  model(radioData.models[modelId]),
-  generalSettings(radioData.generalSettings),
+  radioData(radioData),
   firmware(firmware)
 {
   Stopwatch s1("ModelEdit");
@@ -49,27 +48,30 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   setWindowIcon(CompanionIcon("edit.png"));
   restoreGeometry(g.modelEditGeo());
   ui->pushButton->setIcon(CompanionIcon("simulate.png"));
-  SetupPanel * setupPanel = new SetupPanel(this, model, generalSettings, firmware);
+  SetupPanel * setupPanel = new SetupPanel(this, radioData.models[modelId], radioData.generalSettings, firmware);
   addTab(setupPanel, tr("Setup"));
   if (firmware->getCapability(Heli))
-    addTab(new HeliPanel(this, model, generalSettings, firmware), tr("Heli"));
-  addTab(new FlightModesPanel(this, model, generalSettings, firmware), tr("Flight Modes"));
-  addTab(new InputsPanel(this, model, generalSettings, firmware), tr("Inputs"));
+    addTab(new HeliPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Heli"));
+  addTab(new FlightModesPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Flight Modes"));
+  addTab(new InputsPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Inputs"));
   s1.report("inputs");
-  addTab(new MixesPanel(this, model, generalSettings, firmware), tr("Mixes"));
+  addTab(new MixesPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Mixes"));
   s1.report("Mixes");
-  Channels * chnPanel = new Channels(this, model, generalSettings, firmware);
+  Channels * chnPanel = new Channels(this, radioData.models[modelId], radioData.generalSettings, firmware);
   addTab(chnPanel, tr("Outputs"));
   s1.report("Outputs");
-  addTab(new Curves(this, model, generalSettings, firmware), tr("Curves"));
-  addTab(new LogicalSwitchesPanel(this, model, generalSettings, firmware), tr("Logical Switches"));
+  addTab(new Curves(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Curves"));
+  addTab(new LogicalSwitchesPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Logical Switches"));
   s1.report("LS");
-  addTab(new CustomFunctionsPanel(this, &model, generalSettings, firmware), tr("Special Functions"));
+  addTab(new CustomFunctionsPanel(this, &radioData.models[modelId], radioData.generalSettings, firmware), tr("Special Functions"));
   s1.report("CF");
   if (firmware->getCapability(Telemetry) & TM_HASTELEMETRY)
-    addTab(new TelemetryPanel(this, model, generalSettings, firmware), tr("Telemetry"));
+    addTab(new TelemetryPanel(this, radioData.models[modelId], radioData.generalSettings, firmware), tr("Telemetry"));
 
-  connect(setupPanel, SIGNAL(extendedLimitsToggled()), chnPanel, SLOT(refreshExtendedLimits()));
+  connect(setupPanel, &SetupPanel::extendedLimitsToggled, chnPanel, &Channels::refreshExtendedLimits);
+  connect(ui->tabWidget, &QTabWidget::currentChanged, this, &ModelEdit::onTabIndexChanged);
+  connect(ui->pushButton, &QPushButton::clicked, this, &ModelEdit::launchSimulation);
+
   s1.report("end");
   gStopwatch.report("ModelEdit end constructor");
 }
@@ -92,38 +94,16 @@ void ModelEdit::addTab(GenericPanel *panel, QString text)
   VerticalScrollArea * area = new VerticalScrollArea(widget, panel);
   baseLayout->addWidget(area);
   ui->tabWidget->addTab(widget, text);
-  connect(panel, SIGNAL(modified()), this, SLOT(onTabModified()));
+  connect(panel, &GenericPanel::modified, this, &ModelEdit::modified);
 }
 
-void ModelEdit::onTabModified()
+void ModelEdit::onTabIndexChanged(int index)
 {
-  emit modified();
-}
-
-void ModelEdit::on_tabWidget_currentChanged(int index)
-{
-  panels[index]->update();
-}
-
-void ModelEdit::on_pushButton_clicked()
-{
-  launchSimulation();
+  if (index < panels.size())
+    panels.at(index)->update();
 }
 
 void ModelEdit::launchSimulation()
 {
-  RadioData * simuData = new RadioData();
-  simuData->generalSettings = generalSettings;
-  /*: Translators do NOT use accent for this, this is the default category name on Horus. */
-  CategoryData category(qPrintable(tr("Models")));
-  simuData->categories.push_back(category);
-  if (simuData->models.size() == 0) {
-    simuData->models.push_back(model);
-  }
-  else {
-    simuData->models[0] = model;
-  }
-  simuData->models[0].category = 0;
-  startSimulation(this, *simuData, 0);
-  delete simuData;
+  startSimulation(this, radioData, modelId);
 }

--- a/companion/src/modeledit/modeledit.h
+++ b/companion/src/modeledit/modeledit.h
@@ -46,7 +46,7 @@ class ModelEdit : public QDialog
   public:
     ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmware * firmware);
     ~ModelEdit();
-  
+
   protected:
     void closeEvent(QCloseEvent *event);
 
@@ -54,15 +54,12 @@ class ModelEdit : public QDialog
     void modified();
 
   private slots:
-    void onTabModified();
-    void on_pushButton_clicked();
-    void on_tabWidget_currentChanged(int index);
+    void onTabIndexChanged(int index);
 
   private:
     Ui::ModelEdit *ui;
     int modelId;
-    ModelData & model;
-    GeneralSettings & generalSettings;
+    RadioData & radioData;
     Firmware * firmware;
     QVector<GenericPanel *> panels;
 


### PR DESCRIPTION
Now acts the same as simulating a model from the models list widget using "Simulate Model" menu item (that is, including the other radio data as well, whereas before a default radio data object was created and the model inserted into that).  

Besides simplifying the code, making it more consistent with the other way to simulate a model, and removing the extra category name (re: #4712), I'm not sure it makes sense to simulate a model w/out the rest of the radio data -- what if the model relies on general settings like global functions?