### PR TITLE
Fully adjustable splash timer on x7, matching x9 implementation

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -880,7 +880,7 @@ PACK(struct TrainerData {
   #define SPLASH_MODE uint8_t splashSpares:3
 #elif defined(FSPLASH)
   #define SPLASH_MODE uint8_t splashMode:3
-#elif defined(PCBTARANIS)
+#elif defined(CPUARM)
   #define SPLASH_MODE int8_t splashMode:3
 #else
   #define SPLASH_MODE uint8_t splashMode:1; uint8_t splashSpare:2

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -467,6 +467,7 @@ void menuRadioSetup(event_t event)
 #if defined(SPLASH) && !defined(FSPLASH)
       case ITEM_SETUP_DISABLE_SPLASH:
       {
+#if defined(CPUARM)
         lcdDrawTextAlignedLeft(y, STR_SPLASHSCREEN);
         if (SPLASH_NEEDED()) {
           lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, SPLASH_TIMEOUT/100, attr|LEFT);
@@ -477,6 +478,11 @@ void menuRadioSetup(event_t event)
         }
         if (attr) g_eeGeneral.splashMode = -checkIncDecGen(event, -g_eeGeneral.splashMode, -3, 4);
         break;
+#else
+        uint8_t b = 1-g_eeGeneral.splashMode;
+        g_eeGeneral.splashMode = 1 - editCheckBox(b, RADIO_SETUP_2ND_COLUMN, y, STR_SPLASHSCREEN, attr, event);
+        break;
+#endif
       }
 #endif
 

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -467,8 +467,15 @@ void menuRadioSetup(event_t event)
 #if defined(SPLASH) && !defined(FSPLASH)
       case ITEM_SETUP_DISABLE_SPLASH:
       {
-        uint8_t b = 1-g_eeGeneral.splashMode;
-        g_eeGeneral.splashMode = 1 - editCheckBox(b, RADIO_SETUP_2ND_COLUMN, y, STR_SPLASHSCREEN, attr, event);
+        lcdDrawTextAlignedLeft(y, STR_SPLASHSCREEN);
+        if (SPLASH_NEEDED()) {
+          lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, SPLASH_TIMEOUT/100, attr|LEFT);
+          lcdDrawChar(lcdLastRightPos, y, 's');
+        }
+        else {
+          lcdDrawMMM(RADIO_SETUP_2ND_COLUMN, y, attr);
+        }
+        if (attr) g_eeGeneral.splashMode = -checkIncDecGen(event, -g_eeGeneral.splashMode, -3, 4);
         break;
       }
 #endif


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5167938/26815609/90af7e8a-4a8d-11e7-9c17-17833cdb4fde.png)

This fixes #5007