### PR TITLE
Improve German translations

### DIFF
--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -718,39 +718,39 @@
 #define TR_RANGE               TR(INDENT "Bereich", INDENT "Variobereich m/s") // 9XR-Pro
 #define TR_CENTER              TR(INDENT "Mitte m/s", INDENT "Variomitte     m/s")
 #define TR_BAR                 "Balken"
-#define TR_ALARM               TR(INDENT "Alarme ", INDENT "Ein bei Alarm")  //9XR-Pro
+#define TR_ALARM               TR(INDENT "Alarme ", INDENT "Aufleuchten bei Alarm")  //9XR-Pro
 #define TR_USRDATA             "Daten berechnen aus"
 #define TR_BLADES              TR(INDENT "Prop", INDENT "Prop-Blätter") //9XR-Pro
-#define TR_SCREEN              "Telm-Bild "
-#define TR_SOUND_LABEL         "----Töne---------"
+#define TR_SCREEN              "Telm-Anzeige "
+#define TR_SOUND_LABEL         "Töne"
 #define TR_LENGTH              INDENT "Dauer"
 #define TR_BEEP_LENGTH         INDENT "Beep-Länge"
 #define TR_SPKRPITCH           INDENT "Beep-Freq. +/-"
-#define TR_HAPTIC_LABEL        "----Haptik-------" //9XR-Pro
+#define TR_HAPTIC_LABEL        "Haptik"
 #define TR_HAPTICSTRENGTH      INDENT "Stärke"
 #define TR_CONTRAST            "LCD-Kontrast"
-#define TR_ALARMS_LABEL        "----Alarm wenn---"
-#define TR_BATTERY_RANGE       TR("Akku Bereich", "Akku Spgs-Bereich") // Symbol Akku Ladezustand
-#define TR_BATTERYWARNING      INDENT "Akkuspg kleiner"
+#define TR_ALARMS_LABEL        "Alarme"
+#define TR_BATTERY_RANGE       TR("Akku Bereich", "Akku Spgannungsbereich") // Symbol Akku Ladezustand
+#define TR_BATTERYWARNING      TR(INDENT "Akkuspg kleiner", "Akkuspannungswarnung")
 #define TR_INACTIVITYALARM     TR(INDENT "Inaktivität", INDENT "Inaktivität nach") //9XR-Pro
 #define TR_MEMORYWARNING       INDENT "Speicher voll"
 #define TR_ALARMWARNING        TR(INDENT "Alle Töne aus?", INDENT "Alle Töne ganz aus?")
-#define TR_RSSISHUTDOWNALARM   TR(INDENT "Rssi Shutdown", INDENT "Check Rssi on Shutdown")
+#define TR_RSSISHUTDOWNALARM   TR(INDENT "Rssi Shutdown", INDENT "Rssi-Warnung beim Auschalten")
 #define TR_MODEL_STILL_POWERED "Model still powered"
 #define TR_PRESS_ENTER_TO_CONFIRM      "Press enter to confirm"
 #define TR_RENAVIG             "Drehgeb. Navig."
-#define TR_THROTTLE_LABEL      "----Gas-Kontrolle----"
+#define TR_THROTTLE_LABEL      "Gas-Kontrolle"
 #define TR_THROTTLEREVERSE     TR("Gas invers", INDENT "Vollgas hinten?") //Änderung wg TH9x, Taranis
 #define TR_TIMER_NAME          INDENT "Name"
 #define TR_MINUTEBEEP          TR(INDENT "Min-Alarm", INDENT "Minuten-Alarm")
 #define TR_BEEPCOUNTDOWN       INDENT "Countdown"
 #define TR_PERSISTENT          TR(INDENT "Permanent", INDENT "Permanent")
-#define TR_BACKLIGHT_LABEL     "----LCD-Beleuchtg----"
+#define TR_BACKLIGHT_LABEL     "LCD-Beleuchtung"
 #define TR_BLDELAY             INDENT "Dauer"
 #define TR_BLONBRIGHTNESS      INDENT "An-Helligkeit"
 #define TR_BLOFFBRIGHTNESS     INDENT "Aus-Helligkeit"
 #define TR_BLCOLOR             INDENT "Farbe"
