### PR TITLE
Model ID between internal and external module do not conflict

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -401,11 +401,9 @@ void checkModelIdUnique(uint8_t index, uint8_t module)
   if (modelId != 0) {
     for (uint8_t i=0; i<MAX_MODELS; i++) {
       if (i != index) {
-        for (uint8_t j=0; j<NUM_MODULES; j++) {
-          if (modelId == modelHeaders[i].modelId[j]) {
-            POPUP_WARNING(STR_MODELIDUSED);
-            return;
-          }
+        if (modelId == modelHeaders[i].modelId[module]) {
+          POPUP_WARNING(STR_MODELIDUSED);
+          return;
         }
       }
     }


### PR DESCRIPTION
An internal xjt with model 2 and a ext xjt with model 2 are not binding the same receiver, other external modules do not even use the same protocol.