### PR TITLE
[Companion] Fix a few translations.

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -21,6 +21,8 @@
 #ifndef _CONSTANTS_H_
 #define _CONSTANTS_H_
 
+#include <QCoreApplication>
+
 #define CPN_MAX_MODELS                 60
 #define CPN_MAX_TIMERS                 3
 #define CPN_MAX_FLIGHT_MODES           9
@@ -47,23 +49,23 @@
 #define CPN_MAX_MOUSE_ANALOGS          2
 #define CPN_MAX_ANALOGS                (CPN_MAX_STICKS + CPN_MAX_POTS + CPN_MAX_MOUSE_ANALOGS)
 
-#define CPN_STR_FILES                  QT_TRANSLATE_NOOP("CompanionMacros", "files")
-#define CPN_STR_RAD_MOD_SETTINGS       QT_TRANSLATE_NOOP("CompanionMacros", "Radio and Models settings")
-#define HEX_FILES_FILTER               "HEX " CPN_STR_FILES " (*.hex);;"
-#define BIN_FILES_FILTER               "BIN " CPN_STR_FILES " (*.bin);;"
-#define DFU_FILES_FILTER               "DFU " CPN_STR_FILES " (*.dfu);;"
-#define EEPE_FILES_FILTER              "EEPE " CPN_STR_FILES " (*.eepe);;"
-#define OTX_FILES_FILTER               "OpenTX " CPN_STR_FILES " (*.otx);;"
-#define EEPROM_FILES_FILTER            CPN_STR_RAD_MOD_SETTINGS " " CPN_STR_FILES " (*.otx *.eepe *.bin *.hex);;" OTX_FILES_FILTER EEPE_FILES_FILTER BIN_FILES_FILTER HEX_FILES_FILTER
-#define FLASH_FILES_FILTER             "FLASH " CPN_STR_FILES " (*.bin *.hex *.dfu);;" BIN_FILES_FILTER HEX_FILES_FILTER DFU_FILES_FILTER
-#define EXTERNAL_EEPROM_FILES_FILTER   "EEPROM " CPN_STR_FILES " (*.bin *.hex);;" BIN_FILES_FILTER HEX_FILES_FILTER
+#define CPN_STR_FILES                  QCoreApplication::translate("Companion", "files")
+#define CPN_STR_RAD_MOD_SETTINGS       QCoreApplication::translate("Companion", "Radio and Models settings")
+#define HEX_FILES_FILTER               "HEX " % CPN_STR_FILES % " (*.hex);;"
+#define BIN_FILES_FILTER               "BIN " % CPN_STR_FILES % " (*.bin);;"
+#define DFU_FILES_FILTER               "DFU " % CPN_STR_FILES % " (*.dfu);;"
+#define EEPE_FILES_FILTER              "EEPE " % CPN_STR_FILES % " (*.eepe);;"
+#define OTX_FILES_FILTER               "OpenTX " % CPN_STR_FILES % " (*.otx);;"
+#define EEPROM_FILES_FILTER            CPN_STR_RAD_MOD_SETTINGS % " " % CPN_STR_FILES % " (*.otx *.eepe *.bin *.hex);;" % OTX_FILES_FILTER % EEPE_FILES_FILTER % BIN_FILES_FILTER % HEX_FILES_FILTER
+#define FLASH_FILES_FILTER             "FLASH " % CPN_STR_FILES % " (*.bin *.hex *.dfu);;" % BIN_FILES_FILTER % HEX_FILES_FILTER % DFU_FILES_FILTER
+#define EXTERNAL_EEPROM_FILES_FILTER   "EEPROM " % CPN_STR_FILES % " (*.bin *.hex);;" % BIN_FILES_FILTER % HEX_FILES_FILTER
 #define ER9X_EEPROM_FILE_TYPE          "ER9X_EEPROM_FILE"
 #define EEPE_EEPROM_FILE_HEADER        "EEPE EEPROM FILE"
 #define EEPE_MODEL_FILE_HEADER         "EEPE MODEL FILE"
 
-#define CPN_STR_SW_INDICATOR_UP        QT_TRANSLATE_NOOP("RawSwitch", "\xE2\x86\x91")   // Switch up position indicator: Up arrow, or similar.
-#define CPN_STR_SW_INDICATOR_DN        QT_TRANSLATE_NOOP("RawSwitch", "\xE2\x86\x93")  // Switch down position indicator: Down arrow, or similar.
-#define CPN_STR_SW_INDICATOR_NEUT      QT_TRANSLATE_NOOP("RawSwitch", "-")             // Switch neutral (middle) position indicator.
-#define CPN_STR_SW_INDICATOR_REV       QT_TRANSLATE_NOOP("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
+#define CPN_STR_SW_INDICATOR_UP        QCoreApplication::translate("RawSwitch", "\xE2\x86\x91")  // Switch up position indicator: Up arrow, or similar.
+#define CPN_STR_SW_INDICATOR_DN        QCoreApplication::translate("RawSwitch", "\xE2\x86\x93")  // Switch down position indicator: Down arrow, or similar.
+#define CPN_STR_SW_INDICATOR_NEUT      QCoreApplication::translate("RawSwitch", "-")             // Switch neutral (middle) position indicator.
+#define CPN_STR_SW_INDICATOR_REV       QCoreApplication::translate("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
 
 #endif // _CONSTANTS_H_

