### PR TITLE
[Companion] Speed up findMassstoragePath() for SD Sync dialog.

### DIFF
--- a/companion/src/process_flash.cpp
+++ b/companion/src/process_flash.cpp
@@ -34,7 +34,6 @@
 #define sleep(x) Sleep(x*1000)
 #else
 #include <unistd.h>
-#include "mountlist.h"
 #endif
 
 FlashProcess::FlashProcess(const QString &cmd, const QStringList &args, ProgressWidget *progress):
@@ -240,7 +239,7 @@ void FlashProcess::onReadyReadStandardError()
 void FlashProcess::errorWizard()
 {
   QString output = progress->getText();
-  
+
   if (output.contains("avrdude: Expected signature for")) { // wrong signature
     int pos = output.indexOf("avrdude: Device signature = ");
     bool fwexist = false;


### PR DESCRIPTION
As a followup to #4906 , figured out why the initial scan was so slow on my Mac.  It was checking network locations (I have a fairly large LAN and also VPN/etc).  In the process also discovered there's a "native Qt" way to do it since Qt 5.4.  Only checks FAT[32] type partitions now, great speed improvement all around.

Would be really, really nice to dump old Qt versions entirely... getting tired of  `#if (QT_VERSION >= QT_VERSION_CHECK(5, x, 0))` nonsense, bloated code, and especially testing on Linux with 3 Qt versions.