### PR TITLE
Horus : adjust INVERS background for all text sizes

### DIFF
--- a/radio/src/gui/480x272/bitmapbuffer.cpp
+++ b/radio/src/gui/480x272/bitmapbuffer.cpp
@@ -343,19 +343,19 @@ void BitmapBuffer::drawSizedText(coord_t x, coord_t y, const char * s, uint8_t l
       }
     }
     else if (fontindex == TINSIZE_INDEX) {
-      drawSolidFilledRect(x-INVERT_HORZ_MARGIN+2, y-INVERT_VERT_MARGIN+2, width+2*INVERT_HORZ_MARGIN-5, INVERT_LINE_HEIGHT-7, TEXT_INVERTED_BGCOLOR);
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN+2, y, width+2*INVERT_HORZ_MARGIN-5, height+2, TEXT_INVERTED_BGCOLOR);
     }
     else if (fontindex == SMLSIZE_INDEX) {
-      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT-5, TEXT_INVERTED_BGCOLOR);
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y, width+2*INVERT_HORZ_MARGIN-2, height+2, TEXT_INVERTED_BGCOLOR);
     }
     else if (fontindex == MIDSIZE_INDEX) {
-      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+4, TEXT_INVERTED_BGCOLOR);
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y-1, width+2*INVERT_HORZ_MARGIN-2, height+3, TEXT_INVERTED_BGCOLOR);  // MIDSIZE and DBLSIZE font are missing a pixel on top compared to others
     }
     else if (fontindex == DBLSIZE_INDEX) {
-      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+13, TEXT_INVERTED_BGCOLOR);
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y-1, width+2*INVERT_HORZ_MARGIN-2, height+3, TEXT_INVERTED_BGCOLOR); // MIDSIZE and DBLSIZE font are missing a pixel on top compared to others
     }
     else if (fontindex == XXLSIZE_INDEX) {
-      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+52, TEXT_INVERTED_BGCOLOR);
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y, width+2*INVERT_HORZ_MARGIN-2, height+2, TEXT_INVERTED_BGCOLOR);
     }
     else {
       drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y, width+2*INVERT_HORZ_MARGIN, INVERT_LINE_HEIGHT, TEXT_INVERTED_BGCOLOR);

--- a/radio/src/gui/480x272/bitmapbuffer.cpp
+++ b/radio/src/gui/480x272/bitmapbuffer.cpp
@@ -348,6 +348,15 @@ void BitmapBuffer::drawSizedText(coord_t x, coord_t y, const char * s, uint8_t l
     else if (fontindex == SMLSIZE_INDEX) {
       drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT-5, TEXT_INVERTED_BGCOLOR);
     }
+    else if (fontindex == MIDSIZE_INDEX) {
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+4, TEXT_INVERTED_BGCOLOR);
+    }
+    else if (fontindex == DBLSIZE_INDEX) {
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+13, TEXT_INVERTED_BGCOLOR);
+    }
+    else if (fontindex == XXLSIZE_INDEX) {
+      drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y+1, width+2*INVERT_HORZ_MARGIN-2, INVERT_LINE_HEIGHT+52, TEXT_INVERTED_BGCOLOR);
+    }
     else {
       drawSolidFilledRect(x-INVERT_HORZ_MARGIN, y, width+2*INVERT_HORZ_MARGIN, INVERT_LINE_HEIGHT, TEXT_INVERTED_BGCOLOR);
     }

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -93,7 +93,7 @@ uint8_t getStringInfo(const char *s)
 
 uint8_t getFontHeight(LcdFlags flags)
 {
-  static const uint8_t heightTable[16] = { 12, 10, 11, 14, 32, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 };
+  static const uint8_t heightTable[16] = { 9, 13, 16, 24, 32, 64, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12 };
   return heightTable[FONTINDEX(flags)];
 }
 


### PR DESCRIPTION
This fixes #4751 

![image](https://cloud.githubusercontent.com/assets/5167938/24700935/0618fcca-19f9-11e7-8f18-69b37405f350.png)