--- a/companion/src/flasheepromdialog.cpp
+++ b/companion/src/flasheepromdialog.cpp
@@ -102,7 +102,7 @@ void FlashEEpromDialog::updateUI()
 
 void FlashEEpromDialog::on_eepromLoad_clicked()
 {
-  QString filename = QFileDialog::getOpenFileName(this, tr("Choose Radio Backup file"), g.eepromDir(), tr(EXTERNAL_EEPROM_FILES_FILTER));
+  QString filename = QFileDialog::getOpenFileName(this, tr("Choose Radio Backup file"), g.eepromDir(), EXTERNAL_EEPROM_FILES_FILTER);
   if (!filename.isEmpty()) {
     eepromFilename = filename;
     updateUI();

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -657,9 +657,7 @@ void MainWindow::openFile(const QString & fileName, bool updateLastUsedDir)
 
 void MainWindow::openFile()
 {
-  QString fileFilter;
-  fileFilter = tr(EEPROM_FILES_FILTER);
-  QString fileName = QFileDialog::getOpenFileName(this, tr("Open Models and Settings file"), g.eepromDir(), fileFilter);
+  QString fileName = QFileDialog::getOpenFileName(this, tr("Open Models and Settings file"), g.eepromDir(), EEPROM_FILES_FILTER);
   openFile(fileName);
 }
 
@@ -861,7 +859,7 @@ void MainWindow::readBackup()
     return;
     // TODO implementation
   }
-  QString fileName = QFileDialog::getSaveFileName(this, tr("Save Radio Backup to File"), g.eepromDir(), tr(EXTERNAL_EEPROM_FILES_FILTER));
+  QString fileName = QFileDialog::getSaveFileName(this, tr("Save Radio Backup to File"), g.eepromDir(), EXTERNAL_EEPROM_FILES_FILTER);
   if (!fileName.isEmpty()) {
     if (!readEepromFromRadio(fileName))
       return;
@@ -870,7 +868,7 @@ void MainWindow::readBackup()
 
 void MainWindow::readFlash()
 {
-  QString fileName = QFileDialog::getSaveFileName(this,tr("Read Radio Firmware to File"), g.flashDir(),tr(FLASH_FILES_FILTER));
+  QString fileName = QFileDialog::getSaveFileName(this,tr("Read Radio Firmware to File"), g.flashDir(), FLASH_FILES_FILTER);
   if (!fileName.isEmpty()) {
     readFirmwareFromRadio(fileName);
   }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1480,7 +1480,7 @@ void MdiChild::writeEeprom()  // write to Tx
 
 bool MdiChild::loadBackup()
 {
-  QString fileName = QFileDialog::getOpenFileName(this, tr("Open backup Models and Settings file"), g.eepromDir(), tr(EEPROM_FILES_FILTER));
+  QString fileName = QFileDialog::getOpenFileName(this, tr("Open backup Models and Settings file"), g.eepromDir(), EEPROM_FILES_FILTER);
   if (fileName.isEmpty())
     return false;
   QFile file(fileName);

--- a/companion/src/simulation/simulateduiwidget9X.cpp
+++ b/companion/src/simulation/simulateduiwidget9X.cpp
@@ -48,12 +48,12 @@ SimulatedUIWidget9X::SimulatedUIWidget9X(SimulatorInterface * simulator, QWidget
 
   polygon.clear();
   polygon << QPoint(x, y) << polyArc(x, y, oR, 45, 135);
-  act = new RadioUiAction(4, QList<int>() << Qt::Key_Right << Qt::Key_Minus, SIMU_STR_HLP_KEY_RGT % " " % SIMU_STR_HLP_KEY_MIN, SIMU_STR_HLP_ACT_MIN);
+  act = new RadioUiAction(4, QList<int>() << Qt::Key_Right << Qt::Key_Minus, SIMU_STR_HLP_KEY_RGT % "|" % SIMU_STR_HLP_KEY_MIN, SIMU_STR_HLP_ACT_MIN);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursmin.png", act));
 
   polygon.clear();
   polygon << QPoint(x, y) << polyArc(x, y, oR, 225, 315);
-  act = new RadioUiAction(5, QList<int>() << Qt::Key_Left << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_LFT % " " % SIMU_STR_HLP_KEY_PLS, SIMU_STR_HLP_ACT_PLS);
+  act = new RadioUiAction(5, QList<int>() << Qt::Key_Left << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_LFT % "|" % SIMU_STR_HLP_KEY_PLS, SIMU_STR_HLP_ACT_PLS);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursplus.png", act));
 
   act = new RadioUiAction(0, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEY_ENTER, SIMU_STR_HLP_ACT_MENU);
@@ -61,7 +61,7 @@ SimulatedUIWidget9X::SimulatedUIWidget9X(SimulatorInterface * simulator, QWidget
 
   if (!hasRotEnc) {
     m_mouseMidClickAction = act;
-    m_mouseMidClickAction->setText(act->getText() % " " % SIMU_STR_HLP_MOUSE_MID);
+    m_mouseMidClickAction->setText(act->getText() % "|" % SIMU_STR_HLP_MOUSE_MID);
   }
 
   act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_EXIT);
@@ -70,8 +70,8 @@ SimulatedUIWidget9X::SimulatedUIWidget9X(SimulatorInterface * simulator, QWidget
   addRadioWidget(ui->leftbuttons->addArea(QRect(6, 149, 30, 30), "9X/9xcursphoto.png", m_screenshotAction));
 
   if (hasRotEnc) {
-    addRadioAction(new RadioUiAction(-1, 0, SIMU_STR_HLP_MOUSE_SCRL, SIMU_STR_HLP_ROTENC % " " % SIMU_STR_HLP_ROTENC_LR));
-    m_mouseMidClickAction = new RadioUiAction(14, Qt::Key_Insert, SIMU_STR_HLP_KEY_INS % " " % SIMU_STR_HLP_MOUSE_MID,  SIMU_STR_HLP_ACT_ROT_DN);
+    addRadioAction(new RadioUiAction(-1, 0, SIMU_STR_HLP_MOUSE_SCRL, SIMU_STR_HLP_ROTENC % "|" % SIMU_STR_HLP_ROTENC_LR));
+    m_mouseMidClickAction = new RadioUiAction(14, Qt::Key_Insert, SIMU_STR_HLP_KEY_INS % "|" % SIMU_STR_HLP_MOUSE_MID,  SIMU_STR_HLP_ACT_ROT_DN);
     addRadioWidget(ui->leftbuttons->addArea(QRect(0, 0, 0, 0), "9X/9xcurs.png", m_mouseMidClickAction));
   }
 

--- a/companion/src/simulation/simulateduiwidget9X.cpp
+++ b/companion/src/simulation/simulateduiwidget9X.cpp
@@ -38,40 +38,40 @@ SimulatedUIWidget9X::SimulatedUIWidget9X(SimulatorInterface * simulator, QWidget
   int x = 68, y = 91, oR = 63;
 
   polygon << QPoint(x, y) << polyArc(x, y, oR, -45, 45);
-  act = new RadioUiAction(3, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, tr(SIMU_STR_HLP_KEYS_GO_UP) % (hasRotEnc ? "" :  tr("|" SIMU_STR_HLP_MOUSE_UP)), tr(SIMU_STR_HLP_ACT_UP));
+  act = new RadioUiAction(3, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, SIMU_STR_HLP_KEYS_GO_UP % (hasRotEnc ? QString("") :  "|" % SIMU_STR_HLP_MOUSE_UP), SIMU_STR_HLP_ACT_UP);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursup.png", act));
 
   polygon.clear();
   polygon << QPoint(x, y) << polyArc(x, y, oR, 135, 225);
-  act = new RadioUiAction(2, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, tr(SIMU_STR_HLP_KEYS_GO_DN) % (hasRotEnc ? "" :  tr("|" SIMU_STR_HLP_MOUSE_DN)), tr(SIMU_STR_HLP_ACT_DN));
+  act = new RadioUiAction(2, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, SIMU_STR_HLP_KEYS_GO_DN % (hasRotEnc ? QString("") :  "|" % SIMU_STR_HLP_MOUSE_DN), SIMU_STR_HLP_ACT_DN);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursdown.png", act));
 
   polygon.clear();
   polygon << QPoint(x, y) << polyArc(x, y, oR, 45, 135);
-  act = new RadioUiAction(4, QList<int>() << Qt::Key_Right << Qt::Key_Minus, tr(SIMU_STR_HLP_KEY_RGT "|" SIMU_STR_HLP_KEY_MIN), tr(SIMU_STR_HLP_ACT_MIN));
+  act = new RadioUiAction(4, QList<int>() << Qt::Key_Right << Qt::Key_Minus, SIMU_STR_HLP_KEY_RGT % " " % SIMU_STR_HLP_KEY_MIN, SIMU_STR_HLP_ACT_MIN);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursmin.png", act));
 
   polygon.clear();
   polygon << QPoint(x, y) << polyArc(x, y, oR, 225, 315);
-  act = new RadioUiAction(5, QList<int>() << Qt::Key_Left << Qt::Key_Plus << Qt::Key_Equal, tr(SIMU_STR_HLP_KEY_LFT "|" SIMU_STR_HLP_KEY_PLS), tr(SIMU_STR_HLP_ACT_PLS));
+  act = new RadioUiAction(5, QList<int>() << Qt::Key_Left << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_LFT % " " % SIMU_STR_HLP_KEY_PLS, SIMU_STR_HLP_ACT_PLS);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "9X/9xcursplus.png", act));
 
-  act = new RadioUiAction(0, QList<int>() << Qt::Key_Enter << Qt::Key_Return, tr(SIMU_STR_HLP_KEY_ENTER), tr(SIMU_STR_HLP_ACT_MENU));
+  act = new RadioUiAction(0, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEY_ENTER, SIMU_STR_HLP_ACT_MENU);
   addRadioWidget(ui->rightbuttons->addArea(QRect(16, 54, 60, 34), "9X/9xmenumenu.png", act));
 
   if (!hasRotEnc) {
     m_mouseMidClickAction = act;
-    m_mouseMidClickAction->setText(act->getText() % "|" SIMU_STR_HLP_MOUSE_MID);
+    m_mouseMidClickAction->setText(act->getText() % " " % SIMU_STR_HLP_MOUSE_MID);
   }
 
-  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, tr(SIMU_STR_HLP_KEYS_EXIT), tr(SIMU_STR_HLP_ACT_EXIT));
+  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_EXIT);
   addRadioWidget(ui->rightbuttons->addArea(QRect(16, 114, 60, 34), "9X/9xmenuexit.png", act));
 
   addRadioWidget(ui->leftbuttons->addArea(QRect(6, 149, 30, 30), "9X/9xcursphoto.png", m_screenshotAction));
 
   if (hasRotEnc) {
-    addRadioAction(new RadioUiAction(-1, 0, tr(SIMU_STR_HLP_MOUSE_SCRL), tr(SIMU_STR_HLP_ROTENC " " SIMU_STR_HLP_ROTENC_LR)));
-    m_mouseMidClickAction = new RadioUiAction(14, Qt::Key_Insert, tr(SIMU_STR_HLP_KEY_INS "|" SIMU_STR_HLP_MOUSE_MID),  tr(SIMU_STR_HLP_ACT_ROT_DN));
+    addRadioAction(new RadioUiAction(-1, 0, SIMU_STR_HLP_MOUSE_SCRL, SIMU_STR_HLP_ROTENC % " " % SIMU_STR_HLP_ROTENC_LR));
+    m_mouseMidClickAction = new RadioUiAction(14, Qt::Key_Insert, SIMU_STR_HLP_KEY_INS % " " % SIMU_STR_HLP_MOUSE_MID,  SIMU_STR_HLP_ACT_ROT_DN);
     addRadioWidget(ui->leftbuttons->addArea(QRect(0, 0, 0, 0), "9X/9xcurs.png", m_mouseMidClickAction));
   }
 

--- a/companion/src/simulation/simulateduiwidgetX12.cpp
+++ b/companion/src/simulation/simulateduiwidgetX12.cpp
@@ -64,8 +64,8 @@ SimulatedUIWidgetX12::SimulatedUIWidgetX12(SimulatorInterface *simulator, QWidge
                          SIMU_STR_HLP_KEY_DN % "<br>" % SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_RTN);
   addRadioWidget(ui->rightbuttons->addArea(polygon, "Horus/right_btnD.png", act));
 
-  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus, SIMU_STR_HLP_KEY_MIN % " " % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_ROT_LFT);
-  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_PLS % " " % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_ROT_RGT);
+  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus, SIMU_STR_HLP_KEY_MIN % "|" % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_ROT_LFT);
+  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_PLS % "|" % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_ROT_RGT);
   connectScrollActions();
 
   m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEYS_ACTIVATE, SIMU_STR_HLP_ACT_ROT_DN);

