### PR TITLE
[Companion] Model Setup: Prevent bogus modification signals.

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -480,7 +480,7 @@ void ModulePanel::update()
     ui->optionValue->setMinimum(pdef.getOptionMin());
     ui->optionValue->setMaximum(pdef.getOptionMax());
     ui->optionValue->setValue(module.multi.optionValue);
-    ui->label_option->setText(pdef.optionsstr);
+    ui->label_option->setText(qApp->translate("Multiprotocols", qPrintable(pdef.optionsstr)));
   }
   ui->multiSubType->setCurrentIndex(module.subType);
 
@@ -576,8 +576,8 @@ void ModulePanel::on_channelsCount_editingFinished()
 
 void ModulePanel::on_channelsStart_editingFinished()
 {
-  if (!lock && module.channelsStart != ui->channelsStart->value() - 1) {
-    module.channelsStart = ui->channelsStart->value() - 1;
+  if (!lock && module.channelsStart != (unsigned)ui->channelsStart->value() - 1) {
+    module.channelsStart = (unsigned)ui->channelsStart->value() - 1;
     update();
     emit channelsRangeChanged();
     emit modified();
@@ -595,8 +595,8 @@ void ModulePanel::on_ppmDelay_editingFinished()
 
 void ModulePanel::on_rxNumber_editingFinished()
 {
-  if (module.modelId != ui->rxNumber->value()) {
-    module.modelId = ui->rxNumber->value();
+  if (module.modelId != (unsigned)ui->rxNumber->value()) {
+    module.modelId = (unsigned)ui->rxNumber->value();
     emit modified();
   }
 }

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -71,7 +71,7 @@ class ModulePanel : public ModelPanel
   private slots:
     void setupFailsafes();
     void on_trainerMode_currentIndexChanged(int index);
-    void on_protocol_currentIndexChanged(int index);
+    void onProtocolChanged(int index);
     void on_ppmDelay_editingFinished();
     void on_channelsCount_editingFinished();
     void on_channelsStart_editingFinished();
@@ -81,7 +81,7 @@ class ModulePanel : public ModelPanel
     void on_antennaMode_currentIndexChanged(int index);
     void on_rxNumber_editingFinished();
     void on_failsafeMode_currentIndexChanged(int value);
-    void on_multiProtocol_currentIndexChanged(int index);
+    void onMultiProtocolChanged(int index);
     void on_multiSubType_currentIndexChanged(int index);
     void on_autoBind_stateChanged(int state);
     void on_lowPower_stateChanged(int state);
@@ -140,7 +140,6 @@ class SetupPanel : public ModelPanel
     void startupSwitchToggled(bool checked);
     void potWarningToggled(bool checked);
     void on_potWarningMode_currentIndexChanged(int index);
-    void onChildModified();
 
   private:
     Ui::Setup *ui;

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -22,6 +22,7 @@
 #include "modelprinter.h"
 #include "multiprotocols.h"
 
+#include <QApplication>
 #include <QPainter>
 #include <QFile>
 #include <QUrl>

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -146,7 +146,7 @@ QString ModelPrinter::printMultiSubType(int rfProtocol, bool custom, unsigned in
   Multiprotocols::MultiProtocolDefinition pdef = multiProtocols.getProtocol(rfProtocol);
 
   if (subType < (unsigned int) pdef.subTypeStrings.size())
-    return pdef.subTypeStrings[subType];
+    return qApp->translate("Multiprotocols", qPrintable(pdef.subTypeStrings[subType]));
   else
     return "???";
 }


### PR DESCRIPTION
Eg. when populating protocols box or when removing focus from some fields w/out the value actually changing.  Especially affects OS X which puts the focus in the model name field by default and (at least in some cases) emits the modified signal right away even when nothing changed.  Similar to #4895 in that respect.