### PR TITLE
Tentative fix for 9xr-pro

### DIFF
--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -1207,7 +1207,7 @@ class MixField: public TransformedField {
 
       if (mix.srcRaw.type != SOURCE_TYPE_NONE) {
         mix.destCh = _destCh + 1;
-        if (!IS_STM32(board) || version < 216) {
+        if (!IS_ARM(board) || (!IS_STM32(board) && version < 218) || version < 216) {
           if (!_curveMode)
             mix.curve = CurveReference(CurveReference::CURVE_REF_DIFF, smallGvarToC9x(_curveParam));
           else if (_curveParam > 6)
@@ -1410,7 +1410,7 @@ class InputField: public TransformedField {
         expo.offset = smallGvarToC9x(_offset);
       }
 
-      if (!IS_STM32(board) || version < 216) {
+      if (!IS_ARM(board) || (!IS_STM32(board) && version < 218) || version < 216) {
         if (!_curveMode)
           expo.curve = CurveReference(CurveReference::CURVE_REF_EXPO, smallGvarToC9x(_curveParam));
         else if (_curveParam > 6)


### PR DESCRIPTION
Issue submitted by ulf detailed bellow. This fix seems to work but need your check @bsongis! 

my Companion 2.2.0N371 crashs if I select radio type 9XR-PRO in profile.
Tested on 2 PCs (both Win7) - same result
everything is fine with N369
everything is fine with N371 and radio type QX7

What I had done:

start Companion

create new profile
select radio type "Turnigy 9XR-PRO"
check options gvars,battgraph,autosouce,autoswitch
select folder for backup and SD
select stick mode to mode 1
set default channel order to "TERA"
click OK

create a new .OTX file
jump through the wizzard and build a fixed wing model with 2 ailerons
save the .OTX file as 9XR.otx
now I can edit the model setting
close Companion

--- everything is fine to this point ---

Open Companion
load my 9XR.otx file
doubleclick my model to edit settings
If I click on the "Input" or "Mixes" tab Companion crashs !
maybe the 1st click works. Latest the 2nd click crashs Companion

