### PR TITLE
Projectkk2glider/issue 4827

### DIFF
--- a/radio/src/debug.h
+++ b/radio/src/debug.h
@@ -70,8 +70,18 @@ extern "C" {
 
 #if defined(TRACE_LUA_INTERNALS_ENABLED)
   #define TRACE_LUA_INTERNALS(f_, ...)     debugPrintf(("[LUA INT] " f_ "\r\n"), ##__VA_ARGS__)
+
+  #define TRACE_LUA_INTERNALS_WITH_LINEINFO(L, f_, ...)   do { \
+                                                            lua_Debug ar; \
+                                                            if (lua_getstack(L, 1, &ar)) {  \
+                                                              lua_getinfo(L, ">Sl", &ar); \
+                                                              debugPrintf("%s:%d: ", ar.short_src, ar.currentline); \
+                                                            } \
+                                                            debugPrintf(("[LUA INT] " f_ "\r\n"), ##__VA_ARGS__); \
+                                                          } while(0)
 #else
   #define TRACE_LUA_INTERNALS(...)
+  #define TRACE_LUA_INTERNALS_WITH_LINEINFO(L, f_, ...)
 #endif
 
 #if defined(DEBUG) && !defined(SIMU)

--- a/radio/src/thirdparty/Lua/src/lobject.h
+++ b/radio/src/thirdparty/Lua/src/lobject.h
@@ -569,7 +569,7 @@ typedef struct Node {
 typedef struct Table {
   CommonHeader;
   lu_byte flags;  /* 1<<p means tagmethod(p) is not present */
-  lu_byte lsizenode;  /* size of `node' array */
+  lu_byte lsizenode;  /* log2 of size of `node' array */
   struct Table *metatable;
   TValue *array;  /* array part */
   Node *node;
@@ -588,7 +588,7 @@ typedef struct Table {
 
 
 #define twoto(x)	(1<<(x))
-#define sizenode(t)	((t)->lsizenode)
+#define sizenode(t)	(twoto((t)->lsizenode))
 
 
 /*

--- a/radio/src/thirdparty/Lua/src/lparser.c
+++ b/radio/src/thirdparty/Lua/src/lparser.c
@@ -181,6 +181,7 @@ static void new_localvar (LexState *ls, TString *name) {
   int reg = registerlocalvar(ls, name);
   checklimit(fs, dyd->actvar.n + 1 - fs->firstlocal,
                   MAXVARS, "local variables");
+  TRACE_LUA_INTERNALS("new_localvar %s %d", getstr(name), dyd->actvar.n + 1 - fs->firstlocal);
   luaM_growvector(ls->L, dyd->actvar.arr, dyd->actvar.n + 1,
                   dyd->actvar.size, Vardesc, MAX_INT, "local variables");
   dyd->actvar.arr[dyd->actvar.n++].idx = cast(short, reg);
@@ -1529,6 +1530,7 @@ static void retstat (LexState *ls) {
 static void statement (LexState *ls) {
   int line = ls->linenumber;  /* may be needed for error messages */
   enterlevel(ls);
+  TRACE_LUA_INTERNALS("statement %02x at line %d", ls->t.token, line);
   switch (ls->t.token) {
     case ';': {  /* stat -> ';' (empty statement) */
       luaX_next(ls);  /* skip ';' */

--- a/radio/src/thirdparty/Lua/src/ltable.c
+++ b/radio/src/thirdparty/Lua/src/ltable.c
@@ -306,7 +306,7 @@ void luaH_resize (lua_State *L, Table *t, int nasize, int nhsize) {
   int i;
   int oldasize = t->sizearray;
   int oldhsize = t->lsizenode;
-  TRACE("luaH_resize %d(%d) %d(%d)", nasize, oldasize, nhsize, oldhsize);
+  TRACE_LUA_INTERNALS_WITH_LINEINFO(L, "luaH_resize table %p %d(%d) %d(%d)", t, nasize, oldasize, nhsize, twoto(oldhsize));
   Node *nold = t->node;  /* save old hash ... */
   if (nasize > oldasize)  /* array part must grow? */
     setarrayvector(L, t, nasize);

--- a/radio/src/thirdparty/Lua/src/ltable.c
+++ b/radio/src/thirdparty/Lua/src/ltable.c
@@ -282,16 +282,14 @@ static void setnodevector (lua_State *L, Table *t, int size) {
   int lsize;
   if (size == 0) {  /* no elements to hash part? */
     t->node = cast(Node *, dummynode);  /* use common `dummynode' */
-    lsize = 1;
+    lsize = 0;
   }
   else {
     int i;
-    // lsize = luaO_ceillog2(size);
-    // if (lsize > MAXBITS)
-    //  luaG_runerror(L, "table overflow");
-    // size = twoto(lsize);
-    // size += size/2;
-    lsize = size;
+    lsize = luaO_ceillog2(size);
+    if (lsize > MAXBITS)
+      luaG_runerror(L, "table overflow");
+    size = twoto(lsize);
     t->node = luaM_newvector(L, size, Node);
     for (i=0; i<size; i++) {
       Node *n = gnode(t, i);
@@ -308,6 +306,7 @@ void luaH_resize (lua_State *L, Table *t, int nasize, int nhsize) {
   int i;
   int oldasize = t->sizearray;
   int oldhsize = t->lsizenode;
+  TRACE("luaH_resize %d(%d) %d(%d)", nasize, oldasize, nhsize, oldhsize);
   Node *nold = t->node;  /* save old hash ... */
   if (nasize > oldasize)  /* array part must grow? */
     setarrayvector(L, t, nasize);
@@ -324,7 +323,7 @@ void luaH_resize (lua_State *L, Table *t, int nasize, int nhsize) {
     luaM_reallocvector(L, t->array, oldasize, nasize, TValue);
   }
   /* re-insert elements from hash part */
-  for (i = oldhsize - 1; i >= 0; i--) {
+  for (i = twoto(oldhsize) - 1; i >= 0; i--) {
     Node *old = nold+i;
     if (!ttisnil(gval(old))) {
       /* doesn't need barrier/invalidate cache, as entry was
@@ -333,7 +332,7 @@ void luaH_resize (lua_State *L, Table *t, int nasize, int nhsize) {
     }
   }
   if (!isdummy(nold))
-    luaM_freearray(L, nold, cast(size_t, oldhsize)); /* free old array */
+    luaM_freearray(L, nold, cast(size_t, twoto(oldhsize))); /* free old array */
 }
 
 


### PR DESCRIPTION
Closes #4827 

This reverts part of commit f94b4c7 and restores back the original table hash size calculation. The code before this allowed only 265 hash nodes.

The code now potentially uses more RAM (because it allocates node array in bigger steps), but at the same time there are a lot less node allocations and copying of existing nodes in the new array. Previously each node number increase caused the whole malloc/copy/free process, now it only happens when size overflows a power of two (ie 1, 2, 4, 8, 16, 32, etc,...). So there are a lot less calls to the `rehash()` (which grows a table).

