### PR TITLE
[Taranis] one-click model select

### DIFF
--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -219,7 +219,7 @@ void menuModelSelect(event_t event)
         s_copyMode = 0;
         event = EVT_ENTRY_UP;
       }
-      else if (event == EVT_KEY_LONG(KEY_ENTER) || IS_ROTARY_BREAK(event)) {
+      else if (event == EVT_KEY_BREAK(KEY_ENTER)) {
         s_copyMode = 0;
         killEvents(event);
 #if defined(NAVIGATION_MENUS)
@@ -253,6 +253,7 @@ void menuModelSelect(event_t event)
 #endif
       }
       else if (eeModelExists(sub)) {
+        killEvents(event);
         s_copyMode = (s_copyMode == COPY_MODE ? MOVE_MODE : COPY_MODE);
         s_copyTgtOfs = 0;
         s_copySrcRow = -1;

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -252,12 +252,6 @@ void menuModelSelect(event_t event)
         }
 #endif
       }
-      else if (eeModelExists(sub)) {
-        killEvents(event);
-        s_copyMode = (s_copyMode == COPY_MODE ? MOVE_MODE : COPY_MODE);
-        s_copyTgtOfs = 0;
-        s_copySrcRow = -1;
-      }
       break;
 
 #if defined(PCBX7)

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -162,7 +162,7 @@ void menuModelSelect(event_t event)
           s_copyMode = 0;
           event = EVT_ENTRY_UP;
         }
-        else if (event == EVT_KEY_LONG(KEY_ENTER)) {
+        else if (event == EVT_KEY_BREAK(KEY_ENTER)) {
           s_copyMode = 0;
           killEvents(event);
           if (g_eeGeneral.currModel != sub) {
@@ -186,6 +186,7 @@ void menuModelSelect(event_t event)
           POPUP_MENU_START(onModelSelectMenu);
         }
         else if (eeModelExists(sub)) {
+          killEvents(event);
           s_copyMode = (s_copyMode == COPY_MODE ? MOVE_MODE : COPY_MODE);
           s_copyTgtOfs = 0;
           s_copySrcRow = -1;

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -185,12 +185,6 @@ void menuModelSelect(event_t event)
           }
           POPUP_MENU_START(onModelSelectMenu);
         }
-        else if (eeModelExists(sub)) {
-          killEvents(event);
-          s_copyMode = (s_copyMode == COPY_MODE ? MOVE_MODE : COPY_MODE);
-          s_copyTgtOfs = 0;
-          s_copySrcRow = -1;
-        }
         break;
 
       case EVT_KEY_BREAK(KEY_PAGE):


### PR DESCRIPTION
When on the model select screen, pressing [enter] loads the model currently select, instead of having to press enter long + click “select model” in the pop up menu.

It might not be the case for everyone, but it seems to me the most intuitive action to execute, and should thus not require the user to trigger the pop-up menu.

This PR is the Taranis version of #5385.

EDIT:
So far, the following alternatives have come out of the discussion:
- one-click option (implemented by the PR) (removes the copy/move system from easy access).
- click triggers pop-up menu (like on the X7) (removes the copy/move system from easy access).
- anything else?
