### PR TITLE
Move tm_year to unsigned

### DIFF
--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -137,7 +137,7 @@ bool menuRadioSetup(event_t event)
           switch (j) {
             case 0:
               lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, t.tm_year+TM_YEAR_BASE, flags|rowattr);
-              if (rowattr && s_editMode>0) t.tm_year = checkIncDec(event, t.tm_year, 112, 200, 0);
+              if (rowattr && s_editMode>0) t.tm_year = checkIncDec(event, t.tm_year, 112, 127, 0);
               lcdDrawText(lcdNextPos+3, y, "-", flags);
               break;
             case 1:

--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -137,7 +137,7 @@ bool menuRadioSetup(event_t event)
           switch (j) {
             case 0:
               lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, t.tm_year+TM_YEAR_BASE, flags|rowattr);
-              if (rowattr && s_editMode>0) t.tm_year = checkIncDec(event, t.tm_year, 112, 127, 0);
+              if (rowattr && s_editMode>0) t.tm_year = checkIncDec(event, t.tm_year, 112, 200, 0);
               lcdDrawText(lcdNextPos+3, y, "-", flags);
               break;
             case 1:

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -39,7 +39,7 @@ struct gtm
   int8_t tm_hour;                  /* Hours.       [0-23] */
   int8_t tm_mday;                  /* Day.         [1-31] */
   int8_t tm_mon;                   /* Month.       [0-11] */
-  int8_t tm_year;                  /* Year - 1900. Limited to the year 2115. Oh no! :P */
+  uint8_t tm_year;                  /* Year - 1900. Limited to the year 2155. */
   int8_t tm_wday;                  /* Day of week. [0-6] */
   int16_t tm_yday;                 /* Day of year. [0-365] Needed internally for calculations */
 };


### PR DESCRIPTION
Year set is called with 112, 200 limits, overflowing the int8_t type

This fixes #4627