### PR TITLE
Model print telemetry

### DIFF
--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -24,8 +24,8 @@ QString tdAlign(const QString & s, const QString & align, const QString & color,
 {
   QString str = s;
   if (bold) str = "<b>" + str + "</b>";
-  if (!color.isEmpty()) str = "<font color=" + color + ">" + str + "</font>";
-  return "<td align=" + align + ">" + str + "</td>";
+  if (!color.isEmpty()) str = "<font color='" + color + "'>" + str + "</font>";
+  return "<td align='" + align + "'>" + str + "</td>";
 }
 
 QString doTC(const QString & s, const QString & color, bool bold)
@@ -45,23 +45,23 @@ QString doTL(const QString & s, const QString & color, bool bold)
 
 QString fv(const QString & name, const QString & value, const QString & color)
 {
-  return "<b>" + name + ": </b><font color=" + color + ">" + value + "</font><br>";
+  return "<b>" + name + ": </b><font color='" + color + "'>" + value + "</font><br>";
 }
 
 QString doTableCell(const QString & s, const unsigned int width, const QString & align, const QString & color, bool bold)
 {
   QString prfx = "<td";
   if (width)
-    prfx.append(QString(" width=%1%").arg(QString::number(width)));
+    prfx.append(QString(" width='%1%'").arg(QString::number(width)));
   if (!align.isEmpty())
-    prfx.append(QString(" align=" + align));
+    prfx.append(QString(" align='%1'").arg(align));
   prfx.append(">");
 
   QString str = s;
   if (bold)
     str = "<b>" + str + "</b>";
   if (!color.isEmpty())
-    str = "<font color=" + color + ">" + str + "</font>";
+    str = QString("<font color='%1'>%2</font>").arg(color).arg(str);
 
   str =  prfx + str + "</td>";
   return str;

--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -20,7 +20,7 @@
 
 #include "helpers_html.h"
 
-QString tdAlign(const QString &s, const QString &align, const QString &color, bool bold)
+QString tdAlign(const QString & s, const QString & align, const QString & color, bool bold)
 {
   QString str = s;
   if (bold) str = "<b>" + str + "</b>";
@@ -28,24 +28,50 @@ QString tdAlign(const QString &s, const QString &align, const QString &color, bo
   return "<td align=" + align + ">" + str + "</td>";
 }
 
-QString doTC(const QString &s, const QString &color, bool bold)
+QString doTC(const QString & s, const QString & color, bool bold)
 {
   return tdAlign(s, "center", color, bold);
 }
 
-QString doTR(const QString &s, const QString &color, bool bold)
+QString doTR(const QString & s, const QString & color, bool bold)
 {
   return tdAlign(s, "right", color, bold);
 }
 
-QString doTL(const QString &s, const QString &color, bool bold)
+QString doTL(const QString & s, const QString & color, bool bold)
 {
   return tdAlign(s, "left", color, bold);
 }
 
-QString fv(const QString &name, const QString &value, const QString &color)
+QString fv(const QString & name, const QString & value, const QString & color)
 {
-  return "<b>" + name + ": </b><font color=" +color + ">" + value + "</font><br>";
+  return "<b>" + name + ": </b><font color=" + color + ">" + value + "</font><br>";
 }
 
+QString doTableCell(const QString & s, const unsigned int width, const QString & align, const QString & color, bool bold)
+{
+  QString prfx = "<td";
+  if (width)
+    prfx.append(QString(" width=%1%").arg(QString(width)));
+  if (!align.isEmpty())
+    prfx.append(QString(" align=" + align));
+  prfx.append(">");
 
+  QString str = s;
+  if (bold)
+    str = "<b>" + str + "</b>";
+  if (!color.isEmpty())
+    str = "<font color=" + color + ">" + str + "</font>";
+
+  str =  prfx + str + "</td>";
+  return str;
+}
+
+QString doTableRow(const QStringList & strl, const unsigned int width, const QString & align, const QString & color, bool bold)
+{
+  QString str;
+  for (int i=0; i<strl.count(); i++) {
+    str.append(doTableCell(strl.at(i), width, align, color, bold));
+  }
+  return "<tr>" + str + "</tr>";
+}

--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -52,7 +52,7 @@ QString doTableCell(const QString & s, const unsigned int width, const QString &
 {
   QString prfx = "<td";
   if (width)
-    prfx.append(QString(" width=%1%").arg(QString(width)));
+    prfx.append(QString(" width=%1%").arg(QString::number(width)));
   if (!align.isEmpty())
     prfx.append(QString(" align=" + align));
   prfx.append(">");

--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -75,3 +75,8 @@ QString doTableRow(const QStringList & strl, const unsigned int width, const QSt
   }
   return "<tr>" + str + "</tr>";
 }
+
+QString doTableBlankRow()
+{
+  return "<tr></tr>";
+}

--- a/companion/src/helpers_html.h
+++ b/companion/src/helpers_html.h
@@ -22,10 +22,14 @@
 #define _HELPERS_HTML_H_
 
 #include <QString>
+#include <QStringList>
 
-QString doTC(const QString &s, const QString &color="", bool bold=false);
-QString doTR(const QString &s, const QString &color="", bool bold=false);
-QString doTL(const QString &s, const QString &color="", bool bold=false);
-QString fv(const QString &name, const QString &value, const QString &color="green");
+QString tdAlign(const QString & s, const QString & align, const QString & color, bool bold);
+QString doTC(const QString & s, const QString & color = "", bool bold = false);
+QString doTR(const QString & s, const QString & color = "", bool bold = false);
+QString doTL(const QString & s, const QString & color = "", bool bold = false);
+QString fv(const QString & name, const QString & value, const QString & color = "green");
+QString doTableCell(const QString & s, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
+QString doTableRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
 
 #endif // _HELPERS_HTML_H_

--- a/companion/src/helpers_html.h
+++ b/companion/src/helpers_html.h
@@ -31,5 +31,6 @@ QString doTL(const QString & s, const QString & color = "", bool bold = false);
 QString fv(const QString & name, const QString & value, const QString & color = "green");
 QString doTableCell(const QString & s, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
 QString doTableRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
+QString doTableBlankRow();
 
 #endif // _HELPERS_HTML_H_

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -265,48 +265,47 @@ QString ModelPrinter::printModule(int idx)
   QString result;
   ModuleData module = model.moduleData[(idx<0 ? CPN_MAX_MODULES : idx)];
   if (idx < 0) {
-    str += tr("Mode") + QString("(%1)").arg(printTrainerMode());
+    str << printLabelValue(tr("Mode"), printTrainerMode());
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
       if (model.trainerMode == TRAINER_SLAVE_JACK) {
-        str += tr("Channels") + QString("(%1-%2)").arg(module.channelsStart + 1).arg(module.channelsStart + module.channelsCount);
-        str += tr("Frame length") + QString("(%1ms)").arg(printPPMFrameLength(module.ppm.frameLength));
-        str += tr("PPM delay") + QString("(%1us)").arg(module.ppm.delay);
-        str += tr("Polarity") + QString("(%1)").arg(module.polarityToString());
+        str << printLabelValue(tr("Channels"), QString("%1-%2").arg(module.channelsStart + 1).arg(module.channelsStart + module.channelsCount));
+        str << printLabelValue(tr("Frame length"), QString("%1ms").arg(printPPMFrameLength(module.ppm.frameLength)));
+        str << printLabelValue(tr("PPM delay"), QString("%1us").arg(module.ppm.delay));
+        str << printLabelValue(tr("Polarity"), module.polarityToString());
       }
     }
-    result = str.join(", ");
+    result = str.join(" ");
   }
   else {
-    str += printModuleType(idx);
-    str += tr("Protocol") + QString("(%1)").arg(printModuleProtocol(module.protocol));
+    str << printLabelValue(tr("Protocol"), printModuleProtocol(module.protocol));
     if (module.protocol) {
-      str += tr("Channels") + QString("(%1-%2)").arg(module.channelsStart + 1).arg(module.channelsStart + module.channelsCount);
+      str << printLabelValue(tr("Channels"), QString("%1-%2").arg(module.channelsStart + 1).arg(module.channelsStart + module.channelsCount));
       if (module.protocol == PULSES_PPM || module.protocol == PULSES_SBUS) {
-        str += tr("Frame length") + QString("(%1ms)").arg(printPPMFrameLength(module.ppm.frameLength));
-        str += tr("Polarity") + QString("(%1)").arg(module.polarityToString());
+        str << printLabelValue(tr("Frame length"), QString("%1ms").arg(printPPMFrameLength(module.ppm.frameLength)));
+        str << printLabelValue(tr("Polarity"), module.polarityToString());
         if (module.protocol == PULSES_PPM)
-          str += tr("Delay") + QString("(%1us)").arg(module.ppm.delay);
+          str << printLabelValue(tr("Delay"), QString("%1us").arg(module.ppm.delay));
       }
       else {
         if (!(module.protocol == PULSES_PXX_XJT_D8 || module.protocol == PULSES_CROSSFIRE || module.protocol == PULSES_SBUS)) {
-          str += tr("Receiver") + QString("(%1)").arg(module.modelId);
+          str << printLabelValue(tr("Receiver"), QString::number(module.modelId));
         }
         if (module.protocol == PULSES_MULTIMODULE) {
-          str += tr("Radio protocol") + QString("(%1)").arg(printMultiRfProtocol(module.multi.rfProtocol, module.multi.customProto));
-          str += tr("Subtype") + QString("(%1)").arg(printMultiSubType(module.multi.rfProtocol, module.multi.customProto, module.subType));
-          str += tr("Option value") + QString("(%1)").arg(module.multi.optionValue);
+          str << printLabelValue(tr("Radio protocol"), printMultiRfProtocol(module.multi.rfProtocol, module.multi.customProto));
+          str << printLabelValue(tr("Subtype"), printMultiSubType(module.multi.rfProtocol, module.multi.customProto, module.subType));
+          str << printLabelValue(tr("Option value"), QString::number(module.multi.optionValue));
         }
         if (module.protocol == PULSES_PXX_R9M) {
-          str += tr("Sub Type") + QString("(%1)").arg(printModuleSubType(module.protocol, module.subType));
-          str += tr("RF Output Power") + QString("(%1)").arg(printR9MPowerValue(module.subType, module.pxx.power, module.pxx.sport_out));
-          str += tr("Telemetry") + QString("(%1)").arg(printBoolean(module.pxx.sport_out, BOOLEAN_ENABLEDISABLE));
+          str << printLabelValue(tr("Sub Type"), printModuleSubType(module.protocol, module.subType));
+          str << printLabelValue(tr("RF Output Power"), printR9MPowerValue(module.subType, module.pxx.power, module.pxx.sport_out));
+          str << printLabelValue(tr("Telemetry"), printBoolean(module.pxx.sport_out, BOOLEAN_ENABLEDISABLE));
         }
       }
     }
-    result = str.join(", ");
+    result = str.join(" ");
     if (((PulsesProtocol)module.protocol == PulsesProtocol::PULSES_PXX_XJT_X16 || (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_PXX_R9M)
        && firmware->getCapability(HasFailsafe))
-      result.append(printFailsafe(idx));
+      result.append("<br/>" + printFailsafe(idx));
   }
   return result;
 }
@@ -966,13 +965,14 @@ QString ModelPrinter::printFailsafe(int idx)
 {
   QStringList strl;
   ModuleData module = model.moduleData[idx];
-  strl += "<br>" + tr("Failsafe Mode") + QString("(%1)").arg(printFailsafeMode(module.failsafeMode));
+  strl << printLabelValue(tr("Failsafe Mode"), printFailsafeMode(module.failsafeMode));
   if (module.failsafeMode == FAILSAFE_CUSTOM) {
     for (int i=0; i<module.channelsCount; i++) {
-      strl += QString("%1(%2)").arg(printChannelName(module.channelsStart + i).trimmed()).arg(printFailsafeValue(module.failsafeChannels[i]));
+      //strl << QString("%1(%2)").arg(printChannelName(module.channelsStart + i).trimmed()).arg(printFailsafeValue(module.failsafeChannels[i]));
+      strl << printLabelValue(printChannelName(module.channelsStart + i).trimmed(), printFailsafeValue(module.failsafeChannels[i]));
     }
   }
-  return strl.join(", ");
+  return strl.join(" ");
 }
 
 QString ModelPrinter::printFailsafeValue(int val)
@@ -1395,18 +1395,28 @@ QString ModelPrinter::printTelemetryScreenType(unsigned int val)
 QString ModelPrinter::printTelemetryScreen(unsigned int idx, unsigned int line, unsigned int width)
 {
   QStringList strl;
-  strl << "";  // blank 1st column
+  QStringList hd;
   FrSkyScreenData screen = model.frsky.screens[idx];
+  hd << "";  // blank 1st column
+  strl << "";
   if (screen.type == TelemetryScreenEnum::TELEMETRY_SCREEN_NUMBERS) {
+    if (line == 0) {
+      for (int c=0; c<firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
+        hd << tr("Source");
+      }
+    }
     for (int c=0; c<firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
       RawSource source = screen.body.lines[line].source[c];
       strl << source.toString(&model, &generalSettings);
     }
   }
   else if (screen.type == TelemetryScreenEnum::TELEMETRY_SCREEN_BARS) {
+    if (line == 0) {
+      hd << tr("Source") << tr("Min") << tr("Max");
+    }
     RawSource source = screen.body.bars[line].source;
     RawSourceRange range = source.getRange(&model, generalSettings);
-    strl << printLabelValue(tr("Source"), source.toString(&model, &generalSettings));
+    strl << source.toString(&model, &generalSettings);
     QString unit;
     QString minstr;
     QString maxstr;
@@ -1419,11 +1429,12 @@ QString ModelPrinter::printTelemetryScreen(unsigned int idx, unsigned int line, 
       maxstr = QString::number(range.getValue(screen.body.bars[line].barMax));
       unit = range.unit;
     }
-    strl << printLabelValue(tr("Min"), QString("%1%2").arg(minstr).arg(unit));
-    strl << printLabelValue(tr("Max"), QString("%1%2").arg(maxstr).arg(unit));
+    strl << QString("%1%2").arg(minstr).arg(unit);
+    strl << QString("%1%2").arg(maxstr).arg(unit);
   }
   else if (screen.type == TelemetryScreenEnum::TELEMETRY_SCREEN_SCRIPT && line == 0) {
-    strl << printLabelValue(tr("Filename"), QString("%1.lua").arg(screen.body.script.filename));
+    hd << tr("Filename");
+    strl << QString("%1.lua").arg(screen.body.script.filename);
   }
-  return doTableRow(strl, width / strl.count());
+  return (hd.count() > 1 ? doTableRow(hd, width / hd.count(), "left", "", true) : "" ) + doTableRow(strl, width / strl.count());
 }

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -607,6 +607,27 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
     return "";
 }
 
+QString ModelPrinter::printInputFlightModes(unsigned int flightModes)
+{
+  int numFlightModes = firmware->getCapability(FlightModes);
+  if (numFlightModes && flightModes) {
+    if (flightModes == (unsigned int)(1<<numFlightModes) - 1) {
+      return tr("None");
+    }
+    else {
+      QStringList list;
+      for (int i=0; i<numFlightModes; i++) {
+        if (!(flightModes & (1<<i))) {
+          list << printFlightModeName(i);
+        }
+      }
+      return QString("%1").arg(list.join(" "));
+    }
+  }
+  else
+    return tr("All");
+}
+
 QString ModelPrinter::printLogicalSwitchLine(int idx)
 {
   QString result = "";

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -1294,6 +1294,108 @@ QString ModelPrinter::printSensorTypeCond(unsigned int idx)
     return printSensorType(model.sensorData[idx].type);
 }
 
+QString ModelPrinter::printSensorDetails(unsigned int idx)
+{
+  QString str = "";
+  SensorData sensor = model.sensorData[idx];
+
+  if (!sensor.isAvailable())
+    return str;
+
+  bool isConfigurable = false;
+  bool gpsFieldsPrinted = false;
+  bool cellsFieldsPrinted = false;
+  bool consFieldsPrinted = false;
+  bool ratioFieldsPrinted = false;
+  bool totalizeFieldsPrinted = false;
+  bool sources12FieldsPrinted = false;
+  bool sources34FieldsPrinted = false;
+
+  str.append(doTableCell(printSensorTypeCond(idx)));
+
+  QString tc = "";
+  if (sensor.type == SensorData::TELEM_TYPE_CALCULATED) {
+    isConfigurable = (sensor.formula < SensorData::TELEM_FORMULA_CELL);
+    gpsFieldsPrinted = (sensor.formula == SensorData::TELEM_FORMULA_DIST);
+    cellsFieldsPrinted = (sensor.formula == SensorData::TELEM_FORMULA_CELL);
+    consFieldsPrinted = (sensor.formula == SensorData::TELEM_FORMULA_CONSUMPTION);
+    sources12FieldsPrinted = (sensor.formula <= SensorData::TELEM_FORMULA_MULTIPLY);
+    sources34FieldsPrinted = (sensor.formula < SensorData::TELEM_FORMULA_MULTIPLY);
+    totalizeFieldsPrinted = (sensor.formula == SensorData::TELEM_FORMULA_TOTALIZE);
+
+    tc.append(printLabelValue(tr("Formula"), printSensorFormula(sensor.formula)));
+  }
+  else {
+    isConfigurable = sensor.unit < SensorData::UNIT_FIRST_VIRTUAL;
+    ratioFieldsPrinted = (sensor.unit < SensorData::UNIT_FIRST_VIRTUAL);
+
+    tc.append(printLabelValue(tr("Id"), QString::number(sensor.id,16).toUpper()));
+    tc.append(printLabelValue(tr("Instance"), QString::number(sensor.instance)));
+  }
+  if (cellsFieldsPrinted) {
+    tc.append(printLabelValue(tr("Sensor"), QString("%1 > %2").arg(printTelemetrySource(sensor.source), false).arg(printSensorCells(sensor.index))));
+  }
+  if (sources12FieldsPrinted) {
+    QStringList srcs;
+    for (int i=0;i<4;i++) {
+      if (i < 2 || sources34FieldsPrinted) {
+        srcs << printTelemetrySource(sensor.sources[i]);
+      }
+    }
+    tc.append(printLabelValues(tr("Sources"), srcs));
+  }
+  if (consFieldsPrinted || totalizeFieldsPrinted)
+    tc.append(printLabelValue(tr("Sensor"), printTelemetrySource(sensor.amps)));
+  if (gpsFieldsPrinted) {
+    tc.append(printLabelValue(tr("GPS"), printTelemetrySource(sensor.gps)));
+    tc.append(printLabelValue(tr("Alt."), printTelemetrySource(sensor.alt)));
+  }
+  if (ratioFieldsPrinted && sensor.unit == SensorData::UNIT_RPMS) {
+      tc.append(printLabelValue(tr("Blades"), QString::number(sensor.ratio)));
+      tc.append(printLabelValue(tr("Multi."), QString::number(sensor.offset)));
+  }
+  str.append(doTableCell(tc));
+
+  tc = sensor.unitString();
+  tc = tc.trimmed() == "" ? "-" : tc;
+  str.append(doTableCell(tc));
+
+  if (isConfigurable && sensor.unit != SensorData::UNIT_FAHRENHEIT)
+    tc = QString::number(sensor.prec);
+  else
+    tc = "";
+  str.append(doTableCell(tc));
+
+  if (!ratioFieldsPrinted) {
+    str.append(doTableCell(""));
+    str.append(doTableCell(""));
+  }
+  else if (sensor.unit != SensorData::UNIT_RPMS) {
+      int prec = sensor.prec == 0 ? 1 : pow(10, sensor.prec);
+      str.append(doTableCell(QString::number((float)sensor.ratio / prec)));
+      str.append(doTableCell(QString::number((float)sensor.offset / prec)));
+  }
+
+  if (sensor.unit != SensorData::UNIT_RPMS && isConfigurable)
+    str.append(doTableCell(printBoolean(sensor.autoOffset, BOOLEAN_YN)));
+  else
+    str.append(doTableCell(""));
+
+  if (isConfigurable)
+    str.append(doTableCell(printBoolean(sensor.filter, BOOLEAN_YN)));
+  else
+    str.append(doTableCell(""));
+
+  if (sensor.type == SensorData::TELEM_TYPE_CALCULATED)
+    str.append(doTableCell(printBoolean(sensor.persistent, BOOLEAN_YN)));
+  else
+    str.append(doTableCell(""));
+
+  str.append(doTableCell(printBoolean(sensor.onlyPositive, BOOLEAN_YN)));
+  str.append(doTableCell(printBoolean(sensor.logs, BOOLEAN_YN), false));
+  return str;
+}
+
 QString ModelPrinter::printSensorParams(unsigned int idx)
 {
   QString str = "";
@@ -1320,17 +1422,17 @@ QString ModelPrinter::printSensorParams(unsigned int idx)
     sources34FieldsPrinted = (sensor.formula < SensorData::TELEM_FORMULA_MULTIPLY);
     totalizeFieldsPrinted = (sensor.formula == SensorData::TELEM_FORMULA_TOTALIZE);
 
-    str.append(printLabelValue(tr("Formula"), printSensorFormula(sensor.formula)));
+    str.append(printLabelValue(tr("F"), printSensorFormula(sensor.formula)));
   }
   else {
     isConfigurable = sensor.unit < SensorData::UNIT_FIRST_VIRTUAL;
     ratioFieldsPrinted = (sensor.unit < SensorData::UNIT_FIRST_VIRTUAL);
 
     str.append(printLabelValue(tr("Id"), QString::number(sensor.id,16).toUpper()));
-    str.append(printLabelValue(tr("Instance"), QString::number(sensor.instance)));
+    str.append(printLabelValue(tr("Inst"), QString::number(sensor.instance)));
   }
   if (cellsFieldsPrinted) {
-    str.append(printLabelValue(tr("Cells Sensor"), QString("%1 > %2").arg(printTelemetrySource(sensor.source), false).arg(printSensorCells(sensor.index))));
+    str.append(printLabelValue(tr("Sensor"), QString("%1 %2").arg(printTelemetrySource(sensor.source), false).arg(printSensorCells(sensor.index))));
   }
   if (sources12FieldsPrinted) {
     QStringList srcs;
@@ -1344,16 +1446,14 @@ QString ModelPrinter::printSensorParams(unsigned int idx)
   if (consFieldsPrinted || totalizeFieldsPrinted)
     str.append(printLabelValue(tr("Sensor"), printTelemetrySource(sensor.amps)));
   if (gpsFieldsPrinted) {
-    str.append(printLabelValue(tr("GPS Sensor"), printTelemetrySource(sensor.gps)));
-    str.append(printLabelValue(tr("Alt. Sensor"), printTelemetrySource(sensor.alt)));
+    str.append(printLabelValue(tr("GPS"), printTelemetrySource(sensor.gps)));
+    str.append(printLabelValue(tr("Alt"), printTelemetrySource(sensor.alt)));
   }
-  if ((sensor.type == SensorData::TELEM_TYPE_CALCULATED && (sensor.formula == SensorData::TELEM_FORMULA_DIST)) || isConfigurable) {
-    QString u = sensor.unitString();
-    u = u.trimmed() == "" ? "-" : u;
-    str.append(printLabelValue(tr("Unit"), u));
-  }
+  QString u = sensor.unitString();
+  u = u.trimmed() == "" ? "-" : u;
+  str.append(printLabelValue(tr("Unit"), u));
   if (isConfigurable && sensor.unit != SensorData::UNIT_FAHRENHEIT)
-    str.append(printLabelValue(tr("Precision"), QString::number(sensor.prec)));
+    str.append(printLabelValue(tr("Prec"), QString::number(sensor.prec)));
   if (ratioFieldsPrinted) {
     if (sensor.unit != SensorData::UNIT_RPMS) {
       int prec = sensor.prec == 0 ? 1 : pow(10, sensor.prec);
@@ -1362,17 +1462,17 @@ QString ModelPrinter::printSensorParams(unsigned int idx)
     }
     else if (sensor.unit == SensorData::UNIT_RPMS) {
       str.append(printLabelValue(tr("Blades"), QString::number(sensor.ratio)));
-      str.append(printLabelValue(tr("Multiplier"), QString::number(sensor.offset)));
+      str.append(printLabelValue(tr("Multi"), QString::number(sensor.offset)));
     }
   }
   if (sensor.unit != SensorData::UNIT_RPMS && isConfigurable)
-    str.append(printLabelValue(tr("Auto Offset"), printBoolean(sensor.autoOffset, BOOLEAN_YN)));
+    str.append(printLabelValue(tr("A/Offset"), printBoolean(sensor.autoOffset, BOOLEAN_YN)));
   if (isConfigurable)
     str.append(printLabelValue(tr("Filter"), printBoolean(sensor.filter, BOOLEAN_YN)));
   if (sensor.type == SensorData::TELEM_TYPE_CALCULATED)
-    str.append(printLabelValue(tr("Persistence"), printBoolean(sensor.persistent, BOOLEAN_YN)));
+    str.append(printLabelValue(tr("Persist"), printBoolean(sensor.persistent, BOOLEAN_YN)));
   str.append(printLabelValue(tr("Positive"), printBoolean(sensor.onlyPositive, BOOLEAN_YN)));
-  str.append(printLabelValue(tr("Logs"), printBoolean(sensor.logs, BOOLEAN_YN), false));
+  str.append(printLabelValue(tr("Log"), printBoolean(sensor.logs, BOOLEAN_YN), false));
   return str;
 }
 

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -1220,3 +1220,8 @@ QString ModelPrinter::printMahPersistent(bool mb)
 {
   return printBoolean(mb, BOOLEAN_YESNO);
 }
+
+QString ModelPrinter::printIgnoreSensorIds(bool mb)
+{
+  return printBoolean(mb, BOOLEAN_ENABLEDISABLE);
+}

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -389,7 +389,7 @@ QString ModelPrinter::printCenterBeep()
     if (model.beepANACenter & 0x40)
       strl << "P3";
   }
-  return (strl.isEmpty() ? tr("None") : strl.join(", "));
+  return (strl.isEmpty() ? tr("None") : strl.join(" "));
 }
 
 QString ModelPrinter::printTimer(int idx)
@@ -895,13 +895,12 @@ QString ModelPrinter::printOutputSymetrical(int idx)
 QString ModelPrinter::printSettingsOther()
 {
   QStringList str;
-  if (model.extendedLimits)
-    str += tr("Extended Limits");
-  if (firmware->getCapability(HasDisplayText) && model.displayChecklist)
-    str += tr("Display Checklist");
-  if (firmware->getCapability(GlobalFunctions) && !model.noGlobalFunctions)
-    str += tr("Global Functions");
-  return str.join(", ");
+  str << printLabelValue(tr("Extended Limits"), printBoolean(model.extendedLimits, BOOLEAN_YESNO));
+  if (firmware->getCapability(HasDisplayText))
+    str << printLabelValue(tr("Display Checklist"), printBoolean(model.displayChecklist, BOOLEAN_YESNO));
+  if (firmware->getCapability(GlobalFunctions))
+    str << printLabelValue(tr("Global Functions"), printBoolean(!model.noGlobalFunctions, BOOLEAN_YESNO));
+  return str.join(" ");
 }
 
 QString ModelPrinter::printSwitchWarnings()
@@ -928,7 +927,7 @@ QString ModelPrinter::printSwitchWarnings()
       str += RawSwitch(SWITCH_TYPE_SWITCH, 1+idx*3+value).toString(board.getBoardType(), &generalSettings, &model);
     }
   }
