### PR TITLE
Companion global variables refactor

### DIFF
--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1923,7 +1923,7 @@ void FlightModeData::clear(const int phase)
   }
 }
 
-QString GVarData::unitToString()
+QString GVarData::unitToString() const
 {
   switch (unit) {
     case GVAR_UNIT_NUMBER:
@@ -1935,7 +1935,7 @@ QString GVarData::unitToString()
   }
 }
 
-QString GVarData::precToString()
+QString GVarData::precToString() const
 {
   switch (prec) {
     case GVAR_PREC_MUL10:
@@ -1952,7 +1952,7 @@ int GVarData::multiplierSet()
   return (prec == 0 ? 1 : 10);
 }
 
-float GVarData::multiplierGet()
+float GVarData::multiplierGet() const
 {
   return (prec == 0 ? 1 : 0.1);
 }
@@ -1967,22 +1967,22 @@ void GVarData::setMax(float val)
   max = GVAR_MAX_VALUE - (val * multiplierSet());
 }
 
-int GVarData::getMin()
+int GVarData::getMin() const
 {
   return GVAR_MIN_VALUE + min;
 }
 
-int GVarData::getMax()
+int GVarData::getMax() const
 {
   return GVAR_MAX_VALUE - max;
 }
 
-float GVarData::getMinPrec()
+float GVarData::getMinPrec() const
 {
   return getMin() * multiplierGet();
 }
 
-float GVarData::getMaxPrec()
+float GVarData::getMaxPrec() const
 {
   return getMax() * multiplierGet();
 }

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -598,7 +598,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     {
       const char * name = NULL;
       if (getCurrentFirmware()->getCapability(GvarsName) && model)
-        name = model->gvars_names[index];
+        name = model->gvarData[index].name;
       return getElementName(QCoreApplication::translate("Global Variable", "GV"), index + 1, name);
     }
 
@@ -1564,6 +1564,9 @@ void ModelData::clear()
   for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
     flightModeData[i].clear(i);
   }
+  for (int i=0; i<CPN_MAX_GVARS; i++) {
+    gvarData[i].clear();
+  }
   clearInputs();
   clearMixes();
   for (int i=0; i<CPN_MAX_CHNOUT; i++)
@@ -1697,8 +1700,8 @@ bool ModelData::isGVarLinked(int phaseIdx, int gvarIdx)
 int ModelData::getGVarFieldValue(int phaseIdx, int gvarIdx)
 {
   int idx = flightModeData[phaseIdx].gvars[gvarIdx];
-  for (int i=0; idx>1024 && i<CPN_MAX_FLIGHT_MODES; i++) {
-    int nextPhase = idx - 1025;
+  for (int i=0; idx>GVAR_MAX_VALUE && i<CPN_MAX_FLIGHT_MODES; i++) {
+    int nextPhase = idx - GVAR_MAX_VALUE - 1;
     if (nextPhase >= phaseIdx) nextPhase += 1;
     phaseIdx = nextPhase;
     idx = flightModeData[phaseIdx].gvars[gvarIdx];
@@ -1918,4 +1921,73 @@ void FlightModeData::clear(const int phase)
       rotaryEncoders[idx] = 1025;
     }
   }
+}
+
+QString GVarData::unitToString()
+{
+  switch (unit) {
+    case GVAR_UNIT_NUMBER:
+      return QObject::tr("");
+    case GVAR_UNIT_PERCENT:
+      return QObject::tr("%");
+    default:
+      return QObject::tr("?");  //  highlight unknown value
+  }
+}
+
+QString GVarData::precToString()
+{
+  switch (prec) {
+    case GVAR_PREC_MUL10:
+      return QObject::tr("0._");
+    case GVAR_PREC_MUL1:
+      return QObject::tr("0.0");
+    default:
+      return QObject::tr("?.?");  //  highlight unknown value
+  }
+}
+
+int GVarData::multiplierSet()
+{
+  return (prec == 0 ? 1 : 10);
+}
+
+float GVarData::multiplierGet()
+{
+  return (prec == 0 ? 1 : 0.1);
+}
+
+void GVarData::setMin(float val)
+{
+  min = (val * multiplierSet()) - GVAR_MIN_VALUE;
+}
+
+void GVarData::setMax(float val)
+{
+  max = GVAR_MAX_VALUE - (val * multiplierSet());
+}
+
+int GVarData::getMin()
+{
+  return GVAR_MIN_VALUE + min;
+}
+
+int GVarData::getMax()
+{
+  return GVAR_MAX_VALUE - max;
+}
+
+float GVarData::getMinPrec()
+{
+  return getMin() * multiplierGet();
+}
+
+float GVarData::getMaxPrec()
+{
+  return getMax() * multiplierGet();
+}
+
+float ModelData::getGVarFieldValuePrec(int phaseIdx, int gvarIdx)
+{
+  return getGVarFieldValue(phaseIdx, gvarIdx) * gvarData[gvarIdx].multiplierGet();
 }

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1788,6 +1788,11 @@ bool ModelData::isAvailable(const RawSwitch & swtch) const
   }
 }
 
