### PR TITLE
Replicate center trim beep behavior also when crossing trims

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -644,7 +644,7 @@ int getStickTrimValue(int stick, int stickValue)
     return 0;
 
   int trim = trims[stick];
-  if (stick == virtualInputsTrims[THR_STICK]) {
+  if (IS_THROTTLE_TRIM(stick)) {
     if (g_model.thrTrim) {
       int trimMin = g_model.extendedTrims ? 2*TRIM_EXTENDED_MIN : 2*TRIM_MIN;
       trim = ((g_model.throttleReversed ? (trim+trimMin) : (trim-trimMin)) * (RESX-stickValue)) >> (RESX_SHIFT+1);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1346,7 +1346,7 @@ uint8_t checkTrim(event_t event)
 #else
       before = getRawTrimValue(phase, idx);
 #endif
-      thro = (idx==THR_STICK && g_model.thrTrim);
+      thro = (IS_THROTTLE_TRIM(idx) && g_model.thrTrim);
     }
 #else
     phase = getTrimFlightMode(mixerCurrentFlightMode, idx);
@@ -1355,7 +1355,7 @@ uint8_t checkTrim(event_t event)
 #else
     before = getRawTrimValue(phase, idx);
 #endif
-    thro = (idx==THR_STICK && g_model.thrTrim);
+    thro = (IS_THROTTLE_TRIM(idx) && g_model.thrTrim);
 #endif
     int8_t trimInc = g_model.trimInc + 1;
     int8_t v = (trimInc==-1) ? min(32, abs(before)/4+1) : (1 << trimInc); // TODO flash saving if (trimInc < 0)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -334,6 +334,12 @@ void memswap(void * a, void * b, uint8_t size);
   #define IS_MULTIPOS_CALIBRATED(cal)  (false)
 #endif
 
+#if defined(VIRTUAL_INPUTS)
+  #define IS_THROTTLE_TRIM(x)          (x == virtualInputsTrims[THR_STICK])
+#else
+  #define IS_THROTTLE_TRIM(x)          (x==THR_STICK)
+#endif
+
 #if defined(PWR_BUTTON_PRESS)
   #define pwrOffPressed()              pwrPressed()
 #else

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -337,7 +337,7 @@ void memswap(void * a, void * b, uint8_t size);
 #if defined(VIRTUAL_INPUTS)
   #define IS_THROTTLE_TRIM(x)          (x == virtualInputsTrims[THR_STICK])
 #else
-  #define IS_THROTTLE_TRIM(x)          (x==THR_STICK)
+  #define IS_THROTTLE_TRIM(x)          (x == THR_STICK)
 #endif
 
 #if defined(PWR_BUTTON_PRESS)


### PR DESCRIPTION
Currently, center trim beep is purposefully disabled for throttle when t.trim is active.
This change make this behavior consistent when cross trims is used

This solve the issue reported on rocket:
> rcdiy 19:46
> Cross Trims - works now. Noticed that the trim centre does not work as expected. Chen cross trimmed the trilT does not have a trim centre (remember this has been crossed so actually is ELE trim)
> Also the TrimE, which is now THR trim has a centre when it probably should not... Tried this on the latest companion nightly..

