### PR TITLE
[Companion] Inputs and Mixes lists formatting & DnD fixes:

### DIFF
--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -54,7 +54,6 @@ class InputsPanel : public ModelPanel
   private:
     bool expoInserted;
     MixersListWidget *ExposlistWidget;
-    bool firstLine;
     int inputsCount;
     ModelPrinter modelPrinter;
 

--- a/companion/src/modeledit/mixerslistwidget.h
+++ b/companion/src/modeledit/mixerslistwidget.h
@@ -22,9 +22,9 @@
 #define _MIXERSLISTWIDGET_H_
 
 #include <QtWidgets>
-
-#define MIX_ROW_HEIGHT_INCREASE     8               //how much space is added above mixer row (for new channel), if 0 space adding is disabled
-const int  GroupHeaderRole = (Qt::UserRole+2);      //defines new user role for list items. If value is > 0, then space is added before that item
+#include <QProxyStyle>
+#include <QStyleOption>
+#include <QStyledItemDelegate>
 
 class MixersListWidget : public QListWidget
 {
@@ -40,13 +40,15 @@ class MixersListWidget : public QListWidget
     void keyWasPressed(QKeyEvent *event);
 
   public slots:
+    void addItem(QListWidgetItem *item, const unsigned & rowId, bool topLevel = false, bool hasSib = false);
     bool dropMimeData(int index, const QMimeData *data, Qt::DropAction action);
+    void zoomView();
 
   protected:
     virtual QStringList mimeTypes() const;
 
   private:
-    QPoint dragStartPosition;
+    QString itemMimeFmt;
     bool expo;
 
 };
@@ -60,14 +62,25 @@ class MixersDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
   public:
-    inline MixersDelegate(QObject *parent) : QStyledItemDelegate(parent) {};
+    inline MixersDelegate(QObject *parent) : QStyledItemDelegate(parent) {}
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     QSize sizeHint ( const QStyleOptionViewItem & option, const QModelIndex & index ) const;
 
   private:
-    void SetupDocument(QTextDocument & doc, const QStyleOptionViewItem & options) const;
+    void SetupDocument(QTextDocument & doc, const QStyleOptionViewItem & options, const QModelIndex & index) const;
 
+};
+
+/**
+  @brief Provides custom painting of items on a per-element basis, eg. to change style of drop indicator
+*/
+class MixerItemViewProxyStyle: public QProxyStyle
+{
+  public:
+    explicit MixerItemViewProxyStyle(QStyle * style = 0) : QProxyStyle(style) {}
+
+    void drawPrimitive(PrimitiveElement element, const QStyleOption * option, QPainter * painter, const QWidget * widget = 0) const;
 };
 
 #endif // _MIXERSLISTWIDGET_H_


### PR DESCRIPTION
  * Fix/improve margin/padding issues, consistent between inp/mix views, better handling of x-platform and older Qt (closes #4599, closes #4341);
  * Allow dropping onto lines instead of only between them;
  * Fix dropped data always going to line above the actual drop target (closes #4622);
  * Force DnD _move_ operations between windows to _copy_ data instead (fixes deletion of any selected line in target window, and source line was never actually removed but looked like it was);
  * Add alternate-row coloring for each Input/Mixer group;
  * Fix non-contrasting selected row font color on Linux & OS X (was black on blue);
  * Add actions to change font size (size persists until app close);
  * Show inactive lines with dimmer font for input/channel name;
  * Make drop indicator more obvious;
  * Restore mouse hover highlight (Win), which also helps indicate actual drop target (also re: #4622);
  * cosmetics: Code indentation in MixersListWidget.

I couldn't decide on a good text size between all platforms, so I made it adjustable (but it does not save to settings, for now).  The font tries to find "Courier" and reverts to the system default monospace font if it can't be found.

![image](https://cloud.githubusercontent.com/assets/1366615/25986390/c0eea9ec-36bd-11e7-9b74-fb5ea091c9ed.png)
![image](https://cloud.githubusercontent.com/assets/1366615/25986394/c7b32faa-36bd-11e7-9987-59fcb25f5682.png)

Linux Qt 5.7
![image](https://cloud.githubusercontent.com/assets/1366615/25986401/d0990fe0-36bd-11e7-92b4-04029fd512df.png)
![image](https://cloud.githubusercontent.com/assets/1366615/25986412/de0f2fce-36bd-11e7-89c0-106c2ff94801.png)

Linux Qt 5.2 "native" Mint 17.2
![image](https://cloud.githubusercontent.com/assets/1366615/25986420/e5a0cee6-36bd-11e7-9a4f-5e30549fd06e.png)

![image](https://cloud.githubusercontent.com/assets/1366615/25986445/fd8e8138-36bd-11e7-8251-1cf2c5dbe48a.png)
![image](https://cloud.githubusercontent.com/assets/1366615/25986447/012c1c60-36be-11e7-8deb-75bc13626ea2.png)

And one "before" reminder:
![image](https://cloud.githubusercontent.com/assets/1366615/25986460/0ad7d966-36be-11e7-870a-f2e12e3c7b2d.png)