--- a/companion/src/simulation/simulateduiwidgetX12.cpp
+++ b/companion/src/simulation/simulateduiwidgetX12.cpp
@@ -35,40 +35,40 @@ SimulatedUIWidgetX12::SimulatedUIWidgetX12(SimulatorInterface *simulator, QWidge
   int x = 74, y = 190, oR = 63, iR = 40;
 
   polygon << polyArc(x, y, oR, 225, 315) << polyArc(x, y, iR, 225, 315);
-  act = new RadioUiAction(0, QList<int>() << Qt::Key_PageUp, tr(SIMU_STR_HLP_KEY_PGUP), tr(SIMU_STR_HLP_ACT_PGUP));
+  act = new RadioUiAction(0, QList<int>() << Qt::Key_PageUp, SIMU_STR_HLP_KEY_PGUP, SIMU_STR_HLP_ACT_PGUP);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "Horus/left_btn1.png", act));
 
   polygon.clear();
   polygon << polyArc(x, y, oR, 135, 225) << polyArc(x, y, iR, 135, 225);
-  act = new RadioUiAction(1, QList<int>() << Qt::Key_PageDown, tr(SIMU_STR_HLP_KEY_PGDN), tr(SIMU_STR_HLP_ACT_PGDN));
+  act = new RadioUiAction(1, QList<int>() << Qt::Key_PageDown, SIMU_STR_HLP_KEY_PGDN, SIMU_STR_HLP_ACT_PGDN);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "Horus/left_btn2.png", act));
 
   polygon.clear();
   polygon << polyArc(x, y, oR, -45, 45) << polyArc(x, y, iR, -45, 45);
