### PR TITLE
Fix FrSky D cable telementry for 9XR PRO and DJT module.

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -954,6 +954,7 @@ PACK(struct TrainerData {
 #elif defined(PCBSKY9X)
   #define EXTRA_GENERAL_FIELDS \
     EXTRA_GENERAL_FIELDS_ARM \
+    NOBACKUP(uint8_t  serial2Mode:4); \
     int8_t   txCurrentCalibration; \
     int8_t   temperatureWarn; \
     uint8_t  mAhWarn; \
@@ -1146,7 +1147,7 @@ static inline void check_struct()
   CHKSIZE(FrSkyTelemetryData, 88);
   CHKSIZE(ModelHeader, 12);
   CHKTYPE(CurveData, 4);
-  CHKSIZE(RadioData, 727);
+  CHKSIZE(RadioData, 728);
   CHKSIZE(ModelData, 5188);
 #else
   // Common for all variants

--- a/radio/src/targets/sky9x/board.h
+++ b/radio/src/targets/sky9x/board.h
@@ -404,10 +404,11 @@ void telemetryTransmitBuffer(uint8_t * buffer, uint32_t size);
 void rxPdcUsart( void (*pChProcess)(uint8_t x) );
 
 // Second UART driver
+#define SERIAL2
+#define serial2Init(...)
 void serial2TelemetryInit(unsigned int protocol);
-#if defined(__cplusplus)
-bool telemetrySecondPortReceive(uint8_t & data);
-#endif
+void serial2Putc(const unsigned char c);
+bool telemetrySecondPortReceive(unsigned char & data);
 
 extern const uint8_t BootCode[];
 


### PR DESCRIPTION
Telemetry  wasn't working on the 9XR Pro with the DJT module and the cable from connecting it to the  futaba trainer port.

I've assumed the NOBACKUP macro in datastructs.h prevents the data from being written out so I didn't have to bump the EEPROM_VER.

