### PR TITLE
added case for UNIT_TEXT used by crossfire FM Sensor

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -232,6 +232,9 @@ void luaGetValueAndPush(lua_State* L, int src)
         case UNIT_DATETIME:
           luaPushTelemetryDateTime(L, telemetrySensor, telemetryItems[qr.quot]);
           break;
+        case UNIT_TEXT:
+          lua_pushstring(L, telemetryItems[qr.quot].text);
+          break;
         case UNIT_CELLS:
           if (qr.rem == 0) {
             luaPushCells(L, telemetrySensor, telemetryItems[qr.quot]);


### PR DESCRIPTION
Fixes #5582 
This fixes an issue with Lua scripts being unable to read the FM sensor generated by crossfire which is set to text. Thanks to @schwabe for the fixes, I'm just doing some admin. 

Tested with Taranis X9D, Crossfire Micro TX, Nano RX and inav supplying the telemetry.