-  act = new RadioUiAction(3, QList<int>() << Qt::Key_Up, tr(SIMU_STR_HLP_KEY_UP), tr(SIMU_STR_HLP_ACT_MDL));
+  act = new RadioUiAction(3, QList<int>() << Qt::Key_Up, SIMU_STR_HLP_KEY_UP, SIMU_STR_HLP_ACT_MDL);
   addRadioWidget(ui->rightbuttons->addArea(polygon, "Horus/right_btnU.png", act));
 
   polygon.clear();
   polygon << polyArc(x, y, oR, 225, 315) << polyArc(x, y, iR, 225, 315);
-  act = new RadioUiAction(6, QList<int>() << Qt::Key_Left, tr(SIMU_STR_HLP_KEY_LFT), tr(SIMU_STR_HLP_ACT_SYS));
+  act = new RadioUiAction(6, QList<int>() << Qt::Key_Left, SIMU_STR_HLP_KEY_LFT, SIMU_STR_HLP_ACT_SYS);
   addRadioWidget(ui->rightbuttons->addArea(polygon, "Horus/right_btnL.png", act));
 
   polygon.clear();
   polygon << polyArc(x, y, oR, 45, 135) << polyArc(x, y, iR, 45, 135);
-  act = new RadioUiAction(5, QList<int>() << Qt::Key_Right, tr(SIMU_STR_HLP_KEY_RGT), tr(SIMU_STR_HLP_ACT_TELE));
+  act = new RadioUiAction(5, QList<int>() << Qt::Key_Right, SIMU_STR_HLP_KEY_RGT, SIMU_STR_HLP_ACT_TELE);
   addRadioWidget(ui->rightbuttons->addArea(polygon, "Horus/right_btnR.png", act));
 
   polygon.clear();
   polygon << polyArc(x, y, oR, 135, 225) << polyArc(x, y, iR, 135, 225);
   act = new RadioUiAction(4, QList<int>() << Qt::Key_Down << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace,
-                         tr(SIMU_STR_HLP_KEY_DN "<br>" SIMU_STR_HLP_KEYS_EXIT), tr(SIMU_STR_HLP_ACT_RTN));
+                         SIMU_STR_HLP_KEY_DN % "<br>" % SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_RTN);
   addRadioWidget(ui->rightbuttons->addArea(polygon, "Horus/right_btnD.png", act));
 
-  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus, tr(SIMU_STR_HLP_KEY_MIN "|" SIMU_STR_HLP_MOUSE_UP), tr(SIMU_STR_HLP_ACT_ROT_LFT));
-  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal, tr(SIMU_STR_HLP_KEY_PLS "|" SIMU_STR_HLP_MOUSE_DN), tr(SIMU_STR_HLP_ACT_ROT_RGT));
+  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus, SIMU_STR_HLP_KEY_MIN % " " % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_ROT_LFT);
+  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal, SIMU_STR_HLP_KEY_PLS % " " % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_ROT_RGT);
   connectScrollActions();
 
-  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, tr(SIMU_STR_HLP_KEYS_ACTIVATE), tr(SIMU_STR_HLP_ACT_ROT_DN));
+  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEYS_ACTIVATE, SIMU_STR_HLP_ACT_ROT_DN);
   addRadioWidget(ui->rightbuttons->addArea(polyArc(x, y, iR), "Horus/right_ent.png", m_mouseMidClickAction));
 
   addRadioWidget(ui->leftbuttons->addArea(QRect(9, 259, 30, 30), "Horus/left_scrnsht.png", m_screenshotAction));

--- a/companion/src/simulation/simulateduiwidgetX7.cpp
+++ b/companion/src/simulation/simulateduiwidgetX7.cpp
@@ -14,22 +14,22 @@ SimulatedUIWidgetX7::SimulatedUIWidgetX7(SimulatorInterface *simulator, QWidget 
 
   QPoint ctr(70, 91);
   polygon << polyArc(ctr.x(), ctr.y(), 50, -90, 90) << polyArc(ctr.x(), ctr.y(), 22, -90, 90);
-  act = new RadioUiAction(3, QList<int>() << Qt::Key_PageUp << Qt::Key_Up, tr(SIMU_STR_HLP_KEYS_GO_UP), tr(SIMU_STR_HLP_ACT_PAGE));
+  act = new RadioUiAction(3, QList<int>() << Qt::Key_PageUp << Qt::Key_Up, SIMU_STR_HLP_KEYS_GO_UP, SIMU_STR_HLP_ACT_PAGE);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "X7/left_page.png", act));
 
-  act = new RadioUiAction(0, QList<int>() << Qt::Key_PageDown << Qt::Key_Down, tr(SIMU_STR_HLP_KEYS_GO_DN), tr(SIMU_STR_HLP_ACT_MENU_ICN));
+  act = new RadioUiAction(0, QList<int>() << Qt::Key_PageDown << Qt::Key_Down, SIMU_STR_HLP_KEYS_GO_DN, SIMU_STR_HLP_ACT_MENU_ICN);
   addRadioWidget(ui->leftbuttons->addArea(polyArc(ctr.x(), ctr.y(), 20), "X7/left_menu.png", act));
 
   polygon.clear();
   polygon << polyArc(ctr.x(), ctr.y(), 50, 90, 270) << polyArc(ctr.x(), ctr.y(), 22, 90, 270);
