### PR TITLE
Fixed bad translation.

### DIFF
--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -4343,7 +4343,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1174"/>
         <source>RSSI Poweroff Warning</source>
-        <translation>Désactiver avertissement RSSI</translation>
+        <translation>Vérifier RSSI sur arrêt radio</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2023"/>


### PR DESCRIPTION
The translation wasn't correct.
BTW, it seems this field has not been traduced in the radio firmware...
![tmp](https://user-images.githubusercontent.com/1685030/35780046-6d266d8a-09d6-11e8-9998-05d53405bc36.png)
