### PR TITLE
[Companion][R9M] Adjust for R9M changes

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -172,6 +172,7 @@ void TimerPanel::on_name_editingFinished()
 #define MASK_MULTIOPTION    512
 #define MASK_R9M            1024
 #define MASK_SBUSPPM_FIELDS 2048
+#define MASK_SUBTYPES       4096
 
 quint8 ModulePanel::failsafesValueDisplayType = ModulePanel::FAILSAFE_DISPLAY_PERCENT;
 
@@ -369,7 +370,7 @@ void ModulePanel::update()
     mask |= MASK_PROTOCOL;
     switch (protocol) {
       case PULSES_PXX_R9M:
-        mask |= MASK_R9M;
+        mask |= MASK_R9M | MASK_SUBTYPES;
       case PULSES_PXX_XJT_X16:
       case PULSES_PXX_XJT_D8:
       case PULSES_PXX_XJT_LR12:
@@ -402,7 +403,7 @@ void ModulePanel::update()
         mask |=  MASK_SBUSPPM_FIELDS| MASK_CHANNELS_RANGE;
         break;
       case PULSES_MULTIMODULE:
-        mask |= MASK_CHANNELS_RANGE | MASK_RX_NUMBER | MASK_MULTIMODULE;
+        mask |= MASK_CHANNELS_RANGE | MASK_RX_NUMBER | MASK_MULTIMODULE | MASK_SUBTYPES;
         max_rx_num = 15;
         if (module.multi.rfProtocol == MM_RF_PROTO_DSM2)
           mask |= MASK_CHANNELS_COUNT;
@@ -468,37 +469,49 @@ void ModulePanel::update()
   ui->antennaMode->setVisible(mask & MASK_ANTENNA);
   ui->antennaMode->setCurrentIndex(module.pxx.external_antenna);
 
-  // R9M S.port output
+  // R9M options
   ui->sportOut->setVisible(mask & MASK_R9M);
-  ui->label_sportOut->setVisible(mask & MASK_R9M);
-  ui->sportOut->setCurrentIndex(module.pxx.sport_out);
+  ui->r9mPower->setVisible((mask & MASK_R9M) && module.subType == 0);
+  ui->label_r9mPower->setVisible((mask & MASK_R9M) && module.subType == 0);
+  if (mask & MASK_R9M) {
+    if (model->moduleData[0].protocol == PULSES_PXX_XJT_X16) {
+      module.pxx.sport_out = false;
+      ui->sportOut->setDisabled(true);
+    }
+    else {
+      ui->sportOut->setEnabled(true);
+    }
+    ui->sportOut->setChecked(module.pxx.sport_out);
+    ui->r9mPower->setCurrentIndex(module.pxx.power);
+  }
 
-  ui->r9mPower->setVisible(mask & MASK_R9M);
-  ui->label_r9mPower->setVisible(mask & MASK_R9M);
-  ui->r9mPower->setCurrentIndex(module.pxx.power);
+  // module subtype
+  ui->label_multiSubType->setVisible(mask & MASK_SUBTYPES);
+  ui->multiSubType->setVisible(mask & MASK_SUBTYPES);
+  if (mask & MASK_SUBTYPES) {
+    unsigned numEntries = 2;  // R9M FCC/EU
+    if (mask & MASK_MULTIMODULE)
+      numEntries = (module.multi.customProto ? 8 : multiProtocols.getProtocol(module.multi.rfProtocol).numSubytes());
 
+    const QSignalBlocker blocker(ui->multiSubType);
+    ui->multiSubType->clear();
+    for (unsigned i=0; i < numEntries; i++)
+      ui->multiSubType->addItem(ModelPrinter::printModuleSubType(protocol, i, module.multi.rfProtocol, module.multi.customProto), i);
+    ui->multiSubType->setCurrentIndex(module.subType);
+  }
 
   // Multi settings fields
   ui->label_multiProtocol->setVisible(mask & MASK_MULTIMODULE);
   ui->multiProtocol->setVisible(mask & MASK_MULTIMODULE);
-  ui->multiProtocol->setCurrentIndex(module.multi.rfProtocol);
-  ui->label_multiSubType->setVisible(mask & MASK_MULTIMODULE);
-  ui->multiSubType->setVisible(mask & MASK_MULTIMODULE);
   ui->label_option->setVisible(mask & MASK_MULTIOPTION);
   ui->optionValue->setVisible(mask & MASK_MULTIOPTION);
+  ui->autoBind->setVisible(mask & MASK_MULTIMODULE);
+  ui->lowPower->setVisible(mask & MASK_MULTIMODULE);
 
   if (mask & MASK_MULTIMODULE) {
-    int numEntries = multiProtocols.getProtocol(module.multi.rfProtocol).numSubytes();
-    if (module.multi.customProto)
-      numEntries=8;
-    // Removes extra items
-    ui->multiSubType->setMaxCount(numEntries);
-    for (int i=0; i < numEntries; i++) {
-      if (i < ui->multiSubType->count())
-        ui->multiSubType->setItemText(i, ModelPrinter::printMultiSubType(module.multi.rfProtocol, module.multi.customProto, i));
-      else
-        ui->multiSubType->addItem(ModelPrinter::printMultiSubType(module.multi.rfProtocol, module.multi.customProto, i), (QVariant) i);
-    }
+    ui->multiProtocol->setCurrentIndex(module.multi.rfProtocol);
+    ui->autoBind->setChecked(module.multi.autoBindMode ? Qt::Checked : Qt::Unchecked);
+    ui->lowPower->setChecked(module.multi.lowPowerMode ? Qt::Checked : Qt::Unchecked);
   }
 
   if (mask & MASK_MULTIOPTION) {
@@ -508,14 +521,8 @@ void ModulePanel::update()
     ui->optionValue->setValue(module.multi.optionValue);
     ui->label_option->setText(qApp->translate("Multiprotocols", qPrintable(pdef.optionsstr)));
   }
-  ui->multiSubType->setCurrentIndex(module.subType);
 
-  ui->autoBind->setVisible(mask & MASK_MULTIMODULE);
-  ui->autoBind->setChecked(module.multi.autoBindMode ? Qt::Checked : Qt::Unchecked);
-  ui->lowPower->setVisible(mask & MASK_MULTIMODULE);
-  ui->lowPower->setChecked(module.multi.lowPowerMode ? Qt::Checked : Qt::Unchecked);
-
-
+  // Failsafes
   ui->label_failsafeMode->setVisible(mask & MASK_FAILSAFES);
   ui->failsafeMode->setVisible(mask & MASK_FAILSAFES);
 
@@ -584,10 +591,12 @@ void ModulePanel::on_antennaMode_currentIndexChanged(int index)
   emit modified();
 }
 