-  return (str.isEmpty() ? tr("None") : str.join(", ")) ;
+  return (str.isEmpty() ? tr("None") : str.join(" ")) ;
 }
 
 QString ModelPrinter::printPotWarnings()
@@ -936,7 +935,6 @@ QString ModelPrinter::printPotWarnings()
   QStringList str;
   int genAryIdx = 0;
   Boards board = firmware->getBoard();
-  str += (model.potsWarningMode ? tr("Mode") + QString("(%1)").arg(printPotsWarningMode()) : tr("None"));
   if (model.potsWarningMode) {
     for (int i=0; i<board.getCapability(Board::Pots)+board.getCapability(Board::Sliders); i++) {
       RawSource src(SOURCE_TYPE_STICK, CPN_MAX_STICKS + i);
@@ -946,7 +944,8 @@ QString ModelPrinter::printPotWarnings()
       }
     }
   }
-  return str.join(", ");
+  str << printLabelValue(tr("Mode"), printPotsWarningMode());
+  return str.join(" ");
 }
 
 QString ModelPrinter::printPotsWarningMode()
@@ -1039,12 +1038,11 @@ QString ModelPrinter::printTimerPersistent(unsigned int persistent)
 QString ModelPrinter::printSettingsTrim()
 {
   QStringList str;
-  str += tr("Step") + QString("(%1)").arg(printTrimIncrementMode());
-  if (IS_ARM(firmware->getBoard()) && model.trimsDisplay)
-    str += tr("Display") + QString("(%1)").arg(printTrimsDisplayMode());
-  if (model.extendedTrims)
-    str += tr("Extended");
-  return str.join(", ");
+  str << printLabelValue(tr("Step"), printTrimIncrementMode());
+  if (IS_ARM(firmware->getBoard()))
+    str << printLabelValue(tr("Display"), printTrimsDisplayMode());
+  str << printLabelValue(tr("Extended"), printBoolean(model.extendedTrims, BOOLEAN_YESNO));
+  return str.join(" ");
 }
 
 QString ModelPrinter::printThrottleSource(int idx)
