### PR TITLE
Save 256 byte RAM (32 * 8) by removing min,max for text sesnors

### DIFF
--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -36,8 +36,6 @@ class TelemetryItem
       uint32_t distFromEarthAxis;
     };
 
-    uint8_t lastReceived;       // for detection of sensor loss
-
     union {                    // This union allows to use text sensors to also use the space of valueMin and valueMax
       struct {
         union {
@@ -80,6 +78,8 @@ class TelemetryItem
         } gps;
       };
       char text[16];
+
+      uint8_t lastReceived;       // for detection of sensor loss
     };
 
     static uint8_t now()

--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -36,45 +36,49 @@ class TelemetryItem
       uint32_t distFromEarthAxis;
     };
 
-    union {
-      int32_t valueMin;         // min store
-      int32_t pilotLongitude;
-    };
-
-    union {
-      int32_t valueMax;         // max store
-      int32_t pilotLatitude;
-    };
-
     uint8_t lastReceived;       // for detection of sensor loss
 
-    union {
+    union {                    // This union allows to use text sensors to also use the space of valueMin and valueMax
       struct {
-        int32_t  offsetAuto;
-        int32_t  filterValues[TELEMETRY_AVERAGE_COUNT];
-      } std;
-      struct {
-        uint16_t prescale;
-      } consumption;
-      struct {
-        uint8_t   count;
-        CellValue values[6];
-      } cells;
-      struct {
-        uint16_t year;          // full year (4 digits)
-        uint8_t  month;
-        uint8_t  day;
-        uint8_t  hour;
-        uint8_t  min;
-        uint8_t  sec;
-      } datetime;
-      struct {
-        int32_t latitude;
-        int32_t longitude;
-        // pilot longitude is stored in min
-        // pilot latitude is stored in max
-        // distFromEarthAxis is stored in value
-      } gps;
+        union {
+          int32_t valueMin;         // min store
+          int32_t pilotLongitude;
+        };
+
+        union {
+          int32_t valueMax;         // max store
+          int32_t pilotLatitude;
+        };
+      };
+
+      union  {
+        struct {
+          int32_t offsetAuto;
+          int32_t filterValues[TELEMETRY_AVERAGE_COUNT];
+        } std;
+        struct {
+          uint16_t prescale;
+        } consumption;
+        struct {
+          uint8_t count;
+          CellValue values[6];
+        } cells;
+        struct {
+          uint16_t year;          // full year (4 digits)
+          uint8_t month;
+          uint8_t day;
+          uint8_t hour;
+          uint8_t min;
+          uint8_t sec;
+        } datetime;
+        struct {
+          int32_t latitude;
+          int32_t longitude;
+          // pilot longitude is stored in min
+          // pilot latitude is stored in max
+          // distFromEarthAxis is stored in value
+        } gps;
+      };
       char text[16];
     };
 


### PR DESCRIPTION
Before:
00000000 g       .bss.telemetryItems		 00000400 telemetryItems
After:
00000000 g       .bss.telemetryItems		 00000300 telemetryItems

Diff is large because of whitespace changes, here is a diff without whitspaces

```diff
diff --git a/radio/src/telemetry/telemetry_sensors.h b/radio/src/telemetry/telemetry_sensors.h
index 91ae90468..ef084e4d8 100644
--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -36,6 +36,10 @@ class TelemetryItem
       uint32_t distFromEarthAxis;
     };
 
+    uint8_t lastReceived;       // for detection of sensor loss
+
+    union {                    // This union allows to use text sensors to also use the space of valueMin and valueMax
+      struct {
         union {
           int32_t valueMin;         // min store
           int32_t pilotLongitude;
@@ -45,8 +49,7 @@ class TelemetryItem
           int32_t valueMax;         // max store
           int32_t pilotLatitude;
         };
-
-    uint8_t lastReceived;       // for detection of sensor loss
+      };
 
       union  {
         struct {
@@ -75,6 +78,7 @@ class TelemetryItem
           // pilot latitude is stored in max
           // distFromEarthAxis is stored in value
         } gps;
+      };
       char text[16];
     };
```