### PR TITLE
GPS datetime display fixes

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -1147,11 +1147,11 @@ void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
      lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
   }
   else {
-    lcdDrawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
+    lcdDrawNumber(x, y, telemetryItem.datetime.year, att|LEADING0|LEFT, 4);
     lcdDrawChar(lcdLastRightPos, y, '-', att);
     lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
     lcdDrawChar(lcdLastRightPos, y, '-', att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.year, att|LEADING0|LEFT, 4);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
   }
 }
 
@@ -1167,9 +1167,9 @@ void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags att)
   lcdDrawText(lcdNextPos, y, ":", att);
   lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
 
-  lcdDrawNumber(x-29, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
+  lcdDrawNumber(x-29, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
   lcdDrawChar(lcdNextPos, y, '-', att);
-  lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
+  lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
 }
 
 void drawGPSPosition(coord_t x, coord_t y, int32_t longitude, int32_t latitude, LcdFlags flags)

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -1168,7 +1168,7 @@ void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags att)
   lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
 
   lcdDrawNumber(x-29, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-  lcdDrawChar(lcdNextPos, y, '/', att);
+  lcdDrawChar(lcdNextPos, y, '-', att);
   lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
 }
 

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -1137,30 +1137,39 @@ void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, L
   lcdDrawSizedText(lcdLastRightPos+1, y, direction + (value>=0 ? 0 : 1), 1);
 }
 
-void drawTelemScreenDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
+void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 {
-  if (att & DBLSIZE) {
-    x -= 42;
-    att &= ~FONTSIZE_MASK;
-    lcdDrawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos-1, y, '-', att);
-    lcdDrawNumber(lcdNextPos-1, y, telemetryItem.datetime.month, att|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos-1, y, '-', att);
-    lcdDrawNumber(lcdNextPos-1, y, telemetryItem.datetime.year-2000, att|LEFT);
-    y += FH;
-    lcdDrawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos, y, ':', att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos, y, ':', att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
+  if (BLINK_ON_PHASE) {
+     lcdDrawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0, 2);
+     lcdDrawText(lcdNextPos, y, ":", att);
+     lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0, 2);
+     lcdDrawText(lcdNextPos, y, ":", att);
+     lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
   }
   else {
-    lcdDrawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos, y, ':', att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    lcdDrawChar(lcdLastRightPos, y, ':', att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
+    lcdDrawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
+    lcdDrawChar(lcdLastRightPos, y, '-', att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
+    lcdDrawChar(lcdLastRightPos, y, '-', att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.year, att|LEADING0|LEFT, 4);
   }
+}
+
+void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags att)
+{
+  y+=3;
+  sensor = (sensor-MIXSRC_FIRST_TELEM) / 3;
+	TelemetryItem & telemetryItem = telemetryItems[sensor];
+
+  lcdDrawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0, 2);
+  lcdDrawText(lcdNextPos, y, ":", att);
+  lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0, 2);
+  lcdDrawText(lcdNextPos, y, ":", att);
+  lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
+
+  lcdDrawNumber(x-29, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
+  lcdDrawChar(lcdNextPos, y, '/', att);
+  lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0|LEFT, 2);
 }
 
 void drawGPSPosition(coord_t x, coord_t y, int32_t longitude, int32_t latitude, LcdFlags flags)

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -526,7 +526,7 @@ void menuModelTelemetryFrsky(event_t event)
       lcdDrawChar(lcdLastRightPos, y, ':', attr);
       lcdDrawSizedText(3*FW, y, g_model.telemetrySensors[index].label, TELEM_LABEL_LEN, ZCHAR);
       if (telemetryItems[index].isFresh()) {
-        lcdDrawChar(16*FW, y, '*');
+        lcdDrawChar(17*FW, y, '*');
       }
       TelemetryItem & telemetryItem = telemetryItems[index];
       if (telemetryItem.isAvailable()) {

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -356,7 +356,7 @@ bool displayNumbersTelemetryScreen(FrSkyScreenData & screen)
           }
         }
         if(isSensorUnit(1+(field-MIXSRC_FIRST_TELEM)/3, UNIT_DATETIME))
-          drawSourceValue(pos[j+1]-36, 6+FH+2*FH*i, field, SMLSIZE|NO_UNIT);
+          drawTelemScreenDate(pos[j+1]-36, 6+FH+2*FH*i, field, SMLSIZE|NO_UNIT);
         else
           drawSourceValue(pos[j+1]-2, (i==3 ? 1+FH+2*FH*i:FH+2*FH*i), field, att);
       }

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -764,8 +764,30 @@ void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, L
   lcdDrawSizedText(lcdLastRightPos+1, y, direction + (value>=0 ? 0 : 1), 1);
 }
 
