### PR TITLE
[Companion] Adjust X10/S hardware options to match radio (no L1/L2/JSx/JSy)

### DIFF
--- a/companion/src/boards.cpp
+++ b/companion/src/boards.cpp
@@ -172,37 +172,29 @@ const int Boards::getCapability(Board::Type board, Board::Capability capability)
   switch (capability) {
     case Sticks:
       return 4;
+
     case Pots:
-      if (IS_HORUS(board))
-        return 3;
-      else if (IS_TARANIS_X7(board))
+      if (IS_TARANIS_X7(board))
         return 2;
       else if (IS_TARANIS_X9E(board))
         return 4;
-      else if (IS_TARANIS(board))
-        return 3;
       else
         return 3;
+
     case Sliders:
-      if (IS_HORUS(board))
+      if (IS_HORUS_X12S(board) || IS_TARANIS_X9E(board))
         return 4;
-      else if (IS_TARANIS_X7(board))
-        return 0;
-      else if (IS_TARANIS_X9E(board))
-        return 4;
-      else if (IS_TARANIS(board))
+      else if (IS_TARANIS_X9D(board) || IS_HORUS_X10(board))
         return 2;
       else
         return 0;
+
     case MouseAnalogs:
-      if (IS_HORUS(board))
+      if (IS_HORUS_X12S(board))
         return 2;
       else
         return 0;
-    case FactoryInstalledSwitches:
-      if (IS_TARANIS_X9E(board))
-        return 8;
-      // no break
+
     case Switches:
       if (IS_TARANIS_X9E(board))
         return 18;
@@ -212,16 +204,25 @@ const int Boards::getCapability(Board::Type board, Board::Capability capability)
         return 8;
       else
         return 7;
+
+    case FactoryInstalledSwitches:
+      if (IS_TARANIS_X9E(board))
+        return 8;
+      else
+        return getCapability(board, Switches);
+
     case SwitchPositions:
       if (IS_HORUS_OR_TARANIS(board))
         return getCapability(board, Switches) * 3;
       else
         return 9;
+
     case NumTrims:
       if (IS_HORUS(board))
         return 6;
       else
         return 4;
+
     case NumTrimSwitches:
       return getCapability(board, NumTrims) * 2;
   }

--- a/companion/src/eeprominterface.cpp
+++ b/companion/src/eeprominterface.cpp
@@ -1240,13 +1240,13 @@ GeneralSettings::GeneralSettings()
     potConfig[2] = Board::POT_WITHOUT_DETENT;
   }
 
-  if (IS_HORUS(board) || IS_TARANIS_X9E(board)) {
+  if (IS_HORUS_X12S(board) || IS_TARANIS_X9E(board)) {
     sliderConfig[0] = Board::SLIDER_WITH_DETENT;
     sliderConfig[1] = Board::SLIDER_WITH_DETENT;
     sliderConfig[2] = Board::SLIDER_WITH_DETENT;
     sliderConfig[3] = Board::SLIDER_WITH_DETENT;
   }
-  else if (IS_TARANIS(board) && !IS_TARANIS_X7(board)) {
+  else if (IS_TARANIS_X9(board) || IS_HORUS_X10(board)) {
     sliderConfig[0] = Board::SLIDER_WITH_DETENT;
     sliderConfig[1] = Board::SLIDER_WITH_DETENT;
   }

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -759,7 +759,7 @@ QString OpenTxFirmware::getAnalogInputName(unsigned int index)
     };
     return CHECK_IN_ARRAY(pots, index);
   }
-  else if (IS_HORUS(board)) {
+  else if (IS_HORUS_X12S(board)) {
     const QString pots[] = {
       QObject::tr("S1"),
       QObject::tr("6P"),
@@ -770,6 +770,16 @@ QString OpenTxFirmware::getAnalogInputName(unsigned int index)
       QObject::tr("RS"),
       QObject::tr("JSx"),
       QObject::tr("JSy")
+    };
+    return CHECK_IN_ARRAY(pots, index);
+  }
+  else if (IS_HORUS_X10(board)) {
+    const QString pots[] = {
+      QObject::tr("S1"),
+      QObject::tr("6P"),
+      QObject::tr("S2"),
+      QObject::tr("LS"),
+      QObject::tr("RS")
     };
     return CHECK_IN_ARRAY(pots, index);
   }


### PR DESCRIPTION
Removes L1/L2/JSx/JSy as possible inputs on X10, including in radio HW and calibration settings.

Fixes #5488  (tested only in sim)

Does not deal with any conversion issues.  Especially the "silent" conversion between X10 and X12, which is not currently detected at all.

When going from X12 to X10, L1/L2 become LS/RS, and vice-versa when going the other way (same issue with any X9E/X12 <-> X9D/X10 conversion).