-#define TR_SPLASHSCREEN        TR("Startbild Ein", "Startbild Ein für")
+#define TR_SPLASHSCREEN        TR("Startbild Ein", "Startbild Anzeigedauer")
 #define TR_THROTTLEWARNING     TR("Gasalarm", INDENT "Gas Alarm")
 #define TR_SWITCHWARNING       TR("Sch. Alarm", INDENT "Schalter-Alarm")
 #define TR_POTWARNINGSTATE     TR(IF_CPUARM(INDENT) "Pot&Slid.", INDENT "Pots & sliders")
@@ -758,12 +758,12 @@
 #define TR_POTWARNING          TR("Pot Warn.", INDENT "Poti-Warnung")
 #define TR_TIMEZONE            TR("Zeitzone", "GPS-Zeitzone +/-Std")
 #define TR_ADJUST_RTC          TR("Uhrzeit setzen", INDENT "Uhrzeit per GPS setzen")
-#define TR_GPS                 "----GPS--------------"
+#define TR_GPS                 "GPS"
 #define TR_RXCHANNELORD        TR("Kanalanordnung", "Kanalvoreinstellung")
 #define TR_STICKS              "Knüppel"
 #define TR_POTS                "Potis"
 #define TR_SWITCHES            "Schalter"
-#define TR_SWITCHES_DELAY      TR("Sw. Mitte Delay", "Schaltermitte Verz.")   //Schalter Mitten verzögern Anpassung
+#define TR_SWITCHES_DELAY      TR("Sw. Mitte Delay", "Schaltermitte Verzögerung")   //Schalter Mitten verzögern Anpassung
 #define TR_SLAVE               TR("Schüler PPM1-16", "Schüler PPM1-16 als Ausgang")
 #define TR_MODESRC             " Modus\003%  Quelle"
 #define TR_MULTIPLIER          "Multiplik."
@@ -865,7 +865,7 @@
 #define TR_MONITOR_OUTPUT_DESC "Kanäle"
 #define TR_MONITOR_MIXER_DESC  "Mischer"
 #if defined(CPUARM)
-  #define TR_RECEIVER_NUM      TR(INDENT "Empf Nr.", INDENT "Modell-Match-Nr.")
+  #define TR_RECEIVER_NUM      TR(INDENT "Empf Nr.", INDENT "Empfänger Nummer")
   #define TR_RECEIVER          INDENT "Receiver"
 #else
   #define TR_RECEIVER_NUM      "Empf Nr."
@@ -898,14 +898,14 @@
 #define TR_LATITUDE            "Breite:"
 #define TR_LONGITUDE           "Länge:"
 #define TR_GPSCOORD            TR("GPS-Koord.", "GPS-Koordinaten-Format")
-#define TR_VARIO               TR("----Vario--------", "----Variometer----") //9XR-Pro
+#define TR_VARIO               "Variometer"
 #define TR_PITCH_AT_ZERO       INDENT "Niedrigster Ton"
 #define TR_PITCH_AT_MAX        INDENT "Höchster Ton"
 #define TR_REPEAT_AT_ZERO      INDENT "Wiederholrate"
 #define TR_POWEROFF            "\027Power OFF..."
 #define TR_SHUTDOWN            "Herunterfahren"
 #define TR_SAVEMODEL           "Modelleinstellungen speichern"
-#define TR_BATT_CALIB          "AkkuSpg messen"
+#define TR_BATT_CALIB          TR("AkkuSpg kalib.", "Akku Kalibrierung")
 #define TR_CURRENT_CALIB       "Strom abgl."
 #define TR_VOLTAGE             TR(INDENT "Spg", INDENT "Spannungsquelle")  //9XR-Pro
 #define TR_CURRENT             TR(INDENT "Strom", INDENT "Stromquelle")
@@ -993,7 +993,7 @@
 #define TR_SD_SPEED            "Geschw:"
 #define TR_SD_SECTORS          "Sectoren:"
 #define TR_SD_SIZE             "Größe:"
-#define TR_TYPE                INDENT "Type"
+#define TR_TYPE                INDENT "Typ"
 #define TR_GLOBAL_VARS         "Globale Variablen"
 #define TR_GVARS               "GLOBALE V."
 #define TR_GLOBAL_VAR          "Globale Variable"
