### PR TITLE
Add model checklist edit to Companion

### DIFF
--- a/companion/src/modeledit/CMakeLists.txt
+++ b/companion/src/modeledit/CMakeLists.txt
@@ -12,6 +12,7 @@ set(modeledit_NAMES
   telemetry
   expodialog
   mixerdialog
+  checklistdialog
 )
 
 set(modeledit_SRCS

--- a/companion/src/modeledit/checklistdialog.cpp
+++ b/companion/src/modeledit/checklistdialog.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "checklistdialog.h"
+#include "ui_checklistdialog.h"
+
+#include "appdata.h"
+#include "helpers.h"
+
+#include <QFile>
+#include <QTextStream>
+
+extern AppData g;
+
+ChecklistDialog::ChecklistDialog(QWidget *parent, const QString modelName):
+  QDialog(parent),
+  ui(new Ui::ChecklistDialog)
+{
+  ui->setupUi(this);
+  setWindowIcon(CompanionIcon("edit.png"));
+
+  mChecklistFolder = g.profile[g.id()].sdPath() + "/MODELS/";
+  mModelChecklist = mChecklistFolder + modelName + ".txt";
+  ui->file->setText("File: " + mModelChecklist);
+  ui->pteCheck->setPlainText(readFile(mModelChecklist,QFile::exists(mModelChecklist)));
+
+  connect(ui->pbImport, SIGNAL(clicked()), this, SLOT(import()));
+  connect(ui->pbCancel, SIGNAL(clicked()), this, SLOT(reject()));
+  connect(ui->pbOK, SIGNAL(clicked()), this, SLOT(update()));
+}
+
+ChecklistDialog::~ChecklistDialog()
+{
+  delete ui;
+}
+
+void ChecklistDialog::import()
+{
+  QString filename = QFileDialog::getOpenFileName(this, tr("Open Checklist"), mChecklistFolder, tr("Checklist Files (*.txt)"));
+  if (!filename.isNull())
+    ui->pteCheck->setPlainText(readFile(filename,true));
+}
+
+void ChecklistDialog::update()
+{
+  QFile file(mModelChecklist);
+  if (!file.open(QFile::WriteOnly | QFile::Text)) {
+    QMessageBox::critical(this, tr("Model Checklist"), tr("Cannot open file for writing %1:\n%2.").arg(QDir::toNativeSeparators(mModelChecklist), file.errorString()));
+  }
+  else {
+    QTextStream out(&file);
+    if (out.status()==QTextStream::Ok) {
+      out << ui->pteCheck->toPlainText();
+      if (!(out.status()==QTextStream::Ok)) {
+        QMessageBox::critical(this, tr("Model Checklist"), tr("Cannot write to file %1:\n%2.").arg(QDir::toNativeSeparators(mModelChecklist), file.errorString()));
+        if (!file.flush()) {
+          QMessageBox::critical(this, tr("Model Checklist"), tr("Cannot write file %1:\n%2.").arg(QDir::toNativeSeparators(mModelChecklist), file.errorString()));
+        }
+      }
+    }
+  }
+  file.close();
+  emit accept();
+}
+
+QString ChecklistDialog::readFile(const QString filepath, const bool exists)
+{
+  QString data = "";
+  if (filepath.isNull()) return data;
+
+  QFile file(filepath);
+  if (!file.open(QFile::ReadOnly | QFile::Text)) {
+    if (exists) {
+      QMessageBox::critical(this, tr("Model Checklist"), tr("Cannot open file %1:\n%2.").arg(QDir::toNativeSeparators(filepath), file.errorString()));
+    }
+  }
+  else {
+    QTextStream in(&file);
+    if (in.status()==QTextStream::Ok) {
+      data = in.readAll();
+      if (!(in.status()==QTextStream::Ok)) {
+        QMessageBox::critical(this, tr("Model Checklist"), tr("Cannot read file %1:\n%2.").arg(QDir::toNativeSeparators(filepath), file.errorString()));
+        data = "";
+      }
+    }
+  }
+  file.close();
+  return data;
+}

--- a/companion/src/modeledit/checklistdialog.h
+++ b/companion/src/modeledit/checklistdialog.h
@@ -37,12 +37,14 @@ public:
 private slots:
   void import();
   void update();
+  void changed();
 
 private:
   Ui::ChecklistDialog *ui;
   QString mModelChecklist;
   QString mChecklistFolder;
-  QString readFile(const QString filepath, const bool exists);
+  QString readFile(const QString & filepath, const bool exists);
+  bool mDirty;
 };
 
 #endif // _CHECKLISTDIALOG_H_

