### PR TITLE
3djc/gps display fixes

### DIFF
--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -231,7 +231,7 @@ void menuModelSensor(event_t event)
   SUBMENU(STR_MENUSENSOR, SENSOR_FIELD_MAX, {0, 0, sensor->type == TELEM_TYPE_CALCULATED ? (uint8_t)0 : (uint8_t)1, SENSOR_UNIT_ROWS, SENSOR_PREC_ROWS, SENSOR_PARAM1_ROWS, SENSOR_PARAM2_ROWS, SENSOR_PARAM3_ROWS, SENSOR_PARAM4_ROWS, SENSOR_AUTOOFFSET_ROWS, SENSOR_FILTER_ROWS, SENSOR_PERSISTENT_ROWS, 0 });
   lcdDrawNumber(PSIZE(TR_MENUSENSOR)*FW+1, 0, s_currIdx+1, INVERS|LEFT);
 
-  drawSensorCustomValue(SENSOR_2ND_COLUMN, 0, s_currIdx, getValue(MIXSRC_FIRST_TELEM+3*s_currIdx), LEFT);
+  if (!isGPSSensor(s_currIdx+1)) drawSensorCustomValue(SENSOR_2ND_COLUMN, 0, s_currIdx, getValue(MIXSRC_FIRST_TELEM+3*s_currIdx), LEFT);
 
   int8_t sub = menuVerticalPosition;
 

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -797,7 +797,7 @@ void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, Lcd
   }
   else {
     drawGPSCoord(x, y, telemetryItem.gps.latitude, "NS", att, false);
-    drawGPSCoord(lcdNextPos+FWNUM, y, telemetryItem.gps.longitude, "EW", att, false);
+    drawGPSCoord(lcdLastRightPos+2*FWNUM, y, telemetryItem.gps.longitude, "EW", att, false);
   }
 }
 

--- a/radio/src/gui/212x64/view_telemetry.cpp
+++ b/radio/src/gui/212x64/view_telemetry.cpp
@@ -127,7 +127,8 @@ bool displayNumbersTelemetryScreen(FrSkyScreenData & screen)
           }
         }
         else if (field >= MIXSRC_FIRST_TELEM && isGPSSensor(1+(field-MIXSRC_FIRST_TELEM)/3) && telemetryItems[(field-MIXSRC_FIRST_TELEM)/3].isAvailable()) {
-          // we don't display GPS name, no space for it
+          // we don't display GPS name, no space for it, but we shift x by some pixel to allow it to fit on max coord
+          x -=2;
         }
         else {
           drawSource(pos[j], 1+FH+2*FH*i, field, 0);


### PR DESCRIPTION
This does two things:
- on x7 sensor edit, remove the gps coord display on top bar, it is not usefull and there is not enough place for it

- on X9, adjust display on 'short GPS ' display (like in telemetry setup screen), and adjust the display on telem view for soem coords (-189] and the likes)

Given the little detail given I can only assume it fixes #4834
