### PR TITLE
[Companion] Input names formatting 

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -508,7 +508,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
   int genAryIdx = 0;
   switch (type) {
     case SOURCE_TYPE_VIRTUAL_INPUT:
-      result = QObject::tr("[I%1]").arg(index+1);
+      result = QObject::tr("[I%1]").arg(index+1, 2, 10, QChar('0'));
       if (model && model->inputNames[index][0])
           result.append(":" + QString(model->inputNames[index]).trimmed());
       return result;
@@ -550,7 +550,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       return QObject::tr("CYC%1").arg(index+1);
 
     case SOURCE_TYPE_PPM:
-      return QObject::tr("TR%1").arg(index+1);
+      return QObject::tr("TR%1").arg(index+1, 2, 10, QChar('0'));
 
     case SOURCE_TYPE_CH:
       result = QObject::tr("CH%1").arg(index+1, 2, 10, QChar('0'));
@@ -564,7 +564,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     case SOURCE_TYPE_TELEMETRY:
       if (IS_ARM(getCurrentBoard())) {
         div_t qr = div(index, 3);
-        result = model ? QString(model->sensorData[qr.quot].label) : QString("[T%1]").arg(qr.quot+1);
+        result = model ? QString(model->sensorData[qr.quot].label) : QString("[T%1]").arg(qr.quot+1, 2, 10, QChar('0'));
         if (qr.rem)
           result += (qr.rem == 1 ? "-" : "+");
         return result;
@@ -574,7 +574,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       }
 
     case SOURCE_TYPE_GVAR:
-      result = QObject::tr("GV%1").arg(index+1);
+      result = QObject::tr("GV%1").arg(index+1, 2, 10, QChar('0'));
       if (getCurrentFirmware()->getCapability(GvarsName) && model && model->gvars_names[index][0])
         result.append(":" + QString(model->gvars_names[index]).trimmed());
       return result;

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -509,8 +509,9 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
   switch (type) {
     case SOURCE_TYPE_VIRTUAL_INPUT:
       result = QObject::tr("[I%1]").arg(index+1, 2, 10, QChar('0'));
-      if (model && model->inputNames[index][0])
-          result.append(":" + QString(model->inputNames[index]).trimmed());
+      result.append(QString(model->inputNames[index]).trimmed());
+      //if (model && model->inputNames[index][0])
+      //  result.append(":" + QString(model->inputNames[index]).trimmed());
       return result;
 
     case SOURCE_TYPE_LUA_OUTPUT:

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -509,9 +509,8 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
   switch (type) {
     case SOURCE_TYPE_VIRTUAL_INPUT:
       result = QObject::tr("[I%1]").arg(index+1, 2, 10, QChar('0'));
-      result.append(QString(model->inputNames[index]).trimmed());
-      //if (model && model->inputNames[index][0])
-      //  result.append(":" + QString(model->inputNames[index]).trimmed());
+      if (model && model->inputNames[index][0])
+        result.append(/*":" + */QString(model->inputNames[index]).trimmed());
       return result;
 
     case SOURCE_TYPE_LUA_OUTPUT:

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -41,7 +41,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     cb_fp[i] = tmp[i];
   }
 
-  setWindowTitle(tr("Edit %1").arg(modelPrinter.printInputName(ed->chn)));
+  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_STICK);
+  setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
   QRegExp rx(CHAR_FOR_NAMES_REGEX);
 
   if (IS_HORUS_OR_TARANIS(getCurrentBoard())) {

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -153,26 +153,26 @@ bool InputsPanel::AddInputLine(int dest)
 QString InputsPanel::getInputText(int dest, bool * new_ch)
 {
   QString str;
-  if (new_ch) *new_ch = 0;
+
+  if (new_ch)
+    *new_ch = false;
+
   if (dest < 0) {
     str = modelPrinter.printInputName(-dest-1);
-    if (new_ch) *new_ch = 1;
+    if (new_ch)
+      *new_ch = true;
   }
   else {
     ExpoData & input = model->expoData[dest];
+    int nameChars = (firmware->getCapability(VirtualInputs) ? 10 : 4);
 
     if ((dest == 0) || (model->expoData[dest-1].chn != input.chn)) {
-      if (new_ch) *new_ch = 1;
-      if (firmware->getCapability(VirtualInputs))
-        str += QString("%1").arg(modelPrinter.printInputName(input.chn), -10, ' ');
-      else
-        str = modelPrinter.printInputName(input.chn);
+      if (new_ch)
+        *new_ch = true;
+      str = QString("%1").arg(modelPrinter.printInputName(input.chn), -nameChars, QChar(' '));
     }
     else {
-      if (firmware->getCapability(VirtualInputs))
-        str = "          ";
-      else
-        str = "   ";
+      str = QString(nameChars, QChar(' '));
     }
     str.replace(" ", "&nbsp;");
     str += modelPrinter.printInputLine(input);

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -40,7 +40,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, G
     cb_fp[i] = tmp[i];
   }
 
-  this->setWindowTitle(tr("DEST -> CH%1").arg(md->destCh));
+  this->setWindowTitle(tr("DEST -> %1").arg(RawSource(SOURCE_TYPE_CH, md->destCh-1).toString(&model, &generalSettings)));
 
   ui->sourceCB->setModel(Helpers::getRawSourceItemModel(&generalSettings, &model, POPULATE_NONE | POPULATE_SOURCES | POPULATE_SCRIPT_OUTPUTS | POPULATE_VIRTUAL_INPUTS | POPULATE_SWITCHES | POPULATE_TRIMS));
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -327,20 +327,8 @@ QString ModelPrinter::printRotaryEncoder(int flightModeIndex, int reIndex)
 
 QString ModelPrinter::printInputName(int idx)
 {
-  QString result;
-  if (firmware->getCapability(VirtualInputs)) {
-    if (strlen(model.inputNames[idx]) > 0) {
-      result = tr("[I%1]").arg(idx+1);
-      result += QString(model.inputNames[idx]);
-    }
-    else {
-      result = tr("Input%1").arg(idx+1, 2, 10, QChar('0'));
-    }
-  }
-  else {
-    result = RawSource(SOURCE_TYPE_STICK, idx).toString(&model, &generalSettings);
-  }
-  return result.toHtmlEscaped();
+  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_STICK);
+  return RawSource(srcType, idx).toString(&model, &generalSettings).toHtmlEscaped();
 }
 
 QString ModelPrinter::printInputLine(int idx)


### PR DESCRIPTION
Re: #4879 

With colons after input number:
![image](https://cloud.githubusercontent.com/assets/1366615/25653326/637d7608-2fba-11e7-8a9c-b39dd10ca41a.png)
![image](https://cloud.githubusercontent.com/assets/1366615/25653329/690b9514-2fba-11e7-9dbb-17e17b6315f8.png)


Without colons (current version of this code):
![image](https://cloud.githubusercontent.com/assets/1366615/25653113/7dc8b1c2-2fb9-11e7-8115-fb2d31a7f70b.png)
![image](https://cloud.githubusercontent.com/assets/1366615/25653128/871adf98-2fb9-11e7-8655-80c4bc7dd5c6.png)

(Those are from someone's actual radio file.)

I'd rather just pick a version and stick to it, vs. making exceptions in the code for the different view types.  If we're to have exceptions then they should at least be systematic, eg. a "verbose" view vs. "short" view, or whatever.  IMHO.