### PR TITLE
[Companion] Fix crash with gvars on AVR radios, gvar misc. cleanup.

### DIFF
--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -160,9 +160,12 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
 
     // Column headers
     int headerCol = 1;
-    QLabel *nameLabel = new QLabel(ui->gvGB);
-    nameLabel->setText(tr("Name"));
-    gvLayout->addWidget(nameLabel, 0, headerCol++, 1, 1);
+
+    if (firmware->getCapability(GvarsName)) {
+      QLabel *nameLabel = new QLabel(ui->gvGB);
+      nameLabel->setText(tr("Name"));
+      gvLayout->addWidget(nameLabel, 0, headerCol++, 1, 1);
+    }
 
     if (phaseIdx > 0) {
       QLabel *sourceLabel = new QLabel(ui->gvGB);
@@ -170,11 +173,11 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
       gvLayout->addWidget(sourceLabel, 0, headerCol++, 1, 1);
     }
 
-    if (IS_HORUS_OR_TARANIS(board) && phaseIdx == 0) {
-      QLabel *valueLabel = new QLabel(ui->gvGB);
-      valueLabel->setText(tr("Value"));
-      gvLayout->addWidget(valueLabel, 0, headerCol++, 1, 1);
+    QLabel *valueLabel = new QLabel(ui->gvGB);
+    valueLabel->setText(tr("Value"));
+    gvLayout->addWidget(valueLabel, 0, headerCol++, 1, 1);
 
+    if (IS_HORUS_OR_TARANIS(board) && phaseIdx == 0) {
       QLabel *unitLabel = new QLabel(ui->gvGB);
       unitLabel->setText(tr("Unit"));
       gvLayout->addWidget(unitLabel, 0, headerCol++, 1, 1);
@@ -269,6 +272,7 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
   }
   else {
     ui->gvGB->hide();
+    gvCount = 0;
   }
 
   disableMouseScrolling();
@@ -332,7 +336,7 @@ void FlightModePanel::updateGVar(int index)
   }
   gvValues[index]->setDisabled(model->isGVarLinked(phaseIdx, index));
   setGVSB(gvValues[index], model->gvarData[index].getMin(), model->gvarData[index].getMax(), model->getGVarFieldValue(phaseIdx, index));
-  if (IS_TARANIS(getCurrentBoard()) && phaseIdx == 0) {
+  if (IS_HORUS_OR_TARANIS(getCurrentBoard()) && phaseIdx == 0) {
     gvUnit[index]->setCurrentIndex(model->gvarData[index].unit);
     gvPrec[index]->setCurrentIndex(model->gvarData[index].prec);
     setGVSB(gvMin[index], GVAR_MIN_VALUE, model->gvarData[index].getMax(), model->gvarData[index].getMin());


### PR DESCRIPTION
- Fix Companion crash when trying to edit a model with gvars enabled but no GvarsFlightModes (all AVR radios except MEGA); 
- Fix to properly update unit/prec/min/max field values for Horus also (was only on Taranis);
- Always show Value column label but hide Name label if not used.