### PR TITLE
Ignore UNIX dotfiles

### DIFF
--- a/radio/src/gui/480x272/radio_sdmanager.cpp
+++ b/radio/src/gui/480x272/radio_sdmanager.cpp
@@ -279,6 +279,7 @@ bool menuRadioSdManager(event_t _event)
         res = sdReadDir(&dir, &fno, firstTime);
         if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
         if (strlen(fno.fname) > SD_SCREEN_FILE_LENGTH) continue;
+        if (fno.fname[0] == '.') continue;             /* Ignore hidden files under UNIX */
 
         reusableBuffer.sdmanager.count++;
 

--- a/radio/src/gui/480x272/radio_sdmanager.cpp
+++ b/radio/src/gui/480x272/radio_sdmanager.cpp
@@ -279,7 +279,7 @@ bool menuRadioSdManager(event_t _event)
         res = sdReadDir(&dir, &fno, firstTime);
         if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
         if (strlen(fno.fname) > SD_SCREEN_FILE_LENGTH) continue;
-        if (fno.fname[0] == '.') continue;             /* Ignore hidden files under UNIX */
+        if (fno.fname[0] == '.' && fno.fname[1] != '.') continue;             /* Ignore hidden files under UNIX, but not .. */
 
         reusableBuffer.sdmanager.count++;
 

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -340,6 +340,7 @@ void menuRadioSdManager(event_t _event)
         res = sdReadDir(&dir, &fno, firstTime);
         if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
         if (strlen(fno.fname) > SD_SCREEN_FILE_LENGTH) continue;
+        if (fno.fname[0] == '.') continue;             /* Ignore hidden files under UNIX */
 
         reusableBuffer.sdmanager.count++;
 

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -340,7 +340,7 @@ void menuRadioSdManager(event_t _event)
         res = sdReadDir(&dir, &fno, firstTime);
         if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
         if (strlen(fno.fname) > SD_SCREEN_FILE_LENGTH) continue;
-        if (fno.fname[0] == '.') continue;             /* Ignore hidden files under UNIX */
+        if (fno.fname[0] == '.' && fno.fname[1] != '.') continue;             /* Ignore hidden files under UNIX, but not .. */
 
         reusableBuffer.sdmanager.count++;
 


### PR DESCRIPTION
This has the advantage of hiding all the stupid .DS_STORE and ._foo.lua attributes files from Mac OS X