-void ModulePanel::on_sportOut_currentIndexChanged(int index)
+void ModulePanel::on_sportOut_toggled(bool checked)
 {
-  module.pxx.sport_out = index;
-  emit modified();
+  if (module.pxx.sport_out != checked) {
+    module.pxx.sport_out = checked;
+    emit modified();
+  }
 }
 
 void ModulePanel::on_r9mPower_currentIndexChanged(int index)

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -88,7 +88,7 @@ class ModulePanel : public ModelPanel
     void on_multiSubType_currentIndexChanged(int index);
     void on_autoBind_stateChanged(int state);
     void on_lowPower_stateChanged(int state);
-    void on_sportOut_currentIndexChanged(int index);
+    void on_sportOut_toggled(bool checked);
     void on_r9mPower_currentIndexChanged(int index);
     void setChannelFailsafeValue(const int channel, const int value, quint8 updtSb = 0);
     void onFailsafeComboIndexChanged(int index);

--- a/companion/src/modeledit/setup_module.ui
+++ b/companion/src/modeledit/setup_module.ui
@@ -6,12 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>674</width>
-    <height>229</height>
+    <width>708</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string/>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -147,22 +150,43 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_multiSubType">
+         <widget class="QLabel" name="label_rxNumber">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
           <property name="text">
-           <string>SubType</string>
+           <string>Receiver No.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="multiSubType">
+         <widget class="QSpinBox" name="rxNumber">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
+          <property name="suffix">
+           <string/>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>63</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>0</number>
           </property>
          </widget>
         </item>
@@ -206,87 +230,53 @@
          </widget>
         </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="label_antenna">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
