### PR TITLE
[Radio] Adjust value limits for mix sources and update UI for LSs, CFs & telem.

### DIFF
--- a/radio/src/gui/128x64/model_display.cpp
+++ b/radio/src/gui/128x64/model_display.cpp
@@ -193,18 +193,18 @@ void menuModelDisplay(event_t event)
 
         if (IS_BARS_SCREEN(screenIndex)) {
           FrSkyBarData & bar = g_model.frsky.screens[screenIndex].bars[lineIndex];
-          source_t barSource = bar.source;
-          drawSource(DISPLAY_COL1, y, barSource, menuHorizontalPosition==0 ? attr : 0);
-          int barMax = getMaximumValue(barSource);
-          int barMin = -barMax;
-          if (barSource) {
-            if (barSource <= MIXSRC_LAST_CH) {
-              drawSourceCustomValue(DISPLAY_COL2, y, barSource, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | LEFT);
-              drawSourceCustomValue(DISPLAY_COL3, y, barSource, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | LEFT);
+          drawSource(DISPLAY_COL1, y, bar.source, menuHorizontalPosition==0 ? attr : 0);
+          int16_t barMax, barMin;
+          LcdFlags lf = LEFT;
+          getMixSrcRange(bar.source, barMin, barMax, &lf);
+          if (bar.source) {
+            if (bar.source <= MIXSRC_LAST_CH) {
+              drawSourceCustomValue(DISPLAY_COL2, y, bar.source, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | lf);
+              drawSourceCustomValue(DISPLAY_COL3, y, bar.source, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | lf);
             }
             else {
-              drawSourceCustomValue(DISPLAY_COL2, y, barSource, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | LEFT);
-              drawSourceCustomValue(DISPLAY_COL3, y, barSource, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | LEFT);
+              drawSourceCustomValue(DISPLAY_COL2, y, bar.source, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | lf);
+              drawSourceCustomValue(DISPLAY_COL3, y, bar.source, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | lf);
             }
           }
           else if (attr) {
@@ -213,9 +213,9 @@ void menuModelDisplay(event_t event)
           if (attr && s_editMode>0) {
             switch (menuHorizontalPosition) {
               case 0:
-                bar.source = checkIncDec(event, barSource, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
+                bar.source = checkIncDec(event, bar.source, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
                 if (checkIncDec_Ret) {
-                  if (barSource <= MIXSRC_LAST_CH) {
+                  if (bar.source <= MIXSRC_LAST_CH) {
                     bar.barMin = -100;
                     bar.barMax = 100;
                   }

--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -130,7 +130,7 @@ void menuModelLogicalSwitchOne(event_t event)
       {
         INCDEC_DECLARE_VARS(EE_MODEL);
         lcdDrawTextAlignedLeft(y, STR_V2);
-        int v2_min=0, v2_max=MIXSRC_LAST_TELEM;
+        int16_t v2_min = 0, v2_max = MIXSRC_LAST_TELEM;
         if (cstate == LS_FAMILY_BOOL || cstate == LS_FAMILY_STICKY) {
           drawSwitch(CSWONE_2ND_COLUMN, y, cs->v2, attr);
           v2_min = SWSRC_OFF+1; v2_max = SWSRC_ON-1;
@@ -180,13 +180,9 @@ void menuModelLogicalSwitchOne(event_t event)
           else
 #endif // TELEMETRY_FRSKY
           {
-            v2_max = getMaximumValue(v1_val); v2_min = -v2_max;
-            if (v1_val <= MIXSRC_LAST_CH) {
-              drawSourceCustomValue(CSWONE_2ND_COLUMN, y, v1_val, calc100toRESX(cs->v2), LEFT|attr);
-            }
-            else {
-              drawSourceCustomValue(CSWONE_2ND_COLUMN, y, v1_val, cs->v2, LEFT|attr);
-            }
+            LcdFlags lf = attr | LEFT;
+            getMixSrcRange(v1_val, v2_min, v2_max, &lf);
+            drawSourceCustomValue(CSWONE_2ND_COLUMN, y, v1_val, (v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2), lf);
           }
         }
 
@@ -322,13 +318,11 @@ void menuModelLogicalSwitches(event_t event)
         if (v1 >= MIXSRC_FIRST_TELEM) {
           drawSourceCustomValue(CSW_3RD_COLUMN, y, v1, convertLswTelemValue(cs), LEFT);
         }
+        else if (v1 <= MIXSRC_LAST_CH) {
+          drawSourceCustomValue(CSW_3RD_COLUMN, y, v1, calc100toRESX(cs->v2), LEFT);
+        }
         else {
-          if (v1 <= MIXSRC_LAST_CH) {
-            drawSourceCustomValue(CSW_3RD_COLUMN, y, v1, calc100toRESX(cs->v2), LEFT);
-          }
-          else {
-            drawSourceCustomValue(CSW_3RD_COLUMN, y, v1, cs->v2, LEFT);
-          }
+          drawSourceCustomValue(CSW_3RD_COLUMN, y, v1, cs->v2, LEFT | (v1 != MIXSRC_TX_TIME ? TIMEHOUR : 0));
         }
       }
 

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -298,10 +298,12 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           }
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
           else if (func == FUNC_OVERRIDE_CHANNEL) {
-#if !defined(CPUARM)
+#if defined(CPUARM)
+            getMixSrcRange(MIXSRC_FIRST_CH, val_min, val_max);
+#else
             val_displayed = (int8_t)CFN_PARAM(cfn);
-#endif
             val_min = -LIMIT_EXT_PERCENT; val_max = +LIMIT_EXT_PERCENT;
+#endif
             lcdDrawNumber(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT);
           }
 #endif // OVERRIDE_CHANNEL_FUNCTION
@@ -311,7 +313,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             lcdDrawTextAtIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "\004Int.Ext.", CFN_PARAM(cfn), attr);
           }
           else if (func == FUNC_SET_TIMER) {
-            val_max = 539*60+59;
+            getMixSrcRange(MIXSRC_FIRST_TIMER, val_min, val_max);
             drawTimer(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT, attr);
           }
 #endif
@@ -400,7 +402,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             drawSource(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr);
             INCDEC_ENABLE_CHECK(functionsContext == &globalFunctionsContext ? isSourceAvailableInGlobalFunctions : isSourceAvailable);
           }
-#endif
+#endif  // CPUARM
 #if defined(SDCARD)
           else if (func == FUNC_LOGS) {
             if (val_displayed) {
@@ -417,8 +419,13 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             switch (CFN_GVAR_MODE(cfn)) {
               case FUNC_ADJUST_GVAR_CONSTANT:
                 val_displayed = (int16_t)CFN_PARAM(cfn);
+#if defined(CPUARM)
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                drawGVarValue(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, CFN_GVAR_INDEX(cfn), val_displayed, attr|LEFT);
+#else
                 val_min = -CFN_GVAR_CST_MAX; val_max = +CFN_GVAR_CST_MAX;
                 lcdDrawNumber(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT);
+#endif // CPUARM
                 break;
               case FUNC_ADJUST_GVAR_SOURCE:
                 val_max = MIXSRC_LAST_CH;
@@ -433,17 +440,14 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 drawStringWithIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_GV, val_displayed+1, attr);
                 break;
               default: // FUNC_ADJUST_GVAR_INC
-#if defined(PCBX7)
-                val_min = -100; val_max = +100;
-                if (val_displayed < 0)
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "-= ", attr);
-                else
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "+= ", attr);
+#if defined(CPUARM)
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
 #else
                 val_max = 1;
                 lcdDrawTextAtIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, PSTR("\003-=1+=1"), val_displayed, attr);
-#endif // PCBX7
+#endif // CPUARM
                 break;
             }
 

--- a/radio/src/gui/212x64/model_display.cpp
+++ b/radio/src/gui/212x64/model_display.cpp
@@ -195,18 +195,18 @@ void menuModelDisplay(event_t event)
 
         if (IS_BARS_SCREEN(screenIndex)) {
           FrSkyBarData & bar = g_model.frsky.screens[screenIndex].bars[lineIndex];
-          source_t barSource = bar.source;
-          drawSource(DISPLAY_COL1, y, barSource, menuHorizontalPosition==0 ? attr : 0);
-          int barMax = getMaximumValue(barSource);
-          int barMin = -barMax;
-          if (barSource) {
-            if (barSource <= MIXSRC_LAST_CH) {
-              drawSourceCustomValue(DISPLAY_COL2, y, barSource, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | LEFT);
-              drawSourceCustomValue(DISPLAY_COL3, y, barSource, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | LEFT);
+          drawSource(DISPLAY_COL1, y, bar.source, menuHorizontalPosition==0 ? attr : 0);
+          int16_t barMax, barMin;
+          LcdFlags lf = LEFT;
+          getMixSrcRange(bar.source, barMin, barMax, &lf);
+          if (bar.source) {
+            if (bar.source <= MIXSRC_LAST_CH) {
+              drawSourceCustomValue(DISPLAY_COL2, y, bar.source, calc100toRESX(bar.barMin), (menuHorizontalPosition==1 ? attr : 0) | lf);
+              drawSourceCustomValue(DISPLAY_COL3, y, bar.source, calc100toRESX(bar.barMax), (menuHorizontalPosition==2 ? attr : 0) | lf);
             }
             else {
-              drawSourceCustomValue(DISPLAY_COL2, y, barSource, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | LEFT);
-              drawSourceCustomValue(DISPLAY_COL3, y, barSource, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | LEFT);
+              drawSourceCustomValue(DISPLAY_COL2, y, bar.source, bar.barMin, (menuHorizontalPosition==1 ? attr : 0) | lf);
+              drawSourceCustomValue(DISPLAY_COL3, y, bar.source, bar.barMax, (menuHorizontalPosition==2 ? attr : 0) | lf);
             }
           }
           else if (attr) {
@@ -215,9 +215,9 @@ void menuModelDisplay(event_t event)
           if (attr && s_editMode>0) {
             switch (menuHorizontalPosition) {
               case 0:
-                bar.source = checkIncDec(event, barSource, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
+                bar.source = checkIncDec(event, bar.source, 0, MIXSRC_LAST_TELEM, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailable);
                 if (checkIncDec_Ret) {
-                  if (barSource <= MIXSRC_LAST_CH) {
+                  if (bar.source <= MIXSRC_LAST_CH) {
                     bar.barMin = -100;
                     bar.barMax = 100;
                   }

--- a/radio/src/gui/212x64/model_logical_switches.cpp
+++ b/radio/src/gui/212x64/model_logical_switches.cpp
@@ -115,9 +115,10 @@ void menuModelLogicalSwitches(event_t event)
 
     // CSW params
     unsigned int cstate = lswFamily(cs->func);
-    int v1_val=cs->v1, v1_min=0, v1_max=MIXSRC_LAST_TELEM;
-    int v2_min=0, v2_max=MIXSRC_LAST_TELEM;
-    int v3_min=-1, v3_max=100;
+    int v1_val = cs->v1;
+    int16_t v1_min = 0, v1_max = MIXSRC_LAST_TELEM;
+    int16_t v2_min = 0, v2_max = MIXSRC_LAST_TELEM;
+    int16_t v3_min =-1, v3_max = 100;
 
     if (cstate == LS_FAMILY_BOOL || cstate == LS_FAMILY_STICKY) {
       drawSwitch(CSW_2ND_COLUMN, y, cs->v1, attr1);
@@ -168,14 +169,9 @@ void menuModelLogicalSwitches(event_t event)
         INCDEC_SET_FLAG(EE_MODEL);
         INCDEC_ENABLE_CHECK(NULL);
       }
-      v2_max = getMaximumValue(v1_val);
-      v2_min = - v2_max;
-      if (v1_val <= MIXSRC_LAST_CH) {
-        drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, calc100toRESX(cs->v2), LEFT|attr2);
-      }
-      else {
-        drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, cs->v2, LEFT|attr2);
-      }
+      LcdFlags lf = attr2 | LEFT;
+      getMixSrcRange(v1_val, v2_min, v2_max, &lf);
+      drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, (v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2), lf);
     }
 
     // CSW AND switch

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -258,7 +258,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           }
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
           else if (func == FUNC_OVERRIDE_CHANNEL) {
-            val_min = -LIMIT_EXT_PERCENT; val_max = +LIMIT_EXT_PERCENT;
+            getMixSrcRange(MIXSRC_FIRST_CH, val_min, val_max);
             lcdDrawNumber(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT);
           }
 #endif
@@ -267,7 +267,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             lcdDrawTextAtIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "\004Int.Ext.", CFN_PARAM(cfn), attr);
           }
           else if (func == FUNC_SET_TIMER) {
-            val_max = 539*60+59; //8:59:59
+            getMixSrcRange(MIXSRC_FIRST_TIMER, val_min, val_max);
             drawTimer(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT|TIMEHOUR, attr);
           }
           else if (func == FUNC_PLAY_SOUND) {
@@ -345,11 +345,9 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             switch (CFN_GVAR_MODE(cfn)) {
               case FUNC_ADJUST_GVAR_CONSTANT:
               {
-                uint8_t gvar_index = CFN_GVAR_INDEX(cfn);
                 val_displayed = (int16_t)CFN_PARAM(cfn);
-                val_min = max<int16_t>(CFN_GVAR_CST_MIN, MODEL_GVAR_MIN(gvar_index));
-                val_max = min<int16_t>(CFN_GVAR_CST_MAX, MODEL_GVAR_MAX(gvar_index));
-                drawGVarValue(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, gvar_index, val_displayed, attr|LEFT);
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                drawGVarValue(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, CFN_GVAR_INDEX(cfn), val_displayed, attr|LEFT);
                 break;
               }
               case FUNC_ADJUST_GVAR_SOURCE:
@@ -365,12 +363,10 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 drawStringWithIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_GV, val_displayed+1, attr);
                 break;
               default: // FUNC_ADJUST_GVAR_INC
-                val_min = -100; val_max = +100;
-                if (val_displayed < 0)
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "-= ", attr);
-                else
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "+= ", attr);
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
+                break;
             }
           }
 #endif

--- a/radio/src/gui/480x272/model_logical_switches.cpp
+++ b/radio/src/gui/480x272/model_logical_switches.cpp
@@ -119,9 +119,10 @@ bool menuModelLogicalSwitches(event_t event)
 
     // CSW params
     cstate = lswFamily(cs->func);
-    int v1_val=cs->v1, v1_min=0, v1_max=MIXSRC_LAST_TELEM;
-    int v2_min=0, v2_max=MIXSRC_LAST_TELEM;
-    int v3_min=-1, v3_max=100;
+    int v1_val = cs->v1;
+    int16_t v1_min = 0, v1_max = MIXSRC_LAST_TELEM;
+    int16_t v2_min = 0, v2_max = MIXSRC_LAST_TELEM;
+    int16_t v3_min =-1, v3_max = 100;
 
     if (cstate == LS_FAMILY_BOOL || cstate == LS_FAMILY_STICKY) {
       drawSwitch(CSW_2ND_COLUMN, y, cs->v1, attr1);
@@ -172,9 +173,9 @@ bool menuModelLogicalSwitches(event_t event)
         INCDEC_SET_FLAG(EE_MODEL);
         INCDEC_ENABLE_CHECK(NULL);
       }
-      v2_max = getMaximumValue(v1_val);
-      v2_min = -v2_max;
-      drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2, LEFT|attr2);
+      LcdFlags lf = attr2 | LEFT;
+      getMixSrcRange(v1_val, v2_min, v2_max, &lf);
+      drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, (v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2), lf);
     }
 
     // CSW AND switch

