### PR TITLE
Make THR warning work for reverse POTS too

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1182,6 +1182,9 @@ void checkTHR()
   evalInputs(e_perout_mode_notrainer); // let do evalInputs do the job
 
   int16_t v = calibratedAnalogs[thrchn];
+  if (g_model.thrTraceSrc && g_model.throttleReversed) { //TODO : proper review of THR source definition and handling
+    v = -v;
+  }
   if (v <= THRCHK_DEADBAND-1024) {
     return; // prevent warning if throttle input OK
   }
@@ -1201,6 +1204,9 @@ void checkTHR()
     evalInputs(e_perout_mode_notrainer); // let do evalInputs do the job
 
     v = calibratedAnalogs[thrchn];
+    if (g_model.thrTraceSrc && g_model.throttleReversed) { //TODO : proper review of THR source definition and handling
+      v = -v;
+    }
 
 #if defined(PWR_BUTTON_PRESS)
     uint32_t pwr_check = pwrCheck();


### PR DESCRIPTION
THR warning on POT source is working, but only when non reversed. This fixes it.

This does not fix the bigger issue of THR source review