+         <widget class="QLabel" name="label_r9mPower">
           <property name="text">
-           <string>Antenna</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <string>RF Output Power</string>
           </property>
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QComboBox" name="antennaMode">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
+         <widget class="QComboBox" name="r9mPower">
           <item>
            <property name="text">
-            <string>Internal</string>
+            <string>10 mW</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Ext. + Int.</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_ppmOutputType">
-          <property name="text">
-           <string>Output type</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="ppmOutputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-          <item>
-           <property name="text">
-            <string>Open Drain</string>
+            <string>100 mW</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Push Pull</string>
+            <string>500 mW</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>1000 mW</string>
            </property>
           </item>
          </widget>
         </item>
-        <item row="5" column="1">
-         <widget class="QSpinBox" name="optionValue">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_option">
-          <property name="text">
-           <string>Option value</string>
-          </property>
-         </widget>
+        <item row="4" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="autoBind">
+            <property name="text">
+             <string>Bind on startup</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="lowPower">
+            <property name="text">
+             <string>Low Power</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -352,61 +342,6 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_rxNumber">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Receiver No.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="rxNumber">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="minimum">
-           <number>0</number>
-          </property>
-          <property name="maximum">
-           <number>63</number>
-          </property>
-          <property name="singleStep">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>0</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QCheckBox" name="autoBind">
-          <property name="text">
-           <string>Bind on startup</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="lowPower">
-          <property name="text">
-           <string>Low Power</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
          <widget class="QLabel" name="label_ppmDelay">
           <property name="maximumSize">
            <size>
@@ -422,7 +357,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="1" column="1">
          <widget class="QSpinBox" name="ppmDelay">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -450,7 +385,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="label_ppmFrameLength">
           <property name="maximumSize">
            <size>
@@ -466,7 +401,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="2" column="1">
          <widget class="QDoubleSpinBox" name="ppmFrameLength">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -491,6 +426,89 @@
           </property>
           <property name="value">
            <double>22.500000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_antenna">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Antenna</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="antennaMode">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>Internal</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Ext. + Int.</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_ppmOutputType">
+          <property name="text">
+           <string>Output type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="ppmOutputType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>Open Drain</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Push Pull</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_option">
+          <property name="text">
+           <string>Option value</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="optionValue">
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -560,6 +578,26 @@
          </widget>
         </item>
         <item row="2" column="0">
+         <widget class="QLabel" name="label_multiSubType">
+          <property name="text">
+           <string>Sub Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="multiSubType">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
          <widget class="QLabel" name="label_failsafeMode">
           <property name="maximumSize">
            <size>
@@ -575,7 +613,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="4" column="1">
          <widget class="QComboBox" name="failsafeMode">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -613,7 +651,7 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_trainerMode">
           <property name="maximumSize">
            <size>
@@ -629,7 +667,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="5" column="1">
          <widget class="QComboBox" name="trainerMode">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -667,62 +705,11 @@
           </item>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_sportOut">
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="sportOut">
           <property name="text">
-           <string>S.port output</string>
+           <string>Enable Module Telemetry</string>
           </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="sportOut">
-          <property name="currentText">
-           <string>Disable</string>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
-          </property>
-          <item>
-           <property name="text">
-            <string>Disable</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Enable</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_r9mPower">
-          <property name="text">
-           <string>RF Output Power</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QComboBox" name="r9mPower">
-          <item>
-           <property name="text">
-            <string>10 mW</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>100 mW</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>500 mW</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>1000 mW</string>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -45,6 +45,14 @@ ModelPrinter::~ModelPrinter()
 {
 }
 
+QString ModelPrinter::printBoolean(bool val)
+{
+  if (val)
+    return tr("Y");
+  else
+    return tr("N");
+}
+
 void debugHtml(const QString & html)
 {
   QFile file("foo.html");
@@ -140,7 +148,7 @@ QString ModelPrinter::printMultiRfProtocol(int rfProtocol, bool custom)
     return CHECK_IN_ARRAY(strings, rfProtocol);
 }
 
