### PR TITLE
[Companion] Radio data translation/strings

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -270,27 +270,27 @@ const int Boards::getCapability(Board::Type board, Board::Capability capability)
 const QString Boards::getAxisName(int index)
 {
   const QString axes[] = {
-    QObject::tr("Left Horizontal"),
-    QObject::tr("Left Vertical"),
-    QObject::tr("Right Vertical"),
-    QObject::tr("Right Horizontal"),
-    QObject::tr("Aux. 1"),
-    QObject::tr("Aux. 2"),
+    tr("Left Horizontal"),
+    tr("Left Vertical"),
+    tr("Right Vertical"),
+    tr("Right Horizontal"),
+    tr("Aux. 1"),
+    tr("Aux. 2"),
   };
   if (index < (int)DIM(axes))
     return axes[index];
   else
-    return QObject::tr("Unknown");
+    return tr("Unknown");
 }
 
 const QString Boards::getAnalogInputName(Board::Type board, unsigned index)
 {
   if ((int)index < getBoardCapability(board, Board::Sticks)) {
     const QString sticks[] = {
-      QObject::tr("Rud"),
-      QObject::tr("Ele"),
-      QObject::tr("Thr"),
-      QObject::tr("Ail")
+      tr("Rud"),
+      tr("Ele"),
+      tr("Thr"),
+      tr("Ail")
     };
     return sticks[index];
   }
@@ -398,7 +398,7 @@ const QString Boards::getBoardName(Board::Type board)
     case BOARD_X10:
       return "X10";
     default:
-      return QObject::tr("Unknown");
+      return tr("Unknown");
   }
 }
 */

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -21,6 +21,7 @@
 #ifndef _BOARDS_H_
 #define _BOARDS_H_
 
+#include <QtCore>
 #include <QObject>
 #include <QString>
 