--- a/companion/src/modeledit/checklistdialog.h
+++ b/companion/src/modeledit/checklistdialog.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _CHECKLISTDIALOG_H_
+#define _CHECKLISTDIALOG_H_
+
+#include <QtWidgets>
+
+namespace Ui {
+  class ChecklistDialog;
+}
+
+class ChecklistDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  ChecklistDialog(QWidget *parent, const QString modelName);
+  ~ChecklistDialog();
+
+private slots:
+  void import();
+  void update();
+
+private:
+  Ui::ChecklistDialog *ui;
+  QString mModelChecklist;
+  QString mChecklistFolder;
+  QString readFile(const QString filepath, const bool exists);
+};
+
+#endif // _CHECKLISTDIALOG_H_

--- a/companion/src/modeledit/checklistdialog.ui
+++ b/companion/src/modeledit/checklistdialog.ui
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ChecklistDialog</class>
+ <widget class="QDialog" name="ChecklistDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>373</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Checklist</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>3</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPlainTextEdit" name="pteCheck">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+     <property name="lineWrapMode">
+      <enum>QPlainTextEdit::NoWrap</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinimumSize</enum>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbImport">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Import...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbCancel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbOK">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;OK</string>
+       </property>
+       <property name="shortcut">
+        <string/>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Please note, the maximum width displayable is radio model limited. Also, renaming the model will break the link to this checklist file.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="file">
+     <property name="text">
+      <string>File: unknown</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>pteCheck</tabstop>
+  <tabstop>pbOK</tabstop>
+  <tabstop>pbCancel</tabstop>
+  <tabstop>pbImport</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -26,6 +26,7 @@
 #include "appdata.h"
 #include "modelprinter.h"
 #include "multiprotocols.h"
+#include "checklistdialog.h"
 
 TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, GeneralSettings & generalSettings, Firmware * firmware, QWidget * prevFocus):
   ModelPanel(parent, model, generalSettings, firmware),
@@ -891,6 +892,8 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
 
   if (!firmware->getCapability(HasDisplayText)) {
     ui->displayText->hide();
+    ui->editText->hide();
+    connect(ui->editText, SIGNAL(clicked()), this, SLOT(on_editText_clicked()));
   }
 
   if (!firmware->getCapability(GlobalFunctions)) {
@@ -1134,6 +1137,7 @@ void SetupPanel::update()
   ui->extendedLimits->setChecked(model->extendedLimits);
   ui->extendedTrims->setChecked(model->extendedTrims);
   ui->displayText->setChecked(model->displayChecklist);
+  ui->editText->setEnabled(model->displayChecklist);
   ui->gfEnabled->setChecked(!model->noGlobalFunctions);
 
   updateBeepCenter();
@@ -1279,6 +1283,7 @@ void SetupPanel::on_potWarningMode_currentIndexChanged(int index)
 void SetupPanel::on_displayText_toggled(bool checked)
 {
   model->displayChecklist = checked;
+  ui->editText->setEnabled(checked);
   emit modified();
 }
 
@@ -1305,4 +1310,10 @@ void SetupPanel::onBeepCenterToggled(bool checked)
       model->beepANACenter &= ~mask;
     emit modified();
   }