--- a/radio/src/gui/480x272/model_special_functions.cpp
+++ b/radio/src/gui/480x272/model_special_functions.cpp
@@ -259,7 +259,7 @@ bool menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           }
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
           else if (func == FUNC_OVERRIDE_CHANNEL) {
-            val_min = -LIMIT_EXT_PERCENT; val_max = +LIMIT_EXT_PERCENT;
+            getMixSrcRange(MIXSRC_FIRST_CH, val_min, val_max);
             lcdDrawNumber(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT);
           }
 #endif
@@ -270,9 +270,8 @@ bool menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           }
 #endif
           else if (func == FUNC_SET_TIMER) {
-            // TODO 539 ? TIMEHOUR ?
-            val_max = 59*60+59;
-            drawTimer(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT);
+            getMixSrcRange(MIXSRC_FIRST_TIMER, val_min, val_max);
+            drawTimer(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT|TIMEHOUR);
           }
           else if (func == FUNC_PLAY_SOUND) {
             val_max = AU_SPECIAL_SOUND_LAST-AU_SPECIAL_SOUND_FIRST-1;
@@ -341,11 +340,9 @@ bool menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             switch (CFN_GVAR_MODE(cfn)) {
               case FUNC_ADJUST_GVAR_CONSTANT:
               {
-                uint8_t gvar_index = CFN_GVAR_INDEX(cfn);
-                val_displayed = (int16_t) CFN_PARAM(cfn);
-                val_min = max<int16_t>(CFN_GVAR_CST_MIN, MODEL_GVAR_MIN(gvar_index));
-                val_max = min<int16_t>(CFN_GVAR_CST_MAX, MODEL_GVAR_MAX(gvar_index));
-                drawGVarValue(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, gvar_index, val_displayed, attr|LEFT);
+                val_displayed = (int16_t)CFN_PARAM(cfn);
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                drawGVarValue(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, CFN_GVAR_INDEX(cfn), val_displayed, attr|LEFT);
                 break;
               }
               case FUNC_ADJUST_GVAR_SOURCE:
@@ -361,11 +358,8 @@ bool menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 drawStringWithIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_GV, val_displayed+1, attr);
                 break;
               default: // FUNC_ADJUST_GVAR_INC
-                val_min = -100; val_max = +100;
-                if (val_displayed < 0)
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "-= ", attr);
-                else
-                  lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, "+= ", attr);
+                getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
                 break;
             }

