### PR TITLE
Binding popup : handles premature exit (no pun intended)

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -911,8 +911,14 @@ void menuModelSetup(event_t event)
                       POPUP_MENU_START(onBindMenu);
                       continue;
                     }
-                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND)
+                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND) {
                       newFlag = MODULE_BIND;
+                    }
+                    else {
+                      if (!popupMenuNoItems) {
+                        s_editMode=0;  // this is when popup is exited before a choice is made
+                      }
+                    }
                   }
                   else {
                     newFlag = MODULE_BIND;

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -925,8 +925,14 @@ void menuModelSetup(event_t event)
                       POPUP_MENU_START(onBindMenu);
                       continue;
                     }
-                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND)
+                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND) {
                       newFlag = MODULE_BIND;
+                    }
+                    else {
+                      if (!popupMenuNoItems) {
+                        s_editMode=0;  // this is when popup is exited before a choice is made
+                      }
+                    }
                   }
                   else {
                     newFlag = MODULE_BIND;

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -835,8 +835,14 @@ bool menuModelSetup(event_t event)
                       POPUP_MENU_START(onBindMenu);
                       continue;
                     }
-                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND)
+                    if (moduleFlag[INTERNAL_MODULE] == MODULE_BIND) {
                       newFlag = MODULE_BIND;
+                    }
+                    else {
+                      if (!popupMenuNoItems) {
+                        s_editMode=0;  // this is when popup is exited before a choice is made
+                      }
+                    }
                   }
                   else {
                     newFlag = MODULE_BIND;


### PR DESCRIPTION
This is when someone pushing RTN/EXITG before making an actual mode choice, et would get  kinda stuck with binding selected but not working