### PR TITLE
fix drawSource

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -873,7 +873,7 @@ void drawSource(coord_t x, coord_t y, uint32_t idx, LcdFlags att)
     }
   }
 #endif
-  else if (idx < MIXSRC_LAST_POT) {
+  else if (idx <= MIXSRC_LAST_POT) {
     idx = idx - MIXSRC_Rud;
     if (ZEXIST(g_eeGeneral.anaNames[idx])) {
       if (idx < MIXSRC_FIRST_POT-MIXSRC_Rud )

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -607,7 +607,7 @@ void drawSource(coord_t x, coord_t y, uint32_t idx, LcdFlags att)
     }
   }
 
-  else if (idx < MIXSRC_LAST_POT) {
+  else if (idx <= MIXSRC_LAST_POT) {
     idx = idx-MIXSRC_Rud;
     if (ZEXIST(g_eeGeneral.anaNames[idx])) {
       if (idx < MIXSRC_FIRST_POT-MIXSRC_Rud )


### PR DESCRIPTION
drawSource was not displaying name when defined for the last POT source. on x7 and x9

X12 does not seem to be exhibiting the issue

This fixes #4840 