### PR TITLE
Add Lua getUsage() function that returns percent of already used up i…

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1178,7 +1178,7 @@ Get percent of already used Lua instructions in current script execution cycle.
 
 @retval usage (number) a value from 0 to 100 (percent)
 
-@status current Introduced in 2.2.0
+@status current Introduced in 2.2.1
 */
 static int luaGetUsage(lua_State * L)
 {

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1171,6 +1171,21 @@ static int luaLoadScript(lua_State * L)
   }
 }
 
+/*luadoc
+@function getUsage()
+
+Get the percent of already used Lua instructions in current script execution cycle.
+
+@retval usage (number) a value from 0 to 100 (percent)
+
+@status current Introduced in 2.2.0
+*/
+static int getUsage(lua_State * L)
+{
+  lua_pushinteger(L, instructionsPercent);
+  return 1;
+}
+
 const luaL_Reg opentxLib[] = {
   { "getTime", luaGetTime },
   { "getDateTime", luaGetDateTime },
@@ -1193,6 +1208,7 @@ const luaL_Reg opentxLib[] = {
   { "getRSSI", luaGetRSSI },
   { "killEvents", luaKillEvents },
   { "loadScript", luaLoadScript },
+  { "getUsage", luaGetUsage },
 #if LCD_DEPTH > 1 && !defined(COLORLCD)
   { "GREY", luaGrey },
 #endif

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1174,13 +1174,13 @@ static int luaLoadScript(lua_State * L)
 /*luadoc
 @function getUsage()
 
-Get the percent of already used Lua instructions in current script execution cycle.
+Get percent of already used Lua instructions in current script execution cycle.
 
 @retval usage (number) a value from 0 to 100 (percent)
 
 @status current Introduced in 2.2.0
 */
-static int getUsage(lua_State * L)
+static int luaGetUsage(lua_State * L)
 {
   lua_pushinteger(L, instructionsPercent);
   return 1;

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -75,7 +75,7 @@ void luaHook(lua_State * L, lua_Debug *ar)
 
 void luaSetInstructionsLimit(lua_State * L, int count)
 {
-  instructionsPercent=0;
+  instructionsPercent = 0;
   lua_sethook(L, luaHook, LUA_MASKCOUNT, count);
 }
 

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -65,12 +65,27 @@ int custom_lua_atpanic(lua_State * L)
 void luaHook(lua_State * L, lua_Debug *ar)
 {
   instructionsPercent++;
+#if defined(DEBUG)
+  // Disable Lua script instructions limit in DEBUG mode,
+  // just report max value reached
+  static uint16_t max = 0;
+  if (instructionsPercent > 100) {
+    if (max + 10 < instructionsPercent) {
+      max = instructionsPercent;
+      TRACE("LUA instructionsPercent %u%%", (uint32_t)max);
+    }
+  }
+  else if (instructionsPercent < 10) {
+    max = 0;
+  }
+#else
   if (instructionsPercent > 100) {
     // From now on, as soon as a line is executed, error
     // keep erroring until you're script reaches the top
     lua_sethook(L, luaHook, LUA_MASKLINE, 0);
     luaL_error(L, "CPU limit");
   }
+#endif
 }
 
 void luaSetInstructionsLimit(lua_State * L, int count)

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -44,7 +44,7 @@ ScriptInternalData standaloneScript;
 uint16_t maxLuaInterval = 0;
 uint16_t maxLuaDuration = 0;
 bool luaLcdAllowed;
-int instructionsPercent = 0;
+uint8_t instructionsPercent = 0;
 char lua_warning_info[LUA_WARNING_INFO_LEN+1];
 struct our_longjmp * global_lj = 0;
 #if defined(COLORLCD)

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -151,6 +151,7 @@ extern struct our_longjmp * global_lj;
 
 extern uint16_t maxLuaInterval;
 extern uint16_t maxLuaDuration;
+extern uint8_t instructionsPercent;
 
 #if defined(PCBTARANIS)
   #define IS_MASKABLE(key) ((key) != KEY_EXIT && (key) != KEY_ENTER && ((luaState & INTERPRETER_RUNNING_STANDALONE_SCRIPT) || (key) != KEY_PAGE))


### PR DESCRIPTION
…nstructions in current script execution cycle. It can be used to avoid script being killed when doing long lasting tasks (like telemetry logs loading and parsing)