### PR TITLE
Export flight session to its own CSV log file

### DIFF
--- a/companion/src/logsdialog.h
+++ b/companion/src/logsdialog.h
@@ -78,6 +78,7 @@ private slots:
   void removeAllGraphs();
   void plotLogs();
   void on_fileOpen_BT_clicked();
+  void on_saveSession_BT_clicked();
   void on_sessions_CB_currentIndexChanged(int index);
   void on_mapsButton_clicked();
   void yAxisChangeRanges(QCPRange range);

--- a/companion/src/logsdialog.ui
+++ b/companion/src/logsdialog.ui
@@ -37,6 +37,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="SaveSession_PB">
+       <property name="text">
+        <string>Save session CSV</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Currently the transmitter logs all flight sessions for the same day into a single log file and the log file viewer allows for switching between session data. 
It can be a bit of a tedious job to separate the records up if feeding the CSV data into anything but the the log file viewer though.
This change adds a button beside the session selector dropdown in the log viewer that allows the user to export the CSV data for the selected session to its own log file.