@@ -1102,14 +1100,11 @@ QString ModelPrinter::printPxxPower(int power)
 QString ModelPrinter::printThrottle()
 {
   QStringList result;
-  result += tr("Source") + QString("(%1)").arg(printThrottleSource(model.thrTraceSrc));
-  if (model.thrTrim)
-    result += tr("Trim idle only");
-  if (!model.disableThrottleWarning)
-    result += tr("Warning");
-  if (model.throttleReversed)
-    result +=  tr("Reversed");
-  return result.join(", ");
+  result << printLabelValue(tr("Source"), printThrottleSource(model.thrTraceSrc));
+  result << printLabelValue(tr("Trim idle only"), printBoolean(model.thrTrim, BOOLEAN_YESNO));
+  result << printLabelValue(tr("Warning"), printBoolean(!model.disableThrottleWarning, BOOLEAN_YESNO));
+  result << printLabelValue(tr("Reversed"), printBoolean(model.throttleReversed, BOOLEAN_YESNO));
+  return result.join(" ");
 }
 
 QString ModelPrinter::printPPMFrameLength(int ppmFL)

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -76,6 +76,10 @@ QString addFont(const QString & input, const QString & color, const QString & si
   return "<font " + sizeStr + " " + faceStr + " " + colorStr + ">" + input + "</font>";
 }
 
