### PR TITLE
[X9] Allow LSs 33-64 in main view & fix X9E view of channels 17-32

### DIFF
--- a/radio/src/gui/212x64/view_channels.cpp
+++ b/radio/src/gui/212x64/view_channels.cpp
@@ -40,6 +40,10 @@ void menuChannelsView(event_t event)
       break;
     case EVT_KEY_FIRST(KEY_RIGHT):
     case EVT_KEY_FIRST(KEY_LEFT):
+#if defined(ROTARY_ENCODER_NAVIGATION)
+    case EVT_ROTARY_LEFT:
+    case EVT_ROTARY_RIGHT:
+#endif
       secondPage = !secondPage;
       break;
     case EVT_KEY_FIRST(KEY_ENTER):

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -433,6 +433,8 @@ int getSwitchCount()
 
 void menuMainView(event_t event)
 {
+  static bool secondPage = false;
+
   STICK_SCROLL_DISABLE();
 
   switch(event) {
@@ -491,6 +493,15 @@ void menuMainView(event_t event)
       }
 #endif
       break;
+
+    case EVT_KEY_FIRST(KEY_RIGHT):
+    case EVT_KEY_FIRST(KEY_LEFT):
+#if defined(ROTARY_ENCODER_NAVIGATION)
+    case EVT_ROTARY_LEFT:
+    case EVT_ROTARY_RIGHT:
+#endif
+      secondPage = !secondPage;
+      break;
   }
 
   // Flight Mode Name
@@ -548,11 +559,17 @@ void menuMainView(event_t event)
   }
   else {
     // Logical Switches
-    lcdDrawText(TRIM_RH_X - TRIM_LEN/2 + 5, 6*FH-1, "LS 1-32");
-    for (int sw=0; sw<32; ++sw) {
-      div_t qr = div(sw, 10);
-      uint8_t y = 13 + 11 * qr.quot;
-      uint8_t x = TRIM_RH_X - TRIM_LEN + qr.rem*5 + (qr.rem >= 5 ? 3 : 0);
+    int sw = (secondPage && MAX_LOGICAL_SWITCHES > 32 ? 32 : 0);
+    const int end = sw + 32;
+    uint8_t y = 6*FH-1;
+    lcdDrawText(TRIM_RH_X - TRIM_LEN/2 + 1, y, "LS");
+    lcdDrawNumber(lcdLastRightPos + 1, y, sw + 1, LEFT);
+    lcdDrawText(lcdLastRightPos, y, "-");
+    lcdDrawNumber(lcdLastRightPos, y, end, LEFT);
+    for ( ; sw < end; ++sw) {
+      const div_t qr = div(sw + 32 - end, 10);
+      const uint8_t x = TRIM_RH_X - TRIM_LEN + qr.rem*5 + (qr.rem >= 5 ? 3 : 0);
+      y = 13 + 11 * qr.quot;
       LogicalSwitchData * cs = lswAddress(sw);
       if (cs->func == LS_FUNC_NONE) {
         lcdDrawSolidHorizontalLine(x, y+6, 4);

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -563,7 +563,7 @@ void menuMainView(event_t event)
     const int end = sw + 32;
     uint8_t y = 6*FH-1;
     lcdDrawText(TRIM_RH_X - TRIM_LEN/2 + 1, y, "LS");
-    lcdDrawNumber(lcdLastRightPos + 1, y, sw + 1, LEFT);
+    lcdDrawNumber(lcdLastRightPos + 1, y, sw + 1, LEFT|LEADING0, 2);
     lcdDrawText(lcdLastRightPos, y, "-");
     lcdDrawNumber(lcdLastRightPos, y, end, LEFT);
     for ( ; sw < end; ++sw) {


### PR DESCRIPTION
+/- keys or left/right encoder will switch between LS groups 1-32 and 33-64.
Also with X9E (encoder only) there was no way to navigate in channels/mixes monitor to the higher channels.

Closes #5476

![screenshot_x9d _17-12-08_19-33-14](https://user-images.githubusercontent.com/1366615/33790502-a766b5b4-dc4e-11e7-9dae-39cd55f4aa81.png)
![screenshot_x9d _17-12-08_11-33-30](https://user-images.githubusercontent.com/1366615/33775203-a510aa92-dc0b-11e7-8963-e204994c7b4f.png)
