### PR TITLE
Improve pilotPosition when internal GPS is available

### DIFF
--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -103,8 +103,6 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
       pilotLatitude = newVal;
       distFromEarthAxis = getDistFromEarthAxis(newVal);
     }
-
-
     gps.latitude = newVal;
     lastReceived = now();
     return;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -93,15 +93,28 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
     newVal = 0;
   }
   else if (unit == UNIT_GPS_LATITUDE) {
+#if defined(INTERNAL_GPS)
+    if (gpsData.fix) {
+      pilotLatitude = gpsData.latitude;
+      distFromEarthAxis = getDistFromEarthAxis(pilotLatitude);
+    }
+#endif
     if (!pilotLatitude) {
       pilotLatitude = newVal;
       distFromEarthAxis = getDistFromEarthAxis(newVal);
     }
+
+
     gps.latitude = newVal;
     lastReceived = now();
     return;
   }
   else if (unit == UNIT_GPS_LONGITUDE) {
+#if defined(INTERNAL_GPS)
+    if (gpsData.fix) {
+      pilotLongitude = gpsData.longitude;
+    }
+#endif
     if (!pilotLongitude) {
       pilotLongitude = newVal;
     }


### PR DESCRIPTION
For radio with internal GPS, pilotPosition is updated using intenal GPS data.
When internal GPS doesn't lock works as before.