### PR TITLE
Hide checked but unused flight modes in inputs and mixes lists

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -71,6 +71,7 @@ void AppPreferencesDialog::writeValues()
   g.simuSW(ui->simuSW->isChecked());
   g.removeModelSlots(ui->opt_removeBlankSlots->isChecked());
   g.newModelAction(ui->opt_newMdl_useWizard->isChecked() ? 1 : ui->opt_newMdl_useEditor->isChecked() ? 2 : 0);
+  g.displayAllFMs(ui->opt_displayAllFMs->isChecked());
   g.historySize(ui->historySize->value());
   g.backLight(ui->backLightColor->currentIndex());
   g.profile[g.id()].volumeGain(round(ui->volumeGain->value() * 10.0));
@@ -160,6 +161,7 @@ void AppPreferencesDialog::initSettings()
   ui->opt_newMdl_useNone->setChecked(g.newModelAction() == 0);
   ui->opt_newMdl_useWizard->setChecked(g.newModelAction() == 1);
   ui->opt_newMdl_useEditor->setChecked(g.newModelAction() == 2);
+  ui->opt_displayAllFMs->setChecked(g.displayAllFMs());
   ui->libraryPath->setText(g.libDir());
   ui->ge_lineedit->setText(g.gePath());
 

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>703</width>
-    <height>534</height>
+    <width>869</width>
+    <height>619</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -859,7 +859,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="20" column="0">
+         <item row="21" column="0">
           <widget class="QLabel" name="ge_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -872,7 +872,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="12" column="0">
+         <item row="13" column="0">
           <widget class="QLabel" name="label_17">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -885,7 +885,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="10" column="0" rowspan="2" colspan="2">
+         <item row="11" column="0" rowspan="2" colspan="2">
           <widget class="Line" name="line_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -905,6 +905,13 @@ Mode 4:
            </property>
           </widget>
          </item>
+         <item row="4" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
          <item row="6" column="1">
           <widget class="QCheckBox" name="showSplash">
            <property name="text">
@@ -915,7 +922,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="12" column="1">
+         <item row="13" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_8">
            <item>
             <widget class="QLineEdit" name="backupPath">
@@ -939,7 +946,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="17" column="1">
+         <item row="18" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_7">
            <item>
             <widget class="QLineEdit" name="libraryPath">
@@ -966,7 +973,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="23" column="0">
+         <item row="24" column="0">
           <widget class="QLabel" name="lbl_appLogsDir">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -976,13 +983,6 @@ Mode 4:
            </property>
            <property name="text">
             <string>Output Logs Folder</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -1030,7 +1030,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="13" column="1">
+         <item row="14" column="1">
           <widget class="QCheckBox" name="backupEnable">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1043,7 +1043,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="22" column="0">
+         <item row="23" column="0">
           <widget class="QLabel" name="label_12">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1056,14 +1056,21 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="18" column="0" rowspan="2" colspan="2">
+         <item row="15" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="0" rowspan="2" colspan="2">
           <widget class="Line" name="line_7">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-         <item row="16" column="1">
+         <item row="17" column="1">
           <widget class="QComboBox" name="splashincludeCB">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1083,14 +1090,7 @@ Mode 4:
            </item>
           </widget>
          </item>
-         <item row="14" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="20" column="1">
+         <item row="21" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_9">
            <item>
             <widget class="QLineEdit" name="ge_lineedit">
@@ -1114,7 +1114,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="23" column="1">
+         <item row="24" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <item>
             <widget class="QLineEdit" name="appLogsDir">
@@ -1135,7 +1135,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="22" column="1">
+         <item row="23" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QCheckBox" name="opt_appDebugLog">
@@ -1159,7 +1159,7 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="16" column="0">
+         <item row="17" column="0">
           <widget class="QLabel" name="label_10">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1172,7 +1172,14 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="17" column="0">
+         <item row="22" column="0" colspan="2">
+          <widget class="Line" name="line_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="18" column="0">
           <widget class="QLabel" name="label_9">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1198,10 +1205,20 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="21" column="0" colspan="2">
-          <widget class="Line" name="line_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+         <item row="10" column="0">
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Display</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QCheckBox" name="opt_displayAllFMs">
+           <property name="text">
+            <string>All flight modes in inputs and mixes lists</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -472,8 +472,10 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
       }
       if (list.size() > 1)
         return tr("Flight modes(%1)").arg(list.join(", "));
