### PR TITLE
X7 : Differentiate message for external flashing

### DIFF
--- a/radio/src/io/frsky_sport.cpp
+++ b/radio/src/io/frsky_sport.cpp
@@ -203,8 +203,16 @@ const char * sportUpdatePowerOn(ModuleIndex module)
   if (!IS_FRSKY_SPORT_PROTOCOL()) {
     return TR("Not responding", "Not S.Port 2");
   }
-
+#if defined(PCBX7)
+  if (IS_PCBREV_40()) {
+    return TR("Bottom pin no resp", "Bottom pin not responding");
+  }
+  else {
+    return TR("Module pin no resp", "Module pin not responding");
+  }
+#else
   return TR("Not responding", "Module not responding");
+#endif
 }
 
 const char * sportUpdateReqVersion()


### PR DESCRIPTION
Use hardware revision to help troubleshoot user error.

This fixes #4847