### PR TITLE
[Simulator] Show gvars with precision and unit in Radio Outputs

### DIFF
--- a/companion/src/simulation/radiooutputswidget.cpp
+++ b/companion/src/simulation/radiooutputswidget.cpp
@@ -305,13 +305,15 @@ void RadioOutputsWidget::onGVarValueChange(quint8 index, qint32 value)
 
   QHash<int, QLabel *> fmMap = m_globalVarsMap.value(index);
   SimulatorInterface::gVarMode_t gv(value);
+  QLabel * lbl;
 
-  if (fmMap.contains(gv.mode)) {
-    QLabel * lbl = fmMap.value(gv.mode);
-    if (lbl)
-      lbl->setText(QString::number(gv.value));
+  if (fmMap.contains(gv.mode) && (lbl = fmMap.value(gv.mode))) {
+    GVarData gvar;
+    gvar.prec = gv.prec;
+    gvar.unit = gv.unit;
+    lbl->setText(QString::number(gv.value * gvar.multiplierGet(), 'f', gv.prec) + gvar.unitToString());
   }
-  //qDebug() << index << value << gv.mode << gv.value;
+  //qDebug() << index << value << gv.mode << gv.value << gv.prec << gv.unit;
 }
 
 void RadioOutputsWidget::onPhaseChanged(qint32 phase, const QString &)

--- a/companion/src/simulation/simulatorinterface.h
+++ b/companion/src/simulation/simulatorinterface.h
@@ -83,16 +83,20 @@ class SimulatorInterface : public QObject
     struct gVarMode_t {
       int16_t value;
       uint8_t mode;
+      uint8_t prec:2;
+      uint8_t unit:2;
 
       gVarMode_t(int i = 0) {
         set(i);
       }
       void set(int i) {
+        unit = (i >> 26) & 0x3;
+        prec = (i >> 24) & 0x3;
         mode = (i >> 16) & 0xFF;
         value = (i & 0xFFFF);
       }
       operator int() {
-        return ((mode << 16) | (value & 0xFFFF));
+        return (((unit & 0x3) << 26) | ((prec & 0x3) << 24) | ((mode & 0xFF) << 16) | (value & 0xFFFF));
       }
       gVarMode_t & operator =(const int i) {
         set(i);
@@ -106,7 +110,7 @@ class SimulatorInterface : public QObject
 
       int16_t chans[CPN_MAX_CHNOUT];       // final channel outputs
       int16_t ex_chans[CPN_MAX_CHNOUT];    // raw mix outputs
-      int16_t gvars[CPN_MAX_FLIGHT_MODES][CPN_MAX_GVARS];
+      qint32 gvars[CPN_MAX_FLIGHT_MODES][CPN_MAX_GVARS];
       int trims[CPN_MAX_TRIMS];            // Board::TrimAxes enum
       bool vsw[CPN_MAX_LOGICAL_SWITCHES];  // virtual/logic switches
       int8_t phase;

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -526,14 +526,15 @@ void OpenTxSimulator::checkOutputsChanged()
 
 #if defined(GVAR_VALUE) && defined(GVARS)
   gVarMode_t gvar;
-  for (uint8_t fm=0; fm < MAX_FLIGHT_MODES; fm++) {
-    gvar.mode = fm;
-    for (uint8_t gv=0; gv < MAX_GVARS; gv++) {
-      tmpVal = GVAR_VALUE(gv, getGVarFlightMode(fm, gv));
+  for (uint8_t gv=0; gv < MAX_GVARS; gv++) {
+    gvar.prec = g_model.gvars[gv].prec;
+    gvar.unit = g_model.gvars[gv].unit;
+    for (uint8_t fm=0; fm < MAX_FLIGHT_MODES; fm++) {
+      gvar.mode = fm;
+      gvar.value = (int16_t)GVAR_VALUE(gv, getGVarFlightMode(fm, gv));
+      tmpVal = gvar;
       if (lastOutputs.gvars[fm][gv] != tmpVal || m_resetOutputsData) {
         lastOutputs.gvars[fm][gv] = tmpVal;
-        gvar.value = (int16_t)tmpVal;
-        tmpVal = gvar;
         emit gVarValueChange(gv, tmpVal);
         emit outputValueChange(OUTPUT_SRC_GVAR, gv, tmpVal);
       }


### PR DESCRIPTION

![radio-outputs-gvar-prec-unit](https://user-images.githubusercontent.com/1366615/32986309-79d87a08-cc9d-11e7-9099-4276032f4735.png)

Fixes #5360

This is a quick fix for now, because currently the simulator does not read or refresh individual model settings (only general radio) -- same reason GVs, LSs, & Channels don't display custom names. 