+float ModelData::getGVarFieldValuePrec(int phaseIdx, int gvarIdx)
+{
+  return getGVarFieldValue(phaseIdx, gvarIdx) * gvarData[gvarIdx].multiplierGet();
+}
+
 QList<EEPROMInterface *> eepromInterfaces;
 
 void unregisterEEpromInterfaces()
@@ -1985,9 +1990,4 @@ float GVarData::getMinPrec() const
 float GVarData::getMaxPrec() const
 {
   return getMax() * multiplierGet();
-}
-
-float ModelData::getGVarFieldValuePrec(int phaseIdx, int gvarIdx)
-{
-  return getGVarFieldValue(phaseIdx, gvarIdx) * gvarData[gvarIdx].multiplierGet();
 }

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -3226,18 +3226,18 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
   if (board != BOARD_STOCK && (board != BOARD_M128 || version < 215)) {
     for (int i=0; i<MAX_GVARS(board, version); i++) {
       if (version >= 218) {
-        internalField.Append(new ZCharField<3>(this, modelData.gvars_names[i], "GVar name"));
-        internalField.Append(new SpareBitsField<12>(this)); // TODO min
-        internalField.Append(new SpareBitsField<12>(this)); // TODO max
-        internalField.Append(new BoolField<1>(this, modelData.gvars_popups[i]));
-        internalField.Append(new SpareBitsField<1>(this));
-        internalField.Append(new SpareBitsField<2>(this));
+        internalField.Append(new ZCharField<3>(this, modelData.gvarData[i].name, "GVar name"));
+        internalField.Append(new SignedField<12>(this, modelData.gvarData[i].min));
+        internalField.Append(new SignedField<12>(this, modelData.gvarData[i].max));
+        internalField.Append(new BoolField<1>(this, modelData.gvarData[i].popup));
+        internalField.Append(new UnsignedField<1>(this, modelData.gvarData[i].prec));
+        internalField.Append(new UnsignedField<2>(this, modelData.gvarData[i].unit));
         internalField.Append(new SpareBitsField<4>(this));
       }
       else {
-        internalField.Append(new ZCharField<6>(this, modelData.gvars_names[i], "GVar name"));
+        internalField.Append(new ZCharField<6>(this, modelData.gvarData[i].name, "GVar name"));
         if (version >= 216) {
-          internalField.Append(new BoolField<1>(this, modelData.gvars_popups[i]));
+          internalField.Append(new BoolField<1>(this, modelData.gvarData[i].popup));
           internalField.Append(new SpareBitsField<7>(this));
         }
       }

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -22,6 +22,7 @@
 #include "ui_flightmode.h"
 #include "switchitemmodel.h"
 #include "helpers.h"
+#include "customdebug.h"
 
 FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseIdx, GeneralSettings & generalSettings, Firmware * firmware):
   ModelPanel(parent, model, generalSettings, firmware),
@@ -156,21 +157,45 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
   // GVars
   if (gvCount > 0 && (firmware->getCapability(GvarsFlightModes) || phaseIdx == 0) ) {
     QGridLayout *gvLayout = new QGridLayout(ui->gvGB);
-    
+
     // Column headers
     int headerCol = 1;
     QLabel *nameLabel = new QLabel(ui->gvGB);
     nameLabel->setText(tr("Name"));
     gvLayout->addWidget(nameLabel, 0, headerCol++, 1, 1);
+
     if (phaseIdx > 0) {
       QLabel *sourceLabel = new QLabel(ui->gvGB);
       sourceLabel->setText(tr("Value source"));
       gvLayout->addWidget(sourceLabel, 0, headerCol++, 1, 1);
     }
-    QLabel *valueLabel = new QLabel(ui->gvGB);
-    valueLabel->setText(tr("Value"));
-    gvLayout->addWidget(valueLabel, 0, headerCol++, 1, 1);
-    
+
+    if (IS_TARANIS(board) && phaseIdx == 0) {
+      QLabel *valueLabel = new QLabel(ui->gvGB);
+      valueLabel->setText(tr("Value"));
+      gvLayout->addWidget(valueLabel, 0, headerCol++, 1, 1);
+
+      QLabel *unitLabel = new QLabel(ui->gvGB);
+      unitLabel->setText(tr("Unit"));
+      gvLayout->addWidget(unitLabel, 0, headerCol++, 1, 1);
+
+      QLabel *precLabel = new QLabel(ui->gvGB);
+      precLabel->setText(tr("Prec"));
+      gvLayout->addWidget(precLabel, 0, headerCol++, 1, 1);
+
+      QLabel *minLabel = new QLabel(ui->gvGB);
+      minLabel->setText(tr("Min"));
+      gvLayout->addWidget(minLabel, 0, headerCol++, 1, 1);
+
+      QLabel *maxLabel = new QLabel(ui->gvGB);
+      maxLabel->setText(tr("Max"));
+      gvLayout->addWidget(maxLabel, 0, headerCol++, 1, 1);
+
+      QLabel *popupLabel = new QLabel(ui->gvGB);
+      popupLabel->setText(tr("Popup enabled"));
+      gvLayout->addWidget(popupLabel, 0, headerCol++, 1, 1);
+    }
+
     for (int i=0; i<gvCount; i++) {
       int col = 0;
       // GVar label
@@ -191,25 +216,49 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
         gvUse[i] = new QComboBox(ui->gvGB);
         gvUse[i]->setProperty("index", i);
         Helpers::populateGvarUseCB(gvUse[i], phaseIdx);
-        if (phase.gvars[i] > 1024) {
-          gvUse[i]->setCurrentIndex(phase.gvars[i] - 1024);
+        if (phase.gvars[i] > GVAR_MAX_VALUE) {
+          gvUse[i]->setCurrentIndex(phase.gvars[i] - GVAR_MAX_VALUE);
         }
         connect(gvUse[i], SIGNAL(currentIndexChanged(int)), this, SLOT(phaseGVUse_currentIndexChanged(int)));
         gvLayout->addWidget(gvUse[i], i+1, col++, 1, 1);
       }
       // GVar value
-      gvValues[i] = new QSpinBox(ui->gvGB);
+      gvValues[i] = new QDoubleSpinBox(ui->gvGB);
       gvValues[i]->setProperty("index", i);
       connect(gvValues[i], SIGNAL(editingFinished()), this, SLOT(phaseGVValue_editingFinished()));
-      gvValues[i]->setMinimum(-1024);
-      gvValues[i]->setMaximum(1024);
       gvLayout->addWidget(gvValues[i], i+1, col++, 1, 1);
 
-      // Popups
       if (IS_TARANIS(board) && phaseIdx == 0) {
+        // GVar unit
+        gvUnit[i] = new QComboBox(ui->gvGB);
+        gvUnit[i]->setProperty("index", i);
+        populateGvarUnitCB(gvUnit[i]);
+        connect(gvUnit[i], SIGNAL(currentIndexChanged(int)), this, SLOT(phaseGVUnit_currentIndexChanged(int)));
+        gvLayout->addWidget(gvUnit[i], i+1, col++, 1, 1);
+
+        // GVar precision
+        gvPrec[i] = new QComboBox(ui->gvGB);
+        gvPrec[i]->setProperty("index", i);
+        populateGvarPrecCB(gvPrec[i]);
+        connect(gvPrec[i], SIGNAL(currentIndexChanged(int)), this, SLOT(phaseGVPrec_currentIndexChanged(int)));
+        gvLayout->addWidget(gvPrec[i], i+1, col++, 1, 1);
+
+        // GVar min
+        gvMin[i] = new QDoubleSpinBox(ui->gvGB);
+        gvMin[i]->setProperty("index", i);
+        connect(gvMin[i], SIGNAL(editingFinished()), this, SLOT(phaseGVMin_editingFinished()));
+        gvLayout->addWidget(gvMin[i], i+1, col++, 1, 1);
+
+        // GVar max
+        gvMax[i] = new QDoubleSpinBox(ui->gvGB);
+        gvMax[i]->setProperty("index", i);
+        connect(gvMax[i], SIGNAL(editingFinished()), this, SLOT(phaseGVMax_editingFinished()));
+        gvLayout->addWidget(gvMax[i], i+1, col++, 1, 1);
+
+        // Popups
         gvPopups[i] = new QCheckBox(ui->gvGB);
         gvPopups[i]->setProperty("index", i);
-        gvPopups[i]->setText(tr("Popup enabled"));
+        //gvPopups[i]->setText(tr("Popup enabled"));
         connect(gvPopups[i], SIGNAL(toggled(bool)), this, SLOT(phaseGVPopupToggled(bool)));
         gvLayout->addWidget(gvPopups[i], i+1, col++, 1, 1);
       }
@@ -254,17 +303,8 @@ void FlightModePanel::update()
     trimUpdate(i);
   }
 
-  if (ui->gvGB->isVisible()) {
-    for (int i=0; i<gvCount; i++) {
-      if (firmware->getCapability(GvarsName) > 0) {
-        gvNames[i]->setText(model->gvars_names[i]);
-      }
-      gvValues[i]->setDisabled(model->isGVarLinked(phaseIdx, i));
-      gvValues[i]->setValue(model->getGVarFieldValue(phaseIdx, i));
-      if (IS_TARANIS(getCurrentBoard()) && phaseIdx == 0) {
-        gvPopups[i]->setChecked(model->gvars_popups[i]);
-      }
-    }
+  for (int i=0; i<gvCount; i++) {
+    updateGVar(i);
   }
 
   for (int i=0; i<reCount; i++) {
@@ -280,6 +320,49 @@ void FlightModePanel::update()
     }
     reValues[i]->setValue(phasere->rotaryEncoders[i]);
   }
+}
+void FlightModePanel::updateGVar(int index)
+{
+  lock = true;
+  if (firmware->getCapability(GvarsName) > 0) {
+    gvNames[index]->setText(model->gvarData[index].name);
+  }
+  gvValues[index]->setDisabled(model->isGVarLinked(phaseIdx, index));
+  setGVSB(gvValues[index], model->gvarData[index].getMin(), model->gvarData[index].getMax(), model->getGVarFieldValue(phaseIdx, index));
+  if (IS_TARANIS(getCurrentBoard()) && phaseIdx == 0) {
+    gvUnit[index]->setCurrentIndex(model->gvarData[index].unit);
+    gvPrec[index]->setCurrentIndex(model->gvarData[index].prec);
+    setGVSB(gvMin[index], GVAR_MIN_VALUE, model->gvarData[index].getMax(), model->gvarData[index].getMin());
+    setGVSB(gvMax[index], model->gvarData[index].getMin(), GVAR_MAX_VALUE, model->gvarData[index].getMax());
+    gvPopups[index]->setChecked(model->gvarData[index].popup);
+  }
+  lock = false;
+}
+
+void FlightModePanel::setGVSB(QDoubleSpinBox * sb, int min, int max, int val)
+{
+  int idx = sb->property("index").toInt();
+  float mul = model->gvarData[idx].multiplierGet();
+  sb->setDecimals(model->gvarData[idx].prec);
+  sb->setSingleStep(mul);
+  sb->setSuffix(model->gvarData[idx].unitToString());
+  sb->setMinimum(min * mul);
+  sb->setMaximum(max * mul);
+  sb->setValue(val * mul);
+}
+
+void FlightModePanel::populateGvarUnitCB(QComboBox * cb)
+{
+  cb->clear();
+  cb->addItem(QObject::tr(""));
+  cb->addItem(QObject::tr("%"));
+}
+
+void FlightModePanel::populateGvarPrecCB(QComboBox * cb)
+{
+  cb->clear();
+  cb->addItem(QObject::tr("0._"));
+  cb->addItem(QObject::tr("0.0"));
 }
 
 void FlightModePanel::phaseName_editingFinished()
@@ -348,9 +431,9 @@ void FlightModePanel::trimUpdate(unsigned int trim)
 void FlightModePanel::phaseGVValue_editingFinished()
 {
   if (!lock) {
-    QSpinBox *spinBox = qobject_cast<QSpinBox*>(sender());
+    QDoubleSpinBox *spinBox = qobject_cast<QDoubleSpinBox*>(sender());
     int gvar = spinBox->property("index").toInt();
-    phase.gvars[gvar] = spinBox->value();
+    phase.gvars[gvar] = spinBox->value() * model->gvarData[gvar].multiplierSet();
     emit modified();
   }
 }
@@ -360,8 +443,8 @@ void FlightModePanel::GVName_editingFinished()
   if (!lock) {
     QLineEdit *lineedit = qobject_cast<QLineEdit*>(sender());
     int gvar = lineedit->property("index").toInt();
-    memset(&model->gvars_names[gvar], 0, sizeof(model->gvars_names[gvar]));
-    strcpy(model->gvars_names[gvar], lineedit->text().toLatin1());
+    memset(&model->gvarData[gvar].name, 0, sizeof(model->gvarData[gvar].name));
+    strcpy(model->gvarData[gvar].name, lineedit->text().toLatin1());
     emit modified();
   }
 }
