### PR TITLE
[Companion] Some radio settings Hardware tab fixes.

### DIFF
--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -215,7 +215,7 @@ void HardwarePanel::on_PPM2_editingFinished()
 
 void HardwarePanel::on_PPM3_editingFinished()
 {
-  if (generalSettings.trainer.calib[2] = ui->PPM3->value()) {
+  if (generalSettings.trainer.calib[2] != ui->PPM3->value()) {
     generalSettings.trainer.calib[2] = ui->PPM3->value();
     emit modified();
   }

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -110,6 +110,8 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
     ui->thrName->hide();
     ui->ailLabel->hide();
     ui->ailName->hide();
+    ui->potsTypeSeparator_1->hide();
+    ui->potsTypeSeparator_2->hide();
   }
 
   setupPotType(0, ui->pot1Label, ui->pot1Name, ui->pot1Type);
@@ -141,10 +143,11 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
   setupSwitchType(16, ui->sqLabel, ui->sqName, ui->sqType);
   setupSwitchType(17, ui->srLabel, ui->srName, ui->srType);
 
-  if (IS_HORUS_OR_TARANIS(board) && !IS_TARANIS_X7(board)) {
+  if (IS_TARANIS(board) && !IS_TARANIS_X7(board)) {
     ui->serialPortMode->setCurrentIndex(generalSettings.hw_uartMode);
   }
   else {
+    ui->serialPortMode->setCurrentIndex(0);
     ui->serialPortMode->hide();
     ui->serialPortLabel->hide();
   }
@@ -160,8 +163,7 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
   }
   else {
     ui->bluetoothLabel->hide();
-    ui->bluetoothEnable->hide();
-    ui->bluetoothName->hide();
+    ui->bluetoothWidget->hide();
   }
 
   if (IS_HORUS_OR_TARANIS(board)) {
@@ -188,39 +190,52 @@ void HardwarePanel::on_filterEnable_stateChanged()
 
 void HardwarePanel::on_PPM_MultiplierDSB_editingFinished()
 {
-  generalSettings.PPM_Multiplier = (int)(ui->PPM_MultiplierDSB->value()*10)-10;
-  emit modified();
+  int val = (int)(ui->PPM_MultiplierDSB->value()*10)-10;
+  if (generalSettings.PPM_Multiplier != val) {
+    generalSettings.PPM_Multiplier = val;
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_PPM1_editingFinished()
 {
-  generalSettings.trainer.calib[0] = ui->PPM1->value();
-  emit modified();
+  if (generalSettings.trainer.calib[0] != ui->PPM1->value()) {
+    generalSettings.trainer.calib[0] = ui->PPM1->value();
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_PPM2_editingFinished()
 {
-  generalSettings.trainer.calib[1] = ui->PPM2->value();
-  emit modified();
+  if (generalSettings.trainer.calib[1] != ui->PPM2->value()) {
+    generalSettings.trainer.calib[1] = ui->PPM2->value();
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_PPM3_editingFinished()
 {
-  generalSettings.trainer.calib[2] = ui->PPM3->value();
-  emit modified();
+  if (generalSettings.trainer.calib[2] = ui->PPM3->value()) {
+    generalSettings.trainer.calib[2] = ui->PPM3->value();
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_PPM4_editingFinished()
 {
-  generalSettings.trainer.calib[3] = ui->PPM4->value();
-  emit modified();
+  if (generalSettings.trainer.calib[3] != ui->PPM4->value()) {
+    generalSettings.trainer.calib[3] = ui->PPM4->value();
+    emit modified();
+  }
 }
 
 
-void HardwarePanel::on_txCurrentHardware_editingFinished()
+void HardwarePanel::on_txCurrentCalibration_editingFinished()
 {
-  generalSettings.txCurrentCalibration = ui->txCurrentCalibration->value();
-  emit modified();
+  if (generalSettings.txCurrentCalibration != ui->txCurrentCalibration->value()) {
+    generalSettings.txCurrentCalibration = ui->txCurrentCalibration->value();
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_bluetoothEnable_stateChanged(int)
@@ -241,10 +256,12 @@ void HardwarePanel::setValues()
   ui->PPM_MultiplierDSB->setValue((qreal)(generalSettings.PPM_Multiplier+10)/10);
 }
 
-void HardwarePanel::on_txVoltageHardware_editingFinished()
+void HardwarePanel::on_txVoltageCalibration_editingFinished()
 {
-  generalSettings.txVoltageCalibration = ui->txVoltageCalibration->value()*10;
-  emit modified();
+  if (generalSettings.txVoltageCalibration != ui->txVoltageCalibration->value()*10) {
+    generalSettings.txVoltageCalibration = ui->txVoltageCalibration->value()*10;
+    emit modified();
+  }
 }
 
 void HardwarePanel::on_serialPortMode_currentIndexChanged(int index)

--- a/companion/src/generaledit/hardware.h
+++ b/companion/src/generaledit/hardware.h
@@ -40,14 +40,14 @@ class HardwarePanel : public GeneralPanel
     virtual ~HardwarePanel();
 
   private slots:
-    void on_txVoltageHardware_editingFinished();
     void on_PPM1_editingFinished();
     void on_PPM2_editingFinished();
     void on_PPM3_editingFinished();
     void on_PPM4_editingFinished();
     void on_PPM_MultiplierDSB_editingFinished();
 
-    void on_txCurrentHardware_editingFinished();
+    void on_txCurrentCalibration_editingFinished();
+    void on_txVoltageCalibration_editingFinished();
     void on_bluetoothEnable_stateChanged(int);
     void on_filterEnable_stateChanged();
 

--- a/companion/src/generaledit/hardware.ui
+++ b/companion/src/generaledit/hardware.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+  <layout class="QGridLayout" name="gridLayout_2">
    <property name="spacing">
     <number>6</number>
    </property>
@@ -1083,12 +1083,43 @@
    <item row="32" column="1">
     <widget class="QWidget" name="bluetoothWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QCheckBox" name="bluetoothEnable">
         <property name="text">
          <string/>
         </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <widget class="QLabel" name="btNameLabel">

--- a/companion/src/generaledit/hardware.ui
+++ b/companion/src/generaledit/hardware.ui
@@ -6,14 +6,23 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>359</width>
-    <height>1594</height>
+    <width>470</width>
+    <height>1095</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
+  <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0">
+   <property name="spacing">
+    <number>6</number>
+   </property>
    <item row="29" column="0">
     <widget class="QLabel" name="sqLabel">
      <property name="text">
@@ -122,19 +131,6 @@
     <widget class="QLabel" name="label_33">
      <property name="text">
       <string>PPM 2</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="5">
-    <widget class="Line" name="potsTypeSeparator_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
@@ -730,32 +726,6 @@
      </property>
     </widget>
    </item>
-   <item row="31" column="0" colspan="4">
-    <widget class="Line" name="potsTypeSeparator_3">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="38" column="0" colspan="4">
-    <widget class="Line" name="potsTypeSeparator_4">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
    <item row="25" column="0">
     <widget class="QLabel" name="smLabel">
      <property name="text">
@@ -1075,6 +1045,12 @@
    </item>
    <item row="32" column="0">
     <widget class="QLabel" name="bluetoothLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>Bluetooth</string>
      </property>
@@ -1090,24 +1066,6 @@
      </property>
     </widget>
    </item>
-   <item row="32" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="bluetoothEnable">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="AutoLineEdit" name="bluetoothName">
-       <property name="maxLength">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="33" column="1">
     <widget class="QCheckBox" name="filterEnable">
      <property name="text">
@@ -1122,18 +1080,84 @@
      </property>
     </widget>
    </item>
+   <item row="32" column="1">
+    <widget class="QWidget" name="bluetoothWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="bluetoothEnable">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="btNameLabel">
+        <property name="text">
+         <string>Device Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="AutoLineEdit" name="bluetoothName">
+        <property name="maxLength">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="31" column="0" colspan="3">
+    <widget class="Line" name="potsTypeSeparator_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="38" column="0" colspan="3">
+    <widget class="Line" name="ppmSeparator">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="3">
+    <widget class="Line" name="potsTypeSeparator_1">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AutoLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>autolineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>AutoComboBox</class>
    <extends>QComboBox</extends>
    <header>autocombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>AutoLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>autolineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
- Hide external serial port option for Horus; 
- Fix battery voltage and current calibration changes not registering (wrong signal handler name); 
- Prevent modified() event if edited value wasn't actually changed (this is a problem in all panels with onEditingFinished() signals if focus is placed & removed on an editable field by eg. click or tab); 
- Fix some cosmetic layout issues when no hardware names are editable (vertical stretch, extra separators).