### PR TITLE
Fix #4881

### DIFF
--- a/radio/src/pulses/pxx_arm.cpp
+++ b/radio/src/pulses/pxx_arm.cpp
@@ -134,7 +134,7 @@ void pxxPutPcmTail(uint8_t port)
 #else
 void pxxPutPcmPart(uint8_t port, uint8_t value)
 {
-  pulse_duration_t duration = value ? 48 : 32;
+  pulse_duration_t duration = value ? 47 : 31;
   *modulePulsesData[port].pxx.ptr++ = duration;
   modulePulsesData[port].pxx.rest -= duration + 1;
 }


### PR DESCRIPTION
Thanks Mike for noticing: In pxx_arm.cpp, the pulse duration is set to either 48 or 32. This value gets put into the ARR register of the timer (via DMA). Counters count from 0 to the ARR value, then go back to 0. This will result in either 49 or 33 counts for the pulse width, thus making the pulses 0.5uS too long.

I tested only with external PXX with my logic analyzer but this code also affects internal pxx.