@@ -376,28 +459,84 @@ void FlightModePanel::phaseGVUse_currentIndexChanged(int index)
       phase.gvars[gvar] = 0;
     }
     else {
-      phase.gvars[gvar] = 1024 + index;
+      phase.gvars[gvar] = GVAR_MAX_VALUE + index;
     }
-    update();
+    updateGVar(gvar);
     emit modified();
     lock = false;
   }
 }
 
+void FlightModePanel::phaseGVUnit_currentIndexChanged(int index)
+{
+  if (!lock) {
+    QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
+    int gvar = comboBox->property("index").toInt();
+    model->gvarData[gvar].unit = index;
+    emit modified();
+    updateGVar(gvar);
+  }
+}
+
+void FlightModePanel::phaseGVPrec_currentIndexChanged(int index)
+{
+  if (!lock) {
+    QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
+    int gvar = comboBox->property("index").toInt();
+    model->gvarData[gvar].prec = index;
+    emit modified();
+    updateGVar(gvar);
+  }
+}
+
+void FlightModePanel::phaseGVMin_editingFinished()
+{
+  if (!lock) {
+    QDoubleSpinBox *spinBox = qobject_cast<QDoubleSpinBox*>(sender());
+    int gvar = spinBox->property("index").toInt();
+    model->gvarData[gvar].setMin(spinBox->value());
+    if (!model->isGVarLinked(phaseIdx, gvar)) {
+      if (model->getGVarFieldValuePrec(phaseIdx, gvar) < spinBox->value()) {
+        phase.gvars[gvar] = model->gvarData[gvar].getMin();
+      }
+    }
+    emit modified();
+    updateGVar(gvar);
+  }
+}
+
+void FlightModePanel::phaseGVMax_editingFinished()
+{
+  if (!lock) {
+    QDoubleSpinBox *spinBox = qobject_cast<QDoubleSpinBox*>(sender());
+    int gvar = spinBox->property("index").toInt();
+    model->gvarData[gvar].setMax(spinBox->value());
+    if (!model->isGVarLinked(phaseIdx, gvar)) {
+      if (model->getGVarFieldValuePrec(phaseIdx, gvar) > spinBox->value()) {
+        phase.gvars[gvar] = model->gvarData[gvar].getMax();
+      }
+    }
+    emit modified();
+    updateGVar(gvar);
+  }
+}
+
 void FlightModePanel::phaseGVPopupToggled(bool checked)
 {
-  QCheckBox *cb = qobject_cast<QCheckBox*>(sender());
-  int gvar = cb->property("index").toInt();
-  model->gvars_popups[gvar] = checked;
-  emit modified();
+  if (!lock) {
+    QCheckBox *cb = qobject_cast<QCheckBox*>(sender());
+    int gvar = cb->property("index").toInt();
+    model->gvarData[gvar].popup = checked;
+    emit modified();
+  }
 }
 
 void FlightModePanel::phaseREValue_editingFinished()
 {
   if (!lock) {
     QSpinBox *spinBox = qobject_cast<QSpinBox*>(sender());
-    int gvar = spinBox->property("index").toInt();
-    phase.rotaryEncoders[gvar] = spinBox->value();
+    int re = spinBox->property("index").toInt();
+    phase.rotaryEncoders[re] = spinBox->value();
     emit modified();
   }
 }