+}
+
+void SetupPanel::on_editText_clicked()
+{
+  ChecklistDialog *g = new ChecklistDialog(this, ui->name->text());
+  g->exec();
 }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -893,7 +893,6 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   if (!firmware->getCapability(HasDisplayText)) {
     ui->displayText->hide();
     ui->editText->hide();
-    connect(ui->editText, SIGNAL(clicked()), this, SLOT(on_editText_clicked()));
   }
 
   if (!firmware->getCapability(GlobalFunctions)) {

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -140,6 +140,7 @@ class SetupPanel : public ModelPanel
     void startupSwitchToggled(bool checked);
     void potWarningToggled(bool checked);
     void on_potWarningMode_currentIndexChanged(int index);
+    void on_editText_clicked();
 
   private:
     Ui::Setup *ui;

--- a/companion/src/modeledit/setup.ui
+++ b/companion/src/modeledit/setup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>840</width>
-    <height>371</height>
+    <width>893</width>
+    <height>405</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -343,16 +343,6 @@
      </item>
      <item row="6" column="1">
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="2">
-        <widget class="QCheckBox" name="extendedTrims">
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string>Extended Trims</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="3">
         <widget class="QCheckBox" name="displayText">
          <property name="layoutDirection">
@@ -363,40 +353,29 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="extendedLimits">
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string>Extended Limits</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QCheckBox" name="throttleReverse">
-         <property name="whatsThis">
-          <string>Reverse throttle operation.
-If this is checked the throttle will be reversed.  Idle will be forward, trim will also be reversed and the throttle warning will be reversed as well.
-
-</string>
-         </property>
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
-         <property name="text">
-          <string>Reverse Throttle</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QComboBox" name="throttleSource">
+       <item row="2" column="0">
+        <widget class="AutoComboBox" name="trimsDisplay">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <item>
+          <property name="text">
+           <string>Never</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>On change</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Always</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="0" column="1">
@@ -406,6 +385,13 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
          </property>
          <property name="text">
           <string>Throttle Trim Idle Only</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="gfEnabled">
+         <property name="text">
+          <string>Global Functions</string>
          </property>
         </widget>
        </item>
@@ -419,18 +405,15 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
          </property>
         </widget>
        </item>
-       <item row="0" column="4">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+       <item row="0" column="0">
+        <widget class="QComboBox" name="throttleSource">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item row="1" column="0">
         <widget class="QComboBox" name="trimIncrement">
@@ -467,37 +450,67 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
          </item>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="AutoComboBox" name="trimsDisplay">
+       <item row="0" column="3">
+        <widget class="QCheckBox" name="throttleReverse">
+         <property name="whatsThis">
+          <string>Reverse throttle operation.
+If this is checked the throttle will be reversed.  Idle will be forward, trim will also be reversed and the throttle warning will be reversed as well.
+
+</string>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Reverse Throttle</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QPushButton" name="editText">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <item>
-          <property name="text">
-           <string>Never</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>On change</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Always</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="QCheckBox" name="gfEnabled">
          <property name="text">
-          <string>Global Functions</string>
+          <string>Edit Checklist...</string>
          </property>
         </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="extendedTrims">
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Extended Trims</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="extendedLimits">
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Extended Limits</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
First attempt for feedback.
There are a few requests for editors. I decided a basic editor for model checklist would be useful for the majority.
Further improvements could include:
- limiting line length to the display area of each radio model
- handling model name renames. However, renaming the checklist file would need to be delayed until the otx is saved as the user can discard the changes. Maybe just too much effort for little gain. The Import feature can be used to retrieve the file contents with the old name and load the file for the new name.
Import can also be used to load a template.

![screenshot from 2017-06-20 17-56-30](https://user-images.githubusercontent.com/15316949/27323297-6b1b356c-55e4-11e7-828f-9a4fb3ece487.png)

![screenshot from 2017-06-20 17-56-41](https://user-images.githubusercontent.com/15316949/27323307-7705d238-55e4-11e7-804f-eb287a9c9cb0.png)
