### PR TITLE
Fixes 5602 Special Functions Inc/Dec Gvar

### DIFF
--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -207,8 +207,17 @@ QString CustomFunctionData::paramToString(const ModelData * model) const
       case FUNC_ADJUST_GVAR_GVAR:
         return RawSource(param).toString();
       case FUNC_ADJUST_GVAR_INCDEC:
-        if (param==0) return tr("Decr:") + " -1";
-        else          return tr("Incr:") + " +1";
+        float val;
+        QString unit;
+        if (IS_ARM(getCurrentBoard())) {
+          val = param * model->gvarData[func - FuncAdjustGV1].multiplierGet();
+          unit = model->gvarData[func - FuncAdjustGV1].unitToString();
+        }
+        else {
+          val = param;
+          unit = "";
+        }
+        return QString("Increment: %1%2").arg(val).arg(unit);
     }
   }
   return "";

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -436,8 +436,19 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
             fswtchParam[i]->setDecimals(model->gvarData[gvidx].prec);
             fswtchParam[i]->setSingleStep(model->gvarData[gvidx].multiplierGet());
             fswtchParam[i]->setSuffix(model->gvarData[gvidx].unitToString());
-            fswtchParam[i]->setMinimum(model->gvarData[gvidx].getMinPrec());
-            fswtchParam[i]->setMaximum(model->gvarData[gvidx].getMaxPrec());
+            if (cfn.adjustMode==FUNC_ADJUST_GVAR_INCDEC) {
+              double rng = abs(model->gvarData[gvidx].getMax() - model->gvarData[gvidx].getMin());
+              if (rng > GVAR_MAX_VALUE) {
+                rng = GVAR_MAX_VALUE;
+              }
+              rng *= model->gvarData[gvidx].multiplierGet();
+              fswtchParam[i]->setMinimum(-rng);
+              fswtchParam[i]->setMaximum(rng);
+            }
+            else {
+              fswtchParam[i]->setMinimum(model->gvarData[gvidx].getMinPrec());
+              fswtchParam[i]->setMaximum(model->gvarData[gvidx].getMaxPrec());
+            }
             fswtchParam[i]->setValue(cfn.param * model->gvarData[gvidx].multiplierGet());
           }
           else {

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -438,9 +438,7 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
             fswtchParam[i]->setSuffix(model->gvarData[gvidx].unitToString());
             if (cfn.adjustMode==FUNC_ADJUST_GVAR_INCDEC) {
               double rng = abs(model->gvarData[gvidx].getMax() - model->gvarData[gvidx].getMin());
-              if (rng > GVAR_MAX_VALUE) {
-                rng = GVAR_MAX_VALUE;
-              }
+              rng = rng > GVAR_MAX_VALUE ? GVAR_MAX_VALUE : rng;
               rng *= model->gvarData[gvidx].multiplierGet();
               fswtchParam[i]->setMinimum(-rng);
               fswtchParam[i]->setMaximum(rng);

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -438,7 +438,6 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
             fswtchParam[i]->setSuffix(model->gvarData[gvidx].unitToString());
             if (cfn.adjustMode==FUNC_ADJUST_GVAR_INCDEC) {
               double rng = abs(model->gvarData[gvidx].getMax() - model->gvarData[gvidx].getMin());
-              rng = rng > GVAR_MAX_VALUE ? GVAR_MAX_VALUE : rng;
               rng *= model->gvarData[gvidx].multiplierGet();
               fswtchParam[i]->setMinimum(-rng);
               fswtchParam[i]->setMaximum(rng);

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -451,6 +451,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               default: // FUNC_ADJUST_GVAR_INC
 #if defined(CPUARM)
                 getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                getGVarIncDecRange(val_min, val_max);
                 lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
 #else

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -364,6 +364,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 break;
               default: // FUNC_ADJUST_GVAR_INC
                 getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                getGVarIncDecRange(val_min, val_max);
                 lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
                 break;

--- a/radio/src/gui/480x272/model_special_functions.cpp
+++ b/radio/src/gui/480x272/model_special_functions.cpp
@@ -359,6 +359,7 @@ bool menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 break;
               default: // FUNC_ADJUST_GVAR_INC
                 getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
+                getGVarIncDecRange(val_min, val_max);
                 lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, (val_displayed < 0 ? "-= " : "+= "), attr);
                 drawGVarValue(lcdNextPos, y, CFN_GVAR_INDEX(cfn), abs(val_displayed), attr|LEFT);
                 break;

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1078,6 +1078,16 @@ inline void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax,
 }
 #endif
 
+#if defined(GVARS)
+inline void getGVarIncDecRange(int16_t & valMin, int16_t & valMax)
+{
+  int16_t rng = abs(valMax - valMin);
+  rng = rng > GVAR_MAX ? GVAR_MAX : rng;
+  valMin = -rng;
+  valMax = rng;
+}
+#endif
+
 // Curves
 enum BaseCurves {
   CURVE_NONE,

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1078,7 +1078,7 @@ inline void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax,
 }
 #endif
 
-#if defined(GVARS)
+#if defined(CPUARM) && defined(GVARS)
 inline void getGVarIncDecRange(int16_t & valMin, int16_t & valMax)
 {
   int16_t rng = abs(valMax - valMin);

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1080,7 +1080,6 @@ inline void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax,
 inline void getGVarIncDecRange(int16_t & valMin, int16_t & valMax)
 {
   int16_t rng = abs(valMax - valMin);
-  rng = rng > GVAR_MAX ? GVAR_MAX : rng;
   valMin = -rng;
   valMax = rng;
 }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1076,9 +1076,7 @@ inline void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax,
     valMin = -valMax;
   }
 }
-#endif
-
-#if defined(CPUARM) && defined(GVARS)
+#if defined(GVAR_MAX)
 inline void getGVarIncDecRange(int16_t & valMin, int16_t & valMax)
 {
   int16_t rng = abs(valMax - valMin);
@@ -1086,6 +1084,7 @@ inline void getGVarIncDecRange(int16_t & valMin, int16_t & valMax)
   valMin = -rng;
   valMax = rng;
 }
+#endif
 #endif
 
 // Curves


### PR DESCRIPTION
Fixes #5602 
I made the decision to limit inc/dec to +/-1024 (+/-102.4) to avoid possible unexpected consequences.
In theory if a gvar has range of -1024 to +1024 the max inc/dec is +/-2048.
Though relative to current value even a +/-1024 inc/dec could push the calculated value outside the gvars min/max range. This should be handled by the radio mixer.
