### PR TITLE
[Companion] Qualify all translation strings

### DIFF
--- a/companion/src/burnconfigdialog.cpp
+++ b/companion/src/burnconfigdialog.cpp
@@ -57,7 +57,7 @@ burnConfigDialog::burnConfigDialog(QWidget *parent) :
       ui->label_sb1->hide();
       ui->label_sb3->hide();
       ui->samba_location->hide();
-      ui->samba_port->hide();      
+      ui->samba_port->hide();
       ui->sb_browse->hide();
     }
     else if (IS_SKY9X(board)) {
@@ -181,7 +181,7 @@ void burnConfigDialog::getSettings()
       ui->pushButton_3->setEnabled(true);
     } else {
       ui->pushButton_3->setDisabled(true);
-    }    
+    }
 }
 
 void burnConfigDialog::putSettings()
@@ -358,7 +358,7 @@ void burnConfigDialog::on_advCtrChkB_toggled(bool checked)
     else {
       ui->label_av3->show();
       ui->avrdude_mcu->show();
-      QMessageBox::warning(this, tr("Companion"),
+      QMessageBox::warning(this, CPN_STR_APP_NAME,
         tr("<b><u>WARNING!</u></b><br>Normally CPU type is automatically selected according to the chosen firmware.<br>If you change the CPU type the resulting eeprom could be inconsistent."),
         QMessageBox::Ok);
     }

--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -33,6 +33,7 @@
 #include "mainwindow.h"
 #include "version.h"
 #include "appdata.h"
+#include "simulatorinterface.h"
 #include "storage.h"
 #include "translations.h"
 
@@ -75,7 +76,7 @@ int main(int argc, char *argv[])
     QString previousVersion;
     if (g.findPreviousVersionSettings(&previousVersion)) {
        QMessageBox msgBox;
-       msgBox.setText(QObject::tr("We have found existing settings for Companion version: %1.\nDo you want to import them?").arg(previousVersion));
+       msgBox.setText(QCoreApplication::translate("Companion", "We have found existing settings for Companion version: %1.\nDo you want to import them?").arg(previousVersion));
        msgBox.setIcon(QMessageBox::Information);
        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
        msgBox.setDefaultButton(QMessageBox::Yes);

--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -49,6 +49,12 @@
 #define CPN_MAX_MOUSE_ANALOGS          2
 #define CPN_MAX_ANALOGS                (CPN_MAX_STICKS + CPN_MAX_POTS + CPN_MAX_MOUSE_ANALOGS)
 
+#define CPN_STR_APP_NAME               QCoreApplication::translate("Companion", "OpenTX Companion")
+#define CPN_STR_TTL_INFO               QCoreApplication::translate("Companion", "Information")        // shared Title Case words, eg. for a window title or section heading
+#define CPN_STR_TTL_WARNING            QCoreApplication::translate("Companion", "Warning")
+#define CPN_STR_TTL_ERROR              QCoreApplication::translate("Companion", "Error")
+#define CPN_STR_TTL_CONFIRM            QCoreApplication::translate("Companion", "Please Confirm")
+
 #define CPN_STR_FILES                  QCoreApplication::translate("Companion", "files")
 #define CPN_STR_RAD_MOD_SETTINGS       QCoreApplication::translate("Companion", "Radio and Models settings")
 #define HEX_FILES_FILTER               "HEX " % CPN_STR_FILES % " (*.hex);;"

--- a/companion/src/customizesplashdialog.cpp
+++ b/companion/src/customizesplashdialog.cpp
@@ -74,7 +74,7 @@ bool Side::displayImage(QString fileName, Source pictSource)
     if (pictSource== PICT)
       *format = image.width()>WIDTH_9X ? LCDTARANIS : LCD9X;
     else if (pictSource == PROFILE)
-      *format = (g.profile[g.id()].fwType().contains("x9")) ? LCDTARANIS : LCD9X; 
+      *format = (g.profile[g.id()].fwType().contains("x9")) ? LCDTARANIS : LCD9X;
   }
 
   if (image.isNull()) {
@@ -88,17 +88,17 @@ bool Side::displayImage(QString fileName, Source pictSource)
 
   switch (pictSource) {
     case FW:
-      fileNameEdit->setText(QObject::tr("FW: %1").arg(fileName));
+      fileNameEdit->setText(CustomizeSplashDialog::tr("FW: %1").arg(fileName));
       *saveToFileName = fileName;
       *source = FW;
       break;
     case PICT:
-      fileNameEdit->setText(QObject::tr("Pict: %1").arg(fileName));
+      fileNameEdit->setText(CustomizeSplashDialog::tr("Pict: %1").arg(fileName));
       *saveToFileName = fileName;
       *source = PICT;
       break;
     case PROFILE:
-      fileNameEdit->setText(QObject::tr("Profile image"));
+      fileNameEdit->setText(CustomizeSplashDialog::tr("Profile image"));
       *saveToFileName = fileName;
       *source = PROFILE;
       break;
@@ -158,7 +158,7 @@ CustomizeSplashDialog::CustomizeSplashDialog(QWidget *parent) :
   setWindowIcon(CompanionIcon("paintbrush.png"));
   ui->leftLibraryButton->setIcon(CompanionIcon("library.png"));
   ui->rightLibraryButton->setIcon(CompanionIcon("library.png"));
-  
+
   left.imageLabel =  ui->leftImageLabel;
   right.imageLabel = ui->rightImageLabel;
   left.fileNameEdit =  ui->leftFileNameEdit;
@@ -169,7 +169,7 @@ CustomizeSplashDialog::CustomizeSplashDialog(QWidget *parent) :
   right.libraryButton = ui->rightLibraryButton;
   left.invertButton = ui->leftInvertButton;
   right.invertButton = ui->rightInvertButton;
-  
+
   left.loadFwButton =  ui->leftLoadFwButton;
   right.loadFwButton =  ui->rightLoadFwButton;
   left.loadPictButton =  ui->leftLoadPictButton;
@@ -203,7 +203,7 @@ void CustomizeSplashDialog::loadFirmware(Side side)
   QString fileName = QFileDialog::getOpenFileName(this, tr("Open Firmware File"), g.flashDir(), FLASH_FILES_FILTER);
   if (!fileName.isEmpty()) {
     if (!side.displayImage( fileName, FW ))
-      QMessageBox::critical(this, tr("Error"), tr("Can not load embedded image from firmware file %1.").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Can not load embedded image from firmware file %1.").arg(fileName));
     else
     g.flashDir( QFileInfo(fileName).dir().absolutePath() );
   }
@@ -223,7 +223,7 @@ void CustomizeSplashDialog::loadPicture(Side side)
 
   if (!fileName.isEmpty()) {
     if (!side.displayImage( fileName, PICT ))
-      QMessageBox::critical(this, tr("Error"), tr("Cannot load the image file %1.").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot load the image file %1.").arg(fileName));
     else
       g.imagesDir( QFileInfo(fileName).dir().absolutePath() );
   }
@@ -238,7 +238,7 @@ void CustomizeSplashDialog::loadProfile(Side side)
 
   if (!fileName.isEmpty()) {
     if (!side.displayImage( fileName, PROFILE ))
-      QMessageBox::critical(this, tr("Error"), tr("Cannot load profile image %1.").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot load profile image %1.").arg(fileName));
   }
   side.markSourceButton();
 }
@@ -252,7 +252,7 @@ void CustomizeSplashDialog::libraryButton_clicked( Side side )
   ld->exec();
   if (!fileName.isEmpty()) {
     if (!side.displayImage( fileName, UNDEFINED ))
-      QMessageBox::critical(this, tr("Error"), tr("Cannot load the library image %1.").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot load the library image %1.").arg(fileName));
   }
 }
 

--- a/companion/src/downloaddialog.cpp
+++ b/companion/src/downloaddialog.cpp
@@ -20,8 +20,10 @@
 
 #include "downloaddialog.h"
 #include "ui_downloaddialog.h"
-#include <QTime>
+#include "constants.h"
 #include "helpers.h"
+
+#include <QTime>
 
 downloadDialog::downloadDialog(QWidget *parent, QString src, QString tgt):
   QDialog(parent),
@@ -41,7 +43,7 @@ downloadDialog::downloadDialog(QWidget *parent, QString src, QString tgt):
 
     file = new QFile(tgt);
     if (!file->open(QIODevice::WriteOnly)) {
-      QMessageBox::critical(this, "Companion",
+      QMessageBox::critical(this, CPN_STR_APP_NAME,
           tr("Unable to save the file %1: %2.")
           .arg(tgt).arg(file->errorString()));
       QTimer::singleShot(0, this, SLOT(fileError()));
@@ -68,7 +70,7 @@ void downloadDialog::httpFinished()
     bool ok = true;
     if (reply->error()) {
         file->remove();
-        QMessageBox::information(this, tr("Companion"),
+        QMessageBox::information(this, CPN_STR_APP_NAME,
                                  tr("Download failed: %1.")
                                  .arg(reply->errorString()));
         ok = false;
@@ -111,7 +113,7 @@ void downloadDialog::closeEvent( QCloseEvent * event)
   // Delay closing 2 seconds to avoid unpleasant flashing download dialogs
   QTime closeTime= QTime::currentTime().addSecs(2);
   while( QTime::currentTime() < closeTime )
-    QCoreApplication::processEvents(QEventLoop::AllEvents, 100);   
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
 
   event->accept();
 }

--- a/companion/src/firmwares/eepromimportexport.h
+++ b/companion/src/firmwares/eepromimportexport.h
@@ -746,7 +746,7 @@ class ConversionField: public TransformedField {
 
       if (table) {
         if (!table->exportValue(_field, _field)) {
-          setError(error.isEmpty() ? tr("Conversion error on field %1").arg(name) : error);
+          setError(error.isEmpty() ? DataField::tr("Conversion error on field %1").arg(name) : error);
         }
         return;
       }

--- a/companion/src/firmwares/eeprominterface.cpp
+++ b/companion/src/firmwares/eeprominterface.cpp
@@ -113,7 +113,7 @@ void EEPROMInterface::showEepromWarnings(QWidget *parent, const QString &title, 
   QMessageBox msgBox(parent);
   msgBox.setWindowTitle(title);
   msgBox.setIcon(QMessageBox::Warning);
-  msgBox.setText(QT_TRANSLATE_NOOP("EepromInterface", "Warnings!"));
+  msgBox.setText(tr("Warnings!"));
   msgBox.setInformativeText(warningsList.join("\n"));
   msgBox.setStandardButtons(QMessageBox::Ok);
   msgBox.exec();

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -433,8 +433,8 @@ template <int N>
 class SwitchField: public ConversionField< SignedField<N> > {
   public:
     SwitchField(DataField * parent, RawSwitch & sw, Board::Type board, unsigned int version, unsigned long flags=0):
-      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), this->tr("Switch").toLatin1(),
-          this->tr("Switch ").toLatin1() + sw.toString(board) + this->tr(" cannot be exported on this board!").toLatin1()),
+      ConversionField< SignedField<N> >(parent, _switch, SwitchesConversionTable::getInstance(board, version, flags), DataField::tr("Switch").toLatin1(),
+          DataField::tr("Switch ").toLatin1() + sw.toString(board) + DataField::tr(" cannot be exported on this board!").toLatin1()),
       sw(sw),
       _switch(0),
       board(board)
@@ -597,7 +597,7 @@ class SourceField: public ConversionField< UnsignedField<N> > {
   public:
     SourceField(DataField * parent, RawSource & source, Board::Type board, unsigned int version, unsigned int variant, unsigned long flags=0):
       ConversionField< UnsignedField<N> >(parent, _source, SourcesConversionTable::getInstance(board, version, variant, flags),
-            this->tr("Source").toLatin1(), this->tr("Source %1 cannot be exported on this board!").arg(source.toString())),
+            DataField::tr("Source").toLatin1(), DataField::tr("Source %1 cannot be exported on this board!").arg(source.toString())),
       source(source),
       _source(0)
     {
@@ -1569,14 +1569,14 @@ class CurvesField: public TransformedField {
         if (IS_STM32(board) && version >= 216) {
           offset += (curve->type == CurveData::CURVE_TYPE_CUSTOM ? curve->count * 2 - 2 : curve->count);
           if (offset > maxPoints) {
-            setError(tr("OpenTX only accepts %1 points in all curves").arg(maxPoints));
+            setError(DataField::tr("OpenTX only accepts %1 points in all curves").arg(maxPoints));
             break;
           }
         }
         else {
           offset += (curve->type == CurveData::CURVE_TYPE_CUSTOM ? curve->count * 2 - 2 : curve->count) - 5;
           if (offset > maxPoints - 5 * maxCurves) {
-            setError(tr("OpenTx only accepts %1 points in all curves").arg(maxPoints));
+            setError(DataField::tr("OpenTx only accepts %1 points in all curves").arg(maxPoints));
             break;
           }
           _curves[i] = offset;
@@ -2154,11 +2154,11 @@ class ArmCustomFunctionField: public TransformedField {
 
       if (version >= 218) {
         internalField.Append(new SwitchField<9>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<7> >(this, _func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<7> >(this, _func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
       }
       else {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<8> >(this, _func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<8> >(this, _func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
       }
 
       if (IS_TARANIS(board) && version >= 216)
@@ -2394,7 +2394,7 @@ class AvrCustomFunctionField: public TransformedField {
     {
       if (version >= 217 && IS_2560(board)) {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<8> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<8> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new UnsignedField<2>(this, fn.adjustMode));
         internalField.Append(new UnsignedField<4>(this, _union_param));
         internalField.Append(new UnsignedField<1>(this, _active));
@@ -2402,18 +2402,18 @@ class AvrCustomFunctionField: public TransformedField {
       }
       else if (version >= 216) {
         internalField.Append(new SwitchField<6>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<4> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<4> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new UnsignedField<5>(this, _union_param));
         internalField.Append(new UnsignedField<1>(this, _active));
       }
       else if (version >= 213) {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
         internalField.Append(new UnsignedField<3>(this, _union_param));
-        internalField.Append(new ConversionField< UnsignedField<5> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<5> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
       }
       else {
         internalField.Append(new SwitchField<8>(this, fn.swtch, board, version));
-        internalField.Append(new ConversionField< UnsignedField<7> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", tr("OpenTX on this board doesn't accept this function")));
+        internalField.Append(new ConversionField< UnsignedField<7> >(this, (unsigned int &)fn.func, &functionsConversionTable, "Function", DataField::tr("OpenTX on this board doesn't accept this function")));
         internalField.Append(new BoolField<1>(this, (bool &)fn.enabled));
       }
       internalField.Append(new UnsignedField<8>(this, _param));
@@ -3137,7 +3137,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
   if (IS_ARM(board))
     internalField.Append(new UnsignedField<3>(this, modelData.telemetryProtocol));
   else
-    internalField.Append(new ConversionField< UnsignedField<3> >(this, (unsigned int &)modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this telemetry protocol")));
+    internalField.Append(new ConversionField< UnsignedField<3> >(this, (unsigned int &)modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", DataField::tr("OpenTX doesn't accept this telemetry protocol")));
 
   internalField.Append(new BoolField<1>(this, modelData.thrTrim));
 
@@ -3150,7 +3150,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
     internalField.Append(new SpareBitsField<4>(this));
   }
   else {
-    internalField.Append(new ConversionField< SignedField<4> >(this, modelData.moduleData[0].channelsCount, &channelsConversionTable, "Channels number", tr("OpenTX doesn't allow this number of channels")));
+    internalField.Append(new ConversionField< SignedField<4> >(this, modelData.moduleData[0].channelsCount, &channelsConversionTable, "Channels number", DataField::tr("OpenTX doesn't allow this number of channels")));
   }
 
   if (version >= 216)
@@ -3272,7 +3272,7 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
       internalField.Append(new UnsignedField<2>(this, modelData.potsWarningMode));
     }
     else {
-      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[1].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
+      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[1].protocol, &protocolsConversionTable, "Protocol", DataField::tr("OpenTX doesn't accept this radio protocol")));
       internalField.Append(new UnsignedField<8>(this, modelData.trainerMode));
     }
   }
@@ -3284,14 +3284,14 @@ OpenTxModelData::OpenTxModelData(ModelData & modelData, Board::Type board, unsig
     }
     else if (version >= 216) {
       modulesCount = 3;
-      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
+      internalField.Append(new ConversionField< SignedField<8> >(this, modelData.moduleData[0].protocol, &protocolsConversionTable, "Protocol", DataField::tr("OpenTX doesn't accept this radio protocol")));
     }
   }
 
   if (IS_ARM(board) && version >= 215) {
     for (int module=0; module<modulesCount; module++) {
       if (version >= 217) {
-        internalField.Append(new ConversionField<SignedField<4> >(this, modelData.moduleData[module].protocol, &protocolsConversionTable, "Protocol", tr("OpenTX doesn't accept this radio protocol")));
+        internalField.Append(new ConversionField<SignedField<4> >(this, modelData.moduleData[module].protocol, &protocolsConversionTable, "Protocol", DataField::tr("OpenTX doesn't accept this radio protocol")));
         internalField.Append(new SignedField<4>(this, subprotocols[module]));
       }
       else {

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -22,6 +22,7 @@
 #include "opentxeeprom.h"
 #include "rlefile.h"
 #include "appdata.h"
+#include "constants.h"
 #include <bitset>
 #include <QMessageBox>
 #include <QTime>
@@ -234,7 +235,7 @@ unsigned long OpenTxEepromInterface::load(RadioData &radioData, const uint8_t * 
   if (version_error == OLD_VERSION) {
     errors.set(version_error);
     errors.set(HAS_WARNINGS);
-    showEepromWarnings(NULL, tr("Warning"), errors.to_ulong());
+    showEepromWarnings(NULL, CPN_STR_TTL_WARNING, errors.to_ulong());
   }
   else if (version_error == NOT_OPENTX) {
     dbg << " not open9x";
@@ -298,7 +299,7 @@ void OpenTxEepromInterface::showErrors(const QString & title, const QStringList 
   }
 
   QMessageBox::warning(NULL,
-                       tr("Error"),
+                       CPN_STR_TTL_ERROR,
                        title + "\n" + msg);
 }
 

--- a/companion/src/firmwares/opentx/opentxinterface.h
+++ b/companion/src/firmwares/opentx/opentxinterface.h
@@ -23,11 +23,15 @@
 
 #include "eeprominterface.h"
 
+#include <QtCore>
+
 class RleFile;
 class OpenTxFirmware;
 
 class OpenTxEepromInterface : public EEPROMInterface
 {
+  Q_DECLARE_TR_FUNCTIONS(OpenTxEepromInterface)
+
   public:
 
     OpenTxEepromInterface(OpenTxFirmware * firmware);
@@ -35,17 +39,17 @@ class OpenTxEepromInterface : public EEPROMInterface
     virtual ~OpenTxEepromInterface();
 
     virtual unsigned long load(RadioData &, const uint8_t * eeprom, int size);
-    
+
     bool loadModelFromBackup(ModelData & model, const uint8_t * data, unsigned int size, uint8_t version, uint32_t variant);
-    
+
     virtual unsigned long loadBackup(RadioData &, const uint8_t * eeprom, int esize, int index);
-    
+
     virtual int save(uint8_t * eeprom, const RadioData & radioData, uint8_t version=0, uint32_t variant=0);
 
     virtual int getSize(const ModelData &);
 
     virtual int getSize(const GeneralSettings &);
-    
+
   protected:
 
     const char * getName();
@@ -53,33 +57,35 @@ class OpenTxEepromInterface : public EEPROMInterface
     EepromLoadErrors checkVersion(unsigned int version);
 
     bool checkVariant(unsigned int version, unsigned int variant);
-    
+
     template <class T, class M>
     bool loadFromByteArray(T & dest, const QByteArray & data, uint8_t version, uint32_t variant=0);
-    
+
   public:
     template <class T, class M>
     bool loadFromByteArray(T & dest, const QByteArray & data);
-    
+
     template <class T, class M>
     bool saveToByteArray(const T & src, QByteArray & data, uint8_t version=0);
 
     bool loadRadioSettingsFromRLE(GeneralSettings & settings, RleFile * rleFile, uint8_t version);
-    
+
     bool loadModelFromRLE(ModelData & model, RleFile * rleFile, unsigned int index, uint8_t version, uint32_t variant);
 
     void showErrors(const QString & title, const QStringList & errors);
-    
+
     uint8_t getLastDataVersion(Board::Type board);
-    
+
     RleFile * efile;
-    
+
     OpenTxFirmware * firmware;
 
 };
 
 class OpenTxFirmware: public Firmware
 {
+  Q_DECLARE_TR_FUNCTIONS(OpenTxFirmware)
+
   public:
     OpenTxFirmware(const QString & id, OpenTxFirmware * parent):
       Firmware(parent, id, parent->getName(), parent->getBoard())
@@ -124,9 +130,9 @@ class OpenTxFirmware: public Firmware
     virtual QString getFirmwareUrl();
 
     virtual int getCapability(Capability);
-    
+
     virtual QString getAnalogInputName(unsigned int index);
-    
+
     virtual QTime getMaxTimerStart();
 
     virtual int isAvailable(PulsesProtocol proto, int port=0);

--- a/companion/src/flasheepromdialog.cpp
+++ b/companion/src/flasheepromdialog.cpp
@@ -118,7 +118,7 @@ int FlashEEpromDialog::getEEpromVersion(const QString & filename)
     result = radioData->generalSettings.version;
   }
   else {
-    QMessageBox::warning(this, tr("Error"), storage.error());
+    QMessageBox::warning(this, CPN_STR_TTL_ERROR, storage.error());
   }
   return result;
 }
@@ -163,7 +163,7 @@ bool FlashEEpromDialog::patchCalibration()
     return true;
   }
   else {
-    QMessageBox::critical(this, tr("Warning"), tr("Wrong radio calibration data in profile, Settings not patched"));
+    QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Wrong radio calibration data in profile, Settings not patched"));
     return false;
   }
 }
@@ -208,7 +208,7 @@ bool FlashEEpromDialog::patchHardwareSettings()
     return true;
   }
   else {
-    QMessageBox::critical(this, tr("Warning"), tr("Wrong radio setting data in profile, Settings not patched"));
+    QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Wrong radio setting data in profile, Settings not patched"));
     return false;
   }
 }
@@ -233,13 +233,13 @@ void FlashEEpromDialog::on_burnButton_clicked()
       return;
     }
     if (!file.open(QIODevice::WriteOnly)) {
-      QMessageBox::warning(this, tr("Error"), tr("Cannot write file %1:\n%2.").arg(filename).arg(file.errorString()));
+      QMessageBox::warning(this, CPN_STR_TTL_ERROR, tr("Cannot write file %1:\n%2.").arg(filename).arg(file.errorString()));
       return;
     }
     QTextStream outputStream(&file);
     long result = file.write((char*)eeprom, eeprom_size);
     if (result != eeprom_size) {
-      QMessageBox::warning(this, tr("Error"), tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
+      QMessageBox::warning(this, CPN_STR_TTL_ERROR, tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
       return;
     }
   }
@@ -277,16 +277,16 @@ void FlashEEpromDialog::on_burnButton_clicked()
     if (convertEEprom(filename, compatEEprom, firmwareFilename)) {
       int compatVersion = getEEpromVersion(compatEEprom);
       if ((compatVersion / 100) != (eepromVersion / 100)) {
-        QMessageBox::warning(this, tr("Warning"), tr("The radio firmware belongs to another product family, check file and preferences!"));
+        QMessageBox::warning(this, CPN_STR_TTL_WARNING, tr("The radio firmware belongs to another product family, check file and preferences!"));
         return;
       }
       else if (compatVersion < eepromVersion) {
-        QMessageBox::warning(this, tr("Warning"), tr("The radio firmware is outdated, please upgrade!"));
+        QMessageBox::warning(this, CPN_STR_TTL_WARNING, tr("The radio firmware is outdated, please upgrade!"));
         return;
       }
       filename = compatEEprom;
     }
-    else if (QMessageBox::question(this, "Error", tr("Cannot check Models and Settings compatibility! Continue anyway?"), QMessageBox::Yes|QMessageBox::No) == QMessageBox::No) {
+    else if (QMessageBox::question(this, CPN_STR_TTL_ERROR, tr("Cannot check Models and Settings compatibility! Continue anyway?"), QMessageBox::Yes|QMessageBox::No) == QMessageBox::No) {
       return;
     }
     qunlink(firmwareFilename);

--- a/companion/src/flashfirmwaredialog.cpp
+++ b/companion/src/flashfirmwaredialog.cpp
@@ -142,7 +142,7 @@ void FlashFirmwareDialog::on_firmwareLoad_clicked()
   if (!fileName.isEmpty()) {
     fwName = fileName;
     if (!fwName.isEmpty() && !fwName.endsWith(".dfu") && !FirmwareInterface(fwName).isValid()) {
-      QMessageBox::warning(this, tr("Warning"), tr("%1 may not be a valid firmware file").arg(fwName));
+      QMessageBox::warning(this, CPN_STR_TTL_WARNING, tr("%1 may not be a valid firmware file").arg(fwName));
     }
     updateUI();
   }
@@ -152,10 +152,10 @@ void FlashFirmwareDialog::on_useFirmwareSplash_clicked()
 {
   FirmwareInterface firmware(fwName);
   if (!firmware.isValid()) {
-    QMessageBox::warning(this, tr("Error"), tr( "The firmware file is not valid." ));
+    QMessageBox::warning(this, CPN_STR_TTL_ERROR, tr( "The firmware file is not valid." ));
   }
   else if (!firmware.hasSplash()) {
-    QMessageBox::warning(this, tr("Error"), tr( "There is no start screen image in the firmware file." ));
+    QMessageBox::warning(this, CPN_STR_TTL_ERROR, tr( "There is no start screen image in the firmware file." ));
   }
   else {
     imageSource = FIRMWARE;
@@ -169,7 +169,7 @@ void FlashFirmwareDialog::on_useProfileSplash_clicked()
   if (!fileName.isEmpty()) {
     QImage image(fileName);
     if (image.isNull()) {
-      QMessageBox::critical(this, tr("Error"), tr("Profile image %1 is invalid.").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Profile image %1 is invalid.").arg(fileName));
     }
     else {
       imageSource = PROFILE;
@@ -189,12 +189,12 @@ void FlashFirmwareDialog::on_useExternalSplash_clicked()
     g.imagesDir( QFileInfo(fileName).dir().absolutePath() );
     QImage image(fileName);
     if (image.isNull()) {
-      QMessageBox::critical(this, tr("Error"), tr("Image could not be loaded from %1").arg(fileName));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Image could not be loaded from %1").arg(fileName));
     }
     else{
       imageSource = EXTERNAL;
       imageFile = fileName;
-    }  
+    }
   }
   updateUI();
 }
@@ -207,7 +207,7 @@ void FlashFirmwareDialog::on_useLibrarySplash_clicked()
   if (!fileName.isEmpty()) {
     QImage image(fileName);
     if (image.isNull()) {
-      QMessageBox::critical(this, tr("Error"), tr("The library image could not be loaded"));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("The library image could not be loaded"));
     }
     else {
       imageSource = LIBRARY;
@@ -234,7 +234,7 @@ void FlashFirmwareDialog::on_burnButton_clicked()
       image = pixmap->toImage().scaled(ui->splash->width(), ui->splash->height());
     }
     if (image.isNull()) {
-      QMessageBox::critical(this, tr("Warning"), tr("Splash image not found"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Splash image not found"));
       return;
     }
     // write the customized firmware
@@ -247,7 +247,7 @@ void FlashFirmwareDialog::on_burnButton_clicked()
     FirmwareInterface firmware(fwName);
     firmware.setSplash(image);
     if (firmware.save(tempFile) <= 0) {
-      QMessageBox::critical(this, tr("Warning"), tr("Cannot save customized firmware"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Cannot save customized firmware"));
       return;
     }
     startFlash(tempFile);
@@ -304,7 +304,7 @@ void FlashFirmwareDialog::startFlash(const QString &filename)
     backupPath = g.profile[g.id()].pBackupDir();
     if (backupPath.isEmpty()) {
       backupPath=g.backupDir();
-    }     
+    }
     backupFilename = backupPath + "/backup-" + QDateTime().currentDateTime().toString("yyyy-MM-dd-HHmmss") + ".bin";
     result = readEeprom(backupFilename, progressDialog.progress());
     sleep(2);

--- a/companion/src/generaledit/calibration.cpp
+++ b/companion/src/generaledit/calibration.cpp
@@ -41,7 +41,7 @@ CalibrationPanel::CalibrationPanel(QWidget * parent, GeneralSettings & generalSe
   tableWidget->setFrameStyle(QFrame::NoFrame | QFrame::Plain);
   tableWidget->setStyleSheet("QTableWidget {background-color: transparent;}");
   QStringList headerLabels;
-  headerLabels << QObject::tr("Negative span") << QObject::tr("Mid value") << QObject::tr("Positive span");
+  headerLabels << tr("Negative span") << tr("Mid value") << tr("Positive span");
   tableWidget->setHorizontalHeaderLabels(headerLabels);
 
   int rows = CPN_MAX_STICKS + getBoardCapability(getCurrentBoard(), Board::Pots) + getBoardCapability(getCurrentBoard(), Board::Sliders) + getBoardCapability(getCurrentBoard(), Board::MouseAnalogs);

--- a/companion/src/generaledit/generaledit.cpp
+++ b/companion/src/generaledit/generaledit.cpp
@@ -151,7 +151,7 @@ void GeneralEdit::on_calretrieve_PB_clicked()
       }
       generalSettings.PPM_Multiplier=PPM_Multiplier;
     } else {
-      QMessageBox::critical(this, tr("Warning"), tr("Wrong data in profile, radio calibration was not retrieved"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Wrong data in profile, radio calibration was not retrieved"));
     }
     if (hwtypes.length()==numSwPots) {
       QString Byte;
@@ -193,7 +193,7 @@ void GeneralEdit::on_calretrieve_PB_clicked()
         }
       }
     } else {
-      QMessageBox::critical(this, tr("Warning"), tr("Wrong data in profile, Switch/pot config not retrieved"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Wrong data in profile, Switch/pot config not retrieved"));
     }
     if ((DisplaySet.length()==6) && (BeeperSet.length()==4) && (HapticSet.length()==6) && (SpeakerSet.length()==6)) {
       generalSettings.stickMode=GSStickMode;
@@ -234,7 +234,7 @@ void GeneralEdit::on_calretrieve_PB_clicked()
       }
     }
     else {
-      QMessageBox::critical(this, tr("Warning"), tr("Wrong data in profile, hw related parameters were not retrieved"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Wrong data in profile, hw related parameters were not retrieved"));
     }
   }
 
@@ -256,7 +256,7 @@ void GeneralEdit::on_calstore_PB_clicked()
     QString hwtypes=g.profile[profile_id].controlTypes();
     QString controlNames=g.profile[profile_id].controlNames();
     if (!(calib.isEmpty())) {
-      int ret = QMessageBox::question(this, "Companion",
+      int ret = QMessageBox::question(this, CPN_STR_APP_NAME,
                       tr("Do you want to store calibration in %1 profile<br>overwriting existing calibration?").arg(name) ,
                       QMessageBox::Yes | QMessageBox::No);
       if (ret == QMessageBox::No) {
@@ -311,6 +311,6 @@ void GeneralEdit::on_calstore_PB_clicked()
 
     QDateTime dateTime = QDateTime::currentDateTime();
     g.profile[profile_id].timeStamp(dateTime.toString("yyyy-MM-dd hh:mm"));
-    QMessageBox::information(this, "Companion", tr("Calibration and HW parameters saved."));
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("Calibration and HW parameters saved."));
   }
 }

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -182,7 +182,7 @@ ui(new Ui::GeneralSetup)
     ui->BLBright_SB->setDisabled(true);
     ui->label_BLBright->hide();
   }
-  
+
   if (!IS_HORUS(firmware->getBoard())) {
     ui->OFFBright_SB->hide();
     ui->OFFBright_SB->setDisabled(true);
@@ -311,7 +311,7 @@ GeneralSetupPanel::~GeneralSetupPanel()
 void GeneralSetupPanel::populateBacklightCB()
 {
   QComboBox * b = ui->backlightswCB;
-  QString strings[] = { QObject::tr("OFF"), QObject::tr("Keys"), QObject::tr("Sticks"), QObject::tr("Keys + Sticks"), QObject::tr("ON"), NULL };
+  QString strings[] = { tr("OFF"), tr("Keys"), tr("Sticks"), tr("Keys + Sticks"), tr("ON"), NULL };
 
   b->clear();
   for (int i=0; !strings[i].isNull(); i++) {
@@ -325,7 +325,7 @@ void GeneralSetupPanel::populateBacklightCB()
 void GeneralSetupPanel::populateVoiceLangCB()
 {
   QComboBox * b = ui->voiceLang_CB;
-  QString strings[] = { QObject::tr("English"), QObject::tr("Dutch"), QObject::tr("French"), QObject::tr("Italian"), QObject::tr("German"), QObject::tr("Czech"), QObject::tr("Slovak"), QObject::tr("Spanish"), QObject::tr("Polish"), QObject::tr("Portuguese"), QObject::tr("Swedish"), QObject::tr("Hungarian"), NULL};
+  QString strings[] = { tr("English"), tr("Dutch"), tr("French"), tr("Italian"), tr("German"), tr("Czech"), tr("Slovak"), tr("Spanish"), tr("Polish"), tr("Portuguese"), tr("Swedish"), tr("Hungarian"), NULL};
   QString langcode[] = { "en", "nl","fr", "it", "de", "cz", "sk", "es", "pl", "pt", "se", "hu", NULL};
 
   b->clear();
@@ -389,7 +389,7 @@ void GeneralSetupPanel::updateVarioPitchRange()
 
 void GeneralSetupPanel::populateRotEncCB(int reCount)
 {
-  QString strings[] = { QObject::tr("No"), QObject::tr("RotEnc A"), QObject::tr("Rot Enc B"), QObject::tr("Rot Enc C"), QObject::tr("Rot Enc D"), QObject::tr("Rot Enc E")};
+  QString strings[] = { tr("No"), tr("RotEnc A"), tr("Rot Enc B"), tr("Rot Enc C"), tr("Rot Enc D"), tr("Rot Enc E")};
   QComboBox * b = ui->re_CB;
 
   b->clear();

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -429,7 +429,7 @@ void GeneralSetupPanel::setValues()
 void GeneralSetupPanel::on_faimode_CB_stateChanged(int)
 {
   if (ui->faimode_CB->isChecked()) {
-    int ret = QMessageBox::question(this, "Companion",
+    int ret = QMessageBox::question(this, CPN_STR_APP_NAME,
      tr("If you enable FAI, you loose the vario, the play functions, the telemetry screen.\nThis function cannot be disabled by the radio.\nAre you sure ?") ,
      QMessageBox::Yes | QMessageBox::No);
     if (ret==QMessageBox::Yes) {

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -29,6 +29,7 @@
 #include "appdata.h"
 #include "macros.h"
 #include "helpers.h"
+#include "simulatorinterface.h"
 #include "simulatormainwindow.h"
 #include "storage/sdcard.h"
 
@@ -363,12 +364,13 @@ QString Helpers::getAdjustmentString(int16_t val, const ModelData * model, bool 
   return ret;
 }
 
+// TODO: Move lookup to GVarData class (w/out combobox)
 void Helpers::populateGvarUseCB(QComboBox * b, unsigned int phase)
 {
-  b->addItem(QObject::tr("Own value"));
+  b->addItem(QCoreApplication::translate("GVarData", "Own value"));
   for (int i=0; i<getCurrentFirmware()->getCapability(FlightModes); i++) {
     if (i != (int)phase) {
-      b->addItem(QObject::tr("Flight mode %1 value").arg(i));
+      b->addItem(QCoreApplication::translate("GVarData", "Flight mode %1 value").arg(i));
     }
   }
 }
@@ -516,58 +518,30 @@ int findmult(float value, float base)
   return mult;
 }
 
+// TODO: Move to FrSkyAlarmData
 QString getFrSkyAlarmType(int alarm)
 {
   switch (alarm) {
     case 1:
-      return QObject::tr("Yellow");
+      return QCoreApplication::translate("FrSkyAlarmData", "Yellow");
     case 2:
-      return QObject::tr("Orange");
+      return QCoreApplication::translate("FrSkyAlarmData", "Orange");
     case 3:
-      return QObject::tr("Red");
+      return QCoreApplication::translate("FrSkyAlarmData", "Red");
     default:
       return "----";
   }
 }
 
+// TODO: move to FrSkyChannelData
 QString getFrSkyUnits(int units)
 {
   switch(units) {
     case 1:
-      return QObject::tr("---");
+      return QCoreApplication::translate("FrSkyChannelData", "---");
     default:
-      return "V";
+      return QCoreApplication::translate("FrSkyChannelData", "V");
   }
-}
-
-QString getFrSkyProtocol(int protocol)
-{
-  switch(protocol) {
-    case 2:
-      if ((getCurrentFirmware()->getCapability(Telemetry) & TM_HASWSHH))
-        return QObject::tr("Winged Shadow How High");
-      else
-        return QObject::tr("Winged Shadow How High (not supported)");
-    case 1:
-      return QObject::tr("FrSky Sensor Hub");
-    default:
-      return QObject::tr("None");
-  }
-}
-
-QString getFrSkyMeasure(int units)
-{
-  switch(units) {
-    case 1:
-      return QObject::tr("Imperial");
-    default:
-      return QObject::tr("Metric");
-  }
-}
-
-QString getFrSkySrc(int index)
-{
-  return RawSource(SOURCE_TYPE_TELEMETRY, index-1).toString();
 }
 
 QString getTheme()
@@ -608,8 +582,8 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
   QString fwId = SimulatorLoader::findSimulatorByFirmwareName(getCurrentFirmware()->getId());
   if (fwId.isEmpty()) {
     QMessageBox::warning(NULL,
-                         QObject::tr("Warning"),
-                         QObject::tr("Simulator for this firmware is not yet available"));
+                         CPN_STR_TTL_WARNING,
+                         QCoreApplication::translate("Companion", "Simulator for this firmware is not yet available"));
     return;
   }
 
@@ -633,15 +607,15 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
   QString resultMsg;
   if (dialog->getExitStatus(&resultMsg)) {
     if (resultMsg.isEmpty())
-      resultMsg = QObject::tr("Uknown error during Simulator startup.");
-    QMessageBox::critical(NULL, QObject::tr("Simulator Error"), resultMsg);
+      resultMsg = QCoreApplication::translate("Companion", "Uknown error during Simulator startup.");
+    QMessageBox::critical(NULL, QCoreApplication::translate("Companion", "Simulator Error"), resultMsg);
     dialog->deleteLater();
   }
    else if (dialog->setRadioData(simuData)) {
     dialog->show();
   }
   else {
-    QMessageBox::critical(NULL, QObject::tr("Data Load Error"), QObject::tr("Error occurred while starting simulator."));
+    QMessageBox::critical(NULL, QCoreApplication::translate("Companion", "Data Load Error"), QCoreApplication::translate("Companion", "Error occurred while starting simulator."));
     dialog->deleteLater();
   }
 }

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -149,9 +149,6 @@ int findmult(float value, float base);
 /* FrSky helpers */
 QString getFrSkyAlarmType(int alarm);
 QString getFrSkyUnits(int units);
-QString getFrSkyProtocol(int protocol);
-QString getFrSkyMeasure(int units);
-QString getFrSkySrc(int index);
 
 void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx);
 

--- a/companion/src/logsdialog.cpp
+++ b/companion/src/logsdialog.cpp
@@ -336,7 +336,7 @@ void LogsDialog::exportToGoogleEarth()
   }
   QFile geFile(geFilename);
   if (!geFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-    QMessageBox::warning(this, tr("Error"),
+    QMessageBox::warning(this, CPN_STR_TTL_ERROR,
         tr("Cannot write file %1:\n%2.")
         .arg(geFilename)
         .arg(geFile.errorString()));
@@ -354,7 +354,7 @@ void LogsDialog::exportToGoogleEarth()
   outputStream << "\t\t<Style id=\"lineStyle\">\n\t\t\t<LineStyle>\n\t\t\t\t<color>991081f4</color>\n\t\t\t\t<width>6</width>\n\t\t\t</LineStyle>\n\t\t</Style>\n";
   outputStream << "\t\t<Schema id=\"schema\">\n";
   outputStream << "\t\t\t<gx:SimpleArrayField name=\"GPSSpeed\" type=\"float\">\n\t\t\t\t<displayName>GPS Speed</displayName>\n\t\t\t</gx:SimpleArrayField>\n";
-  
+
   // declare additional fields
   for (int i=0; i<dataPoints.at(0).count()-2; i++) {
     if (ui->FieldsTW->item(i, 0) && ui->FieldsTW->item(i, 0)->isSelected() && !nondataCols.contains(i+2)) {
@@ -504,7 +504,7 @@ void LogsDialog::updateCursorsLabel()
   ui->labelCursors->setText(text);
 }
 
-QString LogsDialog::formatTimeDelta(double timeDelta) 
+QString LogsDialog::formatTimeDelta(double timeDelta)
 {
   if (abs(int(timeDelta)) < 10) {
     return QString("%1 s").arg(timeDelta, 1, 'f', 1);
@@ -698,7 +698,7 @@ bool LogsDialog::cvsFileParse()
 
   file.close();
   if (errors > 1) {
-    QMessageBox::warning(this, "Companion", tr("The selected logfile contains %1 invalid lines out of  %2 total lines").arg(errors).arg(lines));
+    QMessageBox::warning(this, CPN_STR_APP_NAME, tr("The selected logfile contains %1 invalid lines out of  %2 total lines").arg(errors).arg(lines));
   }
 
   int n = csvlog.count();
@@ -719,10 +719,10 @@ struct FlightSession {
   QDateTime end;
 };
 
-QDateTime LogsDialog::getRecordTimeStamp(int index) 
+QDateTime LogsDialog::getRecordTimeStamp(int index)
 {
   QString tstamp = csvlog.at(index).at(0) + " " + csvlog.at(index).at(1);
-  if (csvlog.at(index).at(1).contains(".")) 
+  if (csvlog.at(index).at(1).contains("."))
     return QDateTime::fromString(tstamp, "yyyy-MM-dd HH:mm:ss.zzz");
   return QDateTime::fromString(tstamp, "yyyy-MM-dd HH:mm:ss");
 }
@@ -732,10 +732,10 @@ QString LogsDialog::generateDuration(const QDateTime & start, const QDateTime & 
   int secs = start.secsTo(end);
   QString durationString;
   if (secs >= 3600) {
-    durationString = QString("%1:").arg(secs/3600); 
+    durationString = QString("%1:").arg(secs/3600);
     secs %= 3600;
   }
-  durationString += QString("%1:%2").arg(secs/60, 2, 10, QChar('0')).arg(secs%60, 2, 10, QChar('0'));  
+  durationString += QString("%1:%2").arg(secs/60, 2, 10, QChar('0')).arg(secs%60, 2, 10, QChar('0'));
   return durationString;
 }
 
@@ -1126,7 +1126,7 @@ void LogsDialog::addMaxAltitudeMarker(const coords & c, QCPGraph * graph) {
       // qDebug() << "max alt: " << maxAlt << "@" << result;
     }
   }
-  // qDebug() << "max alt: " << maxAlt << "@" << positionIndex; 
+  // qDebug() << "max alt: " << maxAlt << "@" << positionIndex;
 
   // add max altitude marker
   tracerMaxAlt = new QCPItemTracer(ui->customPlot);

--- a/companion/src/logsdialog.cpp
+++ b/companion/src/logsdialog.cpp
@@ -844,7 +844,7 @@ void LogsDialog::plotLogs()
   plots.max_x = 0;
 
   foreach (QTableWidgetItem *plot, ui->FieldsTW->selectedItems()) {
-    coords plotCoords;
+    coords_t plotCoords;
     int plotColumn = plot->row() + 2; // Date and Time first
 
     plotCoords.min_y = INVALID_MIN;
@@ -1113,7 +1113,7 @@ void LogsDialog::yAxisChangeRanges(QCPRange range)
 }
 
 
-void LogsDialog::addMaxAltitudeMarker(const coords & c, QCPGraph * graph) {
+void LogsDialog::addMaxAltitudeMarker(const coords_t & c, QCPGraph * graph) {
   // find max altitude
   int positionIndex = 0;
   double maxAlt = -100000;
@@ -1141,7 +1141,7 @@ void LogsDialog::addMaxAltitudeMarker(const coords & c, QCPGraph * graph) {
   tracerMaxAlt->updatePosition();
 }
 
-void LogsDialog::countNumberOfThrows(const coords & c, QCPGraph * graph)
+void LogsDialog::countNumberOfThrows(const coords_t & c, QCPGraph * graph)
 {
 #if 0
   // find all launches

--- a/companion/src/logsdialog.h
+++ b/companion/src/logsdialog.h
@@ -22,39 +22,11 @@
 #define _LOGSDIALOG_H_
 
 #include <QtCore>
-#include <QtGui>
+#include <QDialog>
 #include "qcustomplot.h"
 
 #define INVALID_MIN 999999
 #define INVALID_MAX -999999
-
-enum yaxes_t {
-  firstLeft = 0,
-  firstRight,
-  secondLeft,
-  secondRight,
-  AXES_LIMIT // = 4
-};
-
-struct coords {
-  QVector<double> x, y;
-  double min_y;
-  double max_y;
-  yaxes_t yaxis;
-  QString name;
-};
-
-struct minMax {
-  double min;
-  double max;
-};
-
-struct plotsCollection {
-  QVarLengthArray<struct coords> coords;
-  double min_x;
-  double max_x;
-  bool tooManyRanges;
-};
 
 namespace Ui {
   class LogsDialog;
@@ -62,7 +34,35 @@ namespace Ui {
 
 class LogsDialog : public QDialog
 {
-    Q_OBJECT
+  Q_OBJECT
+
+  enum yaxes_t {
+    firstLeft = 0,
+    firstRight,
+    secondLeft,
+    secondRight,
+    AXES_LIMIT // = 4
+  };
+
+  struct coords_t {
+    QVector<double> x, y;
+    double min_y;
+    double max_y;
+    yaxes_t yaxis;
+    QString name;
+  };
+
+  struct minMax_t {
+    double min;
+    double max;
+  };
+
+  struct plotsCollection {
+    QVarLengthArray<coords_t> coords;
+    double min_x;
+    double max_x;
+    bool tooManyRanges;
+  };
 
 public:
   explicit LogsDialog(QWidget *parent = 0);
@@ -95,7 +95,7 @@ private:
   QPen pen;
 
   double yAxesRatios[AXES_LIMIT];
-  minMax yAxesRanges[AXES_LIMIT];
+  minMax_t yAxesRanges[AXES_LIMIT];
 
   QCPItemTracer * tracerMaxAlt;
   QCPItemTracer * cursorA;
@@ -109,8 +109,8 @@ private:
   QString generateDuration(const QDateTime & start, const QDateTime & end);
   void setFlightSessions();
 
-  void addMaxAltitudeMarker(const coords & c, QCPGraph * graph);
-  void countNumberOfThrows(const coords & c, QCPGraph * graph);
+  void addMaxAltitudeMarker(const coords_t & c, QCPGraph * graph);
+  void countNumberOfThrows(const coords_t & c, QCPGraph * graph);
   void addCursor(QCPItemTracer ** cursor, QCPGraph * graph, const QColor & color);
   void addCursorLine(QCPItemStraightLine ** line, QCPGraph * graph, const QColor & color);
   void placeCursor(double x, bool second);

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -59,18 +59,18 @@
 #ifdef __APPLE__
   #define COMPANION_STAMP                 "companion-macosx.stamp"
   #define COMPANION_INSTALLER             "macosx/opentx-companion-%1.dmg"
-  #define COMPANION_FILEMASK              tr("Diskimage (*.dmg)")
-  #define COMPANION_INSTALL_QUESTION      tr("Would you like to open the disk image to install the new version?")
+  #define COMPANION_FILEMASK              QT_TRANSLATE_NOOP("MainWindow", "Diskimage (*.dmg)")
+  #define COMPANION_INSTALL_QUESTION      QT_TRANSLATE_NOOP("MainWindow", "Would you like to open the disk image to install the new version?")
 #elif WIN32
   #define COMPANION_STAMP                 "companion-windows.stamp"
   #define COMPANION_INSTALLER             "windows/companion-windows-%1.exe"
-  #define COMPANION_FILEMASK              tr("Executable (*.exe)")
-  #define COMPANION_INSTALL_QUESTION      tr("Would you like to launch the installer?")
+  #define COMPANION_FILEMASK              QT_TRANSLATE_NOOP("MainWindow", "Executable (*.exe)")
+  #define COMPANION_INSTALL_QUESTION      QT_TRANSLATE_NOOP("MainWindow", "Would you like to launch the installer?")
 #else
   #define COMPANION_STAMP                 "companion-linux.stamp"
   #define COMPANION_INSTALLER             "" // no automated updates for linux
   #define COMPANION_FILEMASK              "*.*"
-  #define COMPANION_INSTALL_QUESTION      tr("Would you like to launch the installer?")
+  #define COMPANION_INSTALL_QUESTION      QT_TRANSLATE_NOOP("MainWindow", "Would you like to launch the installer?")
 #endif
 
 const char * const OPENTX_COMPANION_DOWNLOAD_URL[] = {
@@ -336,7 +336,7 @@ void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
 
     if (ret == QMessageBox::Yes) {
       QDir dir(g.updatesDir());
-      QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), dir.absoluteFilePath(QString(COMPANION_INSTALLER).arg(version)), COMPANION_FILEMASK);
+      QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), dir.absoluteFilePath(QString(COMPANION_INSTALLER).arg(version)), tr(COMPANION_FILEMASK));
 
       if (!fileName.isEmpty()) {
         g.updatesDir(QFileInfo(fileName).dir().absolutePath());
@@ -361,7 +361,7 @@ void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
 
 void MainWindow::updateDownloaded()
 {
-  int ret = QMessageBox::question(this, CPN_STR_APP_NAME, COMPANION_INSTALL_QUESTION, QMessageBox::Yes | QMessageBox::No);
+  int ret = QMessageBox::question(this, CPN_STR_APP_NAME, tr(COMPANION_INSTALL_QUESTION), QMessageBox::Yes | QMessageBox::No);
   if (ret == QMessageBox::Yes) {
     if (QDesktopServices::openUrl(QUrl::fromLocalFile(installer_fileName)))
       QApplication::exit();

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -202,7 +202,7 @@ void MainWindow::displayWarnings()
   }
 
   QMessageBox msgBox(this);
-  msgBox.setWindowTitle(tr("Companion"));
+  msgBox.setWindowTitle(CPN_STR_APP_NAME);
   msgBox.setIcon(QMessageBox::Information);
   msgBox.setStandardButtons(QMessageBox::Ok);
   msgBox.setInformativeText(infoTxt);
@@ -291,7 +291,7 @@ void MainWindow::onUpdatesError()
 {
   checkForUpdatesState = 0;
   closeUpdatesWaitDialog();
-  QMessageBox::warning(this, "Companion", tr("Unable to check for updates."));
+  QMessageBox::warning(this, CPN_STR_APP_NAME, tr("Unable to check for updates."));
 }
 
 void MainWindow::closeUpdatesWaitDialog()
@@ -330,7 +330,7 @@ void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
 
   if (ownVersion < webVersion) {
 #if defined WIN32 || defined __APPLE__
-    int ret = QMessageBox::question(this, "Companion", tr("A new version of Companion is available (version %1)<br>"
+    int ret = QMessageBox::question(this, CPN_STR_APP_NAME, tr("A new version of Companion is available (version %1)<br>"
                                                         "Would you like to download it?").arg(version) ,
                                     QMessageBox::Yes | QMessageBox::No);
 
@@ -352,7 +352,7 @@ void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
   }
   else {
     if (downloadDialog_forWait && checkForUpdatesState==0) {
-      QMessageBox::information(this, "Companion", tr("No updates available at this time."));
+      QMessageBox::information(this, CPN_STR_APP_NAME, tr("No updates available at this time."));
     }
   }
 
@@ -361,7 +361,7 @@ void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
 
 void MainWindow::updateDownloaded()
 {
-  int ret = QMessageBox::question(this, "Companion", COMPANION_INSTALL_QUESTION, QMessageBox::Yes | QMessageBox::No);
+  int ret = QMessageBox::question(this, CPN_STR_APP_NAME, COMPANION_INSTALL_QUESTION, QMessageBox::Yes | QMessageBox::No);
   if (ret == QMessageBox::Yes) {
     if (QDesktopServices::openUrl(QUrl::fromLocalFile(installer_fileName)))
       QApplication::exit();
@@ -373,7 +373,7 @@ void MainWindow::firmwareDownloadAccepted()
   QString errormsg;
   QFile file(g.profile[g.id()].fwName());
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {  //reading HEX TEXT file
-    QMessageBox::critical(this, tr("Error"),
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR,
         tr("Error opening file %1:\n%2.")
         .arg(g.profile[g.id()].fwName())
         .arg(file.errorString()));
@@ -412,13 +412,13 @@ void MainWindow::firmwareDownloadAccepted()
     }
     file.close();
     file.remove();
-    QMessageBox::critical(this, tr("Error"), errormsg);
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR, errormsg);
     return;
   }
   file.close();
   g.fwRev.set(Firmware::getCurrentVariant()->getId(), version2index(firmwareVersionString));
   if (g.profile[g.id()].burnFirmware()) {
-    int ret = QMessageBox::question(this, "Companion", tr("Do you want to write the firmware to the radio now ?"), QMessageBox::Yes | QMessageBox::No);
+    int ret = QMessageBox::question(this, CPN_STR_APP_NAME, tr("Do you want to write the firmware to the radio now ?"), QMessageBox::Yes | QMessageBox::No);
     if (ret == QMessageBox::Yes) {
       writeFlash(g.profile[g.id()].fwName());
     }
@@ -451,7 +451,7 @@ void MainWindow::checkForFirmwareUpdateFinished(QNetworkReply * reply)
     QString currentVersionString = index2version(currentVersion);
 
     QMessageBox msgBox;
-    msgBox.setWindowTitle("Companion");
+    msgBox.setWindowTitle(CPN_STR_APP_NAME);
     QSpacerItem * horizontalSpacer = new QSpacerItem(500, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
     QGridLayout * layout = (QGridLayout*)msgBox.layout();
     layout->addItem(horizontalSpacer, layout->rowCount(), 0, 1, layout->columnCount());
@@ -472,7 +472,7 @@ void MainWindow::checkForFirmwareUpdateFinished(QNetworkReply * reply)
       if (msgBox.clickedButton() == rnButton) {
         ReleaseNotesFirmwareDialog * dialog = new ReleaseNotesFirmwareDialog(this, rn);
         dialog->exec();
-        int ret2 = QMessageBox::question(this, "Companion", tr("Do you want to download release %1 now ?").arg(fullVersionString), QMessageBox::Yes | QMessageBox::No);
+        int ret2 = QMessageBox::question(this, CPN_STR_APP_NAME, tr("Do you want to download release %1 now ?").arg(fullVersionString), QMessageBox::Yes | QMessageBox::No);
         if (ret2 == QMessageBox::Yes)
           download = true;
         else
@@ -501,7 +501,7 @@ void MainWindow::checkForFirmwareUpdateFinished(QNetworkReply * reply)
       if( msgBox.clickedButton() == rnButton ) {
         ReleaseNotesFirmwareDialog * dialog = new ReleaseNotesFirmwareDialog(this, rn);
         dialog->exec();
-        int ret2 = QMessageBox::question(this, "Companion", tr("Do you want to download release %1 now ?").arg(fullVersionString),
+        int ret2 = QMessageBox::question(this, CPN_STR_APP_NAME, tr("Do you want to download release %1 now ?").arg(fullVersionString),
               QMessageBox::Yes | QMessageBox::No);
         if (ret2 == QMessageBox::Yes) {
           download = true;
@@ -519,13 +519,13 @@ void MainWindow::checkForFirmwareUpdateFinished(QNetworkReply * reply)
     }
     else {
       if (downloadDialog_forWait && checkForUpdatesState==0) {
-        QMessageBox::information(this, "Companion", tr("No updates available at this time."));
+        QMessageBox::information(this, CPN_STR_APP_NAME, tr("No updates available at this time."));
       }
     }
   }
 
   if (ignore) {
-    int res = QMessageBox::question(this, "Companion", tr("Ignore this release %1?").arg(fullVersionString), QMessageBox::Yes | QMessageBox::No);
+    int res = QMessageBox::question(this, CPN_STR_APP_NAME, tr("Ignore this release %1?").arg(fullVersionString), QMessageBox::Yes | QMessageBox::No);
     if (res==QMessageBox::Yes)   {
       g.fwRev.set(Firmware::getCurrentVariant()->getId(), version);
     }
@@ -602,7 +602,7 @@ void MainWindow::onLanguageChanged(QAction * act)
 void  MainWindow::setTheme(int index)
 {
   g.theme(index);
-  QMessageBox::information(this, tr("Companion"), tr("The new theme will be loaded the next time you start Companion."));
+  QMessageBox::information(this, CPN_STR_APP_NAME, tr("The new theme will be loaded the next time you start Companion."));
 }
 
 void MainWindow::onThemeChanged(QAction * act)
@@ -746,7 +746,7 @@ bool MainWindow::loadProfileId(const unsigned pid)  // TODO Load all variables -
   Firmware * newFw = Firmware::getFirmwareForId(g.profile[pid].fwType());
   // warn if we're switching between incompatible board types and any files have been modified
   if (!Boards::isBoardCompatible(Firmware::getCurrentVariant()->getBoard(), newFw->getBoard()) && anyChildrenDirty()) {
-    if (QMessageBox::question(this, tr("Companion"),
+    if (QMessageBox::question(this, CPN_STR_APP_NAME,
                               tr("There are unsaved file changes which you may lose when switching radio types.\n\nDo you wish to continue?"),
                               (QMessageBox::Yes | QMessageBox::No), QMessageBox::No) != QMessageBox::Yes) {
       updateProfilesActions();
@@ -1123,7 +1123,7 @@ bool MainWindow::readEepromFromRadio(const QString & filename)
 void MainWindow::writeBackup()
 {
   if (IS_HORUS(getCurrentBoard())) {
-    QMessageBox::information(this, "Companion", tr("This function is not yet implemented"));
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("This function is not yet implemented"));
     return;
     // TODO implementation
   }
@@ -1140,7 +1140,7 @@ void MainWindow::writeFlash(QString fileToFlash)
 void MainWindow::readBackup()
 {
   if (IS_HORUS(getCurrentBoard())) {
-    QMessageBox::information(this, "Companion", tr("This function is not yet implemented"));
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("This function is not yet implemented"));
     return;
     // TODO implementation
   }
@@ -1406,7 +1406,7 @@ void MainWindow::retranslateUi(bool showMsg)
   showReadyStatus();
 
   if (showMsg)
-    QMessageBox::information(this, tr("Companion"), tr("Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete."));
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete."));
 }
 
 void MainWindow::createActions()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1320,13 +1320,13 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
 {
   Storage storage(filename);
   if (!storage.load(radioData)) {
-    QMessageBox::critical(this, tr("Error"), storage.error());
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR, storage.error());
     return false;
   }
 
   QString warning = storage.warning();
   if (!warning.isEmpty()) {
-    // TODO EEPROMInterface::showEepromWarnings(this, tr("Warning"), warning);
+    // TODO EEPROMInterface::showEepromWarnings(this, CPN_STR_TTL_WARNING, warning);
   }
 
   if (resetCurrentFile) {
@@ -1501,12 +1501,12 @@ bool MdiChild::convertStorage(Board::Type from, Board::Type to, bool newFile)
 void MdiChild::showWarning(const QString & msg)
 {
   if (!msg.isEmpty())
-    QMessageBox::warning(this, "Companion", msg);
+    QMessageBox::warning(this, CPN_STR_APP_NAME, msg);
 }
 
 int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton)
 {
-  return QMessageBox::question(this, tr("Companion"), msg, buttons, defaultButton);
+  return QMessageBox::question(this, CPN_STR_APP_NAME, msg, buttons, defaultButton);
 }
 
 void MdiChild::writeEeprom()  // write to Tx
@@ -1517,7 +1517,7 @@ void MdiChild::writeEeprom()  // write to Tx
     qDebug() << "Searching for SD card, found" << radioPath;
     if (radioPath.isEmpty()) {
       qDebug() << "MdiChild::writeEeprom(): Horus radio not found";
-      QMessageBox::critical(this, tr("Error"), tr("Unable to find Horus radio SD card!"));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Unable to find Horus radio SD card!"));
       return;
     }
     if (saveFile(radioPath, false)) {
@@ -1531,7 +1531,7 @@ void MdiChild::writeEeprom()  // write to Tx
     QString tempFile = generateProcessUniqueTempFileName("temp.bin");
     saveFile(tempFile, false);
     if (!QFileInfo(tempFile).exists()) {
-      QMessageBox::critical(this, tr("Error"), tr("Cannot write temporary file!"));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot write temporary file!"));
       return;
     }
     FlashEEpromDialog * cd = new FlashEEpromDialog(this, tempFile);
@@ -1547,7 +1547,7 @@ bool MdiChild::loadBackup()
   QFile file(fileName);
 
   if (!file.exists()) {
-    QMessageBox::critical(this, tr("Error"), tr("Unable to find file %1!").arg(fileName));
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Unable to find file %1!").arg(fileName));
     return false;
   }
 
@@ -1555,7 +1555,7 @@ bool MdiChild::loadBackup()
 
   int eeprom_size = file.size();
   if (!file.open(QFile::ReadOnly)) {  //reading binary file   - TODO HEX support
-    QMessageBox::critical(this, tr("Error"),
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR,
                           tr("Error opening file %1:\n%2.")
                           .arg(fileName)
                           .arg(file.errorString()));
@@ -1566,7 +1566,7 @@ bool MdiChild::loadBackup()
   file.close();
 
   if (result != eeprom_size) {
-    QMessageBox::critical(this, tr("Error"),
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR,
                           tr("Error reading file %1:\n%2.")
                           .arg(fileName)
                           .arg(file.errorString()));
@@ -1577,11 +1577,11 @@ bool MdiChild::loadBackup()
 #if 0
   std::bitset<NUM_ERRORS> errorsEeprom((unsigned long long)LoadBackup(radioData, (uint8_t *)eeprom.data(), eeprom_size, index));
   if (!errorsEeprom.test(ALL_OK)) {
-    EEPROMInterface::showEepromErrors(this, tr("Error"), tr("Invalid binary backup File %1").arg(fileName), (errorsEeprom).to_ulong());
+    EEPROMInterface::showEepromErrors(this, CPN_STR_TTL_ERROR, tr("Invalid binary backup File %1").arg(fileName), (errorsEeprom).to_ulong());
     return false;
   }
   if (errorsEeprom.test(HAS_WARNINGS)) {
-    EEPROMInterface::showEepromWarnings(this, tr("Warning"), errorsEeprom.to_ulong());
+    EEPROMInterface::showEepromWarnings(this, CPN_STR_TTL_WARNING, errorsEeprom.to_ulong());
   }
 
   refresh(true);

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -56,7 +56,7 @@ LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout * tableLayout, int row
   spinbox->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 
   QHBoxLayout * horizontalLayout = new QHBoxLayout();
-  QCheckBox * gv = new QCheckBox(QObject::tr("GV"));
+  QCheckBox * gv = new QCheckBox(tr("GV"));
   gv->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
   horizontalLayout->addWidget(gv);
   QComboBox * cb = new QComboBox();

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -24,10 +24,14 @@
 #include "helpers.h"
 #include "modeledit.h"
 
+#include <QtCore>
+
 class GVarGroup;
 
 class LimitsGroup
 {
+  Q_DECLARE_TR_FUNCTIONS(LimitsGroup)
+
   public:
     LimitsGroup(Firmware * firmware, TableLayout *tableLayout, int row, int col, int & value, const ModelData & model, int min, int max, int deflt, ModelPanel * panel=NULL);
     ~LimitsGroup();
@@ -49,7 +53,7 @@ class Channels : public ModelPanel
   public:
     Channels(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
     ~Channels();
-    
+
   private:
     QVector<LimitsGroup *> limitsGroups;
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -35,14 +35,14 @@ RepeatComboBox::RepeatComboBox(QWidget *parent, int & repeatParam):
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
 
   if (step == 1) {
-    addItem(QObject::tr("Played once, not during startup"), -1);
+    addItem(tr("Played once, not during startup"), -1);
     value++;
   }
 
-  addItem(QObject::tr("No repeat"), 0);
+  addItem(tr("No repeat"), 0);
 
   for (unsigned int i=step; i<=60; i+=step) {
-    addItem(QObject::tr("%1s").arg(i), i);
+    addItem(tr("%1s").arg(i), i);
   }
 
   setCurrentIndex(value);
@@ -306,7 +306,7 @@ void CustomFunctionsPanel::playMusic()
     }
     QFile file(track);
     if (!file.exists()) {
-      QMessageBox::critical(this, tr("Error"), tr("Unable to find sound file %1!").arg(track));
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Unable to find sound file %1!").arg(track));
       return;
     }
 
@@ -696,10 +696,10 @@ void CustomFunctionsPanel::populateFuncCB(QComboBox *b, unsigned int value)
 void CustomFunctionsPanel::populateGVmodeCB(QComboBox *b, unsigned int value)
 {
   b->clear();
-  b->addItem(QObject::tr("Value"));
-  b->addItem(QObject::tr("Source"));
-  b->addItem(QObject::tr("GVAR"));
-  b->addItem(QObject::tr("Increment"));
+  b->addItem(tr("Value"));
+  b->addItem(tr("Source"));
+  b->addItem(tr("GVAR"));
+  b->addItem(tr("Increment"));
   b->setCurrentIndex(value);
 }
 

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -100,16 +100,16 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
     QComboBox * cb = trimsUse[i];
     cb->setProperty("index", i);
     if (IS_HORUS_OR_TARANIS(board)) {
-      cb->addItem(QObject::tr("Trim disabled"), -1);
+      cb->addItem(tr("Trim disabled"), -1);
     }
     for (int m=0; m<modesCount; m++) {
       if (m == phaseIdx) {
-        cb->addItem(QObject::tr("Own Trim"), m*2);
+        cb->addItem(tr("Own Trim"), m*2);
       }
       else if (phaseIdx > 0) {
-        cb->addItem(QObject::tr("Use Trim from Flight mode %1").arg(m), m*2);
+        cb->addItem(tr("Use Trim from Flight mode %1").arg(m), m*2);
         if (IS_HORUS_OR_TARANIS(board)) {
-          cb->addItem(QObject::tr("Use Trim from Flight mode %1 + Own Trim as an offset").arg(m), m*2+1);
+          cb->addItem(tr("Use Trim from Flight mode %1 + Own Trim as an offset").arg(m), m*2+1);
         }
       }
     }
@@ -358,18 +358,20 @@ void FlightModePanel::setGVSB(QDoubleSpinBox * sb, int min, int max, int val)
   sb->setValue(val * mul);
 }
 
+// TODO: pull units from GVarData
 void FlightModePanel::populateGvarUnitCB(QComboBox * cb)
 {
   cb->clear();
-  cb->addItem(QObject::tr(""));
-  cb->addItem(QObject::tr("%"));
+  cb->addItem("");
+  cb->addItem("%");
 }
 
+// TODO: pull precision string from GVarData
 void FlightModePanel::populateGvarPrecCB(QComboBox * cb)
 {
   cb->clear();
-  cb->addItem(QObject::tr("0._"));
-  cb->addItem(QObject::tr("0.0"));
+  cb->addItem(tr("0._"));
+  cb->addItem(tr("0.0"));
 }
 
 void FlightModePanel::phaseName_editingFinished()

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -652,7 +652,7 @@ void FlightModePanel::name_customContextMenuRequested(const QPoint & pos)
 
 void FlightModePanel::fmClear()
 {
-  int res = QMessageBox::question(this, "Companion", tr("Clear all current Flight Mode properties?"), QMessageBox::Yes | QMessageBox::No);
+  int res = QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all current Flight Mode properties?"), QMessageBox::Yes | QMessageBox::No);
   if (res == QMessageBox::Yes) {
     phase.clear(phaseIdx);
     if (phaseIdx == 0) {

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -177,7 +177,7 @@ QString InputsPanel::getInputText(int dest, bool * new_ch)
 bool InputsPanel::gm_insertExpo(int idx)
 {
   if (idx<0 || idx>=CPN_MAX_EXPOS || model->expoData[CPN_MAX_EXPOS-1].mode > 0) {
-    QMessageBox::information(this, "Companion", tr("Not enough available inputs!"));
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("Not enough available inputs!"));
     return false;
   }
 

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -1160,7 +1160,7 @@ void SetupPanel::populateThrottleSourceCB()
   Board::Type board = firmware->getBoard();
   lock = true;
   ui->throttleSource->clear();
-  ui->throttleSource->addItem(QObject::tr("THR"));
+  ui->throttleSource->addItem(tr("THR"));
   for (int i=0; i<getBoardCapability(board, Board::Pots)+getBoardCapability(board, Board::Sliders); i++) {
     ui->throttleSource->addItem(firmware->getAnalogInputName(4+i), i);
   }

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -719,7 +719,7 @@ void populateTelemetrySourcesComboBox(AutoComboBox * cb, const ModelData * model
   if (negative) {
     for (int i=-CPN_MAX_SENSORS; i<0; ++i) {
       if (model->sensorData[-i-1].isAvailable())
-        cb->addItem(QObject::tr("-%1").arg(model->sensorData[-i-1].label), i);
+        cb->addItem(QString("-%1").arg(model->sensorData[-i-1].label), i);
     }
   }
   cb->addItem("---", 0);

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -678,7 +678,7 @@ void TreeModel::refresh()
           if (!defaultCategoryItem) {
             defaultCategoryItem = rootItem->appendChild(0, -1);
             /*: Translators do NOT use accent for this, this is the default category name on Horus. */
-            defaultCategoryItem->setData(0, QObject::tr("Models"));
+            defaultCategoryItem->setData(0, tr("Models"));
           }
           categoryItem = defaultCategoryItem;
         }

--- a/companion/src/process_copy.cpp
+++ b/companion/src/process_copy.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "process_copy.h"
+#include "constants.h"
 #include "progresswidget.h"
 #include <QEventLoop>
 #include <QFile>
@@ -67,7 +68,7 @@ void CopyProcess::onTimer()
           progress->setValue(i);
         }
         else {
-          QMessageBox::warning(NULL, tr("Error"), tr("Write error"));
+          QMessageBox::warning(NULL, CPN_STR_TTL_ERROR, tr("Write error"));
           result = false;
           break;
         }
@@ -75,12 +76,12 @@ void CopyProcess::onTimer()
       destinationFile.close();
     }
     else {
-      QMessageBox::warning(NULL, tr("Error"),tr("Cannot write %1 (reason: %2)").arg(destinationFile.fileName()).arg(sourceFile.errorString()));
+      QMessageBox::warning(NULL, CPN_STR_TTL_ERROR,tr("Cannot write %1 (reason: %2)").arg(destinationFile.fileName()).arg(sourceFile.errorString()));
       result = false;
     }
   }
   else {
-    QMessageBox::warning(NULL, tr("Error"),tr("Cannot open %1 (reason: %2)").arg(sourceFile.fileName()).arg(sourceFile.errorString()));
+    QMessageBox::warning(NULL, CPN_STR_TTL_ERROR,tr("Cannot open %1 (reason: %2)").arg(sourceFile.fileName()).arg(sourceFile.errorString()));
     result = false;
   }
 

--- a/companion/src/process_flash.cpp
+++ b/companion/src/process_flash.cpp
@@ -66,7 +66,7 @@ FlashProcess::~FlashProcess()
 bool FlashProcess::run()
 {
   if (!QFile::exists(cmd)) {
-    QMessageBox::critical(NULL, "Companion", tr("Executable %1 not found").arg(cmd));
+    QMessageBox::critical(NULL, CPN_STR_APP_NAME, tr("Executable %1 not found").arg(cmd));
     return false;
   }
 

--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -99,7 +99,8 @@ QStringList getSambaArgs(const QString & tcl)
   }
   QFile tclFile(tclFilename);
   if (!tclFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-    QMessageBox::warning(NULL, QObject::tr("Error"), QObject::tr("Cannot write file %1:\n%2.").arg(tclFilename).arg(tclFile.errorString()));
+    QMessageBox::warning(NULL, CPN_STR_TTL_ERROR,
+                         QCoreApplication::translate("RadioInterface", "Cannot write file %1:\n%2.").arg(tclFilename).arg(tclFile.errorString()));
     return result;
   }
 
@@ -194,10 +195,12 @@ void resetAvrdudeFuses(bool eepromProtect, ProgressWidget * progress)
 
   burnConfigDialog bcd;
   QMessageBox::StandardButton ret = QMessageBox::No;
-  ret = QMessageBox::warning(NULL, QObject::tr("Companion"),
-                             QObject::tr("<b><u>WARNING!</u></b><br>This will reset the fuses of  %1 to the factory settings.<br>"
-                                 "Writing fuses can mess up your radio.<br>Do this only if you are sure they are wrong!<br>"
-                                 "Are you sure you want to continue?").arg(bcd.getMCU()),
+  ret = QMessageBox::warning(NULL, CPN_STR_APP_NAME,
+                             QCoreApplication::translate("RadioInterface",
+                                                         "<b><u>WARNING!</u></b>" \
+                                                         "<br>This will reset the fuses of  %1 to the factory settings.<br>"
+                                                         "Writing fuses can mess up your radio.<br>Do this only if you are sure they are wrong!<br>"
+                                                         "Are you sure you want to continue?").arg(bcd.getMCU()),
                              QMessageBox::Yes | QMessageBox::No);
   if (ret == QMessageBox::Yes) {
     QStringList args = bcd.getAvrdudeArgs();
@@ -257,7 +260,8 @@ bool readFirmware(const QString & filename, ProgressWidget * progress)
 
   QFile file(filename);
   if (file.exists() && !file.remove()) {
-    QMessageBox::warning(NULL, QObject::tr("Error"), QObject::tr("Could not delete temporary file: %1").arg(filename));
+    QMessageBox::warning(NULL, CPN_STR_TTL_ERROR,
+                         QCoreApplication::translate("RadioInterface", "Could not delete temporary file: %1").arg(filename));
     return false;
   }
 
@@ -305,9 +309,8 @@ bool readEeprom(const QString & filename, ProgressWidget * progress)
 
   QFile file(filename);
   if (file.exists() && !file.remove()) {
-    QMessageBox::warning(NULL,
-                         QObject::tr("Error"),
-                         QObject::tr("Could not delete temporary file: %1").arg(filename));
+    QMessageBox::warning(NULL, CPN_STR_TTL_ERROR,
+                         QCoreApplication::translate("RadioInterface", "Could not delete temporary file: %1").arg(filename));
     return false;
   }
 
@@ -315,18 +318,19 @@ bool readEeprom(const QString & filename, ProgressWidget * progress)
     QString radioPath = findMassstoragePath("RADIO", true);
     qDebug() << "Searching for SD card, found" << radioPath;
     if (radioPath.isEmpty()) {
-      QMessageBox::critical(progress, QObject::tr("Error"), QObject::tr("Unable to find Horus radio SD card!"));
+      QMessageBox::critical(progress, CPN_STR_TTL_ERROR,
+                            QCoreApplication::translate("RadioInterface", "Unable to find Horus radio SD card!"));
       return false;
     }
     RadioData radioData;
     Storage inputStorage(radioPath);
     if (!inputStorage.load(radioData)) {
-      QMessageBox::critical(progress, QObject::tr("Error"), inputStorage.error());
+      QMessageBox::critical(progress, CPN_STR_TTL_ERROR, inputStorage.error());
       return false;
     }
     Storage outputStorage(filename);
     if (!outputStorage.write(radioData)) {
-      QMessageBox::critical(progress, QObject::tr("Error"), outputStorage.error());
+      QMessageBox::critical(progress, CPN_STR_TTL_ERROR, outputStorage.error());
       return false;
     }
   }

--- a/companion/src/simulation/joystickdialog.cpp
+++ b/companion/src/simulation/joystickdialog.cpp
@@ -147,7 +147,7 @@ void joystickDialog::joystickOpen(int stick)
     }
   }
   else {
-    QMessageBox::critical(this, tr("Error"), tr("Cannot open joystick."));
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot open joystick."));
   }
 }
 
@@ -255,7 +255,7 @@ void joystickDialog::on_okButton_clicked()
   }
 
   if (started && step < 4) {
-    int resp = QMessageBox::warning(this, tr("Warning"), tr("Calibration not complete, save anyway?"),
+    int resp = QMessageBox::warning(this, CPN_STR_TTL_WARNING, tr("Calibration not complete, save anyway?"),
                                     QDialogButtonBox::Ok | QMessageBox::Default, QDialogButtonBox::Cancel | QMessageBox::Escape, QMessageBox::NoButton);
     if (resp == QDialogButtonBox::Cancel)
       return;

--- a/companion/src/simulation/simulatorstartupdialog.cpp
+++ b/companion/src/simulation/simulatorstartupdialog.cpp
@@ -228,7 +228,7 @@ void SimulatorStartupDialog::onRadioTypeChanged(int index)
 void SimulatorStartupDialog::onDataFileSelect(bool)
 {
   QString filter = EEPROM_FILES_FILTER % tr("All files (*.*)");
-  QString file = QFileDialog::getSaveFileName(this, QObject::tr("Select a data file"), ui->dataFile->text(),
+  QString file = QFileDialog::getSaveFileName(this, tr("Select a data file"), ui->dataFile->text(),
                                               filter, NULL, QFileDialog::DontConfirmOverwrite);
   if (!file.isEmpty()) {
     ui->dataFile->setText(file);
@@ -238,7 +238,7 @@ void SimulatorStartupDialog::onDataFileSelect(bool)
 
 void SimulatorStartupDialog::onDataFolderSelect(bool)
 {
-  QString folder = QFileDialog::getExistingDirectory(this, QObject::tr("Select Data Directory"),
+  QString folder = QFileDialog::getExistingDirectory(this, tr("Select Data Directory"),
                                                      ui->dataFolder->text(), QFileDialog::DontUseNativeDialog);
   if (!folder.isEmpty()) {
     ui->dataFolder->setText(folder);
@@ -249,7 +249,7 @@ void SimulatorStartupDialog::onDataFolderSelect(bool)
 
 void SimulatorStartupDialog::onSdPathSelect(bool)
 {
-  QString folder = QFileDialog::getExistingDirectory(this, QObject::tr("Select SD Card Image Folder"),
+  QString folder = QFileDialog::getExistingDirectory(this, tr("Select SD Card Image Folder"),
                                                      ui->sdPath->text(), QFileDialog::DontUseNativeDialog);
   if (!folder.isEmpty()) {
     ui->sdPath->setText(folder);

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -649,7 +649,7 @@ void SimulatorWidget::setupJoysticks()
       joysticksEnabled = true;
     }
     else {
-      QMessageBox::critical(this, tr("Warning"), tr("Cannot open joystick, joystick disabled"));
+      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Cannot open joystick, joystick disabled"));
     }
   }
   else if (joystick) {

--- a/companion/src/splashlibrarydialog.cpp
+++ b/companion/src/splashlibrarydialog.cpp
@@ -113,13 +113,13 @@ void SplashLibraryDialog::getFileList()
           imageList.append(filename);
         }
         else {
-          QMessageBox::information(this, tr("Warning"), tr("Invalid image in library %1").arg(filename));
+          QMessageBox::warning(this, CPN_STR_TTL_WARNING, tr("Invalid image in library %1").arg(filename));
         }
       }
     }
   }
   if (imageList.size() == 0) {
-    QMessageBox::information(this, tr("Information"), tr("No valid image found in library, check your settings"));
+    QMessageBox::information(this, CPN_STR_TTL_INFO, tr("No valid image found in library, check your settings"));
     QTimer::singleShot(0, this, SLOT(dclose()));
   }
   else {

--- a/companion/src/storage/bineeprom.cpp
+++ b/companion/src/storage/bineeprom.cpp
@@ -94,7 +94,7 @@ bool BinEepromFormat::extract(RadioData & radioData, const QByteArray & eeprom)
     std::bitset<NUM_ERRORS> result((unsigned long long)eepromInterface->load(radioData, (uint8_t *)eeprom.data(), eeprom.size()));
     if (result.test(ALL_OK)) {
       if (errors.test(HAS_WARNINGS)) {
-        // TODO ShowEepromWarnings(this, tr("Warning"), errors.to_ulong());
+        // TODO ShowEepromWarnings(this, CPN_STR_TTL_WARNING, errors.to_ulong());
       }
       board = eepromInterface->getBoard();
       return true;

--- a/companion/src/storage/bineeprom.cpp
+++ b/companion/src/storage/bineeprom.cpp
@@ -39,7 +39,7 @@ bool BinEepromFormat::load(RadioData & radioData)
   QByteArray eeprom(size, 0);
   int result = file.read((char *)eeprom.data(), size);
   if (result != size) {
-    setError(QObject::tr("Error reading %1: %2").arg(filename).arg(file.errorString()));
+    setError(tr("Error reading %1: %2").arg(filename).arg(file.errorString()));
     return false;
   }
 
@@ -61,7 +61,7 @@ bool BinEepromFormat::write(const RadioData & radioData)
   }
   else {
     // TODO here we could call setError(eepromInterface->errors())
-    setError(QObject::tr("Cannot save EEPROM"));
+    setError(tr("Cannot save EEPROM"));
     result = false;
   }
   free(eeprom);
@@ -72,14 +72,14 @@ bool BinEepromFormat::writeToFile(const uint8_t * eeprom, uint32_t size)
 {
   QFile file(filename);
   if (!file.open(QIODevice::WriteOnly)) {
-    setError(QObject::tr("Cannot open file %1:\n%2.").arg(filename).arg(file.errorString()));
+    setError(tr("Cannot open file %1:\n%2.").arg(filename).arg(file.errorString()));
     return false;
   }
 
   QTextStream outputStream(&file);
   qint64 len = file.write((char *)eeprom, size);
   if (len != qint64(size)) {
-    setError(QObject::tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
+    setError(tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
     return false;
   }
 
@@ -94,7 +94,7 @@ bool BinEepromFormat::extract(RadioData & radioData, const QByteArray & eeprom)
     std::bitset<NUM_ERRORS> result((unsigned long long)eepromInterface->load(radioData, (uint8_t *)eeprom.data(), eeprom.size()));
     if (result.test(ALL_OK)) {
       if (errors.test(HAS_WARNINGS)) {
-        // TODO ShowEepromWarnings(this, QObject::tr("Warning"), errors.to_ulong());
+        // TODO ShowEepromWarnings(this, tr("Warning"), errors.to_ulong());
       }
       board = eepromInterface->getBoard();
       return true;
@@ -104,6 +104,6 @@ bool BinEepromFormat::extract(RadioData & radioData, const QByteArray & eeprom)
     }
   }
 
-  setError(QObject::tr("Invalid binary EEPROM file %1").arg(filename));
+  setError(tr("Invalid binary EEPROM file %1").arg(filename));
   return false;
 }

--- a/companion/src/storage/bineeprom.h
+++ b/companion/src/storage/bineeprom.h
@@ -23,18 +23,22 @@
 
 #include "storage.h"
 
+#include <QtCore>
+
 class BinEepromFormat : public StorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(BinEepromFormat)
+
   public:
     BinEepromFormat(const QString & filename):
       StorageFormat(filename)
     {
     }
-    
-    virtual QString name() { return "bin"; };
+
+    virtual QString name() { return "bin"; }
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
-    
+
   protected:
     bool extract(RadioData & radioData, const QByteArray & eeprom);
     virtual bool writeToFile(const uint8_t * eeprom, uint32_t size);

--- a/companion/src/storage/categorized.cpp
+++ b/companion/src/storage/categorized.cpp
@@ -25,7 +25,7 @@ bool CategorizedStorageFormat::load(RadioData & radioData)
 {
   QByteArray radioSettingsBuffer;
   if (!loadFile(radioSettingsBuffer, "RADIO/radio.bin")) {
-    setError(QObject::tr("Can't extract RADIO/radio.bin"));
+    setError(tr("Can't extract RADIO/radio.bin"));
     return false;
   }
 
@@ -38,7 +38,7 @@ bool CategorizedStorageFormat::load(RadioData & radioData)
 
   QByteArray modelsListBuffer;
   if (!loadFile(modelsListBuffer, "RADIO/models.txt")) {
-    setError(QObject::tr("Can't extract RADIO/models.txt"));
+    setError(tr("Can't extract RADIO/models.txt"));
     return false;
   }
 
@@ -82,14 +82,14 @@ bool CategorizedStorageFormat::load(RadioData & radioData)
       qDebug() << "Loading model from file" << fileName << "into slot" << modelIndex;
       QByteArray modelBuffer;
       if (!loadFile(modelBuffer, QString("MODELS/%1").arg(fileName))) {
-        setError(QObject::tr("Can't extract %1").arg(fileName));
+        setError(tr("Can't extract %1").arg(fileName));
         return false;
       }
       if ((int)radioData.models.size() <= modelIndex) {
         radioData.models.resize(modelIndex + 1);
       }
       if (!loadModelFromByteArray(radioData.models[modelIndex], modelBuffer)) {
-        setError(QObject::tr("Error loading models"));
+        setError(tr("Error loading models"));
         return false;
       }
       strncpy(radioData.models[modelIndex].filename, qPrintable(fileName), sizeof(radioData.models[modelIndex].filename));

--- a/companion/src/storage/categorized.h
+++ b/companion/src/storage/categorized.h
@@ -23,14 +23,18 @@
 
 #include "storage.h"
 
+#include <QtCore>
+
 class CategorizedStorageFormat : public StorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(CategorizedStorageFormat)
+
   public:
     CategorizedStorageFormat(const QString & filename):
       StorageFormat(filename)
     {
     }
-    
+
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
 

--- a/companion/src/storage/eepe.cpp
+++ b/companion/src/storage/eepe.cpp
@@ -28,7 +28,7 @@ bool EepeFormat::load(RadioData & radioData)
   QFile file(filename);
 
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-    setError(QObject::tr("Unable to open %1: %2").arg(filename).arg(file.errorString()));
+    setError(tr("Unable to open %1: %2").arg(filename).arg(file.errorString()));
     return false;
   }
 
@@ -44,7 +44,7 @@ bool EepeFormat::load(RadioData & radioData)
   QByteArray eeprom(Boards::getEEpromSize(Board::BOARD_UNKNOWN), 0);
   int eeprom_size = HexInterface(inputStream).load((uint8_t *)eeprom.data(), Boards::getEEpromSize(Board::BOARD_UNKNOWN));
   if (!eeprom_size) {
-    setError(QObject::tr("Invalid EEPROM file %1").arg(filename));
+    setError(tr("Invalid EEPROM file %1").arg(filename));
     return false;
   }
   eeprom.resize(eeprom_size);

--- a/companion/src/storage/eepe.h
+++ b/companion/src/storage/eepe.h
@@ -23,15 +23,19 @@
 
 #include "hexeeprom.h"
 
+#include <QtCore>
+
 class EepeFormat : public HexEepromFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(EepeFormat)
+
   public:
     EepeFormat(const QString & filename):
       HexEepromFormat(filename)
     {
     }
-    
-    virtual QString name() { return "eepe"; };
+
+    virtual QString name() { return "eepe"; }
     virtual bool load(RadioData & radioData);
 };
 

--- a/companion/src/storage/hexeeprom.cpp
+++ b/companion/src/storage/hexeeprom.cpp
@@ -36,7 +36,7 @@ bool HexEepromFormat::load(RadioData & radioData)
   QByteArray eeprom(Boards::getEEpromSize(Board::BOARD_UNKNOWN), 0);
   int eeprom_size = HexInterface(inputStream).load((uint8_t *)eeprom.data(), Boards::getEEpromSize(Board::BOARD_UNKNOWN));
   if (!eeprom_size) {
-    setError(QObject::tr("Invalid EEPROM File %1").arg(filename));
+    setError(tr("Invalid EEPROM File %1").arg(filename));
     return false;
   }
   eeprom.resize(eeprom_size);
@@ -48,13 +48,13 @@ bool HexEepromFormat::writeToFile(const uint8_t * eeprom, uint32_t size)
 {
   QFile file(filename);
   if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-    setError(QObject::tr("Cannot open file %1:\n%2.").arg(filename).arg(file.errorString()));
+    setError(tr("Cannot open file %1:\n%2.").arg(filename).arg(file.errorString()));
     return false;
   }
 
   QTextStream outputStream(&file);
   if (!HexInterface(outputStream).save(eeprom, size)) {
-    setError(QObject::tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
+    setError(tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
     return false;
   }
 

--- a/companion/src/storage/hexeeprom.h
+++ b/companion/src/storage/hexeeprom.h
@@ -23,17 +23,21 @@
 
 #include "bineeprom.h"
 
+#include <QtCore>
+
 class HexEepromFormat : public BinEepromFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(HexEepromFormat)
+
   public:
     HexEepromFormat(const QString & filename):
       BinEepromFormat(filename)
     {
     }
-    
-    virtual QString name() { return "hex"; };
+
+    virtual QString name() { return "hex"; }
     virtual bool load(RadioData & radioData);
-    
+
   protected:
     virtual bool writeToFile(const uint8_t * eeprom, uint32_t size);
 };

--- a/companion/src/storage/otx.cpp
+++ b/companion/src/storage/otx.cpp
@@ -27,23 +27,23 @@
 bool OtxFormat::load(RadioData & radioData)
 {
   QFile file(filename);
-  
+
   if (!file.open(QFile::ReadOnly)) {
-    setError(QObject::tr("Error opening file %1:\n%2.").arg(filename).arg(file.errorString()));
+    setError(tr("Error opening file %1:\n%2.").arg(filename).arg(file.errorString()));
     return false;
   }
-  
+
   QByteArray archiveContents = file.readAll();
-  
+
   qDebug() << "File" << filename << "read, size:" << archiveContents.size();
-  
+
   // open zip file
   memset(&zip_archive, 0, sizeof(zip_archive));
   if (!mz_zip_reader_init_mem(&zip_archive, archiveContents.data(), archiveContents.size(), 0)) {
-    qDebug() << QObject::tr("Error opening OTX archive %1").arg(filename);
+    qDebug() << tr("Error opening OTX archive %1").arg(filename);
     return false;
   }
-  
+
   bool result = CategorizedStorageFormat::load(radioData);
   mz_zip_reader_end(&zip_archive);
   return result;
@@ -52,13 +52,13 @@ bool OtxFormat::load(RadioData & radioData)
 bool OtxFormat::write(const RadioData & radioData)
 {
   qDebug() << "Saving to archive" << filename;
-  
+
   memset(&zip_archive, 0, sizeof(zip_archive));
   if (!mz_zip_writer_init_heap(&zip_archive, 0, MZ_ALLOCATION_SIZE)) {
-    setError(QObject::tr("Error initializing OTX archive writer"));
+    setError(tr("Error initializing OTX archive writer"));
     return false;
   }
-  
+
   bool result = CategorizedStorageFormat::write(radioData);
   if (result) {
     // finalize archive and get contents
@@ -71,21 +71,21 @@ bool OtxFormat::write(const RadioData & radioData)
       if (file.open(QIODevice::WriteOnly)) {
         qint64 len = file.write(archiveContents, archiveSize);
         if (len != (qint64)archiveSize) {
-          setError(QObject::tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
+          setError(tr("Error writing file %1:\n%2.").arg(filename).arg(file.errorString()));
           result = false;
         }
       }
       else {
-        setError(QObject::tr("Error creating OTX file %1:\n%2.").arg(filename).arg(file.errorString()));
+        setError(tr("Error creating OTX file %1:\n%2.").arg(filename).arg(file.errorString()));
         result = false;
       }
     }
     else {
-      setError(QObject::tr("Error creating OTX archive"));
+      setError(tr("Error creating OTX archive"));
       result = false;
     }
   }
-  
+
   mz_zip_writer_end(&zip_archive);
   return result;
 }
@@ -108,9 +108,9 @@ bool OtxFormat::loadFile(QByteArray & filedata, const QString & filename)
 bool OtxFormat::writeFile(const QByteArray & filedata, const QString & filename)
 {
   if (!mz_zip_writer_add_mem(&zip_archive, filename.toStdString().c_str(), filedata.data(), filedata.size(), MZ_DEFAULT_LEVEL)) {
-    setError(QObject::tr("Error adding %1 to OTX archive").arg(filename));
+    setError(tr("Error adding %1 to OTX archive").arg(filename));
     return false;
   }
-  
+
   return true;
 }

--- a/companion/src/storage/otx.h
+++ b/companion/src/storage/otx.h
@@ -23,26 +23,30 @@
 
 #include "categorized.h"
 
+#include <QtCore>
+
 #define MINIZ_HEADER_FILE_ONLY
 #include "miniz.c"
 #undef MINIZ_HEADER_FILE_ONLY
 
 class OtxFormat : public CategorizedStorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(OtxFormat)
+
   public:
     OtxFormat(const QString & filename):
       CategorizedStorageFormat(filename)
     {
     }
-    
-    virtual QString name() { return "otx"; };
+
+    virtual QString name() { return "otx"; }
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
-  
+
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
-    
+
     mz_zip_archive zip_archive;
 };
 

--- a/companion/src/storage/sdcard.cpp
+++ b/companion/src/storage/sdcard.cpp
@@ -35,7 +35,7 @@ bool SdcardFormat::loadFile(QByteArray & filedata, const QString & filename)
   QString path = this->filename + "/" + filename;
   QFile file(path);
   if (!file.open(QFile::ReadOnly)) {
-    setError(QObject::tr("Error opening file %1:\n%2.").arg(path).arg(file.errorString()));
+    setError(tr("Error opening file %1:\n%2.").arg(path).arg(file.errorString()));
     return false;
   }
   filedata = file.readAll();
@@ -48,7 +48,7 @@ bool SdcardFormat::writeFile(const QByteArray & data, const QString & filename)
   QString path = this->filename + "/" + filename;
   QFile file(path);
   if (!file.open(QFile::WriteOnly)) {
-    setError(QObject::tr("Error opening file %1 in write mode:\n%2.").arg(path).arg(file.errorString()));
+    setError(tr("Error opening file %1 in write mode:\n%2.").arg(path).arg(file.errorString()));
     return false;
   }
   file.write(data.data(), data.size());

--- a/companion/src/storage/sdcard.h
+++ b/companion/src/storage/sdcard.h
@@ -23,17 +23,21 @@
 
 #include "categorized.h"
 
+#include <QtCore>
+
 class SdcardFormat : public CategorizedStorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(SdcardFormat)
+
   public:
     SdcardFormat(const QString & filename):
       CategorizedStorageFormat(filename)
     {
     }
-    
-    virtual QString name() { return "sdcard"; };
+
+    virtual QString name() { return "sdcard"; }
     virtual bool write(const RadioData & radioData);
-  
+
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
@@ -46,7 +50,7 @@ class SdcardStorageFactory : public DefaultStorageFactory<SdcardFormat>
       DefaultStorageFactory<SdcardFormat>("sdcard")
     {
     }
-    
+
     virtual bool probe(const QString & name);
 };
 

--- a/companion/src/storage/storage.cpp
+++ b/companion/src/storage/storage.cpp
@@ -74,7 +74,7 @@ bool Storage::load(RadioData & radioData)
 {
   QFile file(filename);
   if (!file.exists()) {
-    setError(QObject::tr("Unable to find file %1!").arg(filename));
+    setError(tr("Unable to find file %1!").arg(filename));
     return false;
   }
 

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -22,6 +22,8 @@
 #define _STORAGE_H_
 
 #include "radiodata.h"
+
+#include <QtCore>
 #include <QString>
 #include <QDebug>
 
@@ -41,6 +43,8 @@ StorageType getStorageType(const QString & filename);
 
 class StorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(StorageFormat)
+
   public:
     StorageFormat(const QString & filename, uint8_t version=0):
       filename(filename),
@@ -129,6 +133,8 @@ class DefaultStorageFactory : public StorageFactory
 
 class Storage : public StorageFormat
 {
+  Q_DECLARE_TR_FUNCTIONS(Storage)
+
   public:
     Storage(const QString & filename):
       StorageFormat(filename)


### PR DESCRIPTION
Gets rid of all remaining generic `QObject::tr()` calls and replaces with class/object-qualified ones.  In most cases the `QObject::` prefix was unnecessary to begin with since the classes already had their own `tr()` methods.

I also centralized some strings which get repeated a lot in dialog titles ("Warning", "Error", "Companion").

This should be the last of the big translation rebases.  No functionality changes here.

@LapinFou The good news is that all existing translations are preserved (here and the previous translation PR). But the ones that have moved to their own class names (from QObject) are now marked "unverified" (with the yellow `?`).  A search/replace in the .ts file (with text editor) would probably work to mark them all verified, though it could cause some inadvertent verification.  Let me know if I can help.