### PR TITLE
Updated Wizard

### DIFF
--- a/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
+++ b/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
@@ -422,15 +422,15 @@ local function createModel(event)
   if(AilFields[1][5] == 1) then
     addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif (AilFields[1][5] == 2) then
-    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail1")
-    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail2", -100)
+    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
+    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
   end
   -- Flaps
   if(FlapsFields[1][5] == 1) then
     addMix(FlapsFields[2][5], MIXSRC_SA, "Flaps")
   elseif (FlapsFields[1][5] == 2) then
-    addMix(FlapsFields[2][5], MIXSRC_SA, "Flaps1")
-    addMix(FlapsFields[3][5], MIXSRC_SA, "Flaps2")
+    addMix(FlapsFields[2][5], MIXSRC_SA, "FlapsL")
+    addMix(FlapsFields[3][5], MIXSRC_SA, "FlapsR")
   end
   -- Tail
   if(TailFields[1][5] == 0) then
@@ -439,14 +439,14 @@ local function createModel(event)
     addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
   elseif (TailFields[1][5] == 2) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev1")
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
-    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev2")
+    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
   elseif (TailFields[1][5] == 3) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "VTailE", 50)
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "VTailR", 50, 1)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "VTailE", 50)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "VTailR", -50, 1)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
   end
   lcd.drawText(70, 90, "Model successfully created !", TEXT_COLOR)
   lcd.drawText(100, 130, "Press RTN to exit", TEXT_COLOR)

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
@@ -1,3 +1,19 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Copyright (C) OpenTX                                                  #
+-----#                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #                                                                       #
+---- # This program is free software; you can redistribute it and/or modify  #
+---- # it under the terms of the GNU General Public License version 2 as     #
+---- # published by the Free Software Foundation.                            #
+---- #                                                                       #
+---- # This program is distributed in the hope that it will be useful        #
+---- # but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+---- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+---- # GNU General Public License for more details.                          #
+---- #                                                                       #
+---- #########################################################################
 -- Delta Wizard pages
 local ENGINE_PAGE = 0
 local ELEVONS_PAGE = 1

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
@@ -1,3 +1,19 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Copyright (C) OpenTX                                                  #
+-----#                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #                                                                       #
+---- # This program is free software; you can redistribute it and/or modify  #
+---- # it under the terms of the GNU General Public License version 2 as     #
+---- # published by the Free Software Foundation.                            #
+---- #                                                                       #
+---- # This program is distributed in the hope that it will be useful        #
+---- # but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+---- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+---- # GNU General Public License for more details.                          #
+---- #                                                                       #
+---- #########################################################################
 -- Multicopter Wizard pages
 local THROTTLE_PAGE = 0
 local ROLL_PAGE = 1

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
@@ -1,3 +1,19 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Copyright (C) OpenTX                                                  #
+-----#                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #                                                                       #
+---- # This program is free software; you can redistribute it and/or modify  #
+---- # it under the terms of the GNU General Public License version 2 as     #
+---- # published by the Free Software Foundation.                            #
+---- #                                                                       #
+---- # This program is distributed in the hope that it will be useful        #
+---- # but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+---- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+---- # GNU General Public License for more details.                          #
+---- #                                                                       #
+---- #########################################################################
 -- Plane Wizard pages
 local ENGINE_PAGE = 0
 local AILERONS_PAGE = 1

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/wizard.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/wizard.lua
@@ -1,3 +1,19 @@
+---- #########################################################################
+---- #                                                                       #
+---- # Copyright (C) OpenTX                                                  #
+-----#                                                                       #
+---- # License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html               #
+---- #                                                                       #
+---- # This program is free software; you can redistribute it and/or modify  #
+---- # it under the terms of the GNU General Public License version 2 as     #
+---- # published by the Free Software Foundation.                            #
+---- #                                                                       #
+---- # This program is distributed in the hope that it will be useful        #
+---- # but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+---- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+---- # GNU General Public License for more details.                          #
+---- #                                                                       #
+---- #########################################################################
 -- Navigation variables
 local dirty = true
 

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/delta.lua
@@ -308,10 +308,10 @@ local function applySettings()
   if engineMode == 1 then
     addMix(thrCH1, MIXSRC_FIRST_INPUT+defaultChannel(2), "Engine")
   end
-  addMix(elevCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL-E", 50)
-  addMix(elevCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "ElevL-A", 50, 1)
-  addMix(elevCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR-E", 50)
-  addMix(elevCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "ElevR-A", -50, 1)
+  addMix(elevCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "D-EleL", 50)
+  addMix(elevCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "D-AilL", 50, 1)
+  addMix(elevCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "D-EleR", 50)
+  addMix(elevCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "D-AilR", -50, 1)
   if rudderMode == 1 then
     addMix(rudCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
   end

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/multi.lua
@@ -265,7 +265,7 @@ end
 local function applySettings()
   model.defaultInputs()
   model.deleteMixes()
-  addMix(thrCH1,   MIXSRC_FIRST_INPUT+defaultChannel(2), "Throttle")
+  addMix(thrCH1,   MIXSRC_FIRST_INPUT+defaultChannel(2), "Engine")
   addMix(rollCH1,  MIXSRC_FIRST_INPUT+defaultChannel(3), "Roll")
   addMix(yawCH1,   MIXSRC_FIRST_INPUT+defaultChannel(0), "Yaw")
   addMix(pitchCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "Pitch")

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/plane.lua
@@ -510,35 +510,35 @@ local function applySettings()
   if aileronsMode == 1 then
     addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif aileronsMode == 2 then
-    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail L")
-    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail R", -100)
+    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
+    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
   end
   if flapsMode == 1 then
     addMix(flapsCH1, MIXSRC_SA, "Flaps")
   elseif flapsMode == 2 then
-    addMix(flapsCH1, MIXSRC_SA, "Flap L")
-    addMix(flapsCH2, MIXSRC_SA, "Flap R")
+    addMix(flapsCH1, MIXSRC_SA, "FlapL")
+    addMix(flapsCH2, MIXSRC_SA, "FlapR")
   end
   if brakesMode == 1 then
     addMix(brakesCH1, MIXSRC_SE, "Brakes")
   elseif brakesMode == 2 then
-    addMix(brakesCH1, MIXSRC_SE, "Brake L")
-    addMix(brakesCH2, MIXSRC_SE, "Brake R")
+    addMix(brakesCH1, MIXSRC_SE, "BrakeL")
+    addMix(brakesCH2, MIXSRC_SE, "BrakeR")
   end
   if tailMode == 3 then
-    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-Ele L", 50)
-    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-Rud L", 50, 1)
-    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-Ele R", 50)
-    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-Rud R", -50, 1)
+    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
+    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
+    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
+    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
   else
     if tailMode > 0 then
       addMix(rudCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
     end
     if tailMode == 1 then
-      addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "Elevator")
+      addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev")
     elseif tailMode == 2 then
-      addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev L")
-      addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev R")
+      addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
+      addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
     end
   end
 end


### PR DESCRIPTION
- Reduced name of mixers to 6 characters.
- Added license GPLv2 header.
- Renamed some mixes in order to keep the same naming convention between all radios.