@@ -1012,8 +1012,8 @@
 #define TR_FIRMWARE_UPDATE_ERROR TR("Firmw Update Error","Firmware update error")
 #define TR_WRITING               "\032Writing..."        //
 #define TR_CONFIRM_FORMAT      "Formatieren bestätigen?"
-#define TR_INTERNALRF          "----Internes HF-Modul----------"
-#define TR_EXTERNALRF          TR("---Externes HF-Modul---", "----Externes HF-Modul----------")  //9XR-Pro
+#define TR_INTERNALRF          "Internes HF-Modul"
+#define TR_EXTERNALRF          "Externes HF-Modul"
 #define TR_FAILSAFE            TR(INDENT "Failsafe", INDENT "Failsafe Mode")
 #define TR_FAILSAFESET         "Failsafe setzen"
 #define TR_HOLD                "HOLD"
@@ -1022,7 +1022,7 @@
 #define TR_SENSOR              "SENSOR"
 #define TR_COUNTRYCODE         "Landescode"
 #define TR_USBMODE             "USB Modus"
-#define TR_VOICELANG           "Sprach-Ansage"
+#define TR_VOICELANG           "Sprach-Ansagen"
 #define TR_UNITSSYSTEM         "Einheiten"
 #define TR_EDIT                "Zeile Editieren"
 #define TR_INSERT_BEFORE       "Neue Zeile davor"
@@ -1054,12 +1054,12 @@
 #define TR_MODULE_RANGE        BUTTON(TR("Rng", "Range"))  //9XR-Pro
 #define TR_RESET_BTN           BUTTON("Reset")
 #define TR_SET                 BUTTON("Set")
-#define TR_TRAINER             "----DSC Buchse PPM In/Out------" //DSC Buchse Trainer Buchse
+#define TR_TRAINER             "DSC Buchse PPM In/Out"
 #define TR_ANTENNAPROBLEM      CENTER "TX-Antennenproblem!"
 #define TR_MODELIDUSED         TR("ID schon benutzt", "Modell-ID schon benutzt")
 #define TR_MODULE              INDENT "Modul-Typ"
 #define TR_TELEMETRY_TYPE      TR("Typ", "Telemetrietyp")
-#define TR_TELEMETRY_SENSORS   "----Sensoren----"
+#define TR_TELEMETRY_SENSORS   "Sensoren"
 #define TR_VALUE               "Wert"
 #define TR_TOPLCDTIMER         "Top LCD Timer"
 #define TR_UNIT                "Einheit"
@@ -1068,8 +1068,8 @@
 #define TR_ANTENNASELECTION    INDENT "Antenne auswählen"
 #define TR_ANTENNACONFIRM1     "Ant. umschalten"
 #define TR_ANTENNACONFIRM2     "Ist eine externe Antenne installiert?"
-#define TR_LOWALARM            INDENT "Vor-Alarm bei"
-#define TR_CRITICALALARM       INDENT "Kritisch-Alarm"
+#define TR_LOWALARM            INDENT "Warnungsschwelle"
+#define TR_CRITICALALARM       INDENT "Kritischer Alarm"
 #define TR_RSSIALARM_WARN      "Telemetry"
 #define TR_NO_RSSIALARM        "Audiowarnungen ausgeschaltet"
 #define TR_DISABLE_ALARM       INDENT "Audiowarnungen ausschalten"
@@ -1095,7 +1095,7 @@
 #define TR_MIXSOURCE           "Mixer Quelle"
 #define TR_CONSTANT            "Konstant"
 #define TR_PERSISTENT_MAH      TR(INDENT "Spr. mAh", INDENT "Speichern mAh") //9XR-Pro
-#define TR_PREFLIGHT           TR("---Vorflug-Checkliste--", "----Vorflug-Checkliste----")
+#define TR_PREFLIGHT           "Vorflug-Checkliste"
 #define TR_CHECKLIST           TR(INDENT "Checkliste", INDENT "Checkliste anzeigen") //9XR-Pro
 #define TR_FAS_OFFSET          TR(INDENT "FAS-Ofs", INDENT "FAS-Offset")
 #define TR_UART3MODE           "Serieller Port"
