### PR TITLE
[Companion] Improve radio profile/current firmware handling.

### DIFF
--- a/companion/src/apppreferencesdialog.h
+++ b/companion/src/apppreferencesdialog.h
@@ -40,6 +40,9 @@ class AppPreferencesDialog : public QDialog
     ~AppPreferencesDialog();
     Joystick * joystick;
 
+  signals:
+    void firmwareProfileChanged(int profId);
+
   private:
     QList<QCheckBox *> optionsCheckBoxes;
     bool updateLock;
@@ -69,7 +72,6 @@ class AppPreferencesDialog : public QDialog
     void on_ge_pathButton_clicked();
 
     void on_sdPathButton_clicked();
-    void on_removeProfileButton_clicked();
     void on_SplashSelect_clicked();
     void on_clearImageButton_clicked();
 

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -46,13 +46,6 @@
        <string>Radio Profile</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
-       <item row="0" column="2" colspan="2">
-        <widget class="QPushButton" name="removeProfileButton">
-         <property name="text">
-          <string>Remove Profile</string>
-         </property>
-        </widget>
-       </item>
        <item row="8" column="2" colspan="2">
         <widget class="QPushButton" name="sdPathButton">
          <property name="text">
@@ -1128,7 +1121,6 @@ Mode 4:
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>profileNameLE</tabstop>
-  <tabstop>removeProfileButton</tabstop>
   <tabstop>downloadVerCB</tabstop>
   <tabstop>langCombo</tabstop>
   <tabstop>voiceCombo</tabstop>

--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
   SimulatorLoader::registerSimulators();
 
   if (g.profile[g.id()].fwType().isEmpty()){
-    g.profile[g.id()].fwType(default_firmware_variant->getId());
+    g.profile[g.id()].fwType(Firmware::getDefaultVariant()->getId());
     g.profile[g.id()].fwName("");
   }
 
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
   QPixmap pixmap = QPixmap(splashScreen);
   QSplashScreen *splash = new QSplashScreen(pixmap);
 