+QString ModelPrinter::printLabelValue(const QString & str, const QString & val) {
+  return QString("<b>%1:</b> %2").arg(str, val);
+}
+
 #define MASK_TIMEVALUE_HRSMINS 1
 #define MASK_TIMEVALUE_ZEROHRS 2
 #define MASK_TIMEVALUE_PADSIGN 3
@@ -1049,7 +1053,7 @@ QString ModelPrinter::printTrimsDisplayMode()
     case 2:
       return tr("Always");
     default:
-      return tr("Unknown");
+      return tr("???");
   }
 }
 
@@ -1114,6 +1118,105 @@ QString ModelPrinter::printTimerTimeValue(unsigned int val)
 }
 
 QString ModelPrinter::printTimerMinuteBeep(bool mb)
+{
+  return printBoolean(mb, BOOLEAN_YESNO);
+}
+
+QString ModelPrinter::printTelemetryProtocol(unsigned int val)
+{
+  switch (val) {
+    case 0:
+      return tr("FrSky S.PORT");
+    case 1:
+      return tr("FrSky D");
+    case 2:
+      return tr("FrSky D (cable)");
+    default:
+      return tr("???");
+  }
+}
+
+QString ModelPrinter::printRssiAlarmsDisabled(bool mb)
+{
+  return printBoolean(!mb, BOOLEAN_ENABLEDISABLE);
+}
+
+QString ModelPrinter::printTelemetrySource(unsigned int val)
+{
+  QStringList strings = QStringList() << "None";
+
+  for (int i=1; i<=CPN_MAX_SENSORS; ++i) {
+    strings << model.sensorData[i-1].label;
+  }
+
+  return strings.value(val);
+}
+
+QString ModelPrinter::printVarioSource(unsigned int val)
+{
+  switch (val) {
+    case TELEMETRY_VARIO_SOURCE_ALTI:
+      return tr("Alti");
+    case TELEMETRY_VARIO_SOURCE_ALTI_PLUS:
+      return tr("Alti+");
+    case TELEMETRY_VARIO_SOURCE_VSPEED:
+      return tr("VSpeed");
+    case TELEMETRY_VARIO_SOURCE_A1:
+      return tr("A1");
+    case TELEMETRY_VARIO_SOURCE_A2:
+      return tr("A2");
+    default:
+      return tr("???");
+  }
+
+}
+
+QString ModelPrinter::printVarioCenterSilent(bool mb)
+{
+  return printBoolean(mb, BOOLEAN_YESNO);
+}
+
+QString ModelPrinter::printVoltsSource(unsigned int val)
+{
+  switch (val) {
+    case TELEMETRY_VOLTS_SOURCE_A1:
+      return tr("A1");
+    case TELEMETRY_VOLTS_SOURCE_A2:
+      return tr("A2");
+    case TELEMETRY_VOLTS_SOURCE_A3:
+      return tr("A3");
+    case TELEMETRY_VOLTS_SOURCE_A4:
+      return tr("A4");
+    case TELEMETRY_VOLTS_SOURCE_FAS:
+      return tr("FAS");
+    case TELEMETRY_VOLTS_SOURCE_CELLS:
+      return tr("Cells");
+    default:
+      return tr("???");
+  }
+}
+
+QString ModelPrinter::printCurrentSource(unsigned int val)
+{
+  switch (val) {
+    case TELEMETRY_CURRENT_SOURCE_NONE:
+      return tr("None");
+    case TELEMETRY_CURRENT_SOURCE_A1:
+      return tr("A1");
+    case TELEMETRY_CURRENT_SOURCE_A2:
+      return tr("A2");
+    case TELEMETRY_CURRENT_SOURCE_A3:
+      return tr("A3");
+    case TELEMETRY_CURRENT_SOURCE_A4:
+      return tr("A4");
+    case TELEMETRY_CURRENT_SOURCE_FAS:
+      return tr("FAS");
+    default:
+      return tr("???");
+  }
+}
+
+QString ModelPrinter::printMahPersistent(bool mb)
 {
   return printBoolean(mb, BOOLEAN_YESNO);
 }

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -117,15 +117,21 @@ class ModelPrinter: public QObject
     QString printTimerMinuteBeep(bool mb);
     QString printTimerTimeValue(unsigned int val);
     QString printTelemetryProtocol(unsigned int val);
