### PR TITLE
allow additional cake params to be passed via env variables

### DIFF
--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -38,7 +38,7 @@ if [ "$(uname)" = "Darwin" ]; then
 else
     SCRIPT=$(readlink -f "$0")
 fi
-#export CMAKE_PREFIX_PATH=/opt/qt${QT_BASE}
+
 if [[ ! -z ${GCC_ARM} ]] ; then
   export PATH=${GCC_ARM}:$PATH
 fi
@@ -47,6 +47,10 @@ fi
 
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=Debug -DTRACE_SIMPGMSPACE=NO -DVERBOSE_CMAKELISTS=YES -DCMAKE_RULE_MESSAGES=OFF -Wno-dev"}
 if (( $WERROR )); then COMMON_OPTIONS+=" -DWARNINGS_AS_ERRORS=YES"; fi
+
+: ${EXTRA_OPTIONS:="$EXTRA_OPTIONS"}
+
+COMMON_OPTIONS+=${EXTRA_OPTIONS}
 
 : ${TEST_OPTIONS:="--gtest_shuffle --gtest_repeat=5 --gtest_break_on_failure"}
 


### PR DESCRIPTION
This allows for non-standard paths and the likes (helps a lot on OSX). With this commit, I can execute all the tests with the following command line:
```
PATH=$PATH:/usr/local/CrossPack-AVR/bin EXTRA_OPTIONS="-DCMAKE_PREFIX_PATH=/usr/local/opt/qt5 -DGTEST_SRCDIR=/Users/rco/Src/googletest/googletest" ./commit-tests.sh
```

@schwabe that could be of interest to you, as we discussed earlier today.