-  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, tr(SIMU_STR_HLP_KEYS_EXIT), tr(SIMU_STR_HLP_ACT_EXIT));
+  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_EXIT);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "X7/left_exit.png", act));
 
-  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus << Qt::Key_Equal << Qt::Key_Left, tr(SIMU_STR_HLP_KEYS_GO_LFT), tr(SIMU_STR_HLP_ACT_ROT_LFT));
-  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Right, tr(SIMU_STR_HLP_KEYS_GO_RGT), tr(SIMU_STR_HLP_ACT_ROT_RGT));
+  m_scrollUpAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Minus << Qt::Key_Equal << Qt::Key_Left, SIMU_STR_HLP_KEYS_GO_LFT, SIMU_STR_HLP_ACT_ROT_LFT);
+  m_scrollDnAction = new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Right, SIMU_STR_HLP_KEYS_GO_RGT, SIMU_STR_HLP_ACT_ROT_RGT);
   connectScrollActions();
 
-  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, tr(SIMU_STR_HLP_KEYS_ACTIVATE), tr(SIMU_STR_HLP_ACT_ROT_DN));
+  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEYS_ACTIVATE, SIMU_STR_HLP_ACT_ROT_DN);
   addRadioWidget(ui->rightbuttons->addArea(polyArc(88, 92, 33), "X7/right_ent.png", m_mouseMidClickAction));
 
   addRadioWidget(ui->leftbuttons->addArea(QRect(9, 154, 30, 30), "X7/left_scrnshot.png", m_screenshotAction));

--- a/companion/src/simulation/simulateduiwidgetX9.cpp
+++ b/companion/src/simulation/simulateduiwidgetX9.cpp
@@ -37,21 +37,21 @@ SimulatedUIWidgetX9::SimulatedUIWidgetX9(SimulatorInterface *simulator, QWidget 
 
   // left side
 
-  act = new RadioUiAction(0, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, tr(SIMU_STR_HLP_KEYS_GO_UP), tr(SIMU_STR_HLP_ACT_MENU));
+  act = new RadioUiAction(0, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, SIMU_STR_HLP_KEYS_GO_UP, SIMU_STR_HLP_ACT_MENU);
   addRadioWidget(ui->leftbuttons->addArea(btn, "Taranis/x9l1.png", act));
   btn.moveTop(btn.top() + btn.height() + vsp);
 
-  act = new RadioUiAction(3, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, tr(SIMU_STR_HLP_KEYS_GO_DN), tr(SIMU_STR_HLP_ACT_PAGE));
+  act = new RadioUiAction(3, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, SIMU_STR_HLP_KEYS_GO_DN, SIMU_STR_HLP_ACT_PAGE);
   addRadioWidget(ui->leftbuttons->addArea(btn, "Taranis/x9l2.png", act));
   btn.moveTop(btn.top() + btn.height() + vsp);
 
-  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, tr(SIMU_STR_HLP_KEYS_EXIT), tr(SIMU_STR_HLP_ACT_EXIT));
+  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_EXIT);
   addRadioWidget(ui->leftbuttons->addArea(btn, "Taranis/x9l3.png", act));
 
   m_scrollUpAction = new RadioUiAction(4, QList<int>() << Qt::Key_Plus << Qt::Key_Equal << Qt::Key_Left,
-                                      tr(SIMU_STR_HLP_KEY_LFT "|" SIMU_STR_HLP_KEY_PLS "|" SIMU_STR_HLP_MOUSE_UP), tr(SIMU_STR_HLP_ACT_PLS));
+                                      SIMU_STR_HLP_KEY_LFT % " " % SIMU_STR_HLP_KEY_PLS % " " % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_PLS);
   m_scrollDnAction = new RadioUiAction(5, QList<int>() << Qt::Key_Minus << Qt::Key_Right,
-                                      tr(SIMU_STR_HLP_KEY_RGT "|" SIMU_STR_HLP_KEY_MIN "|" SIMU_STR_HLP_MOUSE_DN), tr(SIMU_STR_HLP_ACT_MIN));
+                                      SIMU_STR_HLP_KEY_RGT % " " % SIMU_STR_HLP_KEY_MIN % " " % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_MIN);
 
   // right side
   btn.moveTopLeft(QPoint(58, btop));
@@ -62,7 +62,7 @@ SimulatedUIWidgetX9::SimulatedUIWidgetX9(SimulatorInterface *simulator, QWidget 
   addRadioWidget(ui->rightbuttons->addArea(btn, "Taranis/x9r2.png", m_scrollDnAction));
   btn.moveTop(btn.top() + btn.height() + vsp);
 
-  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, tr(SIMU_STR_HLP_KEYS_ACTIVATE), tr(SIMU_STR_HLP_ACT_ENT));
+  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEYS_ACTIVATE, SIMU_STR_HLP_ACT_ENT);
   addRadioWidget(ui->rightbuttons->addArea(btn, "Taranis/x9r3.png", m_mouseMidClickAction));
 
   addRadioWidget(ui->leftbuttons->addArea(QRect(89, 177, 30, 20), "Taranis/x9l4.png", m_screenshotAction));

--- a/companion/src/simulation/simulateduiwidgetX9.cpp
+++ b/companion/src/simulation/simulateduiwidgetX9.cpp
@@ -49,9 +49,9 @@ SimulatedUIWidgetX9::SimulatedUIWidgetX9(SimulatorInterface *simulator, QWidget 
   addRadioWidget(ui->leftbuttons->addArea(btn, "Taranis/x9l3.png", act));
 
   m_scrollUpAction = new RadioUiAction(4, QList<int>() << Qt::Key_Plus << Qt::Key_Equal << Qt::Key_Left,
-                                      SIMU_STR_HLP_KEY_LFT % " " % SIMU_STR_HLP_KEY_PLS % " " % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_PLS);
+                                      SIMU_STR_HLP_KEY_LFT % "|" % SIMU_STR_HLP_KEY_PLS % "|" % SIMU_STR_HLP_MOUSE_UP, SIMU_STR_HLP_ACT_PLS);
   m_scrollDnAction = new RadioUiAction(5, QList<int>() << Qt::Key_Minus << Qt::Key_Right,
-                                      SIMU_STR_HLP_KEY_RGT % " " % SIMU_STR_HLP_KEY_MIN % " " % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_MIN);
+                                      SIMU_STR_HLP_KEY_RGT % "|" % SIMU_STR_HLP_KEY_MIN % "|" % SIMU_STR_HLP_MOUSE_DN, SIMU_STR_HLP_ACT_MIN);
 
   // right side
   btn.moveTopLeft(QPoint(58, btop));