-  current_firmware_variant = getFirmware(g.profile[g.id()].fwType());
+  Firmware::setCurrentVariant(Firmware::getFirmwareForId(g.profile[g.id()].fwType()));
 
   MainWindow *mainWin = new MainWindow();
   if (g.showSplash()) {

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -239,7 +239,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
 {
   RawSourceRange result;
 
-  Firmware * firmware = getCurrentFirmware();
+  Firmware * firmware = Firmware::getCurrentVariant();
   int board = firmware->getBoard();
   bool singleprec = (flags & RANGE_SINGLE_PRECISION);
 
@@ -912,7 +912,7 @@ QString CustomFunctionData::funcToString() const
 void CustomFunctionData::populateResetParams(const ModelData * model, QComboBox * b, unsigned int value = 0)
 {
   int val = 0;
-  Firmware * firmware = getCurrentFirmware();
+  Firmware * firmware = Firmware::getCurrentVariant();
   Board::Type board = firmware->getBoard();
 
   b->addItem(QObject::tr("Timer1"), val++);
@@ -1138,7 +1138,7 @@ GeneralSettings::GeneralSettings()
     calibSpanPos[i] = 0x180;
   }
 
-  Firmware * firmware = getCurrentFirmware();
+  Firmware * firmware = Firmware::getCurrentVariant();
   Board::Type board = firmware->getBoard();
 
   for (int i=0; i<getBoardCapability(board, Board::FactoryInstalledSwitches); i++) {
@@ -1735,10 +1735,6 @@ void unregisterEEpromInterfaces()
   OpenTxEepromCleanup();
 }
 
-QList<Firmware *> firmwares;
-Firmware * default_firmware_variant;
-Firmware * current_firmware_variant;
-
 void ShowEepromErrors(QWidget *parent, const QString &title, const QString &mainMessage, unsigned long errorsFound)
 {
   std::bitset<NUM_ERRORS> errors((unsigned long long)errorsFound);
@@ -1790,16 +1786,22 @@ void ShowEepromWarnings(QWidget *parent, const QString &title, unsigned long err
   msgBox.exec();
 }
 
-Firmware * getFirmware(const QString & id)
+// static
+QVector<Firmware *> Firmware::registeredFirmwares;
+Firmware * Firmware::defaultVariant = NULL;
+Firmware * Firmware::currentVariant = NULL;
+
+// static
+Firmware * Firmware::getFirmwareForId(const QString & id)
 {
-  foreach(Firmware * firmware, firmwares) {
+  foreach(Firmware * firmware, registeredFirmwares) {
     Firmware * result = firmware->getFirmwareVariant(id);
     if (result) {
       return result;
     }
   }
 
-  return default_firmware_variant;
+  return defaultVariant;
 }
 
 void Firmware::addOption(const char *option, QString tooltip, uint32_t variant)

--- a/companion/src/eeprominterface.h
+++ b/companion/src/eeprominterface.h
@@ -325,10 +325,40 @@ class Firmware {
 
     const int getFlashSize();
 
+    static Firmware * getFirmwareForId(const QString & id);
+
+    static QVector<Firmware *> getRegisteredFirmwares()
+    {
+      return registeredFirmwares;
+    }
+    static void addRegisteredFirmware(Firmware * fw)
+    {
+      registeredFirmwares.append(fw);
+    }
+
+    static Firmware * getDefaultVariant()
+    {
+      return defaultVariant;
+    }
+    static void setDefaultVariant(Firmware * value)
+    {
+      defaultVariant = value;
+    }
+
+    static Firmware * getCurrentVariant()
+    {
+      return currentVariant;
+    }
+    static void setCurrentVariant(Firmware * value)
+    {
+      currentVariant = value;
+    }
+
   public:
     QList<const char *> languages;
     QList<const char *> ttslanguages;
     QList< QList<Option> > opts;
+
 
   protected:
     QString id;
@@ -338,30 +368,28 @@ class Firmware {
     Firmware * base;
     EEPROMInterface * eepromInterface;
 
+    static QVector<Firmware *> registeredFirmwares;
+    static Firmware * defaultVariant;
+    static Firmware * currentVariant;
+
   private:
     Firmware();
 
 };
 
-extern QList<Firmware *> firmwares;
-extern Firmware * default_firmware_variant;
-extern Firmware * current_firmware_variant;
-
-Firmware * getFirmware(const QString & id);
-
 inline Firmware * getCurrentFirmware()
 {
-  return current_firmware_variant;
+  return Firmware::getCurrentVariant();
 }
 
 inline EEPROMInterface * getCurrentEEpromInterface()
 {
-  return getCurrentFirmware()->getEEpromInterface();
+  return Firmware::getCurrentVariant()->getEEpromInterface();
 }
 
 inline Board::Type getCurrentBoard()
 {
-  return getCurrentFirmware()->getBoard();
+  return Firmware::getCurrentVariant()->getBoard();
 }
 
 inline int divRoundClosest(const int n, const int d)

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1198,7 +1198,7 @@ void registerOpenTxFirmware(OpenTxFirmware * firmware)
   firmware->setEEpromInterface(eepromInterface);
   opentxEEpromInterfaces.push_back(eepromInterface);
   eepromInterfaces.push_back(eepromInterface);
-  firmwares.push_back(firmware);
+  Firmware::addRegisteredFirmware(firmware);
 }
 
 void registerOpenTxFirmwares()
@@ -1507,13 +1507,13 @@ void registerOpenTxFirmwares()
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
-  default_firmware_variant = getFirmware("opentx-x9d+");
-  current_firmware_variant = default_firmware_variant;
+  Firmware::setDefaultVariant(Firmware::getFirmwareForId("opentx-x9d+"));
+  Firmware::setCurrentVariant(Firmware::getDefaultVariant());
 }
 
 void unregisterOpenTxFirmwares()
 {
-  foreach (Firmware * f, firmwares) {
+  foreach (Firmware * f, Firmware::getRegisteredFirmwares()) {
     delete f;
   }
   unregisterEEpromInterfaces();

--- a/companion/src/fwpreferencesdialog.cpp
+++ b/companion/src/fwpreferencesdialog.cpp
@@ -37,7 +37,7 @@ FirmwarePreferencesDialog::FirmwarePreferencesDialog(QWidget *parent) :
 
   foreach(const char *lang, getCurrentFirmware()->getFirmwareBase()->ttslanguages) {
     ui->voiceCombo->addItem(lang);
-    if (current_firmware_variant->getId().contains(QString("-tts%1").arg(lang)))
+    if (Firmware::getCurrentVariant()->getId().contains(QString("-tts%1").arg(lang)))
       ui->voiceCombo->setCurrentIndex(ui->voiceCombo->count() - 1);
   }
 }

--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -96,6 +96,7 @@ class MainWindow : public QMainWindow
     void saveAs();
     void cut();
     void openRecentFile();
+    void loadProfileId(const unsigned pid);
     void loadProfile();
     void logFile();
     void copy();
@@ -124,6 +125,8 @@ class MainWindow : public QMainWindow
     void updateMenus();
     void createProfile();
     void copyProfile();
+    void deleteProfile(const int pid);
+    void deleteCurrentProfile();
     void setActiveSubWindow(QWidget *window);
     void autoClose();
 
@@ -149,6 +152,7 @@ class MainWindow : public QMainWindow
     void updateRecentFileActions();
     void updateProfilesActions();
 
+    int newProfile(bool loadProfile = true);
     QString strippedName(const QString & fullFileName);
 
     MdiChild * createMdiChild();
@@ -215,6 +219,7 @@ class MainWindow : public QMainWindow
     QAction *profileActs[MAX_PROFILES];
     QAction *createProfileAct;
     QAction *copyProfileAct;
+    QAction *deleteProfileAct;
     QAction *openDocURLAct;
 };
 

--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
     return finish(2);
   }
 
-  current_firmware_variant = getFirmware(simOptions.firmwareId);
+  Firmware::setCurrentVariant(Firmware::getFirmwareForId(simOptions.firmwareId));
 
   g.sessionId(profileId);
   g.simuLastProfId(profileId);


### PR DESCRIPTION
  * Fix possible confusion/data corruption when deleting radio profile (closes #4734, ref: #4686);
  * Add Delete Profile action to Radio Profiles menu (closes #4736) (but remove from app prefs. panel);
  * Add confirmation prompt before deleting profile;
  * Open profile settings dialog when creating/copying a profile (closes #4735);
  * Make sure current (global) firmware flavor is properly updated when changing fw type/options in profile;
  * Append "-Copy" to name of copied profile;
  * Factor out Firmware global vars/functions in favor of static members.