--- a/radio/src/gui/common/arm/widgets.cpp
+++ b/radio/src/gui/common/arm/widgets.cpp
@@ -143,9 +143,11 @@ void drawSourceCustomValue(coord_t x, coord_t y, source_t source, int32_t value,
     }
   }
 #endif
+#if defined(GVARS)
   else if (source >= MIXSRC_FIRST_GVAR && source <= MIXSRC_LAST_GVAR) {
     drawGVarValue(x, y, source - MIXSRC_FIRST_GVAR, value, flags);
   }
+#endif
   else if (source < MIXSRC_FIRST_CH) {
     lcdDrawNumber(x, y, calcRESXto100(value), flags);
   }

--- a/radio/src/gui/common/arm/widgets.cpp
+++ b/radio/src/gui/common/arm/widgets.cpp
@@ -143,6 +143,9 @@ void drawSourceCustomValue(coord_t x, coord_t y, source_t source, int32_t value,
     }
   }
 #endif
+  else if (source >= MIXSRC_FIRST_GVAR && source <= MIXSRC_LAST_GVAR) {
+    drawGVarValue(x, y, source - MIXSRC_FIRST_GVAR, value, flags);
+  }
   else if (source < MIXSRC_FIRST_CH) {
     lcdDrawNumber(x, y, calcRESXto100(value), flags);
   }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1038,12 +1038,14 @@ inline void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax,
     valMax = g_model.extendedLimits ? LIMIT_EXT_PERCENT : 100;
     valMin = -valMax;
   }
