### PR TITLE
Adding regex check for crossfire gps format when reading logs in tele…

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -23,6 +23,7 @@
 #include "ui_telemetrysimu.h"
 #include "simulatorinterface.h"
 #include "radio/src/telemetry/frsky.h"
+#include <QRegularExpression>
 
 TelemetrySimulator::TelemetrySimulator(QWidget * parent, SimulatorInterface * simulator):
   QWidget(parent),
@@ -627,6 +628,7 @@ TelemetrySimulator::LogPlaybackController::LogPlaybackController(Ui::TelemetrySi
 {
   TelemetrySimulator::LogPlaybackController::ui = ui;
   stepping = false;
+  logFileGpsCordsInDecimalFormat = false;
   // initialize the map - TODO: how should this be localized?
   colToFuncMap.clear();
   colToFuncMap.insert("RxBt(V)", RXBT_V);
@@ -690,6 +692,31 @@ QDateTime TelemetrySimulator::LogPlaybackController::parseTransmittterTimestamp(
     format = "M/d/yyyy hh:mm:ss.z";
   }
   return QDateTime::fromString(datePart + " " + timePart, format);
+}
+
+void TelemetrySimulator::LogPlaybackController::checkGpsFormat()
+{
+  // sample the first record to check if cords are in decimal format
+  logFileGpsCordsInDecimalFormat = false;
+  if(csvRecords.count() > 1) {
+    QStringList keys = csvRecords[0].split(',');
+    if(keys.contains("GPS")) {
+      int gpsColIndex = keys.indexOf("GPS");
+      QStringList firstRowVlues = csvRecords[1].split(',');
+      QString gpsSample = firstRowVlues[gpsColIndex];
+      QStringList cords = gpsSample.simplified().split(' ');
+      if (cords.count() == 2) {
+        // frsky and TBS crossfire GPS sensor logs cords in decimal format with a precision of 6 places
+        // if this format is met there is no need to call convertDegMin later on when processing the file
+        QRegularExpression decimalCoordinateFormatRegex("^[-+]?\\d{1,2}[.]\\d{6}$");
+        QRegularExpressionMatch latFormatMatch = decimalCoordinateFormatRegex.match(cords[0]);
+        QRegularExpressionMatch lonFormatMatch = decimalCoordinateFormatRegex.match(cords[1]);
+        if (lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()) {
+          logFileGpsCordsInDecimalFormat = true;
+        }
+      }
+    }
+  }
 }
 
 void TelemetrySimulator::LogPlaybackController::calcLogFrequency()
@@ -760,6 +787,7 @@ void TelemetrySimulator::LogPlaybackController::loadLogFile()
     supportedCols.clear();
     recordIndex = 1;
     calcLogFrequency();
+    checkGpsFormat();
   }
   ui->logFileLabel->setText(QFileInfo(logFileNameAndPath).fileName());
   // iterate through all known mappings and add those that are used
@@ -869,12 +897,7 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
     return ""; // invalid format
   }
   double lon, lat;
-  // crossfire GPS sensor logs cords in decimal format with a precision of 6 places
-  // if this format is met there is no need to call convertDegMin
-  QRegularExpression crossfireCoordinateFormatRegex("^([-+]?\\d{1,2}[.]\\d{6})$");
-  QRegularExpressionMatch latFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[0]);
-  QRegularExpressionMatch lonFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[1]);
-  if (lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()) {
+  if (logFileGpsCordsInDecimalFormat) {
     lat = lonLat[0].toDouble();
     lon = lonLat[1].toDouble();
   }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -878,8 +878,7 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
 	  lat = lonLat[0].toDouble();
 	  lon = lonLat[1].toDouble();
   }
-  else
-  {
+  else {
 	  lon = convertDegMin(lonLat[0]);
 	  lat = convertDegMin(lonLat[1]);
   }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -874,13 +874,13 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
   QRegularExpression crossfireCoordinateFormatRegex("^([-+]?\\d{1,2}[.]\\d{6})$");
   QRegularExpressionMatch latFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[0]);
   QRegularExpressionMatch lonFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[1]);
