### PR TITLE
Fixed: compilation if SIMU_DISKIO = ON

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -279,6 +279,10 @@ if(SIMU_AUDIO)
   add_definitions(-DSIMU_AUDIO)
 endif()
 
+if(SIMU_DISKIO)
+  add_definitions(-DSIMU_DISKIO)
+endif()
+
 if(SDCARD)
   add_definitions(-DSDCARD)
   include_directories(${FATFS_DIR} ${FATFS_DIR}/option)

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -8,7 +8,12 @@ set(SIMU_SRC
   simueeprom.cpp
   simufatfs.cpp
   simudisk.cpp
+
   )
+
+if(SIMU_DISKIO)
+  set(SIMU_SRC ${SIMU_SRC} ../../${FATFS_DIR}/ff.c ../../${FATFS_DIR}/option/ccsbcs.c)
+endif()
 
 remove_definitions(-DCLI)
 

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -35,10 +35,6 @@
   #include <sys/time.h>
 #endif
 
-#if defined(SIMU_DISKIO)
-  FILE * diskImage = 0;
-#endif
-
 #if defined(SIMU_AUDIO) && defined(CPUARM)
   #include <SDL.h>
 #endif

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -465,10 +465,14 @@ inline void delay_01us(int dummy) { }
   #define SIMU_USE_SDCARD
 #endif
 
-#define sdMountPoll()
-#define sdPoll10ms()
-#define sd_card_ready()  (true)
-#if !defined(SIMU_DISKIO)
+#if defined(SIMU_DISKIO)
+  uint32_t sdMounted();
+  #define sdPoll10ms()
+  void sdInit(void);
+  void sdDone(void);
+#else
+  #define sdPoll10ms()
+  uint32_t sdMounted(void);
   #define sdMounted()      (true)
 #endif
 

--- a/radio/src/targets/simu/simudisk.cpp
+++ b/radio/src/targets/simu/simudisk.cpp
@@ -19,13 +19,17 @@
  */
 
 #if defined(SIMU_DISKIO)
-#include "FatFs/diskio.h"
+#include "opentx.h"
+#include "ff.h"
+#include "diskio.h"
 #include <time.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
+FILE * diskImage = 0;
 FATFS g_FATFS_Obj = {0};
 
-pthread_mutex_t ioMutex;
+OS_MutexID ioMutex;
 
 int ff_cre_syncobj (BYTE vol, _SYNC_t* sobj) /* Create a sync object */
 {
@@ -78,7 +82,7 @@ DSTATUS disk_initialize (BYTE pdrv)
 {
   traceDiskStatus();
   TRACE_SIMPGMSPACE("disk_initialize(%u)", pdrv);
-  diskImage = fopen("sdcard.image", "r+");
+  diskImage = fopen("sdcard.image", "rb+");
   return diskImage ? (DSTATUS)0 : (DSTATUS)STA_NODISK;
 }
 

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -146,10 +146,12 @@ uint32_t sdGetSpeed(void);
 #define __disk_read                     disk_read
 #define __disk_write                    disk_write
 #if defined(SIMU)
-#define sdInit()
-#define sdMount()
-#define sdDone()
-#define SD_CARD_PRESENT()               true
+  #if !defined(SIMU_DISKIO)
+    #define sdInit()
+    #define sdDone()
+  #endif
+  #define sdMount()
+  #define SD_CARD_PRESENT()               true
 #else
 void sdInit(void);
 void sdMount(void);


### PR DESCRIPTION
SIMU_DISKIO is really helpful option to debug fatFS and diskio related tasks. I use it to add support of cyrillic chars. 
I've tested SIMU_DISKIO with QX7 simulator, works fine.