### PR TITLE
Jivarofad/mixer update lite

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -907,9 +907,6 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       //========== WEIGHT ===============
       int32_t dv = (int32_t)v * weight;
       int32_t dtrim = (int32_t)trim * weight;
-#if defined(CPUARM)
-      dv = div_and_round(dv, 10);
-#endif
 
       //========== DIFFERENTIAL =========
 #if defined(CPUARM)
@@ -939,6 +936,10 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
         }
         dv += dtrim;
       }
+#endif
+
+#if defined(CPUARM)
+      dv = div_and_round(dv, 10);
 #endif
 
       //========== OFFSET / AFTER ===============

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -907,6 +907,10 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       //========== WEIGHT ===============
       int32_t dv = (int32_t)v * weight;
       int32_t dtrim = (int32_t)trim * weight;
+#if defined(CPUARM)
+      dv = div_and_round(dv, 10);
+      dtrim = div_and_round(dtrim, 10);
+#endif
 
       //========== DIFFERENTIAL =========
 #if defined(CPUARM)
@@ -936,10 +940,6 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
         }
         dv += dtrim;
       }
-#endif
-
-#if defined(CPUARM)
-      dv = div_and_round(dv, 10);
 #endif
 
       //========== OFFSET / AFTER ===============

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -903,6 +903,9 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       //========== WEIGHT ===============
       int32_t dv = (int32_t)v * weight;
       int32_t dtrim = (int32_t) trim * weight;
+#if defined(CPUARM)
+      dv = div_and_round(dv, 10);
+#endif
 
       //========== DIFFERENTIAL =========
 #if defined(CPUARM)
@@ -932,10 +935,6 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
         }
         dv += dtrim;
       }
-#endif
-
-#if defined(CPUARM)
-      dv = div_and_round(dv, 10);
 #endif
 
       //========== OFFSET / AFTER ===============

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -826,7 +826,7 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
         else
           mix_trim = -1;
         if (mix_trim >= 0) {
-          int16_t trim = trims[mix_trim];
+            trim = trims[mix_trim];
           if (mix_trim == THR_STICK && g_model.throttleReversed)
             trim = -trim;
         }

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -841,6 +841,7 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       int16_t weight = GET_GVAR(MD_WEIGHT(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
       weight = calc100to256_16Bits(weight);
 #endif
+
       //========== SPEED ===============
       // now its on input side, but without weight compensation. More like other remote controls
       // lower weight causes slower movement
@@ -902,21 +903,6 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       //========== WEIGHT ===============
       int32_t dv = (int32_t)v * weight;
       int32_t dtrim = (int32_t) trim * weight;
-#if defined(CPUARM)
-      dv = div_and_round(dv, 10);
-      dtrim = div_and_round(dtrim, 10);
-#endif
-
-      //========== OFFSET / AFTER ===============
-      if (apply_offset_and_curve) {
-#if defined(CPUARM)
-        int32_t offset = GET_GVAR_PREC1(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
-        if (offset) dv += div_and_round(calc100toRESX_16Bits(offset), 10) << 8;
-#else
-        int16_t offset = GET_GVAR(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
-        if (offset) dv += int32_t(calc100toRESX_16Bits(offset)) << 8;
-#endif
-      }
 
       //========== DIFFERENTIAL =========
 #if defined(CPUARM)
@@ -947,6 +933,21 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
         dv += dtrim;
       }
 #endif
+
+#if defined(CPUARM)
+      dv = div_and_round(dv, 10);
+#endif
+
+      //========== OFFSET / AFTER ===============
+      if (apply_offset_and_curve) {
+#if defined(CPUARM)
+        int32_t offset = GET_GVAR_PREC1(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
+        if (offset) dv += div_and_round(calc100toRESX_16Bits(offset), 10) << 8;
+#else
+        int16_t offset = GET_GVAR(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
+        if (offset) dv += int32_t(calc100toRESX_16Bits(offset)) << 8;
+#endif
+      }
 
       int32_t * ptr = &chans[md->destCh]; // Save calculating address several times
 

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -887,11 +887,16 @@ TEST_F(MixerTest, DiffConservationThroughTrim)
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_Ail;
   g_model.mixData[0].weight = 100;
+#if !defined(CPUARM)
   g_model.mixData[0].curveMode = 0;
   g_model.mixData[0].curveParam = 50;    //diff = +50%
-  setTrimValue(0, AIL_STICK, +128);      //trim = +25%
+#else
+  g_model.mixData[0].curve.type = CURVE_REF_DIFF;
+  g_model.mixData[0].curve.value = 50;    //diff = +50%
+#endif
+  setTrimValue(0, AIL_STICK, TRIM_MAX);   //trim = +25%
 
-  anaInValues[AIL_STICK] = +256;
+  anaInValues[AIL_STICK] = +256;          //stick = +25%
   evalMixes(1);
   //output = 25%(trim)*100%(nodiffside) + 25%(stick)*100%(nodiffside) = +50%
   EXPECT_EQ(channelOutputs[0], +512);

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -879,6 +879,29 @@ TEST_F(MixerTest, SlowOnMultiply)
   CHECK_NO_MOVEMENT(0, CHANNEL_MAX, 250);
 }
 
+TEST_F(MixerTest, DiffConservationThroughTrim)
+{
+  MODEL_RESET();
+  MIXER_RESET();
+  g_model.mixData[0].destCh = 0;
+  g_model.mixData[0].mltpx = MLTPX_ADD;
+  g_model.mixData[0].srcRaw = MIXSRC_Ail;
+  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].curveMode = 0;
+  g_model.mixData[0].curveParam = 50;    //diff = +50%
+  setTrimValue(0, AIL_STICK, +128);      //trim = +25%
+
+  anaInValues[AIL_STICK] = +256;
+  evalMixes(1);
+  //output = 25%(trim)*100%(nodiffside) + 25%(stick)*100%(nodiffside) = +50%
+  EXPECT_EQ(channelOutputs[0], +512);
+
+  anaInValues[AIL_STICK] = -256;
+  evalMixes(1);
+  //output = 25%(trim)*100%(nodiffside) - 25%(stick)*50%(diffside) = +12.5%   
+  EXPECT_EQ(channelOutputs[0], +128);
+}
+
 
 #if defined(HELI) && defined(VIRTUAL_INPUTS)
 TEST(Heli, BasicTest)

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -894,7 +894,7 @@ TEST_F(MixerTest, DiffConservationThroughTrim)
   g_model.mixData[0].curve.type = CURVE_REF_DIFF;
   g_model.mixData[0].curve.value = 50;    //diff = +50%
 #endif
-  setTrimValue(0, AIL_STICK, TRIM_MAX);   //trim = +25%
+  setTrimValue(0, AIL_STICK, +128);       //trim = +25%
 
   anaInValues[AIL_STICK] = +256;          //stick = +25%
   evalMixes(1);


### PR DESCRIPTION
This mods keep the differential rate constant when trim !=0 (explanation here, in french : http://rcaerolab.eklablog.com/opentx-mixeur-nsrc-p1260994)
No-regression gtest macro added : DiffConservationThroughTrim