### PR TITLE
Align python crossfire parser to c equivalent

### DIFF
--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -79,13 +79,8 @@ def crc8(buffer):
 # note : in python arrays slicing payload[x:y] means from 'x' included to 'y' not included,
 #        y - x gives the number of bytes sliced.
 def ParseGPS(payload):
-    lat = struct.unpack('>i',bytes(bytearray(payload[0:4])))[0] / 1e7          #(degree / 10`000`000)
-    long = struct.unpack('>i',bytes(bytearray(payload[4:8])))[0] / 1e7         #(degree / 10`000`000)
-    speed = struct.unpack('>H',bytes(bytearray(payload[8:10])))[0] / 100       #(km/h / 100)
-    head = struct.unpack('>H',bytes(bytearray(payload[10:12])))[0] / 100       #(degree / 100)
-    alt = struct.unpack('>H',bytes(bytearray(payload[12:14])))[0] - 1000       #(meter - 1000m offset)
-    numsat = payload[14]
-    return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat, long, speed, head, alt, numsat)
+    lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB',bytes(bytearray(payload[0:15])))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
+    return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat / 1e7, long / 1e7, speed / 100, head / 100, alt - 1000, numsat)
 
 def ParseBattery(payload):
     voltage = float((payload[0] << 8) + payload[1]) / 10

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -76,8 +76,6 @@ def crc8(buffer):
         crc = crc8tab[crc ^ c]
     return crc
 
-# note : in python arrays slicing payload[x:y] means from 'x' included to 'y' not included,
-#        y - x gives the number of bytes sliced.
 def ParseGPS(payload):
     lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB',bytes(bytearray(payload[0:15])))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
     return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat / 1e7, long / 1e7, speed / 100, head / 100, alt - 1000, numsat)

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -70,7 +70,15 @@ crc8tab = [
     0xAD, 0x78, 0xD2, 0x07, 0x53, 0x86, 0x2C, 0xF9
 ]
 
-def getCrossfireValue(data=[], *args):
+# logs data are BigEndian
+def getCrossfireValueUnsigned(data=[], *args):
+    value = 0
+    for n in data:
+        value = value << 8
+        value = value + n
+    return value
+
+def getCrossfireValueSigned(data=[], *args):
     sign = data[-1]
     if (sign & 0x80) == 0:
         value = -1
@@ -88,27 +96,27 @@ def crc8(buffer):
     return crc
 
 def ParseGPS(payload):
-    lat = getCrossfireValue(payload[0:4]) / 1e7
-    long = getCrossfireValue(payload[4:8])/ 1e7
-    speed = getCrossfireValue(payload[8:10])
-    head = getCrossfireValue(payload[10:12])
-    alt = getCrossfireValue(payload[12:14]) - 1000
+    lat = getCrossfireValueSigned(payload[0:4]) / 1e7
+    long = getCrossfireValueSigned(payload[4:8])/ 1e7
+    speed = getCrossfireValueUnsigned(payload[8:10]) / 100
+    head = getCrossfireValueUnsigned(payload[10:12]) / 100
+    alt = getCrossfireValueUnsigned(payload[12:14]) - 1000
     numsat = payload[14]
     return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat, long, speed, head, alt, numsat)
 
 def ParseBattery(payload):
-    voltage = getCrossfireValue(payload[0:2]) / 10
-    current = getCrossfireValue(payload[2:4]) / 10
-    consumption = getCrossfireValue(payload[4:7])
+    voltage = getCrossfireValueUnsigned(payload[0:2]) / 10
+    current = getCrossfireValueUnsigned(payload[2:4]) / 10
+    consumption = getCrossfireValueUnsigned(payload[4:7])
     return "[Battery] %.1fV %.1fA %dmAh" % (voltage, current, consumption)
 
 def ParseLinkStatistics(payload):
     return "[Link Statistics] "
 
 def ParseAttitude(payload):
-    pitch = getCrossfireValue(payload[0:2])/ 1000
-    roll = getCrossfireValue(payload[2:4]) / 1000
-    yaw = getCrossfireValue(payload[4:6]) / 1000
+    pitch = getCrossfireValueUnsigned(payload[0:2])/ 1000
+    roll = getCrossfireValueUnsigned(payload[2:4]) / 1000
+    yaw = getCrossfireValueUnsigned(payload[4:6]) / 1000
     return "[Attitude] pitch=%.3f roll=%.3f yaw=%.3f" % (pitch, roll, yaw)
 
 def ParseFlightMode(payload):

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -88,14 +88,14 @@ def crc8(buffer):
         crc = crc8tab[crc ^ c]
     return crc
 
