### PR TITLE
Issue #5696

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1373,9 +1373,14 @@ uint8_t checkTrim(event_t event)
 #if defined(GVARS)
     if (TRIM_REUSED(idx)) {
       int8_t gvar = trimGvar[idx];
+#if defined(CPUARM)
+// TODO: This was necessary to make it compile for AVR9X target - maybe there is a better solution?
       int16_t vmin = GVAR_MIN + g_model.gvars[gvar].min;
       int16_t vmax = GVAR_MAX - g_model.gvars[gvar].max;
-
+#else
+      int16_t vmin = TRIM_MIN;
+      int16_t vmax = TRIM_MAX;
+#endif
       if (after < vmin) {
         after = vmin;
         beepTrim = true;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1360,6 +1360,9 @@ uint8_t checkTrim(event_t event)
     int8_t trimInc = g_model.trimInc + 1;
     int8_t v = (trimInc==-1) ? min(32, abs(before)/4+1) : (1 << trimInc); // TODO flash saving if (trimInc < 0)
     if (thro) v = 4; // if throttle trim and trim trottle then step=4
+#if defined(GVARS)
+    if (TRIM_REUSED(idx)) v = 1;
+#endif
     int16_t after = (k&1) ? before + v : before - v;   // positive = k&1
     bool beepTrim = false;
 
@@ -1374,7 +1377,6 @@ uint8_t checkTrim(event_t event)
     if (TRIM_REUSED(idx)) {
       int8_t gvar = trimGvar[idx];
 #if defined(CPUARM)
-// TODO: This was necessary to make it compile for AVR9X target - maybe there is a better solution?
       int16_t vmin = GVAR_MIN + g_model.gvars[gvar].min;
       int16_t vmax = GVAR_MAX - g_model.gvars[gvar].max;
 #else


### PR DESCRIPTION
When an "Adjust GV" special function is reusing trim buttons to increase/decrease GVs, then the trim limits are applied instead of GV limits. This patch applies the GV limits.

This fixes #5696