### PR TITLE
Horus timer widget : display only timer name if defined

### DIFF
--- a/radio/src/gui/480x272/widgets/timer.cpp
+++ b/radio/src/gui/480x272/widgets/timer.cpp
@@ -69,7 +69,9 @@ void TimerWidget::refresh()
     if (ZLEN(timerData.name) > 0) {
       lcdDrawSizedText(zone.x + 78, zone.y + 20, timerData.name, LEN_TIMER_NAME, ZCHAR | SMLSIZE | TEXT_COLOR);
     }
-    drawStringWithIndex(zone.x + 137, zone.y + 17, "TMR", index + 1, SMLSIZE | TEXT_COLOR);
+    else {
+      drawStringWithIndex(zone.x + 137, zone.y + 17, "TMR", index + 1, SMLSIZE | TEXT_COLOR);
+    }
   }
   else {
     if (timerState.val < 0 && timerState.val % 2) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5167938/36076125-94b61e40-0f58-11e8-9a10-595e55fe689d.png)

This fixes #5683