-# note : python arrays slicing is a bit strange payload[x:y] means from 'x' included to 'y' NOT included
-#        therefore y - x gives the number of bytes sliced.
+# note : in python arrays slicing payload[x:y] means from 'x' included to 'y' not included,
+#        y - x gives the number of bytes sliced.
 def ParseGPS(payload):
-    lat = getCrossfireValue(True, payload[0:4]) / 1e7
+    lat = getCrossfireValue(True, payload[0:4]) / 1e7           #(degree / 10`000`000)
     long = getCrossfireValue(True, payload[4:8])/ 1e7
-    speed = getCrossfireValue(False, payload[8:10]) / 100
-    head = getCrossfireValue(False, payload[10:12]) / 100
-    alt = getCrossfireValue(False, payload[12:14]) - 1000
+    speed = getCrossfireValue(False, payload[8:10]) / 100       #(km/h / 100)
+    head = getCrossfireValue(False, payload[10:12]) / 100       #(degree / 100)
+    alt = getCrossfireValue(False, payload[12:14]) - 1000       #(meter - 1000m offset)
     numsat = payload[14]
     return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat, long, speed, head, alt, numsat)
 

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -77,7 +77,7 @@ def crc8(buffer):
     return crc
 
 def ParseGPS(payload):
-    lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB',bytes(bytearray(payload[0:15])))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
+    lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB', bytes(bytearray(payload[0:15])))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
     return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat / 1e7, long / 1e7, speed / 100, head / 100, alt - 1000, numsat)
 
 def ParseBattery(payload):

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -72,7 +72,6 @@ crc8tab = [
 ]
 
 # logs data are BigEndian
-
 def getCrossfireValue(signed, data=[], *args):
     hexstring = "0x"
     for n in data:
@@ -89,6 +88,8 @@ def crc8(buffer):
         crc = crc8tab[crc ^ c]
     return crc
 
+# note : python arrays slicing is a bit strange payload[x:y] means from 'x' included to 'y' NOT included
+#        therefore y - x gives the number of bytes sliced.
 def ParseGPS(payload):
     lat = getCrossfireValue(True, payload[0:4]) / 1e7
     long = getCrossfireValue(True, payload[4:8])/ 1e7

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -77,7 +77,7 @@ def crc8(buffer):
     return crc
 
 def ParseGPS(payload):
-    lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB', bytes(bytearray(payload[0:15])))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
+    lat, long, speed, head, alt, numsat = struct.unpack('>iiHHHB', bytes(bytearray(payload)))          # bytes(bytearray) casting is required for python 2.7.3 compatibility
     return "[GPS] lat:%f long:%f speed:%d heading:%d alt:%d numsat:%d" % (lat / 1e7, long / 1e7, speed / 100, head / 100, alt - 1000, numsat)
 
 def ParseBattery(payload):

--- a/radio/util/crossfire-parse.py
+++ b/radio/util/crossfire-parse.py
@@ -79,8 +79,8 @@ def crc8(buffer):
 # note : in python arrays slicing payload[x:y] means from 'x' included to 'y' not included,
 #        y - x gives the number of bytes sliced.
 def ParseGPS(payload):
-    lat = struct.unpack('>i',bytes(bytearray(payload[0:4])))[0] / 1e7      #(degree / 10`000`000)
-    long = struct.unpack('>i',bytes(bytearray(payload[4:8])))[0] / 1e7
+    lat = struct.unpack('>i',bytes(bytearray(payload[0:4])))[0] / 1e7          #(degree / 10`000`000)
+    long = struct.unpack('>i',bytes(bytearray(payload[4:8])))[0] / 1e7         #(degree / 10`000`000)
     speed = struct.unpack('>H',bytes(bytearray(payload[8:10])))[0] / 100       #(km/h / 100)
     head = struct.unpack('>H',bytes(bytearray(payload[10:12])))[0] / 100       #(degree / 100)
     alt = struct.unpack('>H',bytes(bytearray(payload[12:14])))[0] - 1000       #(meter - 1000m offset)


### PR DESCRIPTION
Since I do not have access to crossfire specs, I have updated the python scripts based on OpenTx 'c' crossfire parser.

The changes include support for negative values and GPS packets parsing