### PR TITLE
Fix clang warnings

### DIFF
--- a/radio/src/maths.cpp
+++ b/radio/src/maths.cpp
@@ -129,18 +129,18 @@ uint16_t isqrt32(uint32_t n)
 
 #if defined(FRSKY_HUB) && !defined(CPUARM)
 // convert latitude and longitude to 1/10^6 degrees
-void extractLatitudeLongitude(uint32_t & latitude, uint32_t & longitude)
+void extractLatitudeLongitude(uint32_t * latitude, uint32_t * longitude)
 {
   div_t qr = div(telemetryData.hub.gpsLatitude_bp, 100);
-  latitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLatitude_ap) * 5) / 3;
+  *latitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLatitude_ap) * 5) / 3;
 
   qr = div(telemetryData.hub.gpsLongitude_bp, 100);
-  longitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLongitude_ap) * 5) / 3;
+  *longitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLongitude_ap) * 5) / 3;
 }
 
 void getGpsPilotPosition()
 {
-  extractLatitudeLongitude(telemetryData.hub.pilotLatitude, telemetryData.hub.pilotLongitude);
+  extractLatitudeLongitude(&telemetryData.hub.pilotLatitude, &telemetryData.hub.pilotLongitude);
   // distFromEarthAxis = cos(lat) * EARTH_RADIUS
   // 1 - x2/2 + x4/24
   uint32_t lat = telemetryData.hub.pilotLatitude / 10000;
@@ -154,7 +154,7 @@ void getGpsDistance()
 {
   uint32_t lat, lng;
 
-  extractLatitudeLongitude(lat, lng);
+  extractLatitudeLongitude(&lat, &lng);
 
   // printf("lat=%d (%d), long=%d (%d)\n", lat, abs(lat - telemetryData.hub.pilotLatitude), lng, abs(lng - telemetryData.hub.pilotLongitude));
 

--- a/radio/src/maths.cpp
+++ b/radio/src/maths.cpp
@@ -129,18 +129,18 @@ uint16_t isqrt32(uint32_t n)
 
 #if defined(FRSKY_HUB) && !defined(CPUARM)
 // convert latitude and longitude to 1/10^6 degrees
-void extractLatitudeLongitude(uint32_t * latitude, uint32_t * longitude)
+void extractLatitudeLongitude(uint32_t & latitude, uint32_t & longitude)
 {
   div_t qr = div(telemetryData.hub.gpsLatitude_bp, 100);
-  *latitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLatitude_ap) * 5) / 3;
+  latitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLatitude_ap) * 5) / 3;
 
   qr = div(telemetryData.hub.gpsLongitude_bp, 100);
-  *longitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLongitude_ap) * 5) / 3;
+  longitude = ((uint32_t)(qr.quot) * 1000000) + (((uint32_t)(qr.rem) * 10000 + telemetryData.hub.gpsLongitude_ap) * 5) / 3;
 }
 
 void getGpsPilotPosition()
 {
-  extractLatitudeLongitude(&telemetryData.hub.pilotLatitude, &telemetryData.hub.pilotLongitude);
+  extractLatitudeLongitude(telemetryData.hub.pilotLatitude, telemetryData.hub.pilotLongitude);
   // distFromEarthAxis = cos(lat) * EARTH_RADIUS
   // 1 - x2/2 + x4/24
   uint32_t lat = telemetryData.hub.pilotLatitude / 10000;
@@ -154,7 +154,7 @@ void getGpsDistance()
 {
   uint32_t lat, lng;
 
-  extractLatitudeLongitude(&lat, &lng);
+  extractLatitudeLongitude(lat, lng);
 
   // printf("lat=%d (%d), long=%d (%d)\n", lat, abs(lat - telemetryData.hub.pilotLatitude), lng, abs(lng - telemetryData.hub.pilotLongitude));
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2483,7 +2483,18 @@ void opentxInit(OPENTX_INIT_ARGS)
     // g_model.topbarData is still zero here (because it was not yet read from SDCARD),
     // but we only remember the pointer to in in constructor.
     // The storageReadAll() needs topbar object, so it must be created here
+#if __clang__
+// clang does not like this at all, turn into a warning so that -Werror does not stop here
+// taking address of packed member 'topbarData' of class or structure 'ModelData' may result in an unaligned pointer value [-Werror,-Waddress-of-packed-member]
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Waddress-of-packed-member"
+#endif
     topbar = new Topbar(&g_model.topbarData);
+#if __clang__
+// Restore warnings
+#pragma clang diagnostic pop
+#endif
+
     // lua widget state must also be prepared before the call to storageReadAll()
     LUA_INIT_THEMES_AND_WIDGETS();
   }

--- a/radio/src/storage/sdcard_raw.cpp
+++ b/radio/src/storage/sdcard_raw.cpp
@@ -32,7 +32,7 @@ const char * writeFile(const char * filename, const uint8_t * data, uint16_t siz
   TRACE("writeFile(%s)", filename);
   
   FIL file;
-  char buf[8];
+  unsigned char buf[8];
   UINT written;
 
   FRESULT result = f_open(&file, filename, FA_CREATE_ALWAYS | FA_WRITE);

--- a/radio/src/telemetry/mavlink.h
+++ b/radio/src/telemetry/mavlink.h
@@ -48,7 +48,16 @@ extern void SERIAL_send_uart_bytes(const uint8_t * buf, uint16_t len);
 #define MAVLINK_END_UART_SEND(chan,len) SERIAL_end_uart_send()
 #define MAVLINK_SEND_UART_BYTES(chan,buf,len) SERIAL_send_uart_bytes(buf,len)
 
+#if __clang__
+// clang does not like packed member access at all. Since mavlink is a 3rd party library, ignore the errors
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Waddress-of-packed-member"
+#endif
 #include "GCS_MAVLink/include_v1.0/ardupilotmega/mavlink.h"
+#if __clang__
+// Restore warnings about packed member access
+#pragma clang diagnostic pop
+#endif
 
 //#define MAVLINK_PARAMS
 //#define DUMP_RX_TX


### PR DESCRIPTION
- signed char on AVR vs unsigned char on ARM
- use references instead of points in calculation (same code size)
- Ignore packed address warning for mavlink includes
- Turn error on packed addresses to warning for Horus (Cannot fix that without major refactoring, might even need eeprom change)