@@ -1103,7 +1103,7 @@
 #define TR_INPUTS              "Eingaben"
 #define TR_OUTPUTS             "Ausgaben"
 #define TR_EEBACKUP            TR("[ENTER Long] EEPROM->SD"," [ENTER Long] Backup EEPROM->SD-Karte")
-#define TR_FACTORYRESET        TR("[MENU Long] Werksreset","  [MENU Long] Komplett reset")
+#define TR_FACTORYRESET        TR("[MENU Long] Werksreset","  [MENU Long] Auf Werkseinstellungen")
 #define TR_CONFIRMRESET        TR("Alles löschen? ","ALLE Modelle+Einst. löschen?")
 #define TR_TO_MANY_LUA_SCRIPTS "Zu viele Lua-Skripte!"
 
@@ -1239,9 +1239,9 @@
 
 #define TR_BEEP_VOLUME         "Beep-Lautst."
 #define TR_WAV_VOLUME          "Wave-Lautst."
-#define TR_BG_VOLUME           "Hintergr-Lautst."
+#define TR_BG_VOLUME           TR("Hintergr-Lautst.", "Hintergrund-Lautstärke")
 
-#define TR_TOP_BAR             "----Infozeile----"
+#define TR_TOP_BAR             "Infozeile"
 #define TR_ALTITUDE            INDENT "Höhenanzeige"
 #define TR_SCALE               "Skalieren"
 #define TR_VIEW_CHANNELS       "Zeige Kanäle"
@@ -1268,7 +1268,7 @@
 #define TR_SERVOS_OK           "Servos OK"
 #define TR_SERVOS_KO           "Servos KO"
 #define TR_INVERTED_SERIAL     INDENT "Invert."
-#define TR_IGNORE_INSTANCE     TR(INDENT "Keine ID", INDENT "Keine Multisensor-ID")	//unklar
+#define TR_IGNORE_INSTANCE     TR(INDENT "Ignr. Inst.", INDENT "Ignor. Instanzen")
 #define TR_DISCOVER_SENSORS    INDENT "Start Sensorsuche"
 #define TR_STOP_DISCOVER_SENSORS INDENT "Stop Sensorsuche"
 #define TR_DELETE_ALL_SENSORS  INDENT "Lösche alle Sensoren"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -888,7 +888,7 @@
 #define TR_POWEROFF                    "\027Power OFF..."
 #define TR_SHUTDOWN                    "SHUTTING DOWN"
 #define TR_SAVEMODEL                   "Saving model settings"
-#define TR_BATT_CALIB                  "Battery calib"
+#define TR_BATT_CALIB                  TR("Battery calib", "Battery calibration")
 #define TR_CURRENT_CALIB               "Current calib"
 #define TR_VOLTAGE                     TR(INDENT "Voltage", INDENT "Voltage source")
 #define TR_CURRENT                     TR(INDENT "Current", INDENT "Current source")
@@ -1226,7 +1226,7 @@
 
 #define TR_BEEP_VOLUME                 "Beep volume"
 #define TR_WAV_VOLUME                  "Wav volume"
-#define TR_BG_VOLUME                   "Bg volume"
+#define TR_BG_VOLUME                   TR("Bg volume", "Background Volume")
 
 #define TR_TOP_BAR                     "Top bar"
 #define TR_ALTITUDE                    INDENT "Altitude"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -696,14 +696,14 @@
 #define TR_BLADES              "Bladen"
 
 #define TR_SCREEN              "Scherm\001"
-#define TR_SOUND_LABEL         "----Geluid-------"
+#define TR_SOUND_LABEL         "Geluid-"
 #define TR_LENGTH              INDENT "Duur"
 #define TR_BEEP_LENGTH         INDENT "Piep-Lengte"
 #define TR_SPKRPITCH           INDENT "Piep-Freq. +/-"
-#define TR_HAPTIC_LABEL        "----Haptic-------" //9XR-Pro
+#define TR_HAPTIC_LABEL        "Haptic"
 #define TR_HAPTICSTRENGTH      INDENT "Sterkte"
 #define TR_CONTRAST            "LCD-Kontrast"