-QString ModelPrinter::printMultiSubType(int rfProtocol, bool custom, unsigned int subType) {
+QString ModelPrinter::printMultiSubType(unsigned rfProtocol, bool custom, unsigned int subType) {
   /* custom protocols */
 
   if (custom)
@@ -152,6 +160,38 @@ QString ModelPrinter::printMultiSubType(int rfProtocol, bool custom, unsigned in
     return qApp->translate("Multiprotocols", qPrintable(pdef.subTypeStrings[subType]));
   else
     return "???";
+}
+
+QString ModelPrinter::printR9MPowerValue(unsigned subType, unsigned val)
+{
+  static const QStringList strings = QStringList() \
+      << tr("10mW") << tr("100mW") << tr("500mW") << tr("1W") << tr("25mW") << tr("500mW");
+
+  if (subType == 0)
+    return strings.at(val);
+  else if (subType == 1)
+    return strings.at(val + 4);
+  else
+    return "???";
+}
+
+QString ModelPrinter::printModuleSubType(unsigned protocol, unsigned subType, unsigned rfProtocol, bool custom)
+{
+  static const char * strings[] = {
+    "FCC",
+    "LBT(EU)"
+  };
+
+  switch (protocol) {
+    case PULSES_MULTIMODULE:
+      return printMultiSubType(rfProtocol, custom, subType);
+
+    case PULSES_PXX_R9M:
+      return CHECK_IN_ARRAY(strings, subType);
+
+    default:
+      return "???";
+  }
 }
 
 QString ModelPrinter::printModule(int idx) {
@@ -167,6 +207,8 @@ QString ModelPrinter::printModule(int idx) {
     }
     if (module.protocol == PULSES_MULTIMODULE)
       result += " " + tr("radio Protocol %1, subType %2, option value %3").arg(printMultiRfProtocol(module.multi.rfProtocol, module.multi.customProto)).arg(printMultiSubType(module.multi.rfProtocol, module.multi.customProto, module.subType)).arg(module.multi.optionValue);
+    else if (module.protocol == PULSES_PXX_R9M)
+      result += " " + tr("Module Type: %1, Power: %2, Telemetry Enabled: %3").arg(printModuleSubType(module.protocol, module.subType)).arg(printR9MPowerValue(module.subType, module.pxx.power)).arg(printBoolean(module.pxx.receiver_telem_off));
     return result;
   }
 }
@@ -709,7 +751,7 @@ QString ModelPrinter::printGlobalVarMax(int idx)
 
 QString ModelPrinter::printGlobalVarPopup(int idx)
 {
-  return (model.gvarData[idx].popup ? "Y" : "N" );
+  return printBoolean(model.gvarData[idx].popup);
 }
 
 QString ModelPrinter::printOutputValueGVar(int val)
@@ -760,6 +802,6 @@ QString ModelPrinter::printOutputCurve(int idx)
 
 QString ModelPrinter::printOutputSymetrical(int idx)
 {
-  return (model.limitData[idx].symetrical ? "Y": "N");
+  return printBoolean(model.limitData[idx].symetrical);
 }
 

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -54,12 +54,15 @@ class ModelPrinter: public QObject
     ModelPrinter(Firmware * firmware, const GeneralSettings & generalSettings, const ModelData & model);
     virtual ~ModelPrinter();
 
+    QString printBoolean(bool val);
     QString printEEpromSize();
     QString printTrimIncrementMode();
     QString printThrottleTrimMode();
     static QString printModuleProtocol(unsigned int protocol);
     static QString printMultiRfProtocol(int rfProtocol, bool custom);
-    static QString printMultiSubType(int rfProtocol, bool custom, unsigned int subType);
+    static QString printR9MPowerValue(unsigned subType, unsigned val);
+    static QString printMultiSubType(unsigned rfProtocol, bool custom, unsigned int subType);
+    static QString printModuleSubType(unsigned protocol, unsigned subType, unsigned rfProtocol = 0, bool custom = false);
     QString printFlightModeSwitch(const RawSwitch & swtch);
     QString printFlightModeName(int index);
     QString printFlightModes(unsigned int flightModes);


### PR DESCRIPTION
Allow module type selection; 
Adjust UI to better match radio; 
Improve model printer details. 

Related to #5406, based on (and PR target): https://github.com/opentx/opentx/tree/bsongis/R9M_fixes

A new PR could be done against `2.2` instead, there are no changes on radio side or in the import/export, it is GUI-only.