### PR TITLE
Display XJT version in analogs

### DIFF
--- a/radio/src/gui/212x64/radio_diaganas.cpp
+++ b/radio/src/gui/212x64/radio_diaganas.cpp
@@ -45,5 +45,8 @@ void menuRadioDiagAnalogs(event_t event)
   if((IS_MODULE_XJT(INTERNAL_MODULE) && IS_INTERNAL_MODULE_ON()) || (IS_MODULE_XJT(EXTERNAL_MODULE) && !IS_INTERNAL_MODULE_ON())) {
     lcdDrawTextAlignedLeft(MENU_HEADER_HEIGHT+6*FH, "RAS");
     lcdDrawNumber(10*FW-1, MENU_HEADER_HEIGHT+6*FH, telemetryData.swr.value, RIGHT);
+    lcdDrawText(LCD_W/2, MENU_HEADER_HEIGHT+6*FH, "XJTVER");
+    lcdDrawNumber(LCD_W/2 + 10*FW-1, MENU_HEADER_HEIGHT+6*FH, telemetryData.xjtVersion, RIGHT);
+
   }
 }

--- a/radio/src/gui/480x272/view_statistics.cpp
+++ b/radio/src/gui/480x272/view_statistics.cpp
@@ -181,6 +181,9 @@ bool menuStatsAnalogs(event_t event)
   if((IS_MODULE_XJT(INTERNAL_MODULE) && IS_INTERNAL_MODULE_ON()) || (IS_MODULE_XJT(EXTERNAL_MODULE) && !IS_INTERNAL_MODULE_ON())) {
     lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP+7*FH, "RAS");
     lcdDrawNumber(MENUS_MARGIN_LEFT+100, MENU_CONTENT_TOP+7*FH, telemetryData.swr.value);
+    lcdDrawText(MENUS_MARGIN_LEFT + LCD_W/2, MENU_CONTENT_TOP+7*FH, "XJTVER");
+    lcdDrawNumber(LCD_W/2 + MENUS_MARGIN_LEFT+100, MENU_CONTENT_TOP+7*FH, telemetryData.xjtVersion);
+
   }
 
   return true;


### PR DESCRIPTION
To check if only the "broken" XJT modules have a XJT version of 1025 (#5038) include displaying XJT version. So we can ask what version other modules display.