-  if (lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()){
-	  lat = lonLat[0].toDouble();
-	  lon = lonLat[1].toDouble();
+  if (lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()) {
+    lat = lonLat[0].toDouble();
+    lon = lonLat[1].toDouble();
   }
   else {
-	  lon = convertDegMin(lonLat[0]);
-	  lat = convertDegMin(lonLat[1]);
+    lon = convertDegMin(lonLat[0]);
+    lat = convertDegMin(lonLat[1]);
   }
   return QString::number(lat) + ", " + QString::number(lon);
 }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -874,10 +874,12 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
   QRegularExpression crossfireCoordinateFormatRegex("^([-+]?\\d{1,2}[.]\\d{6})$");
   QRegularExpressionMatch latFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[0]);
   QRegularExpressionMatch lonFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[1]);
-  if(lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()){
+  if (lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()){
 	  lat = lonLat[0].toDouble();
 	  lon = lonLat[1].toDouble();
-  }else{
+  }
+  else
+  {
 	  lon = convertDegMin(lonLat[0]);
 	  lat = convertDegMin(lonLat[1]);
   }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -868,8 +868,19 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
   if (lonLat.count() < 2) {
     return ""; // invalid format
   }
-  double lon = convertDegMin(lonLat[0]);
-  double lat = convertDegMin(lonLat[1]);
+  double lon, lat;
+  // crossfire GPS sensor logs cords in decimal format with a precision of 6 places
+  // if this format is met there is no need to call convertDegMin
+  QRegularExpression crossfireCoordinateFormatRegex("^([-+]?\\d{1,2}[.]\\d{6})$");
+  QRegularExpressionMatch latFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[0]);
+  QRegularExpressionMatch lonFormatMatch = crossfireCoordinateFormatRegex.match(lonLat[1]);
+  if(lonFormatMatch.hasMatch() && latFormatMatch.hasMatch()){
+	  lat = lonLat[0].toDouble();
+	  lon = lonLat[1].toDouble();
+  }else{
+	  lon = convertDegMin(lonLat[0]);
+	  lat = convertDegMin(lonLat[1]);
+  }
   return QString::number(lat) + ", " + QString::number(lon);
 }
 

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -27,7 +27,6 @@
 #include <QDateTime>
 #include <QtCore/qmath.h>
 #include <QFileDialog>
-#include <QRegularExpression>
 
 #include "simulatorinterface.h"
 
@@ -97,6 +96,7 @@ class TelemetrySimulator : public QWidget
         void updatePositionLabel(int32_t percentage);
         void setUiDataValues();
         double logFrequency; // in seconds
+        bool logFileGpsCordsInDecimalFormat;
 
       private:
         enum CONVERT_TYPE {
@@ -150,6 +150,7 @@ class TelemetrySimulator : public QWidget
         double convertDegMin(QString input);
         QDateTime parseTransmittterTimestamp(QString row);
         void calcLogFrequency();
+        void checkGpsFormat();
 
         QMap<QString, CONVERT_TYPE> colToFuncMap; // contains all 'known' column headings and how they are to be processed
         Ui::TelemetrySimulator * ui;

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -27,6 +27,7 @@
 #include <QDateTime>
 #include <QtCore/qmath.h>
 #include <QFileDialog>
+#include <QRegularExpression>
 
 #include "simulatorinterface.h"
 


### PR DESCRIPTION
…metry simulator

Adding a regex check when the telemetry simulator parses gps cords from a log file to see if the if the cords are in the crossfire gps log format. 
The GPS telemetry sensor from crossfire logs the coordinates as latitude with a precision of six decimal places followed by a space and then longitude also to six decimal places. e.g. "53.279969 -7.701416"
When the cords are already in this format their is no need to call convertDegMin on the values

Addresses issue #5346