### PR TITLE
[X10] Accept old OTX_FOURCC for X12 as valid when reading data.

### DIFF
--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -120,7 +120,7 @@ const char * getFileExtension(const char * filename, uint8_t size=0, uint8_t ext
   #define O9X_FOURCC 0x3178396F // we forgot it in 2.2 RC ..
 #elif defined(PCBX10)
   #define OTX_FOURCC 0x3778746F // otx for X10
-  #define O9X_FOURCC 0x3478396F // we forgot it in 2.2 RC ..
+  #define O9X_FOURCC 0x3478746F // match X12S, we forgot OTX_FOURCC before 2.2.1 RC2
 #elif defined(PCBX9E)
   #define OTX_FOURCC 0x3578746F // otx for Taranis X9E
   #define O9X_FOURCC 0x3378396F // o9x for Taranis X9E


### PR DESCRIPTION
Due to new OTX_FOURCC for X10 in RC2, existing X10 data is being detected as incompatible.