--- a/companion/src/simulation/simulateduiwidgetX9E.cpp
+++ b/companion/src/simulation/simulateduiwidgetX9E.cpp
@@ -35,24 +35,24 @@ SimulatedUIWidgetX9E::SimulatedUIWidgetX9E(SimulatorInterface *simulator, QWidge
   QPoint ctr(70, 100);
 
   polygon << polyArc(ctr.x(), ctr.y(), 60, -90, 0) << ctr;
-  act = new RadioUiAction(0, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, tr(SIMU_STR_HLP_KEYS_GO_UP), tr(SIMU_STR_HLP_ACT_MENU));
+  act = new RadioUiAction(0, QList<int>() << Qt::Key_Up << Qt::Key_PageUp, SIMU_STR_HLP_KEYS_GO_UP, SIMU_STR_HLP_ACT_MENU);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "X9E/left_menu.png", act));
 
   polygon.clear();
   polygon << polyArc(ctr.x(), ctr.y(), 45, 0, 180);
-  act = new RadioUiAction(3, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, tr(SIMU_STR_HLP_KEYS_GO_DN), tr(SIMU_STR_HLP_ACT_PAGE));
+  act = new RadioUiAction(3, QList<int>() << Qt::Key_Down << Qt::Key_PageDown, SIMU_STR_HLP_KEYS_GO_DN, SIMU_STR_HLP_ACT_PAGE);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "X9E/left_page.png", act));
 
   polygon.clear();
   polygon << polyArc(ctr.x(), ctr.y(), 60, 180, 270) << ctr;
-  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, tr(SIMU_STR_HLP_KEYS_EXIT), tr(SIMU_STR_HLP_ACT_EXIT));
+  act = new RadioUiAction(1, QList<int>() << Qt::Key_Delete << Qt::Key_Escape << Qt::Key_Backspace, SIMU_STR_HLP_KEYS_EXIT, SIMU_STR_HLP_ACT_EXIT);
   addRadioWidget(ui->leftbuttons->addArea(polygon, "X9E/left_exit.png", act));
 
-  m_scrollUpAction = addRadioAction(new RadioUiAction(-1, QList<int>() << Qt::Key_Minus << Qt::Key_Left, tr(SIMU_STR_HLP_KEYS_GO_LFT), tr(SIMU_STR_HLP_ACT_ROT_LFT)));
-  m_scrollDnAction = addRadioAction(new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal << Qt::Key_Right, tr(SIMU_STR_HLP_KEYS_GO_RGT), tr(SIMU_STR_HLP_ACT_ROT_RGT)));
+  m_scrollUpAction = addRadioAction(new RadioUiAction(-1, QList<int>() << Qt::Key_Minus << Qt::Key_Left, SIMU_STR_HLP_KEYS_GO_LFT, SIMU_STR_HLP_ACT_ROT_LFT));
+  m_scrollDnAction = addRadioAction(new RadioUiAction(-1, QList<int>() << Qt::Key_Plus << Qt::Key_Equal << Qt::Key_Right, SIMU_STR_HLP_KEYS_GO_RGT, SIMU_STR_HLP_ACT_ROT_RGT));
   connectScrollActions();
 
-  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, tr(SIMU_STR_HLP_KEYS_ACTIVATE), tr(SIMU_STR_HLP_ACT_ROT_DN));
+  m_mouseMidClickAction = new RadioUiAction(2, QList<int>() << Qt::Key_Enter << Qt::Key_Return, SIMU_STR_HLP_KEYS_ACTIVATE, SIMU_STR_HLP_ACT_ROT_DN);
   addRadioWidget(ui->rightbuttons->addArea(polyArc(90, 100, 50), "X9E/right_enter.png", m_mouseMidClickAction));
 
   addRadioWidget(ui->leftbuttons->addArea(QRect(10, 170, 30, 30), "X9E/left_scrnshot.png", m_screenshotAction));

--- a/companion/src/simulation/simulator_strings.h
+++ b/companion/src/simulation/simulator_strings.h
@@ -1,66 +1,66 @@
 #ifndef SIMULATOR_STRINGS_H
 #define SIMULATOR_STRINGS_H
 
-#include <QtGlobal>
+#include <QCoreApplication>
 
-#define SIMU_STR_HLP_KEY_ENTER         QT_TRANSLATE_NOOP("SimulatedUIWidget", "ENTER")
-#define SIMU_STR_HLP_KEY_PGUP          QT_TRANSLATE_NOOP("SimulatedUIWidget", "PG-UP")
-#define SIMU_STR_HLP_KEY_PGDN          QT_TRANSLATE_NOOP("SimulatedUIWidget", "PG-DN")
-#define SIMU_STR_HLP_KEY_DEL           QT_TRANSLATE_NOOP("SimulatedUIWidget", "DEL")
-#define SIMU_STR_HLP_KEY_BKSP          QT_TRANSLATE_NOOP("SimulatedUIWidget", "BKSP")
-#define SIMU_STR_HLP_KEY_ESC           QT_TRANSLATE_NOOP("SimulatedUIWidget", "ESC")
-#define SIMU_STR_HLP_KEY_INS           QT_TRANSLATE_NOOP("SimulatedUIWidget", "INS")
-#define SIMU_STR_HLP_KEY_PLS           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>+</font>")
-#define SIMU_STR_HLP_KEY_MIN           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>-</font>")
+#define SIMU_STR_HLP_KEY_ENTER         QCoreApplication::translate("SimulatedUIWidget", "ENTER")
+#define SIMU_STR_HLP_KEY_PGUP          QCoreApplication::translate("SimulatedUIWidget", "PG-UP")
+#define SIMU_STR_HLP_KEY_PGDN          QCoreApplication::translate("SimulatedUIWidget", "PG-DN")
+#define SIMU_STR_HLP_KEY_DEL           QCoreApplication::translate("SimulatedUIWidget", "DEL")
+#define SIMU_STR_HLP_KEY_BKSP          QCoreApplication::translate("SimulatedUIWidget", "BKSP")
+#define SIMU_STR_HLP_KEY_ESC           QCoreApplication::translate("SimulatedUIWidget", "ESC")
+#define SIMU_STR_HLP_KEY_INS           QCoreApplication::translate("SimulatedUIWidget", "INS")
+#define SIMU_STR_HLP_KEY_PLS           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>+</font>")
+#define SIMU_STR_HLP_KEY_MIN           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>-</font>")
 
