### PR TITLE
[Companion] Improve first use of Companion & upgrade notice

### DIFF
--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -429,10 +429,15 @@ class AppData: protected CompStoreObj
     void init();
 
     QMap<int, QString> getActiveProfiles();
+    inline bool isFirstUse() const { return firstUse; }
+    inline QString previousVersion() const { return upgradeFromVersion; }
 
   protected:
+    void convertSettings(QSettings & settings);
     bool importSettings(QSettings & toSettings);
 
+    bool firstUse;
+    QString upgradeFromVersion;
 };
 
 extern AppData g;

--- a/companion/src/warnings.h
+++ b/companion/src/warnings.h
@@ -20,9 +20,33 @@
 
 #ifndef _WARNINGS_H_
 #define _WARNINGS_H_
-#define WARNING_LEVEL 0
-#define WARNING_ID 7
-#define WARNING QObject::tr("Thank you for upgrading to OpenTX 2.0. This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully to learn about the changes, and thoroughly check each of your models for proper function.\n\nThe OpenTX Team.")
+
+#define CPN_STR_MSG_WELCOME   QCoreApplication::translate("Companion", \
+  "<p><b>Welcome to OpenTX v%1.</b></p>" \
+  "<p>As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.</p>" \
+  "<p>You may also want to take this time to review the other available options in the displayed Settings dialog.</p>" \
+  "<p>After saving your settings, we recommend you download the latest firmware for your radio by using the <i>File -&gt; Download</i> menu option.</p>" \
+  "<p>Please visit <a href='http://www.open-tx.org'>open-tx.org</a> for latest news, updates and documentation. Thank you for choosing OpenTx!</p>" \
+  "- The OpenTX Team.")
+
+#define CPN_STR_MSG_UPGRADED  QCoreApplication::translate("Companion", \
+  "<p><b>Thank you for upgrading to OpenTX v%1.</b></p>" \
+  "<p>This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully" \
+  "  to learn about the changes, and thoroughly check each of your models for proper function.</p>" \
+  "<p>Please visit <a href='http://www.open-tx.org'>open-tx.org</a> for release notes and other documentation.</p>" \
+  "- The OpenTX Team.")
+
+namespace AppMessages {
+
+// These are used for saving "[don't] show this message again" user preferences.
+enum MessageCodes {
+  MSG_NONE     = 0,
+  MSG_WELCOME  = 0x01,
+  MSG_UPGRADED = 0x02,
+  MSG_RESERVED = 0x04,  // reserved due to legacy code
+};
+
+}  // namespace AppWarnings
 
 #endif // _WARNINGS_H_
 

--- a/companion/src/warnings.h
+++ b/companion/src/warnings.h
@@ -26,7 +26,7 @@
   "<p>As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.</p>" \
   "<p>You may also want to take this time to review the other available options in the displayed Settings dialog.</p>" \
   "<p>After saving your settings, we recommend you download the latest firmware for your radio by using the <i>File -&gt; Download</i> menu option.</p>" \
-  "<p>Please visit <a href='http://www.open-tx.org'>open-tx.org</a> for latest news, updates and documentation. Thank you for choosing OpenTx!</p>" \
+  "<p>Please visit <a href='http://www.open-tx.org'>open-tx.org</a> for latest news, updates and documentation. Thank you for choosing OpenTX!</p>" \
   "- The OpenTX Team.")
 
 #define CPN_STR_MSG_UPGRADED  QCoreApplication::translate("Companion", \


### PR DESCRIPTION
Please see commit notes.  While working on this I discovered that by checking for old version settings, the top-level keys were being created even if they didn't exist.  Eg. calling `QSettings settings("OpenTX", "Companion 2.0");` will actually create *OpenTx/Companion 2.0* file/keys if they don't already exist.  This commit makes sure those are cleaned up.

Here's what the new first-use looks like:
![image](https://cloud.githubusercontent.com/assets/1366615/26293799/2eef0eb0-3e8d-11e7-90a1-0096de7b65f0.png)

And the updated upgrade message:
![image](https://cloud.githubusercontent.com/assets/1366615/26293805/395bac96-3e8d-11e7-9836-e1a521d3d268.png)

