### PR TITLE
Adds CrossTrim Special Function

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -997,6 +997,7 @@ enum Functions {
   FUNC_BACKLIGHT,
 #if defined(PCBTARANIS)
   FUNC_SCREENSHOT,
+  FUNC_CROSSTRIMS,
 #endif
 #if defined(DEBUG)
   FUNC_TEST, // should remain the last before MAX as not added in Companion

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -578,6 +578,9 @@ void evalFunctions()
               mainRequestFlags |= (1 << REQUEST_SCREENSHOT);
             }
             break;
+          case FUNC_CROSSTRIMS:
+            newActiveFunctions |= (1 << FUNC_CROSSTRIMS);
+            break;
 #endif
 
 #if defined(DEBUG)

--- a/radio/src/targets/taranis/keys_driver.cpp
+++ b/radio/src/targets/taranis/keys_driver.cpp
@@ -53,22 +53,41 @@ uint32_t readTrims()
 {
   uint32_t result = 0;
 
-  if (~TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
-    result |= 0x01;
-  if (~TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)
-    result |= 0x02;
-  if (~TRIMS_GPIO_REG_LVD & TRIMS_GPIO_PIN_LVD)
-    result |= 0x04;
-  if (~TRIMS_GPIO_REG_LVU & TRIMS_GPIO_PIN_LVU)
-    result |= 0x08;
-  if (~TRIMS_GPIO_REG_RVD & TRIMS_GPIO_PIN_RVD)
-    result |= 0x10;
-  if (~TRIMS_GPIO_REG_RVU & TRIMS_GPIO_PIN_RVU)
-    result |= 0x20;
-  if (~TRIMS_GPIO_REG_RHL & TRIMS_GPIO_PIN_RHL)
-    result |= 0x40;
-  if (~TRIMS_GPIO_REG_RHR & TRIMS_GPIO_PIN_RHR)
-    result |= 0x80;
+  if (isFunctionActive(FUNC_CROSSTRIMS)){
+    if (~TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
+      result |= 0x40;
+    if (~TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)
+      result |= 0x80;
+    if (~TRIMS_GPIO_REG_LVD & TRIMS_GPIO_PIN_LVD)
+      result |= 0x10;
+    if (~TRIMS_GPIO_REG_LVU & TRIMS_GPIO_PIN_LVU)
+      result |= 0x20;
+    if (~TRIMS_GPIO_REG_RVD & TRIMS_GPIO_PIN_RVD)
+      result |= 0x04;
+    if (~TRIMS_GPIO_REG_RVU & TRIMS_GPIO_PIN_RVU)
+      result |= 0x08;
+    if (~TRIMS_GPIO_REG_RHL & TRIMS_GPIO_PIN_RHL)
+      result |= 0x01;
+    if (~TRIMS_GPIO_REG_RHR & TRIMS_GPIO_PIN_RHR)
+      result |= 0x02;
+  } else {
+    if (~TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
+      result |= 0x01;
+    if (~TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)
+      result |= 0x02;
+    if (~TRIMS_GPIO_REG_LVD & TRIMS_GPIO_PIN_LVD)
+      result |= 0x04;
+    if (~TRIMS_GPIO_REG_LVU & TRIMS_GPIO_PIN_LVU)
+      result |= 0x08;
+    if (~TRIMS_GPIO_REG_RVD & TRIMS_GPIO_PIN_RVD)
+      result |= 0x10;
+    if (~TRIMS_GPIO_REG_RVU & TRIMS_GPIO_PIN_RVU)
+      result |= 0x20;
+    if (~TRIMS_GPIO_REG_RHL & TRIMS_GPIO_PIN_RHL)
+      result |= 0x40;
+    if (~TRIMS_GPIO_REG_RHR & TRIMS_GPIO_PIN_RHR)
+      result |= 0x80;
+  }
 
   // TRACE("readTrims(): result=0x%02x", result);
 

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -306,6 +306,7 @@
 
 #if defined(PCBTARANIS)
   #define TR_SF_SCREENSHOT             "Screenshot"
+  #define TR_SF_CROSSTRIMS             "CrossTrims"
 #else
   #define TR_SF_SCREENSHOT
 #endif
@@ -313,7 +314,7 @@
 #define TR_SF_RESERVE                  "[reserve]\0"
 
 #if defined(CPUARM)
-  #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    ""Set \0     " TR_ADJUST_GVAR "Volume\0   " "SetFailsfe" "RangeCheck" "ModuleBind" TR_SOUND TR_PLAY_TRACK TR_PLAY_VALUE TR_SF_RESERVE TR_SF_PLAY_SCRIPT TR_SF_RESERVE TR_SF_BG_MUSIC TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_SCREENSHOT TR_SF_TEST
+  #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    ""Set \0     " TR_ADJUST_GVAR "Volume\0   " "SetFailsfe" "RangeCheck" "ModuleBind" TR_SOUND TR_PLAY_TRACK TR_PLAY_VALUE TR_SF_RESERVE TR_SF_PLAY_SCRIPT TR_SF_RESERVE TR_SF_BG_MUSIC TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_SCREENSHOT TR_SF_TEST TR_SF_CROSSTRIMS
 #elif defined(PCBGRUVIN9X)
   #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    " TR_ADJUST_GVAR TR_SOUND TR_PLAY_TRACK TR_PLAY_BOTH TR_PLAY_VALUE TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_TEST
 #else

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -313,8 +313,10 @@
 
 #define TR_SF_RESERVE                  "[reserve]\0"
 
-#if defined(CPUARM)
+#if defined(PCBTARANIS)
   #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    ""Set \0     " TR_ADJUST_GVAR "Volume\0   " "SetFailsfe" "RangeCheck" "ModuleBind" TR_SOUND TR_PLAY_TRACK TR_PLAY_VALUE TR_SF_RESERVE TR_SF_PLAY_SCRIPT TR_SF_RESERVE TR_SF_BG_MUSIC TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_SCREENSHOT TR_SF_TEST TR_SF_CROSSTRIMS
+#elif defined(CPUARM)
+  #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    ""Set \0     " TR_ADJUST_GVAR "Volume\0   " "SetFailsfe" "RangeCheck" "ModuleBind" TR_SOUND TR_PLAY_TRACK TR_PLAY_VALUE TR_SF_RESERVE TR_SF_PLAY_SCRIPT TR_SF_RESERVE TR_SF_BG_MUSIC TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_SCREENSHOT TR_SF_TEST
 #elif defined(PCBGRUVIN9X)
   #define TR_VFSWFUNC                  TR_SF_SAFETY "Trainer\0  ""Inst. Trim""Reset\0    " TR_ADJUST_GVAR TR_SOUND TR_PLAY_TRACK TR_PLAY_BOTH TR_PLAY_VALUE TR_VVARIO TR_HAPTIC TR_SDCLOGS "Backlight\0" TR_SF_TEST
 #else


### PR DESCRIPTION
Adds a function that swaps left and right trims. This allows the following:

1. Easy / quick way to enable / disable cross-trims
1. Visually, the trims still show up under the sticks they're affecting
1. Can be assigned globally or as a special function per model
1. Doesn't impact any other setting in the radio (just switches the buttons effectively)

As seen here: https://youtu.be/JKQgAdqzfmY