### PR TITLE
Fix DS3231 RTC read/write on AR9X

### DIFF
--- a/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
+++ b/radio/src/targets/sky9x/rtc_ds3231_driver.cpp
@@ -21,14 +21,14 @@
 #include "opentx.h"
 #include "i2c_driver.h"
 
-#define DS3231_I2C_ADDR 0x68
+#define DS3231_I2C_CHIPID 0x68
 
 void readRtc()
 {
   uint8_t buffer[7];
-  uint8_t readBuffer[7];
+  uint8_t address[]= {0,0};
   gtm utm;
-  int res = i2cReadBuffer(DS3231_I2C_ADDR, readBuffer, 2, buffer, 7);
+  int res = i2cReadBuffer(DS3231_I2C_CHIPID, address, 2, buffer, 7);
   if (res != 0)
     return;
 
@@ -46,7 +46,7 @@ void writeRtc(const gtm* ptr)
 {
   g_ms100 = 0; // start of next second begins now
   uint8_t buffer[7];
-  uint8_t read_buffer[7];
+  uint8_t address[]= {0,0};
 
   buffer[0] = toBCD(ptr->tm_sec);
   buffer[1] = toBCD(ptr->tm_min);
@@ -56,7 +56,7 @@ void writeRtc(const gtm* ptr)
   buffer[5] = toBCD(ptr->tm_mon + 1);
   uint8_t offset = ptr->tm_year >= 100 ? 100 : 0;
   buffer[6] = toBCD(ptr->tm_year - offset);
-  i2cWriteBuffer(DS3231_I2C_ADDR, read_buffer, 1, buffer, 7);
+  i2cWriteBuffer(DS3231_I2C_CHIPID, address, 2, buffer, 7);
 }
 
 void rtcSetTime(const struct gtm * t)


### PR DESCRIPTION
There was some feedback recently on the original issue stating that the rtc is broken on ar9x.
This fixes the issue by properly initializing the address buffer to {0,0} (plus i've changed the define to CHIPID instead of ADDR to avoid confusion).