-#define SIMU_STR_HLP_KEY_LFT           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&larr;</font>")  // ←
-#define SIMU_STR_HLP_KEY_RGT           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&rarr;</font>")  // →
-#define SIMU_STR_HLP_KEY_UP            QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&uarr;</font>")  // ↑
-#define SIMU_STR_HLP_KEY_DN            QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&darr;</font>")  // ↓
+#define SIMU_STR_HLP_KEY_LFT           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&larr;</font>")  // ←
+#define SIMU_STR_HLP_KEY_RGT           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&rarr;</font>")  // →
+#define SIMU_STR_HLP_KEY_UP            QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&uarr;</font>")  // ↑
+#define SIMU_STR_HLP_KEY_DN            QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&darr;</font>")  // ↓
 
-#define SIMU_STR_HLP_ROTENC            QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x2686;</font>")  // ⚆
-#define SIMU_STR_HLP_ROTENC_LFT        QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21b6;</font>")  // ↶
-#define SIMU_STR_HLP_ROTENC_RGT        QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21b7;</font>")  // ↷
-#define SIMU_STR_HLP_ROTENC_LR         QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21c6;</font>")  // ⇆
-#define SIMU_STR_HLP_ROTENC_DN         QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21d3;</font>")  // ⇓
+#define SIMU_STR_HLP_ROTENC            QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x2686;</font>")  // ⚆
+#define SIMU_STR_HLP_ROTENC_LFT        QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21b6;</font>")  // ↶
+#define SIMU_STR_HLP_ROTENC_RGT        QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21b7;</font>")  // ↷
+#define SIMU_STR_HLP_ROTENC_LR         QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21c6;</font>")  // ⇆
+#define SIMU_STR_HLP_ROTENC_DN         QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21d3;</font>")  // ⇓
 
-#define SIMU_STR_HLP_SCRL_UP           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21d1;</font>")  // ⇑
-#define SIMU_STR_HLP_SCRL_DN           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21d3;</font>")  // ⇓
-#define SIMU_STR_HLP_SCRL_UD           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x21d5;</font>")  // ⇕
+#define SIMU_STR_HLP_SCRL_UP           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21d1;</font>")  // ⇑
+#define SIMU_STR_HLP_SCRL_DN           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21d3;</font>")  // ⇓
+#define SIMU_STR_HLP_SCRL_UD           QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x21d5;</font>")  // ⇕
 
-#define SIMU_STR_HLP_MOUSE             QT_TRANSLATE_NOOP("SimulatedUIWidget", "<img src='qrc:/images/simulator/icons/svg/mouse.svg' width=20 height=18 />")
-#define SIMU_STR_HLP_CLICK             QT_TRANSLATE_NOOP("SimulatedUIWidget", "<img src='qrc:/images/simulator/icons/svg/arrow_click.svg' width=18 height=18 />")
-#define SIMU_STR_HLP_MOUSE_MID         SIMU_STR_HLP_MOUSE SIMU_STR_HLP_CLICK
-#define SIMU_STR_HLP_MOUSE_UP          SIMU_STR_HLP_MOUSE SIMU_STR_HLP_SCRL_UP
-#define SIMU_STR_HLP_MOUSE_DN          SIMU_STR_HLP_MOUSE SIMU_STR_HLP_SCRL_DN
-#define SIMU_STR_HLP_MOUSE_SCRL        SIMU_STR_HLP_MOUSE SIMU_STR_HLP_SCRL_UD
+#define SIMU_STR_HLP_MOUSE             QCoreApplication::translate("SimulatedUIWidget", "<img src='qrc:/images/simulator/icons/svg/mouse.svg' width=20 height=18 />")
+#define SIMU_STR_HLP_CLICK             QCoreApplication::translate("SimulatedUIWidget", "<img src='qrc:/images/simulator/icons/svg/arrow_click.svg' width=18 height=18 />")
+#define SIMU_STR_HLP_MOUSE_MID         SIMU_STR_HLP_MOUSE % SIMU_STR_HLP_CLICK
+#define SIMU_STR_HLP_MOUSE_UP          SIMU_STR_HLP_MOUSE % SIMU_STR_HLP_SCRL_UP
+#define SIMU_STR_HLP_MOUSE_DN          SIMU_STR_HLP_MOUSE % SIMU_STR_HLP_SCRL_DN
+#define SIMU_STR_HLP_MOUSE_SCRL        SIMU_STR_HLP_MOUSE % SIMU_STR_HLP_SCRL_UD
 