-void drawTelemScreenDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
+void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 {
+  att &= ~FONTSIZE_MASK;
+  if (BLINK_ON_PHASE) {
+    lcdDrawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0, 2);
+    lcdDrawText(lcdNextPos, y, ":", att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0, 2);
+    lcdDrawText(lcdNextPos, y, ":", att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
+  }
+  else {
+    lcdDrawNumber(x, y, telemetryItem.datetime.day, att|LEADING0, 2);
+    lcdDrawText(lcdNextPos, y, "-", att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0, 2);
+    lcdDrawText(lcdNextPos, y, "-", att);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.year, att|LEADING0,4);
+  }
+}
+
+void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags att)
+{
+  sensor = (sensor-MIXSRC_FIRST_TELEM) / 3;
+	TelemetryItem & telemetryItem = telemetryItems[sensor];
+
   att &= ~FONTSIZE_MASK;
   lcdDrawNumber(x, y+1, telemetryItem.datetime.sec, att|LEADING0, 2);
   lcdDrawText(lcdNextPos, y+1, ":", att);
@@ -775,9 +797,9 @@ void drawTelemScreenDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, Lc
 
   lcdDrawNumber(x, y+9, telemetryItem.datetime.year, att, 4);
   lcdDrawText(lcdNextPos, y+9, "-", att);
-  lcdDrawNumber(lcdNextPos+1, y+9, telemetryItem.datetime.month, att|LEADING0, 2);
-  lcdDrawText(lcdNextPos+1, y+9, "-", att);
-  lcdDrawNumber(lcdNextPos+1, y+9, telemetryItem.datetime.day, att|LEADING0,2);
+  lcdDrawNumber(lcdNextPos, y+9, telemetryItem.datetime.month, att|LEADING0, 2);
+  lcdDrawText(lcdNextPos, y+9, "-", att);
+  lcdDrawNumber(lcdNextPos, y+9, telemetryItem.datetime.day, att|LEADING0,2);
 }
 
 void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -775,11 +775,11 @@ void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
     lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0, 2);
   }
   else {
-    lcdDrawNumber(x, y, telemetryItem.datetime.day, att|LEADING0, 2);
+    lcdDrawNumber(x, y, telemetryItem.datetime.year, att|LEADING0, 4);
     lcdDrawText(lcdNextPos, y, "-", att);
     lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.month, att|LEADING0, 2);
     lcdDrawText(lcdNextPos, y, "-", att);
-    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.year, att|LEADING0,4);
+    lcdDrawNumber(lcdNextPos, y, telemetryItem.datetime.day, att|LEADING0,2);
   }
 }
 
@@ -795,11 +795,11 @@ void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags att)
   lcdDrawText(lcdNextPos, y+1, ":", att);
   lcdDrawNumber(lcdNextPos, y+1, telemetryItem.datetime.hour, att|LEADING0, 2);
 
-  lcdDrawNumber(x, y+9, telemetryItem.datetime.year, att, 4);
+  lcdDrawNumber(x, y+9, telemetryItem.datetime.day, att|LEADING0, 2);
   lcdDrawText(lcdNextPos, y+9, "-", att);
   lcdDrawNumber(lcdNextPos, y+9, telemetryItem.datetime.month, att|LEADING0, 2);
   lcdDrawText(lcdNextPos, y+9, "-", att);
-  lcdDrawNumber(lcdNextPos, y+9, telemetryItem.datetime.day, att|LEADING0,2);
+  lcdDrawNumber(lcdNextPos, y+9, telemetryItem.datetime.year, att|LEADING0,4);
 }
 
 void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)

--- a/radio/src/gui/212x64/view_telemetry.cpp
+++ b/radio/src/gui/212x64/view_telemetry.cpp
@@ -144,7 +144,12 @@ bool displayNumbersTelemetryScreen(FrSkyScreenData & screen)
           }
         }
 
-        drawSourceValue(x, y, field, att);
+        if(isSensorUnit(1+(field-MIXSRC_FIRST_TELEM)/3, UNIT_DATETIME)) {
+          drawTelemScreenDate(x, y, field, att);
+        }
+        else {
+          drawSourceValue(x, y, field, att);
+        }
       }
     }
   }

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -307,7 +307,8 @@ void drawTrimMode(coord_t x, coord_t y, uint8_t phase, uint8_t idx, LcdFlags att
   }
 }
 
-void drawTelemScreenDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
+
+void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 {
   // TODO
   if (att & DBLSIZE) {

--- a/radio/src/gui/common/arm/widgets.cpp
+++ b/radio/src/gui/common/arm/widgets.cpp
@@ -56,7 +56,7 @@ void drawSensorCustomValue(coord_t x, coord_t y, uint8_t sensor, int32_t value, 
   TelemetrySensor & telemetrySensor = g_model.telemetrySensors[sensor];
 
   if (telemetrySensor.unit == UNIT_DATETIME) {
-    drawTelemScreenDate(x, y, telemetryItem, flags);
+    drawDate(x, y, telemetryItem, flags);
   }
   else if (telemetrySensor.unit == UNIT_GPS) {
     drawGPSSensorValue(x, y, telemetryItem, flags);

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -93,7 +93,8 @@ swsrc_t checkIncDecMovedSwitch(swsrc_t val);
 #include "telemetry/telemetry_sensors.h"
 void drawValueWithUnit(coord_t x, coord_t y, int32_t val, uint8_t unit, LcdFlags flags);
 void drawCurveRef(coord_t x, coord_t y, CurveRef & curve, LcdFlags flags=0);
-void drawTelemScreenDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags flags=0);
+void drawDate(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags flags=0);
+void drawTelemScreenDate(coord_t x, coord_t y, source_t sensor, LcdFlags flags=0);
 void drawGPSPosition(coord_t x, coord_t y, int32_t longitude, int32_t latitude, LcdFlags flags=0);
 void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags flags=0);
 void drawSensorCustomValue(coord_t x, coord_t y, uint8_t sensor, int32_t value, LcdFlags flags=0);


### PR DESCRIPTION
Fixes glitches I introduced in #5051 

For x7, in telem setup, date and time are alternating, and in telem view, time is displayed in full, but only day-month are displayed

![image](https://user-images.githubusercontent.com/5167938/31043496-1112a96e-a5bd-11e7-9d9f-1067e33b4195.png)