-      else
+      else if (list.size() == 1)
         return tr("Flight mode(%1)").arg(list.join(", "));
+      else
+        return tr("Inactive in all flight modes");
     }
   }
   else return "";

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -464,7 +464,10 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
       QStringList list;
       for (int i=0; i<numFlightModes; i++) {
         if (!(flightModes & (1<<i))) {
-          list << printFlightModeName(i);
+          const RawSwitch swtch = model.flightModeData[i].swtch;
+          if ((i==0) || (swtch.toValue())) {
+            list << printFlightModeName(i);
+          }
         }
       }
       if (list.size() > 1)

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -465,7 +465,7 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
       for (int i=0; i<numFlightModes; i++) {
         if (!(flightModes & (1<<i))) {
           const RawSwitch swtch = model.flightModeData[i].swtch;
-          if ((i==0) || g.displayAllFMs() || (swtch.toValue())) {
+          if ((i==0) || (g.displayAllFMs()) || (swtch.toValue())) {
             list << printFlightModeName(i);
           }
         }

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -21,12 +21,12 @@
 #include "helpers.h"
 #include "modelprinter.h"
 #include "multiprotocols.h"
+#include "appdata.h"
 
 #include <QApplication>
 #include <QPainter>
 #include <QFile>
 #include <QUrl>
-#include "multiprotocols.h"
 
 QString changeColor(const QString & input, const QString & to, const QString & from)
 {
@@ -465,7 +465,7 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
       for (int i=0; i<numFlightModes; i++) {
         if (!(flightModes & (1<<i))) {
           const RawSwitch swtch = model.flightModeData[i].swtch;
-          if ((i==0) || (swtch.toValue())) {
+          if ((i==0) || g.displayAllFMs() || (swtch.toValue())) {
             list << printFlightModeName(i);
           }
         }

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -600,6 +600,7 @@ void AppData::init()
     useCompanionNightlyBuilds_init();
     useFirmwareNightlyBuilds_init();
     removeModelSlots_init();
+    displayAllFMs_init();
     maximized_init();
     simuSW_init();
     tabbedMdi_init();

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -247,11 +247,12 @@ class AppData: protected CompStoreObj
   PROPERTY(bool, useCompanionNightlyBuilds,  false)
   PROPERTY(bool, useFirmwareNightlyBuilds,   false)
   PROPERTY(bool, removeModelSlots,           true)
-  PROPERTY(bool, maximized,   false)
-  PROPERTY(bool, simuSW,      false)
-  PROPERTY(bool, tabbedMdi,   false)
-  PROPERTY(bool, appDebugLog, false)
-  PROPERTY(bool, fwTraceLog,  false)
+  PROPERTY(bool, displayAllFMs,              true)
+  PROPERTY(bool, maximized,                  false)
+  PROPERTY(bool, simuSW,                     false)
+  PROPERTY(bool, tabbedMdi,                  false)
+  PROPERTY(bool, appDebugLog,                false)
+  PROPERTY(bool, fwTraceLog,                 false)
 
   PROPERTY4(bool, jsSupport,       js_support              ,false)
   PROPERTY4(bool, showSplash,      show_splash             ,true)
@@ -398,6 +399,7 @@ class AppData: protected CompStoreObj
     void updatesDir      (const QString);
 
     void newModelAction  (const int);
+    void displayAllFMs   (const int);
     void backLight       (const int);
     void embedSplashes   (const int);
     void fwServerFails   (const int);


### PR DESCRIPTION
Fixes #5057 

![screenshot from 2017-07-02 09-39-26](https://user-images.githubusercontent.com/15316949/27766151-4eb30b5a-5f0a-11e7-8482-464341ad6498.png)

In this example only FMs 1 & 2 have switches assigned.

Before
![screenshot from 2017-07-02 09-19-05](https://user-images.githubusercontent.com/15316949/27766145-0a95af5e-5f0a-11e7-836d-8b919c7ce6f0.png)

After
![screenshot from 2017-07-02 09-20-18](https://user-images.githubusercontent.com/15316949/27766146-1002a5dc-5f0a-11e7-9f7f-399de8f01436.png)
