### PR TITLE
FRSKY_STICKS option was missing in 2.2

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -40,6 +40,7 @@ option(TEMPLATES "Model templates menu" OFF)
 option(TRACE_SIMPGMSPACE "Turn on traces in simpgmspace.cpp" ON)
 option(TRACE_LUA_INTERNALS "Turn on traces for Lua internals" OFF)
 option(BINDING_OPTIONS "Allow advanced frsky bindings" OFF)
+option(FRSKY_STICKS "Reverse sticks for FrSky sticks" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -329,6 +330,10 @@ endif()
 
 if(BINDING_OPTIONS)
   add_definitions(-DBINDING_OPTIONS)
+endif()
+
+if(FRSKY_STICKS)
+  add_definitions(-DFRSKY_STICKS)
 endif()
 
 if(EEPROM_VARIANT_NEEDED)


### PR DESCRIPTION
This fixes #5087 