@@ -140,6 +141,8 @@ namespace Board {
 
 class Boards
 {
+  Q_DECLARE_TR_FUNCTIONS(Boards)
+
   public:
 
     Boards(Board::Type board)

--- a/companion/src/firmwares/curvereference.cpp
+++ b/companion/src/firmwares/curvereference.cpp
@@ -34,17 +34,17 @@ QString CurveReference::toString(const ModelData * model, bool verbose) const
 
   switch(type) {
     case CURVE_REF_DIFF:
-      ret = QObject::tr("Diff(%1)").arg(Helpers::getAdjustmentString(value, model));
+      ret = tr("Diff(%1)").arg(Helpers::getAdjustmentString(value, model));
       break;
 
     case CURVE_REF_EXPO:
-      ret = QObject::tr("Expo(%1)").arg(Helpers::getAdjustmentString(value, model));
+      ret = tr("Expo(%1)").arg(Helpers::getAdjustmentString(value, model));
       break;
 
     case CURVE_REF_FUNC:
       ret = QString("x>0" "x<0" "|x|" "f>0" "f<0" "|f|").mid(3*(value-1), 3);
       if (verbose)
-        ret = QObject::tr("Function(%1)").arg(ret);
+        ret = tr("Function(%1)").arg(ret);
       break;
 
     default:
@@ -53,7 +53,7 @@ QString CurveReference::toString(const ModelData * model, bool verbose) const
       else
         ret = CurveData().nameToString(idx);
       if (verbose)
-        ret = QObject::tr("Curve(%1)").arg(ret);
+        ret = tr("Curve(%1)").arg(ret);
       if (value < 0)
         ret.prepend(CPN_STR_SW_INDICATOR_REV);
       break;

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -26,6 +26,8 @@
 class ModelData;
 
 class CurveReference {
+  Q_DECLARE_TR_FUNCTIONS(CurveReference)
+
   public:
     enum CurveRefType {
       CURVE_REF_DIFF,

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -37,7 +37,7 @@ bool CustomFunctionData::isEmpty() const
   return (swtch.type == SWITCH_TYPE_NONE);
 }
 
-QString CustomFunctionData::toString(int index, bool globalContext) const
+QString CustomFunctionData::nameToString(int index, bool globalContext) const
 {
   return RadioData::getElementName((globalContext ? tr("GF") : tr("SF")), index+1, 0, true);
 }
@@ -246,7 +246,7 @@ QString CustomFunctionData::enabledToString() const
 void CustomFunctionData::convert(RadioDataConversionState & cstate)
 {
   cstate.setComponent(tr("CFN"), 8);
-  cstate.setSubComp(toString(cstate.subCompIdx, (cstate.toModel() ? false : true)));
+  cstate.setSubComp(nameToString(cstate.subCompIdx, (cstate.toModel() ? false : true)));
   swtch.convert(cstate);
   if (func == FuncVolume || func == FuncPlayValue || (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast && adjustMode == 1)) {
     param = RawSource(param).convert(cstate.withComponentField("PARAM")).toValue();

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -39,69 +39,69 @@ bool CustomFunctionData::isEmpty() const
 
 QString CustomFunctionData::toString(int index, bool globalContext) const
 {
-  return RadioData::getElementName((globalContext ? QObject::tr("GF") : QObject::tr("SF")), index+1, 0, true);
+  return RadioData::getElementName((globalContext ? tr("GF") : tr("SF")), index+1, 0, true);
 }
 
 QString CustomFunctionData::funcToString(const ModelData * model) const
 {
   if (func >= FuncOverrideCH1 && func <= FuncOverrideCH32)
-    return QObject::tr("Override %1").arg(RawSource(SOURCE_TYPE_CH, func).toString(model));
+    return tr("Override %1").arg(RawSource(SOURCE_TYPE_CH, func).toString(model));
   else if (func == FuncTrainer)
-    return QObject::tr("Trainer");
+    return tr("Trainer");
   else if (func == FuncTrainerRUD)
-    return QObject::tr("Trainer RUD");
+    return tr("Trainer RUD");
   else if (func == FuncTrainerELE)
-    return QObject::tr("Trainer ELE");
+    return tr("Trainer ELE");
   else if (func == FuncTrainerTHR)
-    return QObject::tr("Trainer THR");
+    return tr("Trainer THR");
   else if (func == FuncTrainerAIL)
-    return QObject::tr("Trainer AIL");
+    return tr("Trainer AIL");
   else if (func == FuncInstantTrim)
-    return QObject::tr("Instant Trim");
+    return tr("Instant Trim");
   else if (func == FuncPlaySound)
-    return QObject::tr("Play Sound");
+    return tr("Play Sound");
   else if (func == FuncPlayHaptic)
-    return QObject::tr("Haptic");
+    return tr("Haptic");
   else if (func == FuncReset)
-    return QObject::tr("Reset");
+    return tr("Reset");
   else if (func >= FuncSetTimer1 && func <= FuncSetTimer3)
-    return QObject::tr("Set Timer %1").arg(func-FuncSetTimer1+1);
+    return tr("Set Timer %1").arg(func-FuncSetTimer1+1);
   else if (func == FuncVario)
-    return QObject::tr("Vario");
+    return tr("Vario");
   else if (func == FuncPlayPrompt)
-    return QObject::tr("Play Track");
+    return tr("Play Track");
   else if (func == FuncPlayBoth)
-    return QObject::tr("Play Both");
+    return tr("Play Both");
   else if (func == FuncPlayValue)
-    return QObject::tr("Play Value");
+    return tr("Play Value");
   else if (func == FuncPlayScript)
-    return QObject::tr("Play Script");
+    return tr("Play Script");
   else if (func == FuncLogs)
-    return QObject::tr("SD Logs");
+    return tr("SD Logs");
   else if (func == FuncVolume)
-    return QObject::tr("Volume");
+    return tr("Volume");
   else if (func == FuncBacklight)
-    return QObject::tr("Backlight");
+    return tr("Backlight");
   else if (func == FuncScreenshot)
-    return QObject::tr("Screenshot");
+    return tr("Screenshot");
   else if (func == FuncBackgroundMusic)
-    return QObject::tr("Background Music");
+    return tr("Background Music");
   else if (func == FuncBackgroundMusicPause)
-    return QObject::tr("Background Music Pause");
+    return tr("Background Music Pause");
   else if (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast)
-    return QObject::tr("Adjust %1").arg(RawSource(SOURCE_TYPE_GVAR, func-FuncAdjustGV1).toString(model));
+    return tr("Adjust %1").arg(RawSource(SOURCE_TYPE_GVAR, func-FuncAdjustGV1).toString(model));
   else if (func == FuncSetFailsafeInternalModule)
-    return QObject::tr("SetFailsafe Int. Module");
+    return tr("SetFailsafe Int. Module");
   else if (func == FuncSetFailsafeExternalModule)
-    return QObject::tr("SetFailsafe Ext. Module");
+    return tr("SetFailsafe Ext. Module");
   else if (func == FuncRangeCheckInternalModule)
-    return QObject::tr("RangeCheck Int. Module");
+    return tr("RangeCheck Int. Module");
   else if (func == FuncRangeCheckExternalModule)
-    return QObject::tr("RangeCheck Ext. Module");
+    return tr("RangeCheck Ext. Module");
   else if (func == FuncBindInternalModule)
-    return QObject::tr("Bind Int. Module");
+    return tr("Bind Int. Module");
   else if (func == FuncBindExternalModule)
-    return QObject::tr("Bind Ext. Module");
+    return tr("Bind Ext. Module");
   else {
     return QString("???"); // Highlight unknown functions with output of question marks.(BTW should not happen that we do not know what a function is)
   }
@@ -113,20 +113,20 @@ void CustomFunctionData::populateResetParams(const ModelData * model, QComboBox 
   Firmware * firmware = Firmware::getCurrentVariant();
   Board::Type board = firmware->getBoard();
 
-  b->addItem(QObject::tr("Timer1"), val++);
-  b->addItem(QObject::tr("Timer2"), val++);
+  b->addItem(tr("Timer1"), val++);
+  b->addItem(tr("Timer2"), val++);
   if (IS_ARM(board)) {
-    b->addItem( QObject::tr("Timer3"), val++);
+    b->addItem( tr("Timer3"), val++);
   }
-  b->addItem(QObject::tr("Flight"), val++);
-  b->addItem(QObject::tr("Telemetry"), val++);
+  b->addItem(tr("Flight"), val++);
+  b->addItem(tr("Telemetry"), val++);
   int reCount = firmware->getCapability(RotaryEncoders);
   if (reCount == 1) {
-    b->addItem(QObject::tr("Rotary Encoder"), val++);
+    b->addItem(tr("Rotary Encoder"), val++);
   }
   else if (reCount == 2) {
-    b->addItem(QObject::tr("REa"), val++);
-    b->addItem(QObject::tr("REb"), val++);
+    b->addItem(tr("REa"), val++);
+    b->addItem(tr("REb"), val++);
   }
   if ((int)value < b->count()) {
     b->setCurrentIndex(value);
@@ -162,21 +162,21 @@ QString CustomFunctionData::paramToString(const ModelData * model) const
     return QString("%1").arg(param);
   }
   else if (func==FuncLogs) {
-    return QString("%1").arg(param/10.0) + QObject::tr("s");
+    return QString("%1").arg(param/10.0) + tr("s");
   }
   else if (func==FuncPlaySound) {
     CustomFunctionData::populatePlaySoundParams(qs);
     if (param>=0 && param<(int)qs.count())
       return qs.at(param);
     else
-      return QObject::tr("<font color=red><b>Inconsistent parameter</b></font>");
+      return tr("<font color=red><b>Inconsistent parameter</b></font>");
   }
   else if (func==FuncPlayHaptic) {
     CustomFunctionData::populateHapticParams(qs);
     if (param>=0 && param<(int)qs.count())
       return qs.at(param);
     else
-      return QObject::tr("<font color=red><b>Inconsistent parameter</b></font>");
+      return tr("<font color=red><b>Inconsistent parameter</b></font>");
   }
   else if (func==FuncReset) {
     QComboBox cb;
@@ -185,7 +185,7 @@ QString CustomFunctionData::paramToString(const ModelData * model) const
     if (pos >= 0)
       return cb.itemText(pos);
     else
-      return QObject::tr("<font color=red><b>Inconsistent parameter</b></font>");
+      return tr("<font color=red><b>Inconsistent parameter</b></font>");
   }
   else if ((func==FuncVolume)|| (func==FuncPlayValue)) {
     RawSource item(param);
@@ -202,13 +202,13 @@ QString CustomFunctionData::paramToString(const ModelData * model) const
   else if ((func>=FuncAdjustGV1) && (func<FuncCount)) {
     switch (adjustMode) {
       case FUNC_ADJUST_GVAR_CONSTANT:
-        return QObject::tr("Value ")+QString("%1").arg(param);
+        return tr("Value ")+QString("%1").arg(param);
       case FUNC_ADJUST_GVAR_SOURCE:
       case FUNC_ADJUST_GVAR_GVAR:
         return RawSource(param).toString();
       case FUNC_ADJUST_GVAR_INCDEC:
-        if (param==0) return QObject::tr("Decr:") + " -1";
-        else          return QObject::tr("Incr:") + " +1";
+        if (param==0) return tr("Decr:") + " -1";
+        else          return tr("Incr:") + " +1";
     }
   }
   return "";
@@ -217,14 +217,14 @@ QString CustomFunctionData::paramToString(const ModelData * model) const
 QString CustomFunctionData::repeatToString() const
 {
   if (repeatParam == -1) {
-    return QObject::tr("played once, not during startup");
+    return tr("played once, not during startup");
   }
   else if (repeatParam == 0) {
     return "";
   }
   else {
     unsigned int step = IS_ARM(getCurrentBoard()) ? 1 : 10;
-    return QObject::tr("repeat(%1s)").arg(step*repeatParam);
+    return tr("repeat(%1s)").arg(step*repeatParam);
   }
 }
 
@@ -237,7 +237,7 @@ QString CustomFunctionData::enabledToString() const
       (func==FuncVolume) ||
       (func <= FuncInstantTrim)) {
     if (!enabled) {
-      return QObject::tr("DISABLED");
+      return tr("DISABLED");
     }
   }
   return "";
@@ -245,7 +245,7 @@ QString CustomFunctionData::enabledToString() const
 
 void CustomFunctionData::convert(RadioDataConversionState & cstate)
 {
-  cstate.setComponent("CFN", 8);
+  cstate.setComponent(tr("CFN"), 8);
   cstate.setSubComp(toString(cstate.subCompIdx, (cstate.toModel() ? false : true)));
   swtch.convert(cstate);
   if (func == FuncVolume || func == FuncPlayValue || (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast && adjustMode == 1)) {

--- a/companion/src/firmwares/customfunctiondata.h
+++ b/companion/src/firmwares/customfunctiondata.h
@@ -79,7 +79,9 @@ enum GVarAdjustModes
   FUNC_ADJUST_GVAR_INCDEC
 };
 
-class CustomFunctionData { // Function Switches data
+class CustomFunctionData {
+  Q_DECLARE_TR_FUNCTIONS(CustomFunctionData)
+
   public:
     CustomFunctionData(AssignFunc func=FuncOverrideCH1) { clear(); this->func = func; }
     RawSwitch    swtch;

--- a/companion/src/firmwares/customfunctiondata.h
+++ b/companion/src/firmwares/customfunctiondata.h
@@ -94,7 +94,7 @@ class CustomFunctionData {
 
     void clear();
     bool isEmpty() const;
-    QString toString(int index, bool globalContext = false) const;
+    QString nameToString(int index, bool globalContext = false) const;
     QString funcToString(const ModelData * model = NULL) const;
     QString paramToString(const ModelData * model) const;
     QString repeatToString() const;

--- a/companion/src/firmwares/eepromimportexport.h
+++ b/companion/src/firmwares/eepromimportexport.h
@@ -22,9 +22,13 @@
 #define _EEPROMIMPORTEXPORT_H_
 
 #include "customdebug.h"
+
+#include <QtCore>
 #include <QBitArray>
 
 class DataField {
+  Q_DECLARE_TR_FUNCTIONS(DataField)
+
   public:
     DataField(DataField * parent, const char * name=""):
       parent(parent),
@@ -742,7 +746,7 @@ class ConversionField: public TransformedField {
 
       if (table) {
         if (!table->exportValue(_field, _field)) {
-          setError(error.isEmpty() ? QObject::tr("Conversion error on field %1").arg(name) : error);
+          setError(error.isEmpty() ? tr("Conversion error on field %1").arg(name) : error);
         }
         return;
       }

--- a/companion/src/firmwares/eeprominterface.cpp
+++ b/companion/src/firmwares/eeprominterface.cpp
@@ -64,31 +64,32 @@ void unregisterEEpromInterfaces()
   OpenTxEepromCleanup();
 }
 
+#if 0  // TODO: remove if unused, currently commented out in mdiChild.cpp
 // TODO: No GUI here, e.g. return string list instead
-void ShowEepromErrors(QWidget *parent, const QString &title, const QString &mainMessage, unsigned long errorsFound)
+void EEPROMInterface::showEepromErrors(QWidget *parent, const QString &title, const QString &mainMessage, unsigned long errorsFound)
 {
   std::bitset<NUM_ERRORS> errors((unsigned long long)errorsFound);
   QStringList errorsList;
 
-  errorsList << QT_TRANSLATE_NOOP("EepromInterface", "Possible causes for this:");
+  errorsList << tr("Possible causes for this:");
 
-  if (errors.test(UNSUPPORTED_NEWER_VERSION)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is from a newer version of OpenTX"); }
-  if (errors.test(NOT_OPENTX)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is not from OpenTX"); }
-  if (errors.test(NOT_TH9X)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is not from Th9X"); }
-  if (errors.test(NOT_GRUVIN9X)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is not from Gruvin9X"); }
-  if (errors.test(NOT_ERSKY9X)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is not from ErSky9X"); }
-  if (errors.test(NOT_ER9X)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is not from Er9X"); }
-  if (errors.test(WRONG_SIZE)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom size is invalid"); }
-  if (errors.test(WRONG_FILE_SYSTEM)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom file system is invalid"); }
-  if (errors.test(UNKNOWN_BOARD)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is from a unknown board"); }
-  if (errors.test(WRONG_BOARD)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom is from the wrong board"); }
-  if (errors.test(BACKUP_NOT_SUPPORTED)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Eeprom backup not supported"); }
+  if (errors.test(UNSUPPORTED_NEWER_VERSION)) { errorsList << tr("- Eeprom is from a newer version of OpenTX"); }
+  if (errors.test(NOT_OPENTX)) { errorsList << tr("- Eeprom is not from OpenTX"); }
+  if (errors.test(NOT_TH9X)) { errorsList << tr("- Eeprom is not from Th9X"); }
+  if (errors.test(NOT_GRUVIN9X)) { errorsList << tr("- Eeprom is not from Gruvin9X"); }
+  if (errors.test(NOT_ERSKY9X)) { errorsList << tr("- Eeprom is not from ErSky9X"); }
+  if (errors.test(NOT_ER9X)) { errorsList << tr("- Eeprom is not from Er9X"); }
+  if (errors.test(WRONG_SIZE)) { errorsList << tr("- Eeprom size is invalid"); }
+  if (errors.test(WRONG_FILE_SYSTEM)) { errorsList << tr("- Eeprom file system is invalid"); }
+  if (errors.test(UNKNOWN_BOARD)) { errorsList << tr("- Eeprom is from a unknown board"); }
+  if (errors.test(WRONG_BOARD)) { errorsList << tr("- Eeprom is from the wrong board"); }
+  if (errors.test(BACKUP_NOT_SUPPORTED)) { errorsList << tr("- Eeprom backup not supported"); }
 
-  if (errors.test(UNKNOWN_ERROR)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Something that couldn't be guessed, sorry"); }
+  if (errors.test(UNKNOWN_ERROR)) { errorsList << tr("- Something that couldn't be guessed, sorry"); }
 
   if (errors.test(HAS_WARNINGS)) {
-    errorsList << QT_TRANSLATE_NOOP("EepromInterface", "Warning:");
-    if (errors.test(WARNING_WRONG_FIRMWARE)) { errorsList << QT_TRANSLATE_NOOP("EepromInterface", "- Your radio probably uses a wrong firmware,\n eeprom size is 4096 but only the first 2048 are used"); }
+    errorsList << tr("Warning:");
+    if (errors.test(WARNING_WRONG_FIRMWARE)) { errorsList << tr("- Your radio probably uses a wrong firmware,\n eeprom size is 4096 but only the first 2048 are used"); }
   }
 
   QMessageBox msgBox(parent);
@@ -99,14 +100,15 @@ void ShowEepromErrors(QWidget *parent, const QString &title, const QString &main
   msgBox.setStandardButtons(QMessageBox::Ok);
   msgBox.exec();
 }
+#endif
 
 // TODO: No GUI here, e.g. return string list instead
-void ShowEepromWarnings(QWidget *parent, const QString &title, unsigned long errorsFound)
+void EEPROMInterface::showEepromWarnings(QWidget *parent, const QString &title, unsigned long errorsFound)
 {
   std::bitset<NUM_ERRORS> errors((unsigned long long)errorsFound);
   QStringList warningsList;
-  if (errors.test(WARNING_WRONG_FIRMWARE)) { warningsList << QT_TRANSLATE_NOOP("EepromInterface", "- Your radio probably uses a wrong firmware,\n eeprom size is 4096 but only the first 2048 are used"); }
-  if (errors.test(OLD_VERSION)) { warningsList << QT_TRANSLATE_NOOP("EepromInterface", "- Your eeprom is from an old version of OpenTX, upgrading!\n To keep your original file as a backup, please choose File -> Save As specifying a different name."); }
+  if (errors.test(WARNING_WRONG_FIRMWARE)) { warningsList << tr("- Your radio probably uses a wrong firmware,\n eeprom size is 4096 but only the first 2048 are used"); }
+  if (errors.test(OLD_VERSION)) { warningsList << tr("- Your eeprom is from an old version of OpenTX, upgrading!\n To keep your original file as a backup, please choose File -> Save As specifying a different name."); }
 
   QMessageBox msgBox(parent);
   msgBox.setWindowTitle(title);

--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -21,14 +21,18 @@
 #ifndef _EEPROMINTERFACE_H_
 #define _EEPROMINTERFACE_H_
 
+#include "boards.h"
 #include "macros.h"
 #include "radiodata.h"
 #include "../../radio/src/definitions.h"
 #include "simulatorinterface.h"
+
+#include <QtCore>
 #include <QStringList>
 #include <QList>
-#include <iostream>
 #include <QDebug>
+
+#include <iostream>
 
 const uint8_t modn12x3[4][4]= {
   {1, 2, 3, 4},
@@ -143,9 +147,10 @@ enum Capability {
   HasModelCategories
 };
 
-class SimulatorInterface;
 class EEPROMInterface
 {
+  Q_DECLARE_TR_FUNCTIONS(EEPROMInterface)
+
   public:
 
     EEPROMInterface(Board::Type board):
@@ -166,6 +171,9 @@ class EEPROMInterface
     virtual int getSize(const ModelData &) = 0;
 
     virtual int getSize(const GeneralSettings &) = 0;
+
+    //static void showEepromErrors(QWidget *parent, const QString &title, const QString &mainMessage, unsigned long errorsFound);
+    static void showEepromWarnings(QWidget *parent, const QString &title, unsigned long errorsFound);
 
   protected:
 
@@ -234,17 +242,15 @@ enum EepromLoadErrors {
   NUM_ERRORS
 };
 
-void ShowEepromErrors(QWidget *parent, const QString &title, const QString &mainMessage, unsigned long errorsFound);
-void ShowEepromWarnings(QWidget *parent, const QString &title, unsigned long errorsFound);
-
-
 struct Option {
   const char * name;
   QString tooltip;
   uint32_t variant;
 };
 
-class Firmware {
+class Firmware
+{
+  Q_DECLARE_TR_FUNCTIONS(Firmware)
 
   public:
     Firmware(const QString & id, const QString & name, Board::Type board):

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -290,7 +290,7 @@ void GeneralSettings::convert(RadioDataConversionState & cstate)
 {
   // Here we can add explicit conversions when moving from one board to another
 
-  cstate.setOrigin(QObject::tr("Radio Settings"));
+  cstate.setOrigin(tr("Radio Settings"));
 
   setDefaultControlTypes(cstate.toType);  // start with default switches/pots/sliders
 

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -60,6 +60,8 @@ class TrainerData {
 };
 
 class GeneralSettings {
+  Q_DECLARE_TR_FUNCTIONS(GeneralSettings)
+
   public:
 
     enum BeeperMode {

--- a/companion/src/firmwares/gvardata.cpp
+++ b/companion/src/firmwares/gvardata.cpp
@@ -24,11 +24,11 @@ QString GVarData::unitToString() const
 {
   switch (unit) {
     case GVAR_UNIT_NUMBER:
-      return QObject::tr("");
+      return tr("");
     case GVAR_UNIT_PERCENT:
-      return QObject::tr("%");
+      return tr("%");
     default:
-      return QObject::tr("?");  //  highlight unknown value
+      return tr("?");  //  highlight unknown value
   }
 }
 
@@ -36,11 +36,11 @@ QString GVarData::precToString() const
 {
   switch (prec) {
     case GVAR_PREC_MUL10:
-      return QObject::tr("0._");
+      return tr("0._");
     case GVAR_PREC_MUL1:
-      return QObject::tr("0.0");
+      return tr("0.0");
     default:
-      return QObject::tr("?.?");  //  highlight unknown value
+      return tr("?.?");  //  highlight unknown value
   }
 }
 

--- a/companion/src/firmwares/gvardata.cpp
+++ b/companion/src/firmwares/gvardata.cpp
@@ -20,6 +20,8 @@
 
 #include "gvardata.h"
 
+#include "radiodata.h"
+
 QString GVarData::unitToString() const
 {
   switch (unit) {
@@ -42,6 +44,11 @@ QString GVarData::precToString() const
     default:
       return tr("?.?");  //  highlight unknown value
   }
+}
+
+QString GVarData::nameToString(int index) const
+{
+  return RadioData::getElementName(tr("GV"), index + 1, name);
 }
 
 int GVarData::multiplierSet()

--- a/companion/src/firmwares/gvardata.h
+++ b/companion/src/firmwares/gvardata.h
@@ -53,6 +53,7 @@ class GVarData {
     void clear() {memset(this, 0, sizeof(GVarData)); }
     QString unitToString() const;
     QString precToString() const;
+    QString nameToString(int index) const;
     int multiplierSet();
     float multiplierGet() const;
     void setMin(float val);

--- a/companion/src/firmwares/gvardata.h
+++ b/companion/src/firmwares/gvardata.h
@@ -28,6 +28,8 @@
 #define GVAR_MIN_VALUE      -GVAR_MAX_VALUE
 
 class GVarData {
+  Q_DECLARE_TR_FUNCTIONS(GVarData)
+
   public:
     GVarData() { clear(); }
 

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -68,6 +68,11 @@ QString LimitData::revertToString() const
   return revert ? tr("INV") : tr("NOR");
 }
 
+QString LimitData::nameToString(int index) const
+{
+  return RadioData::getElementName(tr("CH"), index + 1, name);
+}
+
 QString LimitData::offsetToString() const
 {
   return QString::number((qreal)offset/10, 'f', 1);
@@ -129,7 +134,7 @@ void FlightModeData::clear(const int phase)
   }
 }
 
-QString FlightModeData::toString(int index) const
+QString FlightModeData::nameToString(int index) const
 {
   return RadioData::getElementName(tr("FM"), index, name);  // names are zero-based, FM0, FM1, etc
 }
@@ -137,6 +142,6 @@ QString FlightModeData::toString(int index) const
 void FlightModeData::convert(RadioDataConversionState & cstate)
 {
   cstate.setComponent("FMD", 2);
-  cstate.setSubComp(toString(cstate.subCompIdx));
+  cstate.setSubComp(nameToString(cstate.subCompIdx));
   swtch.convert(cstate);
 }

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -29,8 +29,8 @@
 
 void ExpoData::convert(RadioDataConversionState & cstate)
 {
-  cstate.setComponent(QObject::tr("INP"), 3);
-  cstate.setSubComp(RawSource(SOURCE_TYPE_VIRTUAL_INPUT, chn).toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType) % QObject::tr(" (@%1)").arg(cstate.subCompIdx));
+  cstate.setComponent(tr("INP"), 3);
+  cstate.setSubComp(RawSource(SOURCE_TYPE_VIRTUAL_INPUT, chn).toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType) % tr(" (@%1)").arg(cstate.subCompIdx));
   srcRaw.convert(cstate);
   swtch.convert(cstate);
 }
@@ -42,8 +42,8 @@ void ExpoData::convert(RadioDataConversionState & cstate)
 
 void MixData::convert(RadioDataConversionState & cstate)
 {
-  cstate.setComponent(QObject::tr("MIX"), 4);
-  cstate.setSubComp(RawSource(SOURCE_TYPE_CH, destCh-1).toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType) % QObject::tr(" (@%1)").arg(cstate.subCompIdx));
+  cstate.setComponent(tr("MIX"), 4);
+  cstate.setSubComp(RawSource(SOURCE_TYPE_CH, destCh-1).toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType) % tr(" (@%1)").arg(cstate.subCompIdx));
   srcRaw.convert(cstate);
   swtch.convert(cstate);
 }
@@ -65,7 +65,7 @@ QString LimitData::maxToString() const
 
 QString LimitData::revertToString() const
 {
-  return revert ? QObject::tr("INV") : QObject::tr("NOR");
+  return revert ? tr("INV") : tr("NOR");
 }
 
 QString LimitData::offsetToString() const
@@ -108,7 +108,7 @@ bool CurveData::isEmpty() const
 
 QString CurveData::nameToString(const int idx) const
 {
-  return RadioData::getElementName(QCoreApplication::translate("Curve", "CV"), idx + 1, name);
+  return RadioData::getElementName(tr("CV"), idx + 1, name);
 }
 
 
@@ -131,7 +131,7 @@ void FlightModeData::clear(const int phase)
 
 QString FlightModeData::toString(int index) const
 {
-  return RadioData::getElementName(QObject::tr("FM"), index, name, true);
+  return RadioData::getElementName(tr("FM"), index, name);  // names are zero-based, FM0, FM1, etc
 }
 
 void FlightModeData::convert(RadioDataConversionState & cstate)

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -38,6 +38,8 @@ enum InputMode {
 };
 
 class ExpoData {
+  Q_DECLARE_TR_FUNCTIONS(ExpoData)
+
   public:
     ExpoData() { clear(); }
     RawSource srcRaw;
@@ -64,6 +66,8 @@ enum MltpxValue {
 #define MIXDATA_NAME_LEN  10
 
 class MixData {
+  Q_DECLARE_TR_FUNCTIONS(MixData)
+
   public:
     MixData() { clear(); }
     void convert(RadioDataConversionState & cstate);
@@ -89,6 +93,8 @@ class MixData {
 };
 
 class LimitData {
+  Q_DECLARE_TR_FUNCTIONS(LimitData)
+
   public:
     LimitData() { clear(); }
     int   min;
@@ -113,6 +119,8 @@ class CurvePoint {
 };
 
 class CurveData {
+  Q_DECLARE_TR_FUNCTIONS(CurveData)
+
   public:
     enum CurveType {
       CURVE_TYPE_STANDARD,
@@ -133,6 +141,8 @@ class CurveData {
 };
 
 class FlightModeData {
+  Q_DECLARE_TR_FUNCTIONS(FlightModeData)
+
   public:
     FlightModeData() { clear(0); }
     int trimMode[CPN_MAX_TRIMS];
@@ -149,7 +159,9 @@ class FlightModeData {
     void convert(RadioDataConversionState & cstate);
 };
 
-class SwashRingData { // Swash Ring data
+class SwashRingData {
+  Q_DECLARE_TR_FUNCTIONS(SwashRingData)
+
   public:
     SwashRingData() { clear(); }
     int elevatorWeight;

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -109,6 +109,7 @@ class LimitData {
     QString maxToString() const;
     QString offsetToString() const;
     QString revertToString() const;
+    QString nameToString(int index) const;
     void clear();
 };
 
@@ -155,7 +156,7 @@ class FlightModeData {
     int rotaryEncoders[CPN_MAX_ENCODERS];
     int gvars[CPN_MAX_GVARS];
     void clear(const int phase);
-    QString toString(int index) const;
+    QString nameToString(int index) const;
     void convert(RadioDataConversionState & cstate);
 };
 

--- a/companion/src/firmwares/logicalswitchdata.cpp
+++ b/companion/src/firmwares/logicalswitchdata.cpp
@@ -20,6 +20,7 @@
 
 #include "logicalswitchdata.h"
 
+#include "radiodata.h"
 #include "radiodataconversionstate.h"
 #include "rawsource.h"
 #include "rawswitch.h"
@@ -106,6 +107,11 @@ QString LogicalSwitchData::funcToString() const
     default:
       return tr("Unknown");
   }
+}
+
+QString LogicalSwitchData::nameToString(int index) const
+{
+  return RadioData::getElementName(tr("L"), index + 1, NULL, true);
 }
 
 void LogicalSwitchData::convert(RadioDataConversionState & cstate)

--- a/companion/src/firmwares/logicalswitchdata.cpp
+++ b/companion/src/firmwares/logicalswitchdata.cpp
@@ -62,55 +62,55 @@ QString LogicalSwitchData::funcToString() const
 {
   switch (func) {
     case LS_FN_OFF:
-      return QObject::tr("---");
+      return tr("---");
     case LS_FN_VPOS:
-      return QObject::tr("a>x");
+      return tr("a>x");
     case LS_FN_VNEG:
-      return QObject::tr("a<x");
+      return tr("a<x");
     case LS_FN_APOS:
-      return QObject::tr("|a|>x");
+      return tr("|a|>x");
     case LS_FN_ANEG:
-      return QObject::tr("|a|<x");
+      return tr("|a|<x");
     case LS_FN_AND:
-      return QObject::tr("AND");
+      return tr("AND");
     case LS_FN_OR:
-      return QObject::tr("OR");
+      return tr("OR");
     case LS_FN_XOR:
-      return QObject::tr("XOR");
+      return tr("XOR");
     case LS_FN_EQUAL:
-      return QObject::tr("a=b");
+      return tr("a=b");
     case LS_FN_NEQUAL:
-      return QObject::tr("a!=b");
+      return tr("a!=b");
     case LS_FN_GREATER:
-      return QObject::tr("a>b");
+      return tr("a>b");
     case LS_FN_LESS:
-      return QObject::tr("a<b");
+      return tr("a<b");
     case LS_FN_EGREATER:
-      return QObject::tr("a>=b");
+      return tr("a>=b");
     case LS_FN_ELESS:
-      return QObject::tr("a<=b");
+      return tr("a<=b");
     case LS_FN_DPOS:
-      return QObject::tr("d>=x");
+      return tr("d>=x");
     case LS_FN_DAPOS:
-      return QObject::tr("|d|>=x");
+      return tr("|d|>=x");
     case LS_FN_VEQUAL:
-      return QObject::tr("a=x");
+      return tr("a=x");
     case LS_FN_VALMOSTEQUAL:
-      return QObject::tr("a~x");
+      return tr("a~x");
     case LS_FN_TIMER:
-      return QObject::tr("Timer");
+      return tr("Timer");
     case LS_FN_STICKY:
-      return QObject::tr("Sticky");
+      return tr("Sticky");
     case LS_FN_EDGE:
-      return QObject::tr("Edge");
+      return tr("Edge");
     default:
-      return QObject::tr("Unknown");
+      return tr("Unknown");
   }
 }
 
 void LogicalSwitchData::convert(RadioDataConversionState & cstate)
 {
-  cstate.setComponent("LSW", 7);
+  cstate.setComponent(tr("LSW"), 7);
   cstate.setSubComp(RawSwitch(SWITCH_TYPE_VIRTUAL, cstate.subCompIdx + 1).toString(cstate.fromType, cstate.fromGS(), cstate.fromModel()));
   CSFunctionFamily family = getFunctionFamily();
   switch(family) {

--- a/companion/src/firmwares/logicalswitchdata.h
+++ b/companion/src/firmwares/logicalswitchdata.h
@@ -60,7 +60,9 @@ enum CSFunctionFamily {
   LS_FAMILY_EDGE,
 };
 
-class LogicalSwitchData { // Logical Switches data
+class LogicalSwitchData {
+  Q_DECLARE_TR_FUNCTIONS(LogicalSwitchData)
+
   public:
     LogicalSwitchData(unsigned int func=0)
     {

--- a/companion/src/firmwares/logicalswitchdata.h
+++ b/companion/src/firmwares/logicalswitchdata.h
@@ -82,6 +82,7 @@ class LogicalSwitchData {
     CSFunctionFamily getFunctionFamily() const;
     unsigned int getRangeFlags() const;
     QString funcToString() const;
+    QString nameToString(int index) const;
     void convert(RadioDataConversionState & cstate);
 };
 

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -61,8 +61,8 @@ QString removeAccents(const QString & str)
 
 void TimerData::convert(RadioDataConversionState & cstate)
 {
-  cstate.setComponent("TMR", 1);
-  cstate.setSubComp(QObject::tr("Timer %1").arg(cstate.subCompIdx + 1));
+  cstate.setComponent(tr("TMR"), 1);
+  cstate.setSubComp(tr("Timer %1").arg(cstate.subCompIdx + 1));
   mode.convert(cstate);
 }
 
@@ -423,11 +423,11 @@ void ModelData::convert(RadioDataConversionState & cstate)
   QString origin = QString(name);
   if (origin.isEmpty())
     origin = QString::number(cstate.modelIdx+1);
-  cstate.setOrigin(QObject::tr("Model: ") % origin);
+  cstate.setOrigin(tr("Model: ") % origin);
 
   cstate.setComponent("SET", 0);
   if (thrTraceSrc && (int)thrTraceSrc < cstate.fromBoard.getCapability(Board::Pots) + cstate.fromBoard.getCapability(Board::Sliders)) {
-    cstate.setSubComp(QObject::tr("Throttle Source"));
+    cstate.setSubComp(tr("Throttle Source"));
     thrTraceSrc = RawSource(SOURCE_TYPE_STICK, (int)thrTraceSrc + 3).convert(cstate).index - 3;
   }
 

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -57,6 +57,8 @@ class RSSIAlarmData {
 #define TIMER_NAME_LEN 8
 
 class TimerData {
+  Q_DECLARE_TR_FUNCTIONS(TimerData)
+
   public:
     enum CountDownMode {
       COUNTDOWN_SILENT,
@@ -124,6 +126,8 @@ enum TrainerMode {
 };
 
 class ModelData {
+  Q_DECLARE_TR_FUNCTIONS(ModelData)
+
   public:
     ModelData();
     ModelData(const ModelData & src);

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -96,6 +96,8 @@ enum TrainerProtocol {
 };
 
 class ModuleData {
+  Q_DECLARE_TR_FUNCTIONS(ModuleData)
+
   public:
     ModuleData() { clear(); }
     unsigned int modelId;
@@ -133,7 +135,7 @@ class ModuleData {
 
 
     void clear() { memset(this, 0, sizeof(ModuleData)); }
-    QString polarityToString() const { return ppm.pulsePol ? QObject::tr("Positive") : QObject::tr("Negative"); } // TODO ModelPrinter
+    QString polarityToString() const { return ppm.pulsePol ? tr("Positive") : tr("Negative"); } // TODO ModelPrinter
 };
 
 #endif // MODULEDATA_H

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -433,8 +433,8 @@ template <int N>
 class SwitchField: public ConversionField< SignedField<N> > {
   public:
     SwitchField(DataField * parent, RawSwitch & sw, Board::Type board, unsigned int version, unsigned long flags=0):
-      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), QObject::tr("Switch").toLatin1(),
-          QObject::tr("Switch ").toLatin1() + sw.toString(board) + QObject::tr(" cannot be exported on this board!").toLatin1()),
+      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), tr("Switch").toLatin1(),
+          tr("Switch ").toLatin1() + sw.toString(board) + tr(" cannot be exported on this board!").toLatin1()),
       sw(sw),
       _switch(0),
       board(board)
@@ -597,7 +597,7 @@ class SourceField: public ConversionField< UnsignedField<N> > {
   public:
     SourceField(DataField * parent, RawSource & source, Board::Type board, unsigned int version, unsigned int variant, unsigned long flags=0):
       ConversionField< UnsignedField<N> >(parent, _source, SourcesConversionTable::getInstance(board, version, variant, flags),
-            "Source", QObject::tr("Source %1 cannot be exported on this board!").arg(source.toString())),
+            "Source", tr("Source %1 cannot be exported on this board!").arg(source.toString())),
       source(source),
       _source(0)
     {
@@ -1569,14 +1569,14 @@ class CurvesField: public TransformedField {
         if (IS_STM32(board) && version >= 216) {
           offset += (curve->type == CurveData::CURVE_TYPE_CUSTOM ? curve->count * 2 - 2 : curve->count);
           if (offset > maxPoints) {
-            setError(QObject::tr("OpenTX only accepts %1 points in all curves").arg(maxPoints));
+            setError(tr("OpenTX only accepts %1 points in all curves").arg(maxPoints));
             break;
           }
         }
         else {
           offset += (curve->type == CurveData::CURVE_TYPE_CUSTOM ? curve->count * 2 - 2 : curve->count) - 5;
           if (offset > maxPoints - 5 * maxCurves) {
-            setError(QObject::tr("OpenTx only accepts %1 points in all curves").arg(maxPoints));
+            setError(tr("OpenTx only accepts %1 points in all curves").arg(maxPoints));
             break;
           }
           _curves[i] = offset;
@@ -2154,11 +2154,11 @@ class ArmCustomFunctionField: public TransformedField {
 
       if (version >= 218) {
         internalField.Append(new SwitchField<9>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<7> >(this, _func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<7> >(this, _func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
       }
       else {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<8> >(this, _func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<8> >(this, _func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
       }
 
       if (IS_TARANIS(board) && version >= 216)
@@ -2394,7 +2394,7 @@ class AvrCustomFunctionField: public TransformedField {
     {
       if (version >= 217 && IS_2560(board)) {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<8> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<8> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new UnsignedField<2>(this, fn.adjustMode));
         internalField.Append(new UnsignedField<4>(this, _union_param));
         internalField.Append(new UnsignedField<1>(this, _active));
@@ -2402,18 +2402,18 @@ class AvrCustomFunctionField: public TransformedField {
       }
       else if (version >= 216) {
         internalField.Append(new SwitchField<6>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<4> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<4> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new UnsignedField<5>(this, _union_param));
         internalField.Append(new UnsignedField<1>(this, _active));
       }
       else if (version >= 213) {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
         internalField.Append(new UnsignedField<3>(this, _union_param));
-        internalField.Append(new ConversionField< UnsignedField<5> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<5> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
       }
       else {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<7> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", ::QObject::tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<7> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new BoolField<1>(this, (bool &)fn.enabled));
       }
       internalField.Append(new UnsignedField<8>(this, _param));
@@ -3137,7 +3137,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
   if (IS_ARM(board))
     internalField.Append(new UnsignedField<3>(this, modelData.telemetryProtocol));
   else
-    internalField.Append(new ConversionField< UnsignedField<3> >(this, (unsigned int &)modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", ::QObject::tr("OpenTX doesn't accept this telemetry protocol")));
+    internalField.Append(new ConversionField< UnsignedField<3> >(this, (unsigned int &)modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this telemetry protocol")));
 
   internalField.Append(new BoolField<1>(this, modelData.thrTrim));
 
@@ -3150,7 +3150,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
     internalField.Append(new SpareBitsField<4>(this));
   }
   else {
-    internalField.Append(new ConversionField< SignedField<4> >(this, modelData.moduleData[0].channelsCount, &channelsConversionTable, "Channels number", ::QObject::tr("OpenTX doesn't allow this number of channels")));
+    internalField.Append(new ConversionField< SignedField<4> >(this, modelData.moduleData[0].channelsCount, &channelsConversionTable, "Channels number", tr("OpenTX doesn't allow this number of channels")));
   }
 
   if (version >= 216)
@@ -3272,7 +3272,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
       internalField.Append(new UnsignedField<2>(this, modelData.potsWarningMode));
     }
     else {
-      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[1].protocol, &protocolsConversionTable, "Protocol", ::QObject::tr("OpenTX doesn't accept this radio protocol")));
+      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[1].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
       internalField.Append(new UnsignedField<8>(this, modelData.trainerMode));
     }
   }
@@ -3284,14 +3284,14 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
     }
     else if (version >= 216) {
       modulesCount = 3;
-      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", ::QObject::tr("OpenTX doesn't accept this radio protocol")));
+      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
     }
   }
 
   if (IS_ARM(board) && version >= 215) {
     for (int module=0; module<modulesCount; module++) {
       if (version >= 217) {
-        internalField.Append(new ConversionField<SignedField<4> >(this, modelData.moduleData[module].protocol, &protocolsConversionTable, "Protocol", ::QObject::tr("OpenTX doesn't accept this radio protocol")));
+        internalField.Append(new ConversionField<SignedField<4> >(this, modelData.moduleData[module].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
         internalField.Append(new SignedField<4>(this, subprotocols[module]));
       }
       else {

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -433,8 +433,8 @@ template <int N>
 class SwitchField: public ConversionField< SignedField<N> > {
   public:
     SwitchField(DataField * parent, RawSwitch & sw, Board::Type board, unsigned int version, unsigned long flags=0):
-      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), tr("Switch").toLatin1(),
-          tr("Switch ").toLatin1() + sw.toString(board) + tr(" cannot be exported on this board!").toLatin1()),
+      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), this->tr("Switch").toLatin1(),
+          this->tr("Switch ").toLatin1() + sw.toString(board) + this->tr(" cannot be exported on this board!").toLatin1()),
       sw(sw),
       _switch(0),
       board(board)
@@ -597,7 +597,7 @@ class SourceField: public ConversionField< UnsignedField<N> > {
   public:
     SourceField(DataField * parent, RawSource & source, Board::Type board, unsigned int version, unsigned int variant, unsigned long flags=0):
       ConversionField< UnsignedField<N> >(parent, _source, SourcesConversionTable::getInstance(board, version, variant, flags),
-            "Source", tr("Source %1 cannot be exported on this board!").arg(source.toString())),
+            this->tr("Source").toLatin1(), this->tr("Source %1 cannot be exported on this board!").arg(source.toString())),
       source(source),
       _source(0)
     {

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -234,7 +234,7 @@ unsigned long OpenTxEepromInterface::load(RadioData &radioData, const uint8_t * 
   if (version_error == OLD_VERSION) {
     errors.set(version_error);
     errors.set(HAS_WARNINGS);
-    ShowEepromWarnings(NULL, QObject::tr("Warning"), errors.to_ulong());
+    showEepromWarnings(NULL, tr("Warning"), errors.to_ulong());
   }
   else if (version_error == NOT_OPENTX) {
     dbg << " not open9x";
@@ -285,7 +285,7 @@ void OpenTxEepromInterface::showErrors(const QString & title, const QStringList 
 {
   QString msg;
   if (errors.empty()) {
-    msg = QObject::tr("Unknown error");
+    msg = tr("Unknown error");
   }
   else {
     int noErrorsToDisplay = std::min((int)errors.size(), 10);
@@ -293,12 +293,12 @@ void OpenTxEepromInterface::showErrors(const QString & title, const QStringList 
       msg += " -" + errors.at(n) + "\n";
     }
     if (noErrorsToDisplay < errors.size()) {
-      msg += QObject::tr(" ... plus %1 errors").arg(errors.size() - noErrorsToDisplay) + "\n" + msg;
+      msg += tr(" ... plus %1 errors").arg(errors.size() - noErrorsToDisplay) + "\n" + msg;
     }
   }
 
   QMessageBox::warning(NULL,
-                       QObject::tr("Error"),
+                       tr("Error"),
                        title + "\n" + msg);
 }
 
@@ -330,7 +330,7 @@ int OpenTxEepromInterface::save(uint8_t * eeprom, const RadioData & radioData, u
   generator.Export(data);
   int sz = efile->writeRlc2(FILE_GENERAL, FILE_TYP_GENERAL, (const uint8_t *)data.constData(), data.size());
   if (sz == 0 || generator.errors().count() > 0) {
-    showErrors(QObject::tr("Cannot write radio settings"), generator.errors());
+    showErrors(tr("Cannot write radio settings"), generator.errors());
     return 0;
   }
 
@@ -342,7 +342,7 @@ int OpenTxEepromInterface::save(uint8_t * eeprom, const RadioData & radioData, u
       generator.Export(data);
       int sz = efile->writeRlc2(FILE_MODEL(i), FILE_TYP_MODEL, (const uint8_t *)data.constData(), data.size());
       if (sz == 0 || generator.errors().count() > 0) {
-        showErrors(QObject::tr("Cannot write model %1").arg(radioData.models[i].name), generator.errors());
+        showErrors(tr("Cannot write model %1").arg(radioData.models[i].name), generator.errors());
         return 0;
       }
     }

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1056,45 +1056,45 @@ QString OpenTxFirmware::getStampUrl()
 
 void addOpenTxCommonOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("ppmus", QObject::tr("Channel values displayed in us"));
-  firmware->addOption("nooverridech", QObject::tr("No OverrideCH functions available"));
-  Option fai_options[] = {{"faichoice", QObject::tr("Possibility to enable FAI MODE (no telemetry) at field")},
-                          {"faimode",   QObject::tr("FAI MODE (no telemetry) always enabled")},
+  firmware->addOption("ppmus", QCoreApplication::translate("Firmare", "Channel values displayed in us"));
+  firmware->addOption("nooverridech", QCoreApplication::translate("Firmare", "No OverrideCH functions available"));
+  Option fai_options[] = {{"faichoice", QCoreApplication::translate("Firmare", "Possibility to enable FAI MODE (no telemetry) at field")},
+                          {"faimode",   QCoreApplication::translate("Firmare", "FAI MODE (no telemetry) always enabled")},
                           {NULL}};
   firmware->addOptions(fai_options);
 }
 
 void addOpenTxArmOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("multimodule", QObject::tr("Support for the DIY-Multiprotocol-TX-Module"));
-  firmware->addOption("eu", QObject::tr("Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015"));
+  firmware->addOption("multimodule", QCoreApplication::translate("Firmare", "Support for the DIY-Multiprotocol-TX-Module"));
+  firmware->addOption("eu", QCoreApplication::translate("Firmare", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015"));
 }
 
 void addOpenTxFrskyOptions(OpenTxFirmware * firmware)
 {
   addOpenTxCommonOptions(firmware);
   addOpenTxArmOptions(firmware);
-  firmware->addOption("noheli", QObject::tr("Disable HELI menu and cyclic mix support"));
-  firmware->addOption("nogvars", QObject::tr("Disable Global variables"));
-  firmware->addOption("lua", QObject::tr("Enable Lua custom scripts screen"));
-  firmware->addOption("luac", QObject::tr("Enable Lua compiler"));
+  firmware->addOption("noheli", QCoreApplication::translate("Firmare", "Disable HELI menu and cyclic mix support"));
+  firmware->addOption("nogvars", QCoreApplication::translate("Firmare", "Disable Global variables"));
+  firmware->addOption("lua", QCoreApplication::translate("Firmare", "Enable Lua custom scripts screen"));
+  firmware->addOption("luac", QCoreApplication::translate("Firmare", "Enable Lua compiler"));
 }
 
 void addOpenTxTaranisOptions(OpenTxFirmware * firmware)
 {
   addOpenTxFrskyOptions(firmware);
-  firmware->addOption("internalppm", QObject::tr("Support for PPM internal module hack"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("internalppm", QCoreApplication::translate("Firmare", "Support for PPM internal module hack"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
 }
 
 void addOpenTxLcdOptions(OpenTxFirmware * firmware)
 {
   Option lcd_options[] = {
-    {"ST7565P",     QObject::tr("ST7565P LCD or compatible")},
-    {"ST7565R",     QObject::tr("ST7565R LCD or compatible")},
-    {"ERC12864FSF", QObject::tr("ERC12864FSF LCD")},
-    {"ST7920",      QObject::tr("ST7920 LCD")},
-    {"KS108",       QObject::tr("KS108 LCD")},
+    {"ST7565P",     QCoreApplication::translate("Firmare", "ST7565P LCD or compatible")},
+    {"ST7565R",     QCoreApplication::translate("Firmare", "ST7565R LCD or compatible")},
+    {"ERC12864FSF", QCoreApplication::translate("Firmare", "ERC12864FSF LCD")},
+    {"ST7920",      QCoreApplication::translate("Firmare", "ST7920 LCD")},
+    {"KS108",       QCoreApplication::translate("Firmare", "KS108 LCD")},
     {NULL}
   };
   firmware->addOptions(lcd_options);
@@ -1103,8 +1103,8 @@ void addOpenTxLcdOptions(OpenTxFirmware * firmware)
 void addOpenTxVoiceOptions(OpenTxFirmware * firmware)
 {
   Option voice_options[] = {
-    {"WTV20",     	QObject::tr("WTV20 voice module")},
-    {"JQ6500", 		QObject::tr("JQ6500 voice module")},
+    {"WTV20",     	QCoreApplication::translate("Firmare", "WTV20 voice module")},
+    {"JQ6500", 		QCoreApplication::translate("Firmare", "JQ6500 voice module")},
     {NULL}
   };
   firmware->addOptions(voice_options);
@@ -1125,303 +1125,303 @@ void registerOpenTxFirmwares()
 {
   OpenTxFirmware * firmware;
 
-  Option ext_options[] = {{"frsky",      QObject::tr("Support for frsky telemetry mod"),  FRSKY_VARIANT},
-                          {"telemetrez", QObject::tr("Support for telemetry easy board"), FRSKY_VARIANT},
-                          {"jeti",       QObject::tr("Support for jeti telemetry mod"),       0},
-                          {"ardupilot",  QObject::tr("Support for receiving ardupilot data"), 0},
-                          {"nmea",       QObject::tr("Support for receiving NMEA data"),      0},
-                          {"mavlink",    QObject::tr("Support for MAVLINK devices"),      MAVLINK_VARIANT},
+  Option ext_options[] = {{"frsky",      QCoreApplication::translate("Firmare", "Support for frsky telemetry mod"),  FRSKY_VARIANT},
+                          {"telemetrez", QCoreApplication::translate("Firmare", "Support for telemetry easy board"), FRSKY_VARIANT},
+                          {"jeti",       QCoreApplication::translate("Firmare", "Support for jeti telemetry mod"),       0},
+                          {"ardupilot",  QCoreApplication::translate("Firmare", "Support for receiving ardupilot data"), 0},
+                          {"nmea",       QCoreApplication::translate("Firmare", "Support for receiving NMEA data"),      0},
+                          {"mavlink",    QCoreApplication::translate("Firmare", "Support for MAVLINK devices"),      MAVLINK_VARIANT},
                           {NULL}};
-  Option extr_options[] = {{"frsky",     QObject::tr("Support for frsky telemetry mod"), FRSKY_VARIANT},
-                           {"jeti",      QObject::tr("Support for jeti telemetry mod"),       0},
-                           {"ardupilot", QObject::tr("Support for receiving ardupilot data"), 0},
-                           {"nmea",      QObject::tr("Support for receiving NMEA data"),      0},
-                           {"mavlink",   QObject::tr("Support for MAVLINK devices"),     MAVLINK_VARIANT},
+  Option extr_options[] = {{"frsky",     QCoreApplication::translate("Firmare", "Support for frsky telemetry mod"), FRSKY_VARIANT},
+                           {"jeti",      QCoreApplication::translate("Firmare", "Support for jeti telemetry mod"),       0},
+                           {"ardupilot", QCoreApplication::translate("Firmare", "Support for receiving ardupilot data"), 0},
+                           {"nmea",      QCoreApplication::translate("Firmare", "Support for receiving NMEA data"),      0},
+                           {"mavlink",   QCoreApplication::translate("Firmare", "Support for MAVLINK devices"),     MAVLINK_VARIANT},
                            {NULL}};
-  Option nav_options[] = {{"rotenc",    QObject::tr("Rotary Encoder use in menus navigation")},
-                          {"potscroll", QObject::tr("Pots use in menus navigation")},
+  Option nav_options[] = {{"rotenc",    QCoreApplication::translate("Firmare", "Rotary Encoder use in menus navigation")},
+                          {"potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation")},
                           {NULL}};
-  Option dsm2_options[] = {{"DSM2",    QObject::tr("Support for DSM2 modules"),                                  0},
-                           {"DSM2PPM", QObject::tr("Support for DSM2 modules using ppm instead of true serial"), 0},
+  Option dsm2_options[] = {{"DSM2",    QCoreApplication::translate("Firmare", "Support for DSM2 modules"),                                  0},
+                           {"DSM2PPM", QCoreApplication::translate("Firmare", "Support for DSM2 modules using ppm instead of true serial"), 0},
                            {NULL}};
 
   /* FrSky Taranis X9D+ board */
-  firmware = new OpenTxFirmware("opentx-x9d+", QObject::tr("FrSky Taranis X9D+"), BOARD_TARANIS_X9DP);
+  firmware = new OpenTxFirmware("opentx-x9d+", QCoreApplication::translate("Firmare", "FrSky Taranis X9D+"), BOARD_TARANIS_X9DP);
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky Taranis X9D board */
-  firmware = new OpenTxFirmware("opentx-x9d", QObject::tr("FrSky Taranis X9D"), BOARD_TARANIS_X9D);
-  firmware->addOption("haptic", QObject::tr("Haptic module installed"));
+  firmware = new OpenTxFirmware("opentx-x9d", QCoreApplication::translate("Firmare", "FrSky Taranis X9D"), BOARD_TARANIS_X9D);
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Haptic module installed"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky Taranis X9E board */
-  firmware = new OpenTxFirmware("opentx-x9e", QObject::tr("FrSky Taranis X9E"), BOARD_TARANIS_X9E);
-  firmware->addOption("shutdownconfirm", QObject::tr("Confirmation before radio shutdown"));
-  firmware->addOption("horussticks", QObject::tr("Horus gimbals installed (Hall sensors)"));
+  firmware = new OpenTxFirmware("opentx-x9e", QCoreApplication::translate("Firmare", "FrSky Taranis X9E"), BOARD_TARANIS_X9E);
+  firmware->addOption("shutdownconfirm", QCoreApplication::translate("Firmare", "Confirmation before radio shutdown"));
+  firmware->addOption("horussticks", QCoreApplication::translate("Firmare", "Horus gimbals installed (Hall sensors)"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X7 board */
-  firmware = new OpenTxFirmware("opentx-x7", QObject::tr("FrSky Taranis X7 / X7S"), BOARD_TARANIS_X7);
+  firmware = new OpenTxFirmware("opentx-x7", QCoreApplication::translate("Firmare", "FrSky Taranis X7 / X7S"), BOARD_TARANIS_X7);
   // No mixersmon for now
   addOpenTxFrskyOptions(firmware);
-  firmware->addOption("internalppm", QObject::tr("Support for PPM internal module hack"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("internalppm", QCoreApplication::translate("Firmare", "Support for PPM internal module hack"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   registerOpenTxFirmware(firmware);
 
   /* FrSky X10 board */
-  firmware = new OpenTxFirmware("opentx-x10", QObject::tr("FrSky Horus X10 / X10S"), BOARD_X10);
+  firmware = new OpenTxFirmware("opentx-x10", QCoreApplication::translate("Firmare", "FrSky Horus X10 / X10S"), BOARD_X10);
   addOpenTxFrskyOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky Horus board */
-  firmware = new OpenTxFirmware("opentx-x12s", QObject::tr("FrSky Horus X12S"), BOARD_X12S);
+  firmware = new OpenTxFirmware("opentx-x12s", QCoreApplication::translate("Firmare", "FrSky Horus X12S"), BOARD_X12S);
   addOpenTxFrskyOptions(firmware);
-  firmware->addOption("pcbdev", QObject::tr("Use ONLY with first DEV pcb version"));
+  firmware->addOption("pcbdev", QCoreApplication::translate("Firmare", "Use ONLY with first DEV pcb version"));
   registerOpenTxFirmware(firmware);
 
   /* 9XR-Pro */
-  firmware = new OpenTxFirmware("opentx-9xrpro", QObject::tr("Turnigy 9XR-PRO"), BOARD_9XRPRO);
-  firmware->addOption("heli", QObject::tr("Enable HELI menu and cyclic mix support"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("bluetooth", QObject::tr("Bluetooth interface"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware = new OpenTxFirmware("opentx-9xrpro", QCoreApplication::translate("Firmare", "Turnigy 9XR-PRO"), BOARD_9XRPRO);
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable HELI menu and cyclic mix support"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("bluetooth", QCoreApplication::translate("Firmare", "Bluetooth interface"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxArmOptions(firmware);
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* 9XR board with M128 chip */
-  firmware = new OpenTxFirmware("opentx-9xr128", QObject::tr("Turnigy 9XR with m128 chip"), BOARD_M128);
+  firmware = new OpenTxFirmware("opentx-9xr128", QCoreApplication::translate("Firmare", "Turnigy 9XR with m128 chip"), BOARD_M128);
   firmware->addOptions(extr_options);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QObject::tr("No splash screen"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("audio", QObject::tr("Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QObject::tr("Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QObject::tr("Support for DSM2 modules"));
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QObject::tr("Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write Progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nosplash", QCoreApplication::translate("Firmare", "No splash screen"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("audio", QCoreApplication::translate("Firmare", "Support for radio modified with regular speaker"));
+  firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Used if you have modified your radio with haptic mode"));
+  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
+  firmware->addOption("DSM2", QCoreApplication::translate("Firmare", "Support for DSM2 modules"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("thrtrace", QCoreApplication::translate("Firmare", "Enable the throttle trace in Statistics"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write Progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* 9XR board */
-  firmware = new OpenTxFirmware("opentx-9xr", QObject::tr("Turnigy 9XR"), BOARD_STOCK);
+  firmware = new OpenTxFirmware("opentx-9xr", QCoreApplication::translate("Firmare", "Turnigy 9XR"), BOARD_STOCK);
   firmware->addOptions(extr_options);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QObject::tr("No splash screen"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("audio", QObject::tr("Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QObject::tr("Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QObject::tr("Support for DSM2 modules"));
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QObject::tr("Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write Progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("nowshh", QObject::tr("No Winged Shadow How High support"));
-  firmware->addOption("novario", QObject::tr("No vario support"));
-  firmware->addOption("nogps", QObject::tr("No GPS support"));
-  firmware->addOption("nogauges", QObject::tr("No gauges in the custom telemetry screen"));
-  firmware->addOption("stickrev", QObject::tr("Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nosplash", QCoreApplication::translate("Firmare", "No splash screen"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("audio", QCoreApplication::translate("Firmare", "Support for radio modified with regular speaker"));
+  firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Used if you have modified your radio with haptic mode"));
+  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
+  firmware->addOption("DSM2", QCoreApplication::translate("Firmare", "Support for DSM2 modules"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("thrtrace", QCoreApplication::translate("Firmare", "Enable the throttle trace in Statistics"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write Progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("nowshh", QCoreApplication::translate("Firmare", "No Winged Shadow How High support"));
+  firmware->addOption("novario", QCoreApplication::translate("Firmare", "No vario support"));
+  firmware->addOption("nogps", QCoreApplication::translate("Firmare", "No GPS support"));
+  firmware->addOption("nogauges", QCoreApplication::translate("Firmare", "No gauges in the custom telemetry screen"));
+  firmware->addOption("stickrev", QCoreApplication::translate("Firmare", "Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* 9x board */
-  firmware = new OpenTxFirmware("opentx-9x", QObject::tr("9X with stock board"), BOARD_STOCK);
+  firmware = new OpenTxFirmware("opentx-9x", QCoreApplication::translate("Firmare", "9X with stock board"), BOARD_STOCK);
   firmware->addOptions(ext_options);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QObject::tr("No splash screen"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("audio", QObject::tr("Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QObject::tr("Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QObject::tr("Support for DSM2 modules"));
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nosplash", QCoreApplication::translate("Firmare", "No splash screen"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("audio", QCoreApplication::translate("Firmare", "Support for radio modified with regular speaker"));
+  firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Used if you have modified your radio with haptic mode"));
+  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
+  firmware->addOption("DSM2", QCoreApplication::translate("Firmare", "Support for DSM2 modules"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
   firmware->addOptions(nav_options);
-  firmware->addOption("sp22", QObject::tr("SmartieParts 2.2 Backlight support"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QObject::tr("Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("nowshh", QObject::tr("No Winged Shadow How High support"));
-  firmware->addOption("novario", QObject::tr("No vario support"));
-  firmware->addOption("nogps", QObject::tr("No GPS support"));
-  firmware->addOption("nogauges", QObject::tr("No gauges in the custom telemetry screen"));
-  firmware->addOption("fasoffset", QObject::tr("Allow compensating for offset errors in FrSky FAS current sensors"));
-  firmware->addOption("stickrev", QObject::tr("Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("sp22", QCoreApplication::translate("Firmare", "SmartieParts 2.2 Backlight support"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("thrtrace", QCoreApplication::translate("Firmare", "Enable the throttle trace in Statistics"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("nowshh", QCoreApplication::translate("Firmare", "No Winged Shadow How High support"));
+  firmware->addOption("novario", QCoreApplication::translate("Firmare", "No vario support"));
+  firmware->addOption("nogps", QCoreApplication::translate("Firmare", "No GPS support"));
+  firmware->addOption("nogauges", QCoreApplication::translate("Firmare", "No gauges in the custom telemetry screen"));
+  firmware->addOption("fasoffset", QCoreApplication::translate("Firmare", "Allow compensating for offset errors in FrSky FAS current sensors"));
+  firmware->addOption("stickrev", QCoreApplication::translate("Firmare", "Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* 9x board with M128 chip */
-  firmware = new OpenTxFirmware("opentx-9x128", QObject::tr("9X with stock board and m128 chip"), BOARD_M128);
+  firmware = new OpenTxFirmware("opentx-9x128", QCoreApplication::translate("Firmare", "9X with stock board and m128 chip"), BOARD_M128);
   firmware->addOptions(ext_options);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QObject::tr("No splash screen"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("audio", QObject::tr("Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QObject::tr("Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QObject::tr("Support for DSM2 modules"));
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nosplash", QCoreApplication::translate("Firmare", "No splash screen"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("audio", QCoreApplication::translate("Firmare", "Support for radio modified with regular speaker"));
+  firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Used if you have modified your radio with haptic mode"));
+  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
+  firmware->addOption("DSM2", QCoreApplication::translate("Firmare", "Support for DSM2 modules"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
   firmware->addOptions(nav_options);
-  firmware->addOption("sp22", QObject::tr("SmartieParts 2.2 Backlight support"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QObject::tr("Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write Progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("sp22", QCoreApplication::translate("Firmare", "SmartieParts 2.2 Backlight support"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("thrtrace", QCoreApplication::translate("Firmare", "Enable the throttle trace in Statistics"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write Progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* ar9x board */
-  firmware = new OpenTxFirmware("opentx-ar9x", QObject::tr("9X with AR9X board"), BOARD_AR9X);
-  firmware->addOption("heli", QObject::tr("Enable HELI menu and cyclic mix support"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("bluetooth", QObject::tr("Bluetooth interface"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
-//  firmware->addOption("rtc", QObject::tr("Optional RTC added"));
-//  firmware->addOption("volume", QObject::tr("i2c volume control added"));
+  firmware = new OpenTxFirmware("opentx-ar9x", QCoreApplication::translate("Firmare", "9X with AR9X board"), BOARD_AR9X);
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable HELI menu and cyclic mix support"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("bluetooth", QCoreApplication::translate("Firmare", "Bluetooth interface"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
+//  firmware->addOption("rtc", QCoreApplication::translate("Firmare", "Optional RTC added"));
+//  firmware->addOption("volume", QCoreApplication::translate("Firmare", "i2c volume control added"));
   addOpenTxArmOptions(firmware);
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* Sky9x board */
-  firmware = new OpenTxFirmware("opentx-sky9x", QObject::tr("9X with Sky9x board"), BOARD_SKY9X);
-  firmware->addOption("heli", QObject::tr("Enable HELI menu and cyclic mix support"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("bluetooth", QObject::tr("Bluetooth interface"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware = new OpenTxFirmware("opentx-sky9x", QCoreApplication::translate("Firmare", "9X with Sky9x board"), BOARD_SKY9X);
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable HELI menu and cyclic mix support"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("bluetooth", QCoreApplication::translate("Firmare", "Bluetooth interface"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxArmOptions(firmware);
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* Gruvin9x board */
-  firmware = new OpenTxFirmware("opentx-gruvin9x", QObject::tr("9X with Gruvin9x board"), BOARD_GRUVIN9X);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("sdcard", QObject::tr("Support for SD memory card"));
-  firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
-  firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
+  firmware = new OpenTxFirmware("opentx-gruvin9x", QCoreApplication::translate("Firmare", "9X with Gruvin9x board"), BOARD_GRUVIN9X);
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("sdcard", QCoreApplication::translate("Firmare", "Support for SD memory card"));
+  firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
+  firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
   firmware->addOptions(dsm2_options);
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
-  firmware->addOption("potscroll", QObject::tr("Pots use in menus navigation"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write Progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmare", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write Progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* MEGA2560 board */
-  firmware = new OpenTxFirmware("opentx-mega2560", QObject::tr("DIY MEGA2560 radio"), BOARD_MEGA2560);
+  firmware = new OpenTxFirmware("opentx-mega2560", QCoreApplication::translate("Firmare", "DIY MEGA2560 radio"), BOARD_MEGA2560);
   addOpenTxLcdOptions(firmware);
-  firmware->addOption("PWR", QObject::tr("Power management by soft-off circuitry"));
+  firmware->addOption("PWR", QCoreApplication::translate("Firmare", "Power management by soft-off circuitry"));
   firmware->addOptions(ext_options);
-  firmware->addOption("PXX", QObject::tr("Support of FrSky PXX protocol"));
+  firmware->addOption("PXX", QCoreApplication::translate("Firmare", "Support of FrSky PXX protocol"));
   firmware->addOptions(dsm2_options);
-  firmware->addOption("heli", QObject::tr("Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QObject::tr("Enable TEMPLATES menu"));
-  firmware->addOption("nofp", QObject::tr("No flight modes"));
-  firmware->addOption("nocurves", QObject::tr("Disable curves menus"));
-  firmware->addOption("sdcard", QObject::tr("Support for SD memory card"));
-  firmware->addOption("audio", QObject::tr("Support for radio modified with regular speaker"));
-  //firmware->addOption("voice", QObject::tr("Used if you have modified your radio with voice mode"));
+  firmware->addOption("heli", QCoreApplication::translate("Firmare", "Enable heli menu and cyclic mix support"));
+  firmware->addOption("templates", QCoreApplication::translate("Firmare", "Enable TEMPLATES menu"));
+  firmware->addOption("nofp", QCoreApplication::translate("Firmare", "No flight modes"));
+  firmware->addOption("nocurves", QCoreApplication::translate("Firmare", "Disable curves menus"));
+  firmware->addOption("sdcard", QCoreApplication::translate("Firmare", "Support for SD memory card"));
+  firmware->addOption("audio", QCoreApplication::translate("Firmare", "Support for radio modified with regular speaker"));
+  //firmware->addOption("voice", QCoreApplication::translate("Firmare", "Used if you have modified your radio with voice mode"));
   addOpenTxVoiceOptions(firmware);
-  firmware->addOption("haptic", QObject::tr("Used if you have modified your radio with haptic mode"));
-  firmware->addOption("ppmca", QObject::tr("PPM center adjustment in limits"));
-  firmware->addOption("gvars", QObject::tr("Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QObject::tr("Symetrical Limits"));
-  firmware->addOption("autosource", QObject::tr("In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QObject::tr("In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QObject::tr("Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QObject::tr("No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QObject::tr("Battery graph"));
-  firmware->addOption("nobold", QObject::tr("Don't use bold font for highlighting active items"));
-  firmware->addOption("pgbar", QObject::tr("EEprom write Progress bar"));
-  firmware->addOption("imperial", QObject::tr("Imperial units"));
-  firmware->addOption("sqt5font", QObject::tr("Use alternative SQT5 font"));
+  firmware->addOption("haptic", QCoreApplication::translate("Firmare", "Used if you have modified your radio with haptic mode"));
+  firmware->addOption("ppmca", QCoreApplication::translate("Firmare", "PPM center adjustment in limits"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmare", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("symlimits", QCoreApplication::translate("Firmare", "Symetrical Limits"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmare", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmare", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("dblkeys", QCoreApplication::translate("Firmare", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmare", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmare", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmare", "Don't use bold font for highlighting active items"));
+  firmware->addOption("pgbar", QCoreApplication::translate("Firmare", "EEprom write Progress bar"));
+  firmware->addOption("imperial", QCoreApplication::translate("Firmare", "Imperial units"));
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmare", "Use alternative SQT5 font"));
   addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -110,7 +110,7 @@ void RadioData::convert(RadioDataConversionState & cstate)
   }
 
   if (categories.size() == 0) {
-    categories.push_back(CategoryData(qPrintable(QObject::tr("Models"))));
+    categories.push_back(CategoryData(qPrintable(tr("Models"))));
     for (unsigned i=0; i<models.size(); i++) {
       models[i].category = 0;
     }

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -17,6 +17,8 @@ class CategoryData {
 };
 
 class RadioData {
+  Q_DECLARE_TR_FUNCTIONS(RadioData)
+
   public:
     RadioData();
 

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -399,12 +399,10 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       return RadioData::getElementName(tr("TR", "as in Trainer"), index + 1);
 
     case SOURCE_TYPE_CH:
-    {
-      const char * name = NULL;
-      if (getCurrentFirmware()->getCapability(ChannelsName) && model)
-        name = model->limitData[index].name;
-      return RadioData::getElementName(QCoreApplication::translate("Channel", "CH"), index + 1, name);
-    }
+      if (model)
+        return model->limitData[index].nameToString(index);
+      else
+        return LimitData().nameToString(index);
 
     case SOURCE_TYPE_SPECIAL:
       return CHECK_IN_ARRAY(special, index);
@@ -412,7 +410,10 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     case SOURCE_TYPE_TELEMETRY:
       if (IS_ARM(board)) {
         div_t qr = div(index, 3);
-        result = RadioData::getElementName(QCoreApplication::translate("Telemetry", "TELE"), qr.quot+1, model ? model->sensorData[qr.quot].label : NULL);
+        if (model)
+          result = model->sensorData[qr.quot].nameToString(qr.quot);
+        else
+          result = SensorData().nameToString(qr.quot);
         if (qr.rem)
           result += (qr.rem == 1 ? "-" : "+");
         return result;
@@ -422,12 +423,10 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       }
 
     case SOURCE_TYPE_GVAR:
-    {
-      const char * name = NULL;
-      if (getCurrentFirmware()->getCapability(GvarsName) && model)
-        name = model->gvarData[index].name;
-      return RadioData::getElementName(QCoreApplication::translate("Global Variable", "GV"), index + 1, name);
-    }
+      if (model)
+        return model->gvarData[index].nameToString(index);
+      else
+        return GVarData().nameToString(index);
 
     default:
       return tr("???");

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -74,19 +74,19 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             result.step = 0.1;
             result.decimals = 1;
             result.max = 25.5;
-            result.unit = QObject::tr("V");
+            result.unit = tr("V");
             break;
           case TELEMETRY_SOURCE_TX_TIME:
             result.step = 60;
             result.max = 24 * 60 * result.step - 60;  // 23:59:00 with 1-minute resolution
-            result.unit = QObject::tr("s");
+            result.unit = tr("s");
             break;
           case TELEMETRY_SOURCE_TIMER1:
           case TELEMETRY_SOURCE_TIMER2:
           case TELEMETRY_SOURCE_TIMER3:
             result.step = 5;
             result.max = 255 * result.step;
-            result.unit = QObject::tr("s");
+            result.unit = tr("s");
             break;
           case TELEMETRY_SOURCE_RSSI_TX:
           case TELEMETRY_SOURCE_RSSI_RX:
@@ -116,10 +116,10 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
               result.step = (result.step * 105) / 32;
               result.min = (result.min * 105) / 32;
               result.max = (result.max * 105) / 32;
-              result.unit = QObject::tr("ft");
+              result.unit = tr("ft");
             }
             else {
-              result.unit = QObject::tr("m");
+              result.unit = tr("m");
             }
             break;
           case TELEMETRY_SOURCE_T1:
@@ -128,13 +128,13 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
           case TELEMETRY_SOURCE_T2_MAX:
             result.min = -30;
             result.max = 225;
-            result.unit = QObject::trUtf8("°C");
+            result.unit = trUtf8("°C");
             break;
           case TELEMETRY_SOURCE_HDG:
             result.step = 2;
             result.max = 360;
             result.offset = 256;
-            result.unit = QObject::trUtf8("°");
+            result.unit = trUtf8("°");
             break;
           case TELEMETRY_SOURCE_RPM:
           case TELEMETRY_SOURCE_RPM_MAX:
@@ -143,7 +143,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             break;
           case TELEMETRY_SOURCE_FUEL:
             result.max = 100;
-            result.unit = QObject::tr("%");
+            result.unit = tr("%");
             break;
           case TELEMETRY_SOURCE_ASPEED:
           case TELEMETRY_SOURCE_ASPEED_MAX:
@@ -153,12 +153,12 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             if (firmware->getCapability(Imperial) || settings.imperial) {
               result.step *= 1.150779;
               result.max *= 1.150779;
-              result.unit = QObject::tr("mph");
+              result.unit = tr("mph");
             }
             else {
               result.step *= 1.852;
               result.max *= 1.852;
-              result.unit = QObject::tr("km/h");
+              result.unit = tr("km/h");
             }
             break;
           case TELEMETRY_SOURCE_SPEED:
@@ -168,12 +168,12 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             if (firmware->getCapability(Imperial) || settings.imperial) {
               result.step *= 1.150779;
               result.max *= 1.150779;
-              result.unit = QObject::tr("mph");
+              result.unit = tr("mph");
             }
             else {
               result.step *= 1.852;
               result.max *= 1.852;
-              result.unit = QObject::tr("km/h");
+              result.unit = tr("km/h");
             }
             break;
           case TELEMETRY_SOURCE_VERTICAL_SPEED:
@@ -181,7 +181,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             result.min = -12.5;
             result.max = 13.0;
             result.decimals = 1;
-            result.unit = QObject::tr("m/s");
+            result.unit = tr("m/s");
             break;
           case TELEMETRY_SOURCE_DTE:
             result.max = 30000;
@@ -190,14 +190,14 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
           case TELEMETRY_SOURCE_DIST_MAX:
             result.step = 8;
             result.max = 2040;
-            result.unit = QObject::tr("m");
+            result.unit = tr("m");
             break;
           case TELEMETRY_SOURCE_CELL:
           case TELEMETRY_SOURCE_CELL_MIN:
             result.step = 0.02;
             result.max = 5.1;
             result.decimals = 2;
-            result.unit = QObject::tr("V");
+            result.unit = tr("V");
             break;
           case TELEMETRY_SOURCE_CELLS_SUM:
           case TELEMETRY_SOURCE_CELLS_MIN:
@@ -206,25 +206,25 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             result.step = 0.1;
             result.max = 25.5;
             result.decimals = 1;
-            result.unit = QObject::tr("V");
+            result.unit = tr("V");
             break;
           case TELEMETRY_SOURCE_CURRENT:
           case TELEMETRY_SOURCE_CURRENT_MAX:
             result.step = 0.5;
             result.max = 127.5;
             result.decimals = 1;
-            result.unit = QObject::tr("A");
+            result.unit = tr("A");
             break;
           case TELEMETRY_SOURCE_CONSUMPTION:
             result.step = 100;
             result.max =  25500;
-            result.unit = QObject::tr("mAh");
+            result.unit = tr("mAh");
             break;
           case TELEMETRY_SOURCE_POWER:
           case TELEMETRY_SOURCE_POWER_MAX:
             result.step = 5;
             result.max = 1275;
-            result.unit = QObject::tr("W");
+            result.unit = tr("W");
             break;
           case TELEMETRY_SOURCE_ACCX:
           case TELEMETRY_SOURCE_ACCY:
@@ -233,7 +233,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
             result.decimals = 2;
             result.max = 2.55;
             result.min = 0;
-            result.unit = QObject::tr("g");
+            result.unit = tr("g");
             break;
           default:
             result.max = 125;
@@ -277,18 +277,18 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
         result.step = 0.1;
         result.decimals = 1;
         result.max = 25.5;
-        result.unit = QObject::tr("V");
+        result.unit = tr("V");
       }
       else if (index == 1) {   //Time
         result.step = 60;
         result.max = 24 * 60 * result.step - 60;  // 23:59:00 with 1-minute resolution
-        result.unit = QObject::tr("s");
+        result.unit = tr("s");
       }
       else {      // Timers 1 - 3
         result.step = 1;
         result.max = 9 * 60 * 60 - 1;  // 8:59:59 (to match firmware)
         result.min = -result.max;
-        result.unit = QObject::tr("s");
+        result.unit = tr("s");
       }
       break;
 
@@ -317,50 +317,50 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
   }
 
   static const QString trims[] = {
-    QObject::tr("TrmR"), QObject::tr("TrmE"), QObject::tr("TrmT"), QObject::tr("TrmA"), QObject::tr("Trm5"), QObject::tr("Trm6")
+    tr("TrmR"), tr("TrmE"), tr("TrmT"), tr("TrmA"), tr("Trm5"), tr("Trm6")
   };
 
   static const QString special[] = {
-    QObject::tr("Batt"), QObject::tr("Time"), QObject::tr("Timer1"), QObject::tr("Timer2"), QObject::tr("Timer3"),
+    tr("Batt"), tr("Time"), tr("Timer1"), tr("Timer2"), tr("Timer3"),
   };
 
   static const QString telemetry[] = {
-    QObject::tr("Batt"), QObject::tr("Time"), QObject::tr("Timer1"), QObject::tr("Timer2"), QObject::tr("Timer3"),
-    QObject::tr("SWR"), QObject::tr("RSSI Tx"), QObject::tr("RSSI Rx"),
-    QObject::tr("A1"), QObject::tr("A2"), QObject::tr("A3"), QObject::tr("A4"),
-    QObject::tr("Alt"), QObject::tr("Rpm"), QObject::tr("Fuel"), QObject::tr("T1"), QObject::tr("T2"),
-    QObject::tr("Speed"), QObject::tr("Dist"), QObject::tr("GPS Alt"),
-    QObject::tr("Cell"), QObject::tr("Cells"), QObject::tr("Vfas"), QObject::tr("Curr"), QObject::tr("Cnsp"), QObject::tr("Powr"),
-    QObject::tr("AccX"), QObject::tr("AccY"), QObject::tr("AccZ"),
-    QObject::tr("Hdg "), QObject::tr("VSpd"), QObject::tr("AirSpeed"), QObject::tr("dTE"),
-    QObject::tr("A1-"),  QObject::tr("A2-"), QObject::tr("A3-"),  QObject::tr("A4-"),
-    QObject::tr("Alt-"), QObject::tr("Alt+"), QObject::tr("Rpm+"), QObject::tr("T1+"), QObject::tr("T2+"), QObject::tr("Speed+"), QObject::tr("Dist+"), QObject::tr("AirSpeed+"),
-    QObject::tr("Cell-"), QObject::tr("Cells-"), QObject::tr("Vfas-"), QObject::tr("Curr+"), QObject::tr("Powr+"),
-    QObject::tr("ACC"), QObject::tr("GPS Time"),
+    tr("Batt"), tr("Time"), tr("Timer1"), tr("Timer2"), tr("Timer3"),
+    tr("SWR"), tr("RSSI Tx"), tr("RSSI Rx"),
+    tr("A1"), tr("A2"), tr("A3"), tr("A4"),
+    tr("Alt"), tr("Rpm"), tr("Fuel"), tr("T1"), tr("T2"),
+    tr("Speed"), tr("Dist"), tr("GPS Alt"),
+    tr("Cell"), tr("Cells"), tr("Vfas"), tr("Curr"), tr("Cnsp"), tr("Powr"),
+    tr("AccX"), tr("AccY"), tr("AccZ"),
+    tr("Hdg "), tr("VSpd"), tr("AirSpeed"), tr("dTE"),
+    tr("A1-"),  tr("A2-"), tr("A3-"),  tr("A4-"),
+    tr("Alt-"), tr("Alt+"), tr("Rpm+"), tr("T1+"), tr("T2+"), tr("Speed+"), tr("Dist+"), tr("AirSpeed+"),
+    tr("Cell-"), tr("Cells-"), tr("Vfas-"), tr("Curr+"), tr("Powr+"),
+    tr("ACC"), tr("GPS Time"),
   };
 
-  static const QString rotary[]  = { QObject::tr("REa"), QObject::tr("REb") };
+  static const QString rotary[]  = { tr("REa"), tr("REb") };
 
   if (index<0) {
-    return QObject::tr("???");
+    return tr("???");
   }
 
   QString result;
   int genAryIdx = 0;
   switch (type) {
     case SOURCE_TYPE_NONE:
-      return QObject::tr("----");
+      return tr("----");
 
     case SOURCE_TYPE_VIRTUAL_INPUT:
     {
       const char * name = NULL;
       if (model)
         name = model->inputNames[index];
-      return RadioData::getElementName(QCoreApplication::translate("Input", "I"), index + 1, name);
+      return RadioData::getElementName(tr("I", "as in Input"), index + 1, name);
     }
 
     case SOURCE_TYPE_LUA_OUTPUT:
-      return QObject::tr("LUA%1%2").arg(index/16+1).arg(QChar('a'+index%16));
+      return tr("LUA%1%2").arg(index/16+1).arg(QChar('a'+index%16));
 
     case SOURCE_TYPE_STICK:
       if (generalSettings) {
@@ -380,7 +380,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     case SOURCE_TYPE_ROTARY_ENCODER:
       return CHECK_IN_ARRAY(rotary, index);
     case SOURCE_TYPE_MAX:
-      return QObject::tr("MAX");
+      return tr("MAX");
 
     case SOURCE_TYPE_SWITCH:
       if (generalSettings)
@@ -393,10 +393,10 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       return RawSwitch(SWITCH_TYPE_VIRTUAL, index+1).toString();
 
     case SOURCE_TYPE_CYC:
-      return QObject::tr("CYC%1").arg(index+1);
+      return tr("CYC%1").arg(index+1);
 
     case SOURCE_TYPE_PPM:
-      return RadioData::getElementName(QCoreApplication::translate("Trainer", "TR"), index + 1);
+      return RadioData::getElementName(tr("TR", "as in Trainer"), index + 1);
 
     case SOURCE_TYPE_CH:
     {
@@ -430,7 +430,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     }
 
     default:
-      return QObject::tr("???");
+      return tr("???");
   }
 }
 
@@ -545,7 +545,7 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
 
 RawSource RawSource::convert(RadioDataConversionState & cstate)
 {
-  cstate.setItemType("SRC", 1);
+  cstate.setItemType(tr("SRC"), 1);
   RadioDataConversionState::EventType evt = RadioDataConversionState::EVT_NONE;
   RadioDataConversionState::LogField oldData(index, toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType));
 

--- a/companion/src/firmwares/rawsource.h
+++ b/companion/src/firmwares/rawsource.h
@@ -184,6 +184,8 @@ enum RawSourceType {
 
 class RawSourceRange
 {
+  Q_DECLARE_TR_FUNCTIONS(RawSourceRange)
+
   public:
     RawSourceRange():
       decimals(0),
@@ -208,6 +210,8 @@ class RawSourceRange
 #define RANGE_ABS_FUNCTION        2
 
 class RawSource {
+  Q_DECLARE_TR_FUNCTIONS(RawSource)
+
   public:
     RawSource():
       type(SOURCE_TYPE_NONE),

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -80,7 +80,10 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         }
 
       case SWITCH_TYPE_VIRTUAL:
-        return RadioData::getElementName(QCoreApplication::translate("Logic Switch", "L"), index, NULL, true);
+        if (modelData)
+          return modelData->logicalSw[index].nameToString(index);
+        else
+          return LogicalSwitchData().nameToString(index);
 
       case SWITCH_TYPE_MULTIPOS_POT:
         if (!Boards::getCapability(board, Board::MultiposPotsPositions))
@@ -108,7 +111,10 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         return tr("One");
 
       case SWITCH_TYPE_FLIGHT_MODE:
-        return RadioData::getElementName(QCoreApplication::translate("Flight mode", "FM"), index - 1, modelData ? modelData->flightModeData[index-1].name : NULL);
+        if (modelData)
+          return modelData->flightModeData[index-1].nameToString(index - 1);
+        else
+          return FlightModeData().nameToString(index - 1);
 
       case SWITCH_TYPE_NONE:
         return tr("----");
@@ -117,7 +123,10 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         return CHECK_IN_ARRAY(timerModes, index);
 
       case SWITCH_TYPE_SENSOR:
-        return RadioData::getElementName(QCoreApplication::translate("Telemetry", "TELE"), index, modelData ? modelData->sensorData[index-1].label : NULL);
+        if (modelData)
+          return modelData->sensorData[index-1].nameToString(index-1);
+        else
+          return SensorData().nameToString(index-1);
 
       case SWITCH_TYPE_TELEMETRY:
         return tr("Telemetry");

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -37,21 +37,21 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
   };
 
   static const QString trimsSwitches[] = {
-    QObject::tr("RudTrim Left"), QObject::tr("RudTrim Right"),
-    QObject::tr("EleTrim Down"), QObject::tr("EleTrim Up"),
-    QObject::tr("ThrTrim Down"), QObject::tr("ThrTrim Up"),
-    QObject::tr("AilTrim Left"), QObject::tr("AilTrim Right"),
-    QObject::tr("Trim 5 Down"), QObject::tr("Trim 5 Up"),
-    QObject::tr("Trim 6 Down"), QObject::tr("Trim 6 Up")
+    tr("RudTrim Left"), tr("RudTrim Right"),
+    tr("EleTrim Down"), tr("EleTrim Up"),
+    tr("ThrTrim Down"), tr("ThrTrim Up"),
+    tr("AilTrim Left"), tr("AilTrim Right"),
+    tr("Trim 5 Down"), tr("Trim 5 Up"),
+    tr("Trim 6 Down"), tr("Trim 6 Up")
   };
 
   static const QString rotaryEncoders[] = {
-    QObject::tr("REa"), QObject::tr("REb")
+    tr("REa"), tr("REb")
   };
 
   static const QString timerModes[] = {
-    QObject::tr("OFF"), QObject::tr("ON"),
-    QObject::tr("THs"), QObject::tr("TH%"), QObject::tr("THt")
+    tr("OFF"), tr("ON"),
+    tr("THs"), tr("TH%"), tr("THt")
   };
 
   const QStringList directionIndicators = QStringList()
@@ -84,7 +84,7 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
 
       case SWITCH_TYPE_MULTIPOS_POT:
         if (!Boards::getCapability(board, Board::MultiposPotsPositions))
-          return QObject::tr("???");
+          return tr("???");
         qr = div(index - 1, Boards::getCapability(board, Board::MultiposPotsPositions));
         if (generalSettings && qr.quot < (int)DIM(generalSettings->potConfig))
           swName = QString(generalSettings->potName[qr.quot]);
@@ -99,19 +99,19 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         return CHECK_IN_ARRAY(rotaryEncoders, index-1);
 
       case SWITCH_TYPE_ON:
-        return QObject::tr("ON");
+        return tr("ON");
 
       case SWITCH_TYPE_OFF:
-        return QObject::tr("OFF");
+        return tr("OFF");
 
       case SWITCH_TYPE_ONE:
-        return QObject::tr("One");
+        return tr("One");
 
       case SWITCH_TYPE_FLIGHT_MODE:
         return RadioData::getElementName(QCoreApplication::translate("Flight mode", "FM"), index - 1, modelData ? modelData->flightModeData[index-1].name : NULL);
 
       case SWITCH_TYPE_NONE:
-        return QObject::tr("----");
+        return tr("----");
 
       case SWITCH_TYPE_TIMER_MODE:
         return CHECK_IN_ARRAY(timerModes, index);
@@ -120,10 +120,10 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         return RadioData::getElementName(QCoreApplication::translate("Telemetry", "TELE"), index, modelData ? modelData->sensorData[index-1].label : NULL);
 
       case SWITCH_TYPE_TELEMETRY:
-        return QObject::tr("Telemetry");
+        return tr("Telemetry");
 
       default:
-        return QObject::tr("???");
+        return tr("???");
     }
   }
 }
@@ -163,7 +163,7 @@ RawSwitch RawSwitch::convert(RadioDataConversionState & cstate)
   if (!index)
     return *this;
 
-  cstate.setItemType("SW", 2);
+  cstate.setItemType(tr("SW"), 2);
   RadioDataConversionState::EventType evt = RadioDataConversionState::EVT_NONE;
   RadioDataConversionState::LogField oldData(index, toString(cstate.fromType, cstate.fromGS(), cstate.fromModel()));
 

--- a/companion/src/firmwares/rawswitch.h
+++ b/companion/src/firmwares/rawswitch.h
@@ -49,6 +49,8 @@ enum RawSwitchType {
 };
 
 class RawSwitch {
+  Q_DECLARE_TR_FUNCTIONS(RawSwitch)
+
   public:
     RawSwitch():
       type(SWITCH_TYPE_NONE),

--- a/companion/src/firmwares/sensordata.cpp
+++ b/companion/src/firmwares/sensordata.cpp
@@ -32,53 +32,53 @@ QString SensorData::unitString() const
 {
   switch (unit) {
     case UNIT_VOLTS:
-      return QObject::tr("V");
+      return tr("V");
     case UNIT_AMPS:
-      return QObject::tr("A");
+      return tr("A");
     case UNIT_MILLIAMPS:
-      return QObject::tr("mA");
+      return tr("mA");
     case UNIT_KTS:
-      return QObject::tr("kts");
+      return tr("kts");
     case UNIT_METERS_PER_SECOND:
-      return QObject::tr("m/s");
+      return tr("m/s");
     case UNIT_KMH:
-      return QObject::tr("km/h");
+      return tr("km/h");
     case UNIT_MPH:
-      return QObject::tr("mph");
+      return tr("mph");
     case UNIT_METERS:
-      return QObject::tr("m");
+      return tr("m");
     case UNIT_FEET:
-      return QObject::tr("f");
+      return tr("f");
     case UNIT_CELSIUS:
-      return QObject::trUtf8("°C");
+      return trUtf8("°C");
     case UNIT_FAHRENHEIT:
-      return QObject::trUtf8("°F");
+      return trUtf8("°F");
     case UNIT_PERCENT:
-      return QObject::tr("%");
+      return tr("%");
     case UNIT_MAH:
-      return QObject::tr("mAh");
+      return tr("mAh");
     case UNIT_WATTS:
-      return QObject::tr("W");
+      return tr("W");
     case UNIT_MILLIWATTS:
-        return QObject::tr("mW");
+        return tr("mW");
     case UNIT_DB:
-      return QObject::tr("dB");
+      return tr("dB");
     case UNIT_RPMS:
-      return QObject::tr("rpms");
+      return tr("rpms");
     case UNIT_G:
-      return QObject::tr("g");
+      return tr("g");
     case UNIT_DEGREE:
-      return QObject::trUtf8("°");
+      return trUtf8("°");
     case UNIT_RADIANS:
-      return QObject::trUtf8("Rad");
+      return trUtf8("Rad");
     case UNIT_HOURS:
-      return QObject::tr("hours");
+      return tr("hours");
     case UNIT_MINUTES:
-      return QObject::tr("minutes");
+      return tr("minutes");
     case UNIT_SECONDS:
-      return QObject::tr("seconds");
+      return tr("seconds");
     case UNIT_CELLS:
-      return QObject::tr("V");
+      return tr("V");
     default:
       return "";
   }

--- a/companion/src/firmwares/sensordata.cpp
+++ b/companion/src/firmwares/sensordata.cpp
@@ -20,6 +20,8 @@
 
 #include "sensordata.h"
 
+#include "radiodata.h"
+
 void SensorData::updateUnit()
 {
   if (type == TELEM_TYPE_CALCULATED) {
@@ -82,4 +84,9 @@ QString SensorData::unitString() const
     default:
       return "";
   }
+}
+
+QString SensorData::nameToString(int index) const
+{
+  return RadioData::getElementName(tr("TELE"), index + 1, label);
 }

--- a/companion/src/firmwares/sensordata.h
+++ b/companion/src/firmwares/sensordata.h
@@ -24,7 +24,9 @@
 #include <QtCore>
 
 #define CPN_MAX_SENSORS       32
+
 class SensorData {
+  Q_DECLARE_TR_FUNCTIONS(SensorData)
 
   public:
 

--- a/companion/src/firmwares/sensordata.h
+++ b/companion/src/firmwares/sensordata.h
@@ -143,6 +143,7 @@ class SensorData {
     bool isAvailable() const { return strlen(label) > 0; }
     void updateUnit();
     QString unitString() const;
+    QString nameToString(int index) const;
     void clear() { memset(this, 0, sizeof(SensorData)); }
 };
 

--- a/companion/src/firmwares/telem_data.cpp
+++ b/companion/src/firmwares/telem_data.cpp
@@ -41,7 +41,7 @@ RawSourceRange FrSkyChannelData::getRange() const
   result.step = ratio / 255;
   result.min = offset * result.step;
   result.max = ratio + result.min;
-  result.unit = QObject::tr("V");
+  result.unit = tr("V");
   return result;
 }
 

--- a/companion/src/firmwares/telem_data.h
+++ b/companion/src/firmwares/telem_data.h
@@ -36,6 +36,8 @@ class FrSkyAlarmData {
 };
 
 class FrSkyChannelData {
+  Q_DECLARE_TR_FUNCTIONS(FrSkyChannelData)
+
   public:
     FrSkyChannelData() { clear(); }
     unsigned int ratio;                // 0.0 means not used, 0.1V steps EG. 6.6 Volts = 66. 25.1V = 251, etc.

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1326,7 +1326,7 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
 
   QString warning = storage.warning();
   if (!warning.isEmpty()) {
-    // TODO ShowEepromWarnings(this, tr("Warning"), warning);
+    // TODO EEPROMInterface::showEepromWarnings(this, tr("Warning"), warning);
   }
 
   if (resetCurrentFile) {
@@ -1577,11 +1577,11 @@ bool MdiChild::loadBackup()
 #if 0
   std::bitset<NUM_ERRORS> errorsEeprom((unsigned long long)LoadBackup(radioData, (uint8_t *)eeprom.data(), eeprom_size, index));
   if (!errorsEeprom.test(ALL_OK)) {
-    ShowEepromErrors(this, tr("Error"), tr("Invalid binary backup File %1").arg(fileName), (errorsEeprom).to_ulong());
+    EEPROMInterface::showEepromErrors(this, tr("Error"), tr("Invalid binary backup File %1").arg(fileName), (errorsEeprom).to_ulong());
     return false;
   }
   if (errorsEeprom.test(HAS_WARNINGS)) {
-    ShowEepromWarnings(this, tr("Warning"), errorsEeprom.to_ulong());
+    EEPROMInterface::showEepromWarnings(this, tr("Warning"), errorsEeprom.to_ulong());
   }
 
   refresh(true);

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -490,7 +490,7 @@ QString ModelPrinter::printFlightModeSwitch(const RawSwitch & swtch)
 
 QString ModelPrinter::printFlightModeName(int index)
 {
-  return model.flightModeData[index].toString(index);
+  return model.flightModeData[index].nameToString(index);
 }
 
 QString ModelPrinter::printFlightModes(unsigned int flightModes)


### PR DESCRIPTION
* Add Qt tr() functions to all radio data classes instead of using generic QObject type (`Q_DECLARE_TR_FUNCTIONS()`).  For translators this means more logical groupings of strings, instead of hundreds in the "QObject" group.
* GVarData, LimitData, LogicalSwitchData, and SensorData now print their own indexed name strings (instead of RawSource/RawSwitch doing it for them).

Found some more string printers in helpers.cpp which will need to be moved/removed (some aren't used).  And more places where QObject::tr() is used, often unnecessarily.  Those can wait for later I suppose, I wanted this to be mostly about the radio data structs (and limit the size as much as possible).

It looks big but there are no functional changes here, the only real difference is going to be for translators.