### PR TITLE
Horus : use filename when no name is defined

### DIFF
--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -74,8 +74,15 @@ class ModelCell
       }
       else {
         zchar2str(modelName, header.name, LEN_MODEL_NAME);
+        if (modelName[0] == 0) {
+          char * tmp;
+          strncpy(modelName, modelFilename, LEN_MODEL_NAME);
+          tmp = (char *) memchr(modelName, '.',  LEN_MODEL_NAME);
+          if (tmp != NULL)
+            *tmp = 0;
+        }
         char timer[LEN_TIMER_STRING];
-        buffer->drawSizedText(5, 2, header.name, LEN_MODEL_NAME, SMLSIZE|ZCHAR|TEXT_COLOR);
+        buffer->drawSizedText(5, 2, modelName, LEN_MODEL_NAME, SMLSIZE|TEXT_COLOR);
         getTimerString(timer, 0);
         buffer->drawText(101, 40, timer, TEXT_COLOR);
         for (int i=0; i<4; i++) {


### PR DESCRIPTION
This deals with "Models with an empty name converted to Horus should have their default name set"

of #4224