-    QString printLabelValue(const QString & str, const QString & val);
+    QString printLabelValue(const QString & lbl, const QString & val, const bool sep = false);
+    QString printLabelValues(const QString & lbl, const QStringList & vals, const bool sep = false);
     QString printRssiAlarmsDisabled(bool mb);
-    QString printTelemetrySource(unsigned int val);
+    QString printTelemetrySource(int val);
     QString printVarioSource(unsigned int val);
     QString printVarioCenterSilent(bool mb);
     QString printVoltsSource(unsigned int val);
     QString printCurrentSource(unsigned int val);
     QString printMahPersistent(bool mb);
     QString printIgnoreSensorIds(bool mb);
+    QString printSensorType(unsigned int val);
+    QString printSensorFormula(unsigned int val);
+    QString printSensorCells(unsigned int val);
+    QString printSensorParams(unsigned int idx);
+
   private:
     Firmware * firmware;
     const GeneralSettings & generalSettings;

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -132,6 +132,7 @@ class ModelPrinter: public QObject
     QString printSensorCells(unsigned int val);
     QString printSensorTypeCond(unsigned int idx);
     QString printSensorParams(unsigned int idx);
+    QString printSensorDetails(unsigned int idx);
     QString printTelemetryScreenType(unsigned int val);
     QString printTelemetryScreen(unsigned int idx, unsigned int line, unsigned int width);
 

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -65,6 +65,7 @@ class ModelPrinter: public QObject
     QString printFlightModeSwitch(const RawSwitch & swtch);
     QString printFlightModeName(int index);
     QString printFlightModes(unsigned int flightModes);
+    QString printInputFlightModes(unsigned int flightModes);
     QString printModule(int idx);
     QString printTrainerMode();
     QString printCenterBeep();

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -116,6 +116,15 @@ class ModelPrinter: public QObject
     QString printTimeValue(const int value, const unsigned int mask);
     QString printTimerMinuteBeep(bool mb);
     QString printTimerTimeValue(unsigned int val);
+    QString printTelemetryProtocol(unsigned int val);
+    QString printLabelValue(const QString & str, const QString & val);
+    QString printRssiAlarmsDisabled(bool mb);
+    QString printTelemetrySource(unsigned int val);
+    QString printVarioSource(unsigned int val);
+    QString printVarioCenterSilent(bool mb);
+    QString printVoltsSource(unsigned int val);
+    QString printCurrentSource(unsigned int val);
+    QString printMahPersistent(bool mb);
   private:
     Firmware * firmware;
     const GeneralSettings & generalSettings;

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -130,7 +130,10 @@ class ModelPrinter: public QObject
     QString printSensorType(unsigned int val);
     QString printSensorFormula(unsigned int val);
     QString printSensorCells(unsigned int val);
+    QString printSensorTypeCond(unsigned int idx);
     QString printSensorParams(unsigned int idx);
+    QString printTelemetryScreenType(unsigned int val);
+    QString printTelemetryScreen(unsigned int idx, unsigned int line, unsigned int width);
 
   private:
     Firmware * firmware;

--- a/companion/src/modelprinter.h
+++ b/companion/src/modelprinter.h
@@ -125,6 +125,7 @@ class ModelPrinter: public QObject
     QString printVoltsSource(unsigned int val);
     QString printCurrentSource(unsigned int val);
     QString printMahPersistent(bool mb);
+    QString printIgnoreSensorIds(bool mb);
   private:
     Firmware * firmware;
     const GeneralSettings & generalSettings;

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -192,7 +192,17 @@ void MultiModelPrinter::MultiColumns::appendFieldSeparator(const bool sep)
   } \
   columns.endCompare();
 
-#define COMPARECELL(lbl, what, width) \
+#define COMPARECELL(what) \
+  columns.appendCellStart(); \
+  COMPARE(what); \
+  columns.appendCellEnd();
+
+#define COMPARECELLWIDTH(what, width) \
+  columns.appendCellStart(width); \
+  COMPARE(what); \
+  columns.appendCellEnd();
+
+#define LABELCOMPARECELL(lbl, what, width) \
   columns.appendCellStart(width); \
   columns.appendFieldLabel(lbl); \
   COMPARE(what); \
@@ -272,7 +282,7 @@ QString MultiModelPrinter::print(QTextDocument * document)
   if (firmware->getCapability(Gvars) && !firmware->getCapability(GvarsFlightModes))
     str.append(printGvars());
   str.append(printLogicalSwitches());
-  str.append(printCustomFunctions());
+  str.append(printSpecialFunctions());
   if (firmware->getCapability(Telemetry) & TM_HASTELEMETRY) {
     str.append(printTelemetry());
     str.append(printSensors());
@@ -320,11 +330,11 @@ QString MultiModelPrinter::printTimers()
     columns.appendCellStart(0, true);
     COMPARE(modelPrinter->printTimerName(i));
     columns.appendCellEnd(true);
-    COMPARECELL("", modelPrinter->printTimerTimeValue(model->timers[i].val), 0);
-    COMPARECELL("", model->timers[i].mode.toString(), 0);
-    COMPARECELL("", modelPrinter->printTimerCountdownBeep(model->timers[i].countdownBeep), 0);
-    COMPARECELL("", modelPrinter->printTimerMinuteBeep(model->timers[i].minuteBeep), 0);
-    COMPARECELL("", modelPrinter->printTimerPersistent(model->timers[i].persistent), 0);
+    COMPARECELL(modelPrinter->printTimerTimeValue(model->timers[i].val));
+    COMPARECELL(model->timers[i].mode.toString());
+    COMPARECELL(modelPrinter->printTimerCountdownBeep(model->timers[i].countdownBeep));
+    COMPARECELL(modelPrinter->printTimerMinuteBeep(model->timers[i].minuteBeep));
+    COMPARECELL(modelPrinter->printTimerPersistent(model->timers[i].persistent));
     columns.appendRowEnd();
   }
   columns.appendTableEnd();