-#define SIMU_STR_HLP_ACT_MENU          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ MENU ]</pre>")
-#define SIMU_STR_HLP_ACT_PAGE          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ PAGE ]</pre>")
-#define SIMU_STR_HLP_ACT_EXIT          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ EXIT ]</pre>")
-#define SIMU_STR_HLP_ACT_ENT           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ ENT ]</pre>")
-#define SIMU_STR_HLP_ACT_UP            QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ UP ]</pre>")
-#define SIMU_STR_HLP_ACT_DN            QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ DN ]</pre>")
-#define SIMU_STR_HLP_ACT_PLS           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ <font size=+2>+</font> ]</pre>")
-#define SIMU_STR_HLP_ACT_MIN           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ <font size=+2>-</font> ]</pre>")
-#define SIMU_STR_HLP_ACT_PGUP          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ PgUp ]</pre>")
-#define SIMU_STR_HLP_ACT_PGDN          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ PgDn ]</pre>")
-#define SIMU_STR_HLP_ACT_MDL           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ MDL ]</pre>")
-#define SIMU_STR_HLP_ACT_RTN           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ RTN ]</pre>")
-#define SIMU_STR_HLP_ACT_SYS           QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ SYS ]</pre>")
-#define SIMU_STR_HLP_ACT_TELE          QT_TRANSLATE_NOOP("SimulatedUIWidget", "<pre>[ TELE ]</pre>")
-#define SIMU_STR_HLP_ACT_MENU_ICN      QT_TRANSLATE_NOOP("SimulatedUIWidget", "<font size=+3>&#x2261;</font>")  // ≡
+#define SIMU_STR_HLP_ACT_MENU          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ MENU ]</pre>")
+#define SIMU_STR_HLP_ACT_PAGE          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ PAGE ]</pre>")
+#define SIMU_STR_HLP_ACT_EXIT          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ EXIT ]</pre>")
+#define SIMU_STR_HLP_ACT_ENT           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ ENT ]</pre>")
+#define SIMU_STR_HLP_ACT_UP            QCoreApplication::translate("SimulatedUIWidget", "<pre>[ UP ]</pre>")
+#define SIMU_STR_HLP_ACT_DN            QCoreApplication::translate("SimulatedUIWidget", "<pre>[ DN ]</pre>")
+#define SIMU_STR_HLP_ACT_PLS           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ <font size=+2>+</font> ]</pre>")
+#define SIMU_STR_HLP_ACT_MIN           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ <font size=+2>-</font> ]</pre>")
+#define SIMU_STR_HLP_ACT_PGUP          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ PgUp ]</pre>")
+#define SIMU_STR_HLP_ACT_PGDN          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ PgDn ]</pre>")
+#define SIMU_STR_HLP_ACT_MDL           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ MDL ]</pre>")
+#define SIMU_STR_HLP_ACT_RTN           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ RTN ]</pre>")
+#define SIMU_STR_HLP_ACT_SYS           QCoreApplication::translate("SimulatedUIWidget", "<pre>[ SYS ]</pre>")
+#define SIMU_STR_HLP_ACT_TELE          QCoreApplication::translate("SimulatedUIWidget", "<pre>[ TELE ]</pre>")
+#define SIMU_STR_HLP_ACT_MENU_ICN      QCoreApplication::translate("SimulatedUIWidget", "<font size=+3>&#x2261;</font>")  // ≡
 
 
-#define SIMU_STR_HLP_KEYS_EXIT         SIMU_STR_HLP_KEY_DEL "|" SIMU_STR_HLP_KEY_BKSP "|" SIMU_STR_HLP_KEY_ESC
-#define SIMU_STR_HLP_KEYS_ACTIVATE     SIMU_STR_HLP_KEY_ENTER "|" SIMU_STR_HLP_MOUSE_MID
-#define SIMU_STR_HLP_KEYS_GO_UP        SIMU_STR_HLP_KEY_UP "|" SIMU_STR_HLP_KEY_PGUP
-#define SIMU_STR_HLP_KEYS_GO_DN        SIMU_STR_HLP_KEY_DN "|" SIMU_STR_HLP_KEY_PGDN
-#define SIMU_STR_HLP_KEYS_GO_LFT       SIMU_STR_HLP_KEY_LFT "|" SIMU_STR_HLP_KEY_MIN "|" SIMU_STR_HLP_MOUSE_UP
-#define SIMU_STR_HLP_KEYS_GO_RGT       SIMU_STR_HLP_KEY_RGT "|" SIMU_STR_HLP_KEY_PLS "|" SIMU_STR_HLP_MOUSE_DN
+#define SIMU_STR_HLP_KEYS_EXIT         SIMU_STR_HLP_KEY_DEL % "|" % SIMU_STR_HLP_KEY_BKSP % "|" % SIMU_STR_HLP_KEY_ESC
+#define SIMU_STR_HLP_KEYS_ACTIVATE     SIMU_STR_HLP_KEY_ENTER % "|" % SIMU_STR_HLP_MOUSE_MID
+#define SIMU_STR_HLP_KEYS_GO_UP        SIMU_STR_HLP_KEY_UP % "|" % SIMU_STR_HLP_KEY_PGUP
+#define SIMU_STR_HLP_KEYS_GO_DN        SIMU_STR_HLP_KEY_DN % "|" % SIMU_STR_HLP_KEY_PGDN
+#define SIMU_STR_HLP_KEYS_GO_LFT       SIMU_STR_HLP_KEY_LFT % "|" % SIMU_STR_HLP_KEY_MIN % "|" % SIMU_STR_HLP_MOUSE_UP
+#define SIMU_STR_HLP_KEYS_GO_RGT       SIMU_STR_HLP_KEY_RGT % "|" % SIMU_STR_HLP_KEY_PLS % "|" % SIMU_STR_HLP_MOUSE_DN
 
-#define SIMU_STR_HLP_ACT_ROT_LFT       SIMU_STR_HLP_ROTENC " " SIMU_STR_HLP_ROTENC_LFT
-#define SIMU_STR_HLP_ACT_ROT_RGT       SIMU_STR_HLP_ROTENC " " SIMU_STR_HLP_ROTENC_RGT
-#define SIMU_STR_HLP_ACT_ROT_DN        SIMU_STR_HLP_ROTENC " " SIMU_STR_HLP_ROTENC_DN
+#define SIMU_STR_HLP_ACT_ROT_LFT       SIMU_STR_HLP_ROTENC % " " % SIMU_STR_HLP_ROTENC_LFT
+#define SIMU_STR_HLP_ACT_ROT_RGT       SIMU_STR_HLP_ROTENC % " " % SIMU_STR_HLP_ROTENC_RGT
+#define SIMU_STR_HLP_ACT_ROT_DN        SIMU_STR_HLP_ROTENC % " " % SIMU_STR_HLP_ROTENC_DN
 
 #endif // SIMULATOR_STRINGS_H

--- a/companion/src/simulation/simulatorstartupdialog.cpp
+++ b/companion/src/simulation/simulatorstartupdialog.cpp
@@ -227,7 +227,7 @@ void SimulatorStartupDialog::onRadioTypeChanged(int index)
 
 void SimulatorStartupDialog::onDataFileSelect(bool)
 {
-  QString filter = tr(EEPROM_FILES_FILTER) + tr("All files (*.*)");
+  QString filter = EEPROM_FILES_FILTER % tr("All files (*.*)");
   QString file = QFileDialog::getSaveFileName(this, QObject::tr("Select a data file"), ui->dataFile->text(),
                                               filter, NULL, QFileDialog::DontConfirmOverwrite);
   if (!file.isEmpty()) {


### PR DESCRIPTION
This will not require re-translating anything, just updates the system to actually use any translations already available (macros using `QT_TRANSLATE_NOOP` macro apparently do not work).  Only affects simulator keymap help strings, and some prompts in file selector dialogs.