### PR TITLE
Fixed syntax error in UDEV rules

### DIFF
--- a/companion/targets/linux/45-companion-taranis.rules
+++ b/companion/targets/linux/45-companion-taranis.rules
@@ -1,1 +1,1 @@
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666";
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE:="0666"


### PR DESCRIPTION
Extraneous semicolon results in an error saying: `invalid key/value pair in
file /lib/udev/rules.d/45-companion22-taranis.rules on line 1, starting
at character 83 (';')`