@@ -339,15 +349,15 @@ QString MultiModelPrinter::printModules()
   columns.appendSectionTableStart();
   for (int i=0; i<firmware->getCapability(NumModules); i++) {
     columns.appendRowStart();
-    columns.appendCellStart(0, true);
+    columns.appendCellStart(20, true);
     COMPARE(modelPrinter->printModuleType(i));
     columns.appendCellEnd(true);
-    COMPARECELL("", modelPrinter->printModule(i), 0);
+    COMPARECELLWIDTH(modelPrinter->printModule(i), 80);
     columns.appendRowEnd();
   }
   if (firmware->getCapability(ModelTrainerEnable))
     columns.appendRowStart(tr("Trainer port"));
-    COMPARECELL("", modelPrinter->printModule(-1), 0);
+    COMPARECELL(modelPrinter->printModule(-1));
     columns.appendRowEnd();
   columns.appendTableEnd();
   str.append(columns.print());
@@ -368,25 +378,25 @@ QString MultiModelPrinter::printHeliSetup()
   MultiColumns columns(modelPrinterMap.size());
   columns.appendSectionTableStart();
   columns.appendRowStart(tr("Swash"), 20);
-  COMPARECELL(tr("Type"), modelPrinter->printHeliSwashType(), 20);
-  COMPARECELL(tr("Ring"), model->swashRingData.value, 20);
+  LABELCOMPARECELL(tr("Type"), modelPrinter->printHeliSwashType(), 20);
+  LABELCOMPARECELL(tr("Ring"), model->swashRingData.value, 20);
   columns.appendRowEnd();
 
   columns.appendRowBlank();
   columns.appendRowHeader(QStringList() << "" << tr("Input") << tr("Weight"));
   columns.appendRowStart(tr("Long. cyc"));
-  COMPARECELL("", model->swashRingData.elevatorSource.toString(model), 0);
-  COMPARECELL("", model->swashRingData.elevatorWeight, 0);
+  COMPARECELL(model->swashRingData.elevatorSource.toString(model));
+  COMPARECELL(model->swashRingData.elevatorWeight);
   columns.appendRowEnd();
 
   columns.appendRowStart(tr("Lateral cyc"));
-  COMPARECELL("", model->swashRingData.aileronSource.toString(model), 0);
-  COMPARECELL("", model->swashRingData.aileronWeight, 0)
+  COMPARECELL(model->swashRingData.aileronSource.toString(model));
+  COMPARECELL(model->swashRingData.aileronWeight)
   columns.appendRowEnd();
 
   columns.appendRowStart(tr("Collective"));
-  COMPARECELL("", model->swashRingData.collectiveSource.toString(model), 0);
-  COMPARECELL("", model->swashRingData.collectiveWeight, 0)
+  COMPARECELL(model->swashRingData.collectiveSource.toString(model));
+  COMPARECELL(model->swashRingData.collectiveWeight)
   columns.appendRowEnd();
 
   columns.appendTableEnd();
@@ -412,11 +422,11 @@ QString MultiModelPrinter::printFlightModes()
       columns.appendCellStart(0,true);
       COMPARE(modelPrinter->printFlightModeName(i));
       columns.appendCellEnd(true);
-      COMPARECELL("", modelPrinter->printFlightModeSwitch(model->flightModeData[i].swtch), 0);
-      COMPARECELL("", model->flightModeData[i].fadeIn, 0);
-      COMPARECELL("", model->flightModeData[i].fadeOut, 0);
+      COMPARECELL(modelPrinter->printFlightModeSwitch(model->flightModeData[i].swtch));
+      COMPARECELL(model->flightModeData[i].fadeIn);
+      COMPARECELL(model->flightModeData[i].fadeOut);
       for (int k=0; k < getBoardCapability(getCurrentBoard(), Board::NumTrims); k++) {
-        COMPARECELL("", modelPrinter->printTrim(i, k), 0);
+        COMPARECELL(modelPrinter->printTrim(i, k));
       }
       columns.appendRowEnd();
     }
@@ -444,32 +454,32 @@ QString MultiModelPrinter::printFlightModes()
     if (firmware->getCapability(GvarsFlightModes)) {
       columns.appendRowStart(tr("Name"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", model->gvarData[i].name, 0);
+        COMPARECELL(model->gvarData[i].name);
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Unit"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", modelPrinter->printGlobalVarUnit(i), 0);
+        COMPARECELL(modelPrinter->printGlobalVarUnit(i));
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Prec"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", modelPrinter->printGlobalVarPrec(i), 0);
+        COMPARECELL(modelPrinter->printGlobalVarPrec(i));
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Min"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", modelPrinter->printGlobalVarMin(i), 0);
+        COMPARECELL(modelPrinter->printGlobalVarMin(i));
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Max"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", modelPrinter->printGlobalVarMax(i), 0);
+        COMPARECELL(modelPrinter->printGlobalVarMax(i));
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Popup"));
       for (int i=0; i<gvars; i++) {
-        COMPARECELL("", modelPrinter->printGlobalVarPopup(i), 0);
+        COMPARECELL(modelPrinter->printGlobalVarPopup(i));
       }
       columns.appendRowEnd();
     }
@@ -484,11 +494,11 @@ QString MultiModelPrinter::printFlightModes()
       columns.appendCellEnd(true);
       if (firmware->getCapability(GvarsFlightModes)) {
         for (int k=0; k<gvars; k++) {
-          COMPARECELL("", modelPrinter->printGlobalVar(i, k), 0);
+          COMPARECELL(modelPrinter->printGlobalVar(i, k));
         }
       }
       for (int k=0; k<firmware->getCapability(RotaryEncoders); k++) {
-        COMPARECELL("", modelPrinter->printRotaryEncoder(i, k), 0);
+        COMPARECELL(modelPrinter->printRotaryEncoder(i, k));
       }
       columns.appendRowEnd();
     }
@@ -523,18 +533,18 @@ QString MultiModelPrinter::printOutputs()
     columns.appendCellStart(0, true);
     COMPARE(modelPrinter->printChannelName(i));
     columns.appendCellEnd(true);
-    COMPARECELL("", modelPrinter->printOutputOffset(i), 0);
-    COMPARECELL("", modelPrinter->printOutputMin(i), 0);
-    COMPARECELL("", modelPrinter->printOutputMax(i), 0);
-    COMPARECELL("", modelPrinter->printOutputRevert(i), 0);
+    COMPARECELL(modelPrinter->printOutputOffset(i));
+    COMPARECELL(modelPrinter->printOutputMin(i));
+    COMPARECELL(modelPrinter->printOutputMax(i));
+    COMPARECELL(modelPrinter->printOutputRevert(i));
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-      COMPARECELL("", modelPrinter->printOutputCurve(i), 0);
+      COMPARECELL(modelPrinter->printOutputCurve(i));
     }
     if (firmware->getCapability(PPMCenter)) {
-      COMPARECELL("", modelPrinter->printOutputPpmCenter(i), 0);
+      COMPARECELL(modelPrinter->printOutputPpmCenter(i));
     }
     if (firmware->getCapability(SYMLimits)) {
-      COMPARECELL("", modelPrinter->printOutputSymetrical(i), 0);
+      COMPARECELL(modelPrinter->printOutputSymetrical(i));
     }
     columns.appendRowEnd();
   }
@@ -556,7 +566,7 @@ QString MultiModelPrinter::printGvars()
   columns.appendRowHeader(hd);
 
   for (int i=0; i<gvars; i++) {
-    COMPARECELL("", model->flightModeData[0].gvars[i], 0);
+    COMPARECELL(model->flightModeData[0].gvars[i]);
   }
   columns.appendRowEnd();
   columns.appendTableEnd();
@@ -621,7 +631,7 @@ QString MultiModelPrinter::printCurves(QTextDocument * document)
   QString str;
   MultiColumns columns(modelPrinterMap.size());
   int count = 0;
