### PR TITLE
Reorder mm_protocol struct and remove pack to silence compiler warnings

### DIFF
--- a/companion/src/multiprotocols.cpp
+++ b/companion/src/multiprotocols.cpp
@@ -62,33 +62,33 @@ static const QStringList NO_SUBTYPE          {STR_MULTI_DEFAULT};
 // Table is designed to be shared with gui_common_arm.cpp
 
 const Multiprotocols multiProtocols {
-  { MM_RF_PROTO_FLYSKY,     STR_SUBTYPE_FLYSKY,   4,  nullptr             },
-  { MM_RF_PROTO_HUBSAN,     NO_SUBTYPE,           0,  STR_MULTI_VIDFREQ   },
-  { MM_RF_PROTO_FRSKY,      STR_SUBTYPE_FRSKY,    5,  STR_MULTI_RFTUNE    },
-  { MM_RF_PROTO_HISKY,      STR_SUBTYPE_HISKY,    1,  nullptr             },
-  { MM_RF_PROTO_V2X2,       STR_SUBTYPE_V2X2,     1,  nullptr             },
-  { MM_RF_PROTO_DSM2,       STR_SUBTYPE_DSM,      3,  nullptr             },
-  { MM_RF_PROTO_YD717,      STR_SUBTYPE_YD717,    4,  nullptr             },
-  { MM_RF_PROTO_KN,         STR_SUBTYPE_KN,       1,  nullptr             },
-  { MM_RF_PROTO_SYMAX,      STR_SUBTYPE_SYMAX,    1,  nullptr             },
-  { MM_RF_PROTO_SLT,        STR_SUBTYPE_SLT,      1,  nullptr             },
-  { MM_RF_PROTO_CX10,       STR_SUBTYPE_CX10,     7,  nullptr             },
-  { MM_RF_PROTO_CG023,      STR_SUBTYPE_CG023,    2,  nullptr             },
-  { MM_RF_PROTO_BAYANG,     STR_SUBTYPE_BAYANG,   1,  STR_MULTI_TELEMETRY },
-  { MM_RF_PROTO_MT99XX,     STR_SUBTYPE_MT99,     4,  nullptr             },
-  { MM_RF_PROTO_MJXQ,       STR_SUBTYPE_MJXQ,     5,  nullptr             },
-  { MM_RF_PROTO_FY326,      STR_SUBTYPE_FY326,    1,  nullptr             },
-  { MM_RF_PROTO_SFHSS,      NO_SUBTYPE,           0,  STR_MULTI_RFTUNE    },
-  { MM_RF_PROTO_HONTAI,     STR_SUBTYPE_HONTAI,   2,  nullptr             },
-  { MM_RF_PROTO_OLRS,       NO_SUBTYPE,           0,  STR_MULTI_RFPOWER   },
-  { MM_RF_PROTO_FS_AFHDS2A, STR_SUBTYPE_AFHDS2A,  3,  STR_MULTI_SERVOFREQ },
-  { MM_RF_PROTO_Q2X2,       STR_SUBTYPE_Q2X2,     2,  nullptr             },
-  { MM_RF_PROTO_WK_2X01,    STR_SUBTYPE_WK2x01,   5,  nullptr             },
-  { MM_RF_PROTO_Q303,       STR_SUBTYPE_Q303,     3,  nullptr             },
-  { MM_RF_CUSTOM_SELECTED,  STR_SUBTYPE_CUSTOM,   7,  STR_MULTI_OPTION    },
+  { MM_RF_PROTO_FLYSKY,     4,  STR_SUBTYPE_FLYSKY,   nullptr             },
+  { MM_RF_PROTO_HUBSAN,     0,  NO_SUBTYPE,           STR_MULTI_VIDFREQ   },
+  { MM_RF_PROTO_FRSKY,      5,  STR_SUBTYPE_FRSKY,    STR_MULTI_RFTUNE    },
+  { MM_RF_PROTO_HISKY,      1,  STR_SUBTYPE_HISKY,    nullptr             },
+  { MM_RF_PROTO_V2X2,       1,  STR_SUBTYPE_V2X2,     nullptr             },
+  { MM_RF_PROTO_DSM2,       3,  STR_SUBTYPE_DSM,      nullptr             },
+  { MM_RF_PROTO_YD717,      4,  STR_SUBTYPE_YD717,    nullptr             },
+  { MM_RF_PROTO_KN,         1,  STR_SUBTYPE_KN,       nullptr             },
+  { MM_RF_PROTO_SYMAX,      1,  STR_SUBTYPE_SYMAX,    nullptr             },
+  { MM_RF_PROTO_SLT,        1,  STR_SUBTYPE_SLT,      nullptr             },
+  { MM_RF_PROTO_CX10,       7,  STR_SUBTYPE_CX10,     nullptr             },
+  { MM_RF_PROTO_CG023,      2,  STR_SUBTYPE_CG023,    nullptr             },
+  { MM_RF_PROTO_BAYANG,     1,  STR_SUBTYPE_BAYANG,   STR_MULTI_TELEMETRY },
+  { MM_RF_PROTO_MT99XX,     4,  STR_SUBTYPE_MT99,     nullptr             },
+  { MM_RF_PROTO_MJXQ,       5,  STR_SUBTYPE_MJXQ,     nullptr             },
+  { MM_RF_PROTO_FY326,      1,  STR_SUBTYPE_FY326,    nullptr             },
+  { MM_RF_PROTO_SFHSS,      0,  NO_SUBTYPE,           STR_MULTI_RFTUNE    },
+  { MM_RF_PROTO_HONTAI,     2,  STR_SUBTYPE_HONTAI,   nullptr             },
+  { MM_RF_PROTO_OLRS,       0,  NO_SUBTYPE,           STR_MULTI_RFPOWER   },
+  { MM_RF_PROTO_FS_AFHDS2A, 3,  STR_SUBTYPE_AFHDS2A,  STR_MULTI_SERVOFREQ },
+  { MM_RF_PROTO_Q2X2,       2,  STR_SUBTYPE_Q2X2,     nullptr             },
+  { MM_RF_PROTO_WK_2X01,    5,  STR_SUBTYPE_WK2x01,   nullptr             },
+  { MM_RF_PROTO_Q303,       3,  STR_SUBTYPE_Q303,     nullptr             },
+  { MM_RF_CUSTOM_SELECTED,  7,  NO_SUBTYPE,           STR_MULTI_OPTION    },
 
-  //Sential and default for protocols not listed above (MM_RF_CUSTOM is 0xff()
-  { 0xfe,                   NO_SUBTYPE,           0,  nullptr             }
+  // Sentinel and default for protocols not listed above (MM_RF_CUSTOM is 0xff)
+  { 0xfe,                   0,  NO_SUBTYPE,           nullptr             }
 };
 
 int Multiprotocols::MultiProtocolDefinition::getOptionMin() const {

--- a/companion/src/multiprotocols.h
+++ b/companion/src/multiprotocols.h
@@ -34,8 +34,8 @@ class Multiprotocols
 
     struct radio_mm_definition {
       int protocol;
-      QStringList protocols;
       unsigned int maxSubtype;
+      QStringList protocols;
       QString optionsstr;
     };
 

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -128,14 +128,15 @@ void lcdDrawMMM(coord_t x, coord_t y, LcdFlags flags=0);
 #define MULTIMODULE_HASOPTIONS(x)       (getMultiProtocolDefinition(x)->optionsstr != nullptr)
 #define MULTIMODULE_OPTIONS_ROW         (IS_MODULE_MULTIMODULE(EXTERNAL_MODULE) && MULTIMODULE_HASOPTIONS(g_model.moduleData[EXTERNAL_MODULE].getMultiProtocol(true))) ? (uint8_t) 0: HIDDEN_ROW
 #define MULTI_MAX_RX_NUM(x)             (g_model.moduleData[x].getMultiProtocol(true) == MM_RF_PROTO_OLRS ? 4 : 15)
-// only packed to save flash
-PACK(
-  struct mm_protocol_definition {
-    uint8_t protocol;
-    const pm_char *subTypeString;
-    uint8_t maxSubtype;
-    const char *optionsstr;
-  } );
+
+// When using packed, the pointer in here end up not being aligned, which clang and gcc complain about
+// Keep the order of the fields that the so that the size stays small
+struct mm_protocol_definition {
+  uint8_t protocol;
+  uint8_t maxSubtype;
+  const pm_char *subTypeString;
+  const char *optionsstr;
+};
 
 const mm_protocol_definition *getMultiProtocolDefinition (uint8_t protocol);
 #else

--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -672,33 +672,33 @@ const pm_char STR_SUBTYPE_BAYANG[] PROGMEM =     "\006""Bayang""H8S3D";
 const pm_char STR_SUBTYPE_FY326[] PROGMEM =      "\005""FY326""FY319";
 
 const mm_protocol_definition multi_protocols[] = {
-  { MM_RF_PROTO_FLYSKY,     STR_SUBTYPE_FLYSKY,   4,  nullptr             },
-  { MM_RF_PROTO_HUBSAN,     NO_SUBTYPE,           0,  STR_MULTI_VIDFREQ   },
-  { MM_RF_PROTO_FRSKY,      STR_SUBTYPE_FRSKY,    5,  STR_MULTI_RFTUNE    },
-  { MM_RF_PROTO_HISKY,      STR_SUBTYPE_HISKY,    1,  nullptr             },
-  { MM_RF_PROTO_V2X2,       STR_SUBTYPE_V2X2,     1,  nullptr             },
-  { MM_RF_PROTO_DSM2,       STR_SUBTYPE_DSM,      3,  nullptr             },
-  { MM_RF_PROTO_YD717,      STR_SUBTYPE_YD717,    4,  nullptr             },
-  { MM_RF_PROTO_KN,         STR_SUBTYPE_KN,       1,  nullptr             },
-  { MM_RF_PROTO_SYMAX,      STR_SUBTYPE_SYMAX,    1,  nullptr             },
-  { MM_RF_PROTO_SLT,        STR_SUBTYPE_SLT,      1,  nullptr             },
-  { MM_RF_PROTO_CX10,       STR_SUBTYPE_CX10,     7,  nullptr             },
-  { MM_RF_PROTO_CG023,      STR_SUBTYPE_CG023,    2,  nullptr             },
-  { MM_RF_PROTO_BAYANG,     STR_SUBTYPE_BAYANG,   1,  STR_MULTI_TELEMETRY },
-  { MM_RF_PROTO_MT99XX,     STR_SUBTYPE_MT99,     4,  nullptr             },
-  { MM_RF_PROTO_MJXQ,       STR_SUBTYPE_MJXQ,     5,  nullptr             },
-  { MM_RF_PROTO_FY326,      STR_SUBTYPE_FY326,    1,  nullptr             },
-  { MM_RF_PROTO_SFHSS,      NO_SUBTYPE,           0,  STR_MULTI_RFTUNE    },
-  { MM_RF_PROTO_HONTAI,     STR_SUBTYPE_HONTAI,   2,  nullptr             },
-  { MM_RF_PROTO_OLRS,       NO_SUBTYPE,           0,  STR_MULTI_RFPOWER   },
-  { MM_RF_PROTO_FS_AFHDS2A, STR_SUBTYPE_AFHDS2A,  3,  STR_MULTI_SERVOFREQ },
-  { MM_RF_PROTO_Q2X2,       STR_SUBTYPE_Q2X2,     2,  nullptr             },
-  { MM_RF_PROTO_WK_2X01,    STR_SUBTYPE_WK2x01,   5,  nullptr             },
-  { MM_RF_PROTO_Q303,       STR_SUBTYPE_Q303,     3,  nullptr             },
-  { MM_RF_CUSTOM_SELECTED,  NO_SUBTYPE,           7,  STR_MULTI_OPTION    },
-
-  //Sential and default for protocols not listed above (MM_RF_CUSTOM is 0xff()
-  { 0xfe,                   NO_SUBTYPE,           0,  nullptr             }
+  { MM_RF_PROTO_FLYSKY,     4,  STR_SUBTYPE_FLYSKY,   nullptr             },
+  { MM_RF_PROTO_HUBSAN,     0,  NO_SUBTYPE,           STR_MULTI_VIDFREQ   },
+  { MM_RF_PROTO_FRSKY,      5,  STR_SUBTYPE_FRSKY,    STR_MULTI_RFTUNE    },
+  { MM_RF_PROTO_HISKY,      1,  STR_SUBTYPE_HISKY,    nullptr             },
+  { MM_RF_PROTO_V2X2,       1,  STR_SUBTYPE_V2X2,     nullptr             },
+  { MM_RF_PROTO_DSM2,       3,  STR_SUBTYPE_DSM,      nullptr             },
+  { MM_RF_PROTO_YD717,      4,  STR_SUBTYPE_YD717,    nullptr             },
+  { MM_RF_PROTO_KN,         1,  STR_SUBTYPE_KN,       nullptr             },
+  { MM_RF_PROTO_SYMAX,      1,  STR_SUBTYPE_SYMAX,    nullptr             },
+  { MM_RF_PROTO_SLT,        1,  STR_SUBTYPE_SLT,      nullptr             },
+  { MM_RF_PROTO_CX10,       7,  STR_SUBTYPE_CX10,     nullptr             },
+  { MM_RF_PROTO_CG023,      2,  STR_SUBTYPE_CG023,    nullptr             },
+  { MM_RF_PROTO_BAYANG,     1,  STR_SUBTYPE_BAYANG,   STR_MULTI_TELEMETRY },
+  { MM_RF_PROTO_MT99XX,     4,  STR_SUBTYPE_MT99,     nullptr             },
+  { MM_RF_PROTO_MJXQ,       5,  STR_SUBTYPE_MJXQ,     nullptr             },
+  { MM_RF_PROTO_FY326,      1,  STR_SUBTYPE_FY326,    nullptr             },
+  { MM_RF_PROTO_SFHSS,      0,  NO_SUBTYPE,           STR_MULTI_RFTUNE    },
+  { MM_RF_PROTO_HONTAI,     2,  STR_SUBTYPE_HONTAI,   nullptr             },
+  { MM_RF_PROTO_OLRS,       0,  NO_SUBTYPE,           STR_MULTI_RFPOWER   },
+  { MM_RF_PROTO_FS_AFHDS2A, 3,  STR_SUBTYPE_AFHDS2A,  STR_MULTI_SERVOFREQ },
+  { MM_RF_PROTO_Q2X2,       2,  STR_SUBTYPE_Q2X2,     nullptr             },
+  { MM_RF_PROTO_WK_2X01,    5,  STR_SUBTYPE_WK2x01,   nullptr             },
+  { MM_RF_PROTO_Q303,       3,  STR_SUBTYPE_Q303,     nullptr             },
+  { MM_RF_CUSTOM_SELECTED,  7,  NO_SUBTYPE,           STR_MULTI_OPTION    },
+                                
+  // Sentinel and default for protocols not listed above (MM_RF_CUSTOM is 0xff)
+  { 0xfe,                   0,  NO_SUBTYPE,           nullptr             }
 };
 
 #undef NO_SUBTYPE


### PR DESCRIPTION
This chance costs 48 byte of flash space