@@ -496,8 +635,8 @@ void FlightModePanel::fmClear()
     if (phaseIdx == 0) {
       if (IS_HORUS_OR_TARANIS(getCurrentBoard())) {
         for (int i=0; i < gvCount; ++i) {
-          memset(&model->gvars_names[i], 0, sizeof(model->gvars_names[i]));
-          model->gvars_popups[i] = 0;
+          memset(&model->gvarData[i].name, 0, sizeof(model->gvarData[i].name));
+          model->gvarData[i].popup = 0;
         }
       }
     }

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -170,7 +170,7 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
       gvLayout->addWidget(sourceLabel, 0, headerCol++, 1, 1);
     }
 
-    if (IS_TARANIS(board) && phaseIdx == 0) {
+    if (IS_HORUS_OR_TARANIS(board) && phaseIdx == 0) {
       QLabel *valueLabel = new QLabel(ui->gvGB);
       valueLabel->setText(tr("Value"));
       gvLayout->addWidget(valueLabel, 0, headerCol++, 1, 1);
@@ -228,7 +228,7 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
       connect(gvValues[i], SIGNAL(editingFinished()), this, SLOT(phaseGVValue_editingFinished()));
       gvLayout->addWidget(gvValues[i], i+1, col++, 1, 1);
 
-      if (IS_TARANIS(board) && phaseIdx == 0) {
+      if (IS_HORUS_OR_TARANIS(board) && phaseIdx == 0) {
         // GVar unit
         gvUnit[i] = new QComboBox(ui->gvGB);
         gvUnit[i]->setProperty("index", i);
@@ -500,6 +500,13 @@ void FlightModePanel::phaseGVMin_editingFinished()
         phase.gvars[gvar] = model->gvarData[gvar].getMin();
       }
     }
+    for (int x=1; x>firmware->getCapability(FlightModes); x++) {
+      if (!model->isGVarLinked(x, gvar)) {
+        if (model->flightModeData[x].gvars[gvar] < model->gvarData[gvar].getMin()) {
+          model->flightModeData[x].gvars[gvar] = model->gvarData[gvar].getMin();
+        }
+      }
+    }
     emit modified();
     updateGVar(gvar);
   }
@@ -514,6 +521,13 @@ void FlightModePanel::phaseGVMax_editingFinished()
     if (!model->isGVarLinked(phaseIdx, gvar)) {
       if (model->getGVarFieldValuePrec(phaseIdx, gvar) > spinBox->value()) {
         phase.gvars[gvar] = model->gvarData[gvar].getMax();
+      }
+    }
+    for (int x=1; x>firmware->getCapability(FlightModes); x++) {
+      if (!model->isGVarLinked(x, gvar)) {
+        if (model->flightModeData[x].gvars[gvar] > model->gvarData[gvar].getMax()) {
+          model->flightModeData[x].gvars[gvar] = model->gvarData[gvar].getMax();
+        }
       }
     }
     emit modified();

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -500,7 +500,7 @@ void FlightModePanel::phaseGVMin_editingFinished()
         phase.gvars[gvar] = model->gvarData[gvar].getMin();
       }
     }