-#define TR_ALARMS_LABEL        "----Alarm---"
+#define TR_ALARMS_LABEL        "Alarm"
 #define TR_BATTERY_RANGE       TR("Accu Bereik", "Accu Spngs-Bereik") // Symbol Akku Ladezustand
 
 #define TR_BATTERYWARNING      INDENT "Accu laag"
@@ -714,13 +714,13 @@
 #define TR_MODEL_STILL_POWERED "Model still powered"
 #define TR_PRESS_ENTER_TO_CONFIRM      "Press enter to confirm"
 #define TR_RENAVIG             "Stappenschakelaar"
-#define TR_THROTTLE_LABEL      "----Gas-------------"
+#define TR_THROTTLE_LABEL      "Gas"
 #define TR_THROTTLEREVERSE     TR("Reverse", INDENT "Omgekeerd")
 #define TR_TIMER_NAME          INDENT "Naam"
 #define TR_MINUTEBEEP          TR(INDENT "Min-Alarm", INDENT "Minuten-Alarm")
 #define TR_BEEPCOUNTDOWN       INDENT "Countdown"
 #define TR_PERSISTENT          TR(INDENT "Vasth.", INDENT "Vasthouden")
-#define TR_BACKLIGHT_LABEL     "----LCD-Verlichting--"
+#define TR_BACKLIGHT_LABEL     "LCD-Verlichting"
 #define TR_BLDELAY             INDENT "Duur"
 #define TR_BLONBRIGHTNESS      INDENT "Aan-Helderheid"
 #define TR_BLOFFBRIGHTNESS     INDENT "Uit-Helderheid"
@@ -733,7 +733,7 @@
 #define TR_POTWARNING          TR(IF_CPUARM(INDENT) "Pot Warn.", INDENT "Pot Posities")
 #define TR_TIMEZONE            TR("Tijdzone", "GPS-Tijdzone +/-Std")
 #define TR_ADJUST_RTC          TR("Klok instellen", INDENT "Klok middels GPS instellen")
-#define TR_GPS                 "----GPS--------------"
+#define TR_GPS                 "GPS"
 #define TR_RXCHANNELORD        TR("Kan.Volgorde", "Kanaalvolgorde")
 #define TR_STICKS              "Sticks"
 #define TR_POTS                "Pots"
@@ -877,7 +877,7 @@
 #define TR_LATITUDE            "Latitude"
 #define TR_LONGITUDE           "Longitude"
 #define TR_GPSCOORD            TR("GPS-coord.", "GPS-coordinaten format")
-#define TR_VARIO               TR("----Vario--------", "----Variometer----") //9XR-Pro
+#define TR_VARIO               "Variometer"
 #define TR_PITCH_AT_ZERO       INDENT "Laagste Toon"
 #define TR_PITCH_AT_MAX        INDENT "Hoogste Toon"
 #define TR_REPEAT_AT_ZERO      INDENT "Herhalen bij 0"
@@ -1037,7 +1037,7 @@
 #define TR_MODELIDUSED         TR("ID al gebruikt", "Model-ID al gebruikt")
 #define TR_MODULE              INDENT "Module-Type"
 #define TR_TELEMETRY_TYPE      TR("Type", "Telemetrietype")
-#define TR_TELEMETRY_SENSORS   "----Sensoren----"
+#define TR_TELEMETRY_SENSORS   "Sensoren"
 #define TR_VALUE               "Waarde"
 #define TR_TOPLCDTIMER         "Top LCD Timer"
 #define TR_UNIT                "Eenheid"
@@ -1224,7 +1224,7 @@
 #define TR_WAV_VOLUME          "Wav-Volume"
 #define TR_BG_VOLUME           "Achtergr-Volume"
 
-#define TR_TOP_BAR             "-------Info------"
+#define TR_TOP_BAR             "Info"
 #define TR_ALTITUDE            INDENT "Hoogte"
 #define TR_SCALE               "Schaal"
 #define TR_VIEW_CHANNELS       "Toon Kanalen"


### PR DESCRIPTION
- No different menu heading than other languages (also in NL)
- Fix a few strings
- also don't shorten two strings in English where we have the space