### PR TITLE
X7 : add missing trainer mode

### DIFF
--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -585,7 +585,9 @@ bool isTrainerModeAvailable(int mode)
 #elif defined(PCBX7)
 bool isTrainerModeAvailable(int mode)
 {
-  if (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE || mode == TRAINER_MODE_MASTER_CPPM_EXTERNAL_MODULE || mode == TRAINER_MODE_MASTER_BATTERY_COMPARTMENT)
+  if (IS_EXTERNAL_MODULE_ENABLED() && (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE || mode == TRAINER_MODE_MASTER_CPPM_EXTERNAL_MODULE))
+    return false;
+  else if (mode == TRAINER_MODE_MASTER_BATTERY_COMPARTMENT)
     return false;
 #if defined(BLUETOOTH)
   else if (g_eeGeneral.bluetoothMode != BLUETOOTH_TRAINER && (mode == TRAINER_MODE_MASTER_BLUETOOTH || mode == TRAINER_MODE_SLAVE_BLUETOOTH))


### PR DESCRIPTION
Add missing CPPM and SBUS ext module trainer modes
This fixes #5649