+#if defined(GVARS)
   else if (source >= MIXSRC_FIRST_GVAR && source <= MIXSRC_LAST_GVAR) {
     valMax = min<int>(CFN_GVAR_CST_MAX, MODEL_GVAR_MAX(source-MIXSRC_FIRST_GVAR));
     valMin = max<int>(CFN_GVAR_CST_MIN, MODEL_GVAR_MIN(source-MIXSRC_FIRST_GVAR));
     if (flags && g_model.gvars[source-MIXSRC_FIRST_GVAR].prec)
       *flags |= PREC1;
   }
+#endif
   else if (source == MIXSRC_TX_VOLTAGE) {
     valMax =  255;
     valMin = 0;

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -179,6 +179,11 @@ char * getTimerString(char * dest, putstime_t tme, uint8_t hours)
     qr.quot = qr2.rem;
   }
 
+  if (!hours && qr.quot > 99) {
+    *s++ = '0' + (qr.quot / 100);
+    qr.quot = qr.quot % 100;
+  }
+
   *s++ = '0' + (qr.quot / 10);
   *s++ = '0' + (qr.quot % 10);
   *s++ = ':';


### PR DESCRIPTION
Adjust some value limits for mix sources and update editing UI for LSs, CFs, & telem. bars:

  * Increase timer limits to +/-8:59:59 when used with LSs, CFs, & bars;
  * Increase Lua script output limits to +/-30K (see #3581);
  * Trim limits based on extended limit model setting;
  * Limit TX voltage to 25.5;
  * Limit TX time comparison value to 29:59m;
  * Use proper GVar limits (user-configured), display precision, & unit in LSs & telem. bars;
  * Display timer values properly with hours (instead of mmm:ss);
  * getTimerString() would fail with times >= 100min if hours weren't shown.

Fixes #3581 (fw part)

This PR relates to #5437 and should be merged together.

Notes/discuss:

Negative times always blink, even in the editor screens.  Obviously distracting especially when it's selected for editing.  I'd vote for changing this, but somehow keep the old default of blinking when timer is not used on editing screen.

I think the X7 (small ARM screen) time display function could be revisited.  When viewing values >=60m it goes into a "HHhMM" display mode where seconds can't be seen (but are still changed when editing).  I understand the problem with space, but at least in the editor screens I think the full h:mm:ss format would fit just about everywhere (there's no place 2-digit hours are shown).  One possible exception is the CF editor where we don't yet have a dedicated "pop up" dialog to edit the values. @3djc ?