-  columns.append("<table cellspacing='0' cellpadding='1' width='100%' border='0' style='border-collapse:collapse'>");
+  columns.appendSectionTableStart();
   for (int i=0; i<firmware->getCapability(NumCurves); i++) {
     bool curveEmpty = true;
     for (int k=0; k < modelPrinterMap.size(); k++) {
@@ -632,16 +642,21 @@ QString MultiModelPrinter::printCurves(QTextDocument * document)
     }
     if (!curveEmpty) {
       count++;
-      columns.append("<tr><td width='20%'><b>");
+      columns.appendRowStart();
+      columns.appendCellStart(20, true);
       COMPARE(modelPrinter->printCurveName(i));
-      columns.append("</b></td><td>");
-      COMPARE(modelPrinter->printCurve(i));
+      columns.appendCellEnd(true);
+      COMPARECELL(modelPrinter->printCurve(i));
+      columns.appendRowEnd();
+      columns.appendRowStart("", 20);
+      columns.appendCellStart();
       for (int k=0; k < modelPrinterMap.size(); k++)
-        columns.append(k, QString("<br/><img src='%1' border='0' />").arg(modelPrinterMap.value(k).second->createCurveImage(i, document)));
-      columns.append("</td></tr>");
+        columns.append(k, QString("<br/><img src='%1' border='0' /><br/>").arg(modelPrinterMap.value(k).second->createCurveImage(i, document)));
+      columns.appendCellEnd();
+      columns.appendRowEnd();
     }
   }
-  columns.append("</table><br/>");
+  columns.appendTableEnd();
   if (count > 0) {
     str.append(printTitle(tr("Curves")));
     str.append(columns.print());
@@ -654,7 +669,7 @@ QString MultiModelPrinter::printLogicalSwitches()
   QString str;
   MultiColumns columns(modelPrinterMap.size());
   int count = 0;
-  columns.append("<table cellspacing='0' cellpadding='1' width='100%' border='0' style='border-collapse:collapse'>");
+  columns.appendSectionTableStart();
   for (int i=0; i<firmware->getCapability(LogicalSwitches); i++) {
     bool lsEmpty = true;
     for (int k=0; k < modelPrinterMap.size(); k++) {
@@ -665,12 +680,12 @@ QString MultiModelPrinter::printLogicalSwitches()
     }
     if (!lsEmpty) {
       count++;
-      columns.append("<tr><td width='20%'><b>" + tr("L%1").arg(i+1) + "</b></td><td>");
-      COMPARE(modelPrinter->printLogicalSwitchLine(i));
-      columns.append("</td></tr>");
+      columns.appendRowStart(tr("L%1").arg(i+1), 20);
+      COMPARECELL(modelPrinter->printLogicalSwitchLine(i));
+      columns.appendRowEnd();
     }
   }
-  columns.append("</table>");
+  columns.appendTableEnd();
   if (count > 0) {
     str.append(printTitle(tr("Logical Switches")));
     str.append(columns.print());
@@ -678,12 +693,12 @@ QString MultiModelPrinter::printLogicalSwitches()
   return str;
 }
 
-QString MultiModelPrinter::printCustomFunctions()
+QString MultiModelPrinter::printSpecialFunctions()
 {
   QString str;
   MultiColumns columns(modelPrinterMap.size());
   int count = 0;
-  columns.append("<table cellspacing='0' cellpadding='1' width='100%' border='0' style='border-collapse:collapse'>");
+  columns.appendSectionTableStart();
   for (int i=0; i < firmware->getCapability(CustomFunctions); i++) {
     bool sfEmpty = true;
     for (int k=0; k < modelPrinterMap.size(); k++) {
@@ -694,12 +709,12 @@ QString MultiModelPrinter::printCustomFunctions()
     }
     if (!sfEmpty) {
       count++;
-      columns.append("<tr><td width='20%'><b>" + tr("SF%1").arg(i+1) + "</b></td><td>");
-      COMPARE(modelPrinter->printCustomFunctionLine(i));
-      columns.append("</td></tr>");
+      columns.appendRowStart(tr("SF%1").arg(i+1), 20);
+      COMPARECELL(modelPrinter->printCustomFunctionLine(i));
+      columns.appendRowEnd();
     }
   }
-  columns.append("</table>");
+  columns.appendTableEnd();
   if (count > 0) {
     str.append(printTitle(tr("Special Functions")));
     str.append(columns.print());
@@ -718,16 +733,16 @@ QString MultiModelPrinter::printTelemetry()
     columns.appendRowHeader(QStringList() << tr("Analogs") << tr("Unit") << tr("Scale") << tr("Offset"));
     for (int i=0; i<2; i++) {
       columns.appendRowStart(QString("A%1").arg(i+1), 20);
-      COMPARECELL("", getFrSkyUnits(model->frsky.channels[i].type), 20);
-      COMPARECELL("", QString::number((model->frsky.channels[i].ratio / (model->frsky.channels[i].type==0 ? 10.0 : 1)), 10, (model->frsky.channels[i].type==0 ? 1 : 0)), 20);
-      COMPARECELL("", QString::number((model->frsky.channels[i].offset*(model->frsky.channels[i].ratio / (model->frsky.channels[i].type==0 ?10.0 : 1)))/255, 10, (model->frsky.channels[i].type==0 ? 1 : 0)), 40);
+      COMPARECELLWIDTH(getFrSkyUnits(model->frsky.channels[i].type), 20);
+      COMPARECELLWIDTH(QString::number((model->frsky.channels[i].ratio / (model->frsky.channels[i].type==0 ? 10.0 : 1)), 10, (model->frsky.channels[i].type==0 ? 1 : 0)), 20);
+      COMPARECELLWIDTH(QString::number((model->frsky.channels[i].offset*(model->frsky.channels[i].ratio / (model->frsky.channels[i].type==0 ?10.0 : 1)))/255, 10, (model->frsky.channels[i].type==0 ? 1 : 0)), 40);
       columns.appendRowEnd();
     }
   }
   else {
     // Protocol
     columns.appendRowStart(tr("Protocol"), 20);
-    COMPARECELL("", modelPrinter->printTelemetryProtocol(model->telemetryProtocol), 0);
+    COMPARECELL(modelPrinter->printTelemetryProtocol(model->telemetryProtocol));
     columns.appendRowEnd();
   }
 
@@ -750,10 +765,10 @@ QString MultiModelPrinter::printTelemetry()
   if (firmware->getCapability(HasVario)) {
     columns.appendRowStart(tr("Altimetry"), 20);
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-      COMPARECELL(tr("Vario source"), modelPrinter->printTelemetrySource(model->frsky.varioSource), 80);
+      LABELCOMPARECELL(tr("Vario source"), modelPrinter->printTelemetrySource(model->frsky.varioSource), 80);
     }
     else {
-      COMPARECELL(tr("Vario source"), modelPrinter->printVarioSource(model->frsky.varioSource), 80);
+      LABELCOMPARECELL(tr("Vario source"), modelPrinter->printVarioSource(model->frsky.varioSource), 80);
     }
     columns.appendRowEnd();
     columns.appendRowStart("", 20);
@@ -789,7 +804,7 @@ QString MultiModelPrinter::printTelemetry()
     columns.appendRowHeader(QStringList() << tr("Various"));
     if (!firmware->getCapability(NoTelemetryProtocol)) {
       columns.appendRowStart("", 20);
-      COMPARECELL(tr("Serial protocol"), modelPrinter->printTelemetrySource(model->frsky.voltsSource), 80);
+      LABELCOMPARECELL(tr("Serial protocol"), modelPrinter->printTelemetrySource(model->frsky.voltsSource), 80);
       columns.appendRowEnd();
     }
     columns.appendRowStart("", 20);
@@ -810,7 +825,7 @@ QString MultiModelPrinter::printTelemetry()
     columns.appendCellEnd();
     columns.appendRowEnd();
     columns.appendRowStart("", 20);
-    COMPARECELL(tr("Blades"), model->frsky.blades, 80);
+    LABELCOMPARECELL(tr("Blades"), model->frsky.blades, 80);
     columns.appendRowEnd();
   }
   columns.appendTableEnd();
@@ -825,6 +840,7 @@ QString MultiModelPrinter::printSensors()
   int count = 0;
   columns.appendSectionTableStart();
   columns.appendRowHeader(QStringList() << tr("Name") << tr("Type") << tr("Parameters"));
+  //columns.appendRowHeader(QStringList() << tr("Name") << tr("Type") << tr("Formula/Source") << tr("Unit") << tr("Prec") << tr("Ratio") << tr("Ofst") << tr("A.Ofst") << tr("Fltr") << tr("Pers.") << tr("+ve") << tr("Log"));
   for (int i=0; i<CPN_MAX_SENSORS; ++i) {
     bool tsEmpty = true;
     for (int k=0; k < modelPrinterMap.size(); k++) {
@@ -839,8 +855,9 @@ QString MultiModelPrinter::printSensors()
       columns.appendCellStart(15, true);
       COMPARE(model->sensorData[i].nameToString(i));
       columns.appendCellEnd(true);
-      COMPARECELL("", modelPrinter->printSensorTypeCond(i), 15);
-      COMPARECELL("", modelPrinter->printSensorParams(i), 70);
+      COMPARECELLWIDTH(modelPrinter->printSensorTypeCond(i), 15);
+      COMPARECELLWIDTH(modelPrinter->printSensorParams(i), 70);
+      //COMPARESTRING("", modelPrinter->printSensorDetails(i), 0);
       columns.appendRowEnd();
     }
   }
@@ -869,10 +886,10 @@ QString MultiModelPrinter::printTelemetryScreens()
     if (!tsEmpty) {
       count++;
       columns.appendRowStart();
-      COMPARECELL(QString("%1").arg(i+1), modelPrinter->printTelemetryScreenType(model->frsky.screens[i].type), 20);
+      LABELCOMPARECELL(QString("%1").arg(i+1), modelPrinter->printTelemetryScreenType(model->frsky.screens[i].type), 20);
       columns.appendRowEnd();
       for (int l=0; l<4; l++) {
-        COMPARE(modelPrinter->printTelemetryScreen(i,l,80));
+        COMPARE(modelPrinter->printTelemetryScreen(i, l, 80));
       }
     }
   }

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -189,6 +189,13 @@ void MultiModelPrinter::MultiColumns::appendFieldSeparator(const bool sep)
   COMPARE(what); \
   columns.appendCellEnd();
 
+#define ROWLABELCOMPARECELL(lbl, lblw, what, width) \
+  columns.appendRowStart(lbl, lblw); \
+  columns.appendCellStart(width); \
+  COMPARE(what); \
+  columns.appendCellEnd(); \
+  columns.appendRowEnd();
+
 #define COMPARESTRING(lbl, what, sep) \
   columns.appendFieldLabel(lbl); \
   COMPARE(what); \
@@ -273,34 +280,21 @@ QString MultiModelPrinter::printSetup()
   QString str = printTitle(tr("General"));
 
   MultiColumns columns(modelPrinterMap.size());
-  columns.appendTitle(tr("Name:"));
-  COMPARE(model->name);
-  columns.append(tr("  EEprom Size: "));
-  COMPARE(modelPrinter->printEEpromSize());
+  columns.appendSectionTableStart();
+  ROWLABELCOMPARECELL(tr("Name"), 25, model->name, 75);
+  ROWLABELCOMPARECELL(tr("EEprom Size"), 0, modelPrinter->printEEpromSize(), 0);
   if (firmware->getCapability(ModelImage)) {
-    columns.append(tr("  Model Image: "));
-    COMPARE(model->bitmap);
+    ROWLABELCOMPARECELL(tr("Model Image"), 0, model->bitmap, 0);
   }
-  columns.append("<br/>");
-  columns.appendTitle(tr("Throttle:"));
-  COMPARE(modelPrinter->printThrottle());
-  columns.append("<br/>");
-  columns.appendTitle(tr("Trims:"));
-  COMPARE(modelPrinter->printSettingsTrim());
-  columns.append("<br/>");
-  columns.appendTitle(tr("Center Beep:"));
-  COMPARE(modelPrinter->printCenterBeep());
-  columns.append("<br/>");
-  columns.appendTitle(tr("Switch Warnings:"));
-  COMPARE(modelPrinter->printSwitchWarnings());
-  columns.append("<br/>");
+  ROWLABELCOMPARECELL(tr("Throttle"), 0, modelPrinter->printThrottle(), 0);
+  ROWLABELCOMPARECELL(tr("Trims"), 0, modelPrinter->printSettingsTrim(), 0);
+  ROWLABELCOMPARECELL(tr("Center Beep"), 0, modelPrinter->printCenterBeep(), 0);
+  ROWLABELCOMPARECELL(tr("Switch Warnings"), 0, modelPrinter->printSwitchWarnings(), 0);
   if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-      columns.appendTitle(tr("Pot Warnings:"));
-      COMPARE(modelPrinter->printPotWarnings());
-      columns.append("<br/>");
+    ROWLABELCOMPARECELL(tr("Pot Warnings"), 0, modelPrinter->printPotWarnings(), 0);
   }
-  columns.appendTitle(tr("Other:"));
-  COMPARE(modelPrinter->printSettingsOther());
+  ROWLABELCOMPARECELL(tr("Other"), 0, modelPrinter->printSettingsOther(), 0);
+  columns.appendTableEnd();
   str.append(columns.print());
   return str;
 }
@@ -831,9 +825,7 @@ QString MultiModelPrinter::printTelemetry()
   }
 
   if (IS_ARM(firmware->getBoard())) {
-    columns.appendRowStart(tr("Multi sensors"), 0);
-    COMPARECELL("", modelPrinter->printIgnoreSensorIds(!model->frsky.ignoreSensorIds), 0);
-    columns.appendRowEnd();
+    ROWLABELCOMPARECELL("Multi sensors", 0, modelPrinter->printIgnoreSensorIds(!model->frsky.ignoreSensorIds), 0);
   }
 
   // Various

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -63,6 +63,8 @@ class MultiModelPrinter: public QObject
         void appendValueCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendHeaderRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendFieldLabel(const QString & lbl = "");
+        void appendFieldSeparator(const bool sep = false);
 
       private:
         int count;
@@ -88,6 +90,8 @@ class MultiModelPrinter: public QObject
     QString printCustomFunctions();
     QString printTelemetry();
     QString printTimers();
+    QString printSensors();
+    QString printTelemetryScreens();
 };
 
 #endif // _MULTIMODELPRINTER_H_

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -88,7 +88,7 @@ class MultiModelPrinter: public QObject
     QString printCurves(QTextDocument * document);
     QString printGvars();
     QString printLogicalSwitches();
-    QString printCustomFunctions();
+    QString printSpecialFunctions();
     QString printTelemetry();
     QString printTimers();
     QString printSensors();

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -51,7 +51,19 @@ class MultiModelPrinter: public QObject
         void append(int idx, const QString & str);
         template <class T> void append(int idx, T val);
         void beginCompare();
-        void endCompare(const QString & color = "grey");
+        void endCompare(const QString & color = "black"); // was grey
+        void appendLineBreak();
+        void appendSectionTableStart();
+        void appendTableEnd();
+        void appendRowStart(const QString & title = "", const unsigned int titlewidth = 0);
+        void appendRowEnd();
+        void appendCellStart(const unsigned int width = 0);
+        void appendCellEnd();
+        void appendLabelCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendValueCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendHeaderRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+
       private:
         int count;
         QString * columns;

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -57,8 +57,8 @@ class MultiModelPrinter: public QObject
         void appendTableEnd();
         void appendRowStart(const QString & title = "", const unsigned int titlewidth = 0);
         void appendRowEnd();
-        void appendCellStart(const unsigned int width = 0);
-        void appendCellEnd();
+        void appendCellStart(const unsigned int width = 0, const bool bold = false);
+        void appendCellEnd(const bool bold = false);
         void appendLabelCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendValueCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -62,7 +62,8 @@ class MultiModelPrinter: public QObject
         void appendLabelCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendValueCell(const QString & str, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
         void appendRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
-        void appendHeaderRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendRowHeader(const QStringList & strl, const unsigned int width = 0, const QString & align = "left", const QString & color = "");
+        void appendRowBlank();
         void appendFieldLabel(const QString & lbl = "");
         void appendFieldSeparator(const bool sep = false);
 


### PR DESCRIPTION
Adds telemetry to model print and compare.
Increased use of helpers and macros to simplify future changes thus the size and complexity of the diffs.
Next step is to move modelPrint internal to display conversions to data class valueToString functions and also reference these elsewhere.