-    for (int x=1; x>firmware->getCapability(FlightModes); x++) {
+    for (int x=1; x<firmware->getCapability(FlightModes); x++) {
       if (!model->isGVarLinked(x, gvar)) {
         if (model->flightModeData[x].gvars[gvar] < model->gvarData[gvar].getMin()) {
           model->flightModeData[x].gvars[gvar] = model->gvarData[gvar].getMin();
@@ -523,7 +523,7 @@ void FlightModePanel::phaseGVMax_editingFinished()
         phase.gvars[gvar] = model->gvarData[gvar].getMax();
       }
     }
-    for (int x=1; x>firmware->getCapability(FlightModes); x++) {
+    for (int x=1; x<firmware->getCapability(FlightModes); x++) {
       if (!model->isGVarLinked(x, gvar)) {
         if (model->flightModeData[x].gvars[gvar] > model->gvarData[gvar].getMax()) {
           model->flightModeData[x].gvars[gvar] = model->gvarData[gvar].getMax();

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -55,6 +55,10 @@ class FlightModePanel : public ModelPanel
     void phaseGVValue_editingFinished();
     void phaseGVUse_currentIndexChanged(int index);
     void phaseGVPopupToggled(bool checked);
+    void phaseGVUnit_currentIndexChanged(int index);
+    void phaseGVPrec_currentIndexChanged(int index);
+    void phaseGVMin_editingFinished();
+    void phaseGVMax_editingFinished();
     void phaseREValue_editingFinished();
     void phaseREUse_currentIndexChanged(int index);
     void name_customContextMenuRequested(const QPoint & pos);
@@ -68,9 +72,13 @@ class FlightModePanel : public ModelPanel
     int gvCount;
     QVector<QLabel *> trimsLabel;
     QLineEdit * gvNames[CPN_MAX_GVARS];
-    QSpinBox * gvValues[CPN_MAX_GVARS];
+    QDoubleSpinBox * gvValues[CPN_MAX_GVARS];
     QCheckBox * gvPopups[CPN_MAX_GVARS];
     QComboBox * gvUse[CPN_MAX_GVARS];
+    QComboBox * gvUnit[CPN_MAX_GVARS];
+    QComboBox * gvPrec[CPN_MAX_GVARS];
+    QDoubleSpinBox * gvMin[CPN_MAX_GVARS];
+    QDoubleSpinBox * gvMax[CPN_MAX_GVARS];
     QSpinBox * reValues[CPN_MAX_ENCODERS];
     QComboBox * reUse[CPN_MAX_ENCODERS];
     QVector<QComboBox *> trimsUse;
@@ -79,7 +87,10 @@ class FlightModePanel : public ModelPanel
     RawSwitchFilterItemModel * rawSwitchItemModel;
 
     void trimUpdate(unsigned int trim);
-
+    void updateGVar(int index);
+    void setGVSB(QDoubleSpinBox * spinBox, int min, int max, int val);
+    void populateGvarUnitCB(QComboBox * cb);
+    void populateGvarPrecCB(QComboBox * cb);
 };
 
 class FlightModesPanel : public ModelPanel

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -63,6 +63,8 @@ class FlightModePanel : public ModelPanel
     void phaseREUse_currentIndexChanged(int index);
     void name_customContextMenuRequested(const QPoint & pos);
     void fmClear();
+    void gvLabel_customContextMenuRequested(const QPoint & pos);
+    void gvClear();
 
   private:
     Ui::FlightMode *ui;
@@ -70,6 +72,7 @@ class FlightModePanel : public ModelPanel
     FlightModeData & phase;
     int reCount;
     int gvCount;
+    int gvIdx;
     QVector<QLabel *> trimsLabel;
     QLineEdit * gvNames[CPN_MAX_GVARS];
     QDoubleSpinBox * gvValues[CPN_MAX_GVARS];

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -305,7 +305,8 @@ QString ModelPrinter::printGlobalVar(int flightModeIndex, int gvarIndex)
   const FlightModeData & fm = model.flightModeData[flightModeIndex];
 
   if (fm.gvars[gvarIndex] <= 1024) {
-    return QString("%1").arg(fm.gvars[gvarIndex]);
+    //double val = fm.gvars[gvarIndex] * model.gvarData[gvarIndex].multiplierGet();
+    return QString("%1").arg(fm.gvars[gvarIndex] * model.gvarData[gvarIndex].multiplierGet());
   }
   else {
     int num = fm.gvars[gvarIndex] - 1025;
@@ -685,3 +686,24 @@ QString ModelPrinter::createCurveImage(int idx, QTextDocument * document)
   // qDebug() << "ModelPrinter::createCurveImage()" << idx << filename;
   return filename;
 }
+
+QString ModelPrinter::printGlobalVarUnit(int idx)
+{
+  return model.gvarData[idx].unitToString().toHtmlEscaped();
+}
+
+QString ModelPrinter::printGlobalVarPrec(int idx)
+{
+  return model.gvarData[idx].precToString().toHtmlEscaped();
+}
+
+QString ModelPrinter::printGlobalVarMin(int idx)
+{
+  return QString::number(model.gvarData[idx].getMinPrec());
+}
+
+QString ModelPrinter::printGlobalVarMax(int idx)
+{
+  return QString::number(model.gvarData[idx].getMaxPrec());
+}
+

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -707,3 +707,8 @@ QString ModelPrinter::printGlobalVarMax(int idx)
   return QString::number(model.gvarData[idx].getMaxPrec());
 }
 
+QString ModelPrinter::printGlobalVarPopup(int idx)
+{
+  return (model.gvarData[idx].popup ? "Y" : "N" );
+}
+

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -86,6 +86,7 @@ class ModelPrinter: public QObject
     QString printGlobalVarPrec(int idx);
     QString printGlobalVarMin(int idx);
     QString printGlobalVarMax(int idx);
+    QString printGlobalVarPopup(int idx);
 
   private:
     Firmware * firmware;

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -82,6 +82,10 @@ class ModelPrinter: public QObject
     QString printCurveName(int idx);
     QString printCurve(int idx);
     QString createCurveImage(int idx, QTextDocument * document);
+    QString printGlobalVarUnit(int idx);
+    QString printGlobalVarPrec(int idx);
+    QString printGlobalVarMin(int idx);
+    QString printGlobalVarMax(int idx);
 
   private:
     Firmware * firmware;

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -311,7 +311,7 @@ QString MultiModelPrinter::printFlightModes()
     if (firmware->getCapability(GvarsFlightModes)) {
       for (int i=0; i<gvars; i++) {
         columns.append("<td><b>" + tr("GV%1").arg(i+1) + "</b><br/>");
-        COMPARE(model->gvars_names[i]);
+        COMPARE(model->gvarData[i].name);
         columns.append("</td>");
       }
     }

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -307,7 +307,7 @@ QString MultiModelPrinter::printFlightModes()
   if ((gvars && firmware->getCapability(GvarsFlightModes)) || firmware->getCapability(RotaryEncoders)) {
     MultiColumns columns(modelPrinterMap.size());
     columns.append("<table cellspacing='0' cellpadding='1' width='100%' border='0' style='border-collapse:collapse'>");
-    columns.append("<tr><td><b>" + tr("Global Variables") + "</b></td>");
+    columns.append("<tr><td><b>" + tr("Global variables") + "</b></td>");
     if (firmware->getCapability(GvarsFlightModes)) {
       for (int i=0; i<gvars; i++) {
         columns.append("<td><b>" + tr("GV%1").arg(i+1) + "</b></td>");
@@ -351,6 +351,13 @@ QString MultiModelPrinter::printFlightModes()
       for (int i=0; i<gvars; i++) {
         columns.append("<td>");
         COMPARE(modelPrinter->printGlobalVarMax(i));
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+      columns.append("<tr><td><b>Popup</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(modelPrinter->printGlobalVarPopup(i));
         columns.append("</td>");
       }
       columns.append("</tr>");

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -307,18 +307,57 @@ QString MultiModelPrinter::printFlightModes()
   if ((gvars && firmware->getCapability(GvarsFlightModes)) || firmware->getCapability(RotaryEncoders)) {
     MultiColumns columns(modelPrinterMap.size());
     columns.append("<table cellspacing='0' cellpadding='1' width='100%' border='0' style='border-collapse:collapse'>");
-    columns.append("<tr><td><b>" + tr("Flight mode") + "</b></td>");
+    columns.append("<tr><td><b>" + tr("Global Variables") + "</b></td>");
     if (firmware->getCapability(GvarsFlightModes)) {
       for (int i=0; i<gvars; i++) {
-        columns.append("<td><b>" + tr("GV%1").arg(i+1) + "</b><br/>");
-        COMPARE(model->gvarData[i].name);
-        columns.append("</td>");
+        columns.append("<td><b>" + tr("GV%1").arg(i+1) + "</b></td>");
       }
     }
     for (int i=0; i<firmware->getCapability(RotaryEncoders); i++) {
       columns.append("<td><b>" + tr("RE%1").arg(i+1) + "</b></td>");
     }
     columns.append("</tr>");
+
+    if (firmware->getCapability(GvarsFlightModes)) {
+      columns.append("<tr><td><b>Name</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(model->gvarData[i].name);
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+      columns.append("<tr><td><b>Unit</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(modelPrinter->printGlobalVarUnit(i));
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+      columns.append("<tr><td><b>Prec</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(modelPrinter->printGlobalVarPrec(i));
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+      columns.append("<tr><td><b>Min</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(modelPrinter->printGlobalVarMin(i));
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+      columns.append("<tr><td><b>Max</b></td>");
+      for (int i=0; i<gvars; i++) {
+        columns.append("<td>");
+        COMPARE(modelPrinter->printGlobalVarMax(i));
+        columns.append("</td>");
+      }
+      columns.append("</tr>");
+    }
+
+    columns.append("<tr><td><b>" + tr("Flight mode") + "</b></td></tr>");
+
     for (int i=0; i<firmware->getCapability(FlightModes); i++) {
       columns.append("<tr><td><b>" + tr("FM%1").arg(i) + "</b>&nbsp;");
       COMPARE(model->flightModeData[i].name);

--- a/companion/src/radiodata.h
+++ b/companion/src/radiodata.h
@@ -1050,16 +1050,16 @@ class GVarData {
     unsigned int unit;     // 0 _    1 %
 
     void clear() {memset(this, 0, sizeof(GVarData)); }
-    QString unitToString();
-    QString precToString();
+    QString unitToString() const;
+    QString precToString() const;
     int multiplierSet();
-    float multiplierGet();
+    float multiplierGet() const;
     void setMin(float val);
     void setMax(float val);
-    int getMin();
-    int getMax();
-    float getMinPrec();
-    float getMaxPrec();
+    int getMin() const;
+    int getMax() const;
+    float getMinPrec() const;
+    float getMaxPrec() const;
 };
 
 class ModelData {

--- a/companion/src/radiodata.h
+++ b/companion/src/radiodata.h
@@ -1024,6 +1024,44 @@ typedef char CustomScreenData[610+1];
 typedef char TopbarData[216+1];
 #endif
 
+#define GVAR_NAME_LEN       3
+#define GVAR_MAX_VALUE      1024
+#define GVAR_MIN_VALUE      -GVAR_MAX_VALUE
+
+class GVarData {
+  public:
+    GVarData() { clear(); }
+
+    enum {
+      GVAR_UNIT_NUMBER,
+      GVAR_UNIT_PERCENT
+    };
+
+    enum {
+      GVAR_PREC_MUL10,
+      GVAR_PREC_MUL1
+    };
+
+    char name[GVAR_NAME_LEN+1];
+    int min;
+    int max;
+    bool popup;
+    unsigned int prec;     // 0 0._  1 0.0
+    unsigned int unit;     // 0 _    1 %
+
+    void clear() {memset(this, 0, sizeof(GVarData)); }
+    QString unitToString();
+    QString precToString();
+    int multiplierSet();
+    float multiplierGet();
+    void setMin(float val);
+    void setMax(float val);
+    int getMin();
+    int getMax();
+    float getMinPrec();
+    float getMaxPrec();
+};
+
 class ModelData {
   public:
     ModelData();
@@ -1078,9 +1116,7 @@ class ModelData {
     bool potsWarningEnabled[CPN_MAX_POTS];
     int          potPosition[CPN_MAX_POTS];
     bool         displayChecklist;
-    // TODO structure
-    char     gvars_names[CPN_MAX_GVARS][6+1];
-    bool     gvars_popups[CPN_MAX_GVARS];
+    GVarData gvarData[CPN_MAX_GVARS];
     MavlinkData mavlink;
     unsigned int telemetryProtocol;
     FrSkyData frsky;
@@ -1113,6 +1149,7 @@ class ModelData {
 
     bool isGVarLinked(int phaseIdx, int gvarIdx);
     int getGVarFieldValue(int phaseIdx, int gvarIdx);
+    float getGVarFieldValuePrec(int phaseIdx, int gvarIdx);
 
     ModelData removeGlobalVars();
 


### PR DESCRIPTION
Fixes #4947
Add radio gvar refactoring to Companion
Tested on X9D+ radio file

Note Companion Simulator radio outputs still broken as gvars displayed without using precision.