### PR TITLE
FAI mode reworks

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -420,8 +420,7 @@ void menuMainView(event_t event)
 
     case EVT_KEY_TELEMETRY:
 #if defined(TELEMETRY_FRSKY)
-      if (!IS_FAI_ENABLED())
-        chainMenu(menuViewTelemetryFrsky);
+      chainMenu(menuViewTelemetryFrsky);
 #elif defined(TELEMETRY_JETI)
       JETI_EnableRXD(); // enable JETI-Telemetry reception
       chainMenu(menuViewTelemetryJeti);

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -481,8 +481,7 @@ void menuMainView(event_t event)
       break;
 
     case EVT_KEY_LONG(KEY_PAGE):
-      if (!IS_FAI_ENABLED())
-        chainMenu(menuViewTelemetryFrsky);
+      chainMenu(menuViewTelemetryFrsky);
       killEvents(event);
       break;
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -218,11 +218,6 @@ static void luaPushCells(lua_State* L, TelemetrySensor & telemetrySensor, Teleme
 
 void luaGetValueAndPush(lua_State* L, int src)
 {
-  if(IS_FAI_FORBIDDEN(src)) {
-    lua_pushinteger(L, 0);
-    return;
-  }
-  
   getvalue_t value = getValue(src); // ignored for GPS, DATETIME, and CELLS
 
   if (src >= MIXSRC_FIRST_TELEM && src <= MIXSRC_LAST_TELEM) {

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -218,6 +218,11 @@ static void luaPushCells(lua_State* L, TelemetrySensor & telemetrySensor, Teleme
 
 void luaGetValueAndPush(lua_State* L, int src)
 {
+  if(IS_FAI_FORBIDDEN(src)) {
+    lua_pushinteger(L, 0);
+    return;
+  }
+  
   getvalue_t value = getValue(src); // ignored for GPS, DATETIME, and CELLS
 
   if (src >= MIXSRC_FIRST_TELEM && src <= MIXSRC_LAST_TELEM) {
@@ -587,6 +592,7 @@ or a name (string) of the source.
 @retval value current source value (number). Zero is returned for:
  * non-existing sources
  * for all telemetry source when the telemetry stream is not received
+ * far all non allowed sensors while FAI MODE is active
 
 @retval table GPS position is returned in a table:
  * `lat` (number) latitude, positive is North

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -448,6 +448,9 @@ getvalue_t getValue(mixsrc_t i)
 
 #if defined(CPUARM)
   else if (i <= MIXSRC_LAST_TELEM) {
+    if(IS_FAI_FORBIDDEN(i)) {
+      return 0;
+    }
     i -= MIXSRC_FIRST_TELEM;
     div_t qr = div(i, 3);
     TelemetryItem & telemetryItem = telemetryItems[qr.quot];

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -231,7 +231,11 @@
   #define IF_FAI_CHOICE(x)
 #endif
 
-#define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() &&  isFaiForbidden(idx))
+#if defined(CPUARM)
+  #define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() &&  isFaiForbidden(idx))
+#else
+  #define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() && idx >= MIXSRC_FIRST_TELEM)
+#endif
 
 #if defined(BLUETOOTH)
 #if defined(X9E) && !defined(USEHORUSBT)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -231,7 +231,7 @@
   #define IF_FAI_CHOICE(x)
 #endif
 
-#define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() && idx >= MIXSRC_FIRST_TELEM)
+#define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() &&  isFaiForbidden(idx))
 
 #if defined(BLUETOOTH)
 #if defined(X9E) && !defined(USEHORUSBT)

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -20,41 +20,6 @@
 
 #include "opentx.h"
 
-struct CrossfireSensor {
-  const uint8_t id;
-  const uint8_t subId;
-  const char * name;
-  const TelemetryUnit unit;
-  const uint8_t precision;
-};
-
-enum CrossfireSensorIndexes {
-  RX_RSSI1_INDEX,
-  RX_RSSI2_INDEX,
-  RX_QUALITY_INDEX,
-  RX_SNR_INDEX,
-  RX_ANTENNA_INDEX,
-  RF_MODE_INDEX,
-  TX_POWER_INDEX,
-  TX_RSSI_INDEX,
-  TX_QUALITY_INDEX,
-  TX_SNR_INDEX,
-  BATT_VOLTAGE_INDEX,
-  BATT_CURRENT_INDEX,
-  BATT_CAPACITY_INDEX,
-  GPS_LATITUDE_INDEX,
-  GPS_LONGITUDE_INDEX,
-  GPS_GROUND_SPEED_INDEX,
-  GPS_HEADING_INDEX,
-  GPS_ALTITUDE_INDEX,
-  GPS_SATELLITES_INDEX,
-  ATTITUDE_PITCH_INDEX,
-  ATTITUDE_ROLL_INDEX,
-  ATTITUDE_YAW_INDEX,
-  FLIGHT_MODE_INDEX,
-  UNKNOWN_INDEX,
-};
-
 const CrossfireSensor crossfireSensors[] = {
   {LINK_ID,        0, ZSTR_RX_RSSI1,    UNIT_DB,            0},
   {LINK_ID,        1, ZSTR_RX_RSSI2,    UNIT_DB,            0},

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -37,6 +37,42 @@
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
 
+
+struct CrossfireSensor {
+  const uint8_t id;
+  const uint8_t subId;
+  const char * name;
+  const TelemetryUnit unit;
+  const uint8_t precision;
+};
+
+enum CrossfireSensorIndexes {
+  RX_RSSI1_INDEX,
+  RX_RSSI2_INDEX,
+  RX_QUALITY_INDEX,
+  RX_SNR_INDEX,
+  RX_ANTENNA_INDEX,
+  RF_MODE_INDEX,
+  TX_POWER_INDEX,
+  TX_RSSI_INDEX,
+  TX_QUALITY_INDEX,
+  TX_SNR_INDEX,
+  BATT_VOLTAGE_INDEX,
+  BATT_CURRENT_INDEX,
+  BATT_CAPACITY_INDEX,
+  GPS_LATITUDE_INDEX,
+  GPS_LONGITUDE_INDEX,
+  GPS_GROUND_SPEED_INDEX,
+  GPS_HEADING_INDEX,
+  GPS_ALTITUDE_INDEX,
+  GPS_SATELLITES_INDEX,
+  ATTITUDE_PITCH_INDEX,
+  ATTITUDE_ROLL_INDEX,
+  ATTITUDE_YAW_INDEX,
+  FLIGHT_MODE_INDEX,
+  UNKNOWN_INDEX,
+};
+
 void processCrossfireTelemetryData(uint8_t data);
 void crossfireSetDefault(int index, uint8_t id, uint8_t subId);
 bool isCrossfireOutputBufferAvailable();

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -28,7 +28,7 @@ bool isFaiForbidden(source_t idx)
   TelemetrySensor * sensor = &g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM)/3];
 
   switch (telemetryProtocol) {
-    
+
     case PROTOCOL_FRSKY_SPORT:
       if (sensor->id == RSSI_ID) {
         return false;
@@ -46,6 +46,19 @@ bool isFaiForbidden(source_t idx)
         return false;
       }
       break;
+
+    case TELEM_PROTO_CROSSFIRE:
+      if (sensor->id == RX_RSSI1_INDEX) {
+        return false;
+      }
+      else if (sensor->id == RX_RSSI2_INDEX) {
+        return false;
+      }
+      else if (sensor->id == BATT_VOLTAGE_INDEX) {
+        return false;
+      }
+      break;
+
   }
   return true;
 }

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -24,11 +24,14 @@ TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
 uint8_t allowNewSensors;
 
 bool isFaiForbidden(source_t idx) {
-  TelemetrySensor * sensor = &g_model.telemetrySensors[idx-MIXSRC_FIRST_TELEM];
+  TelemetrySensor * sensor = &g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM)/3];
   if (sensor->id == RSSI_ID) {
     return false;
   }
-  else {
+  else if (sensor->id == BATT_ID) {
+    return false;
+  }
+  else{
     return true;
   }
 }

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -23,6 +23,16 @@
 TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
 uint8_t allowNewSensors;
 
+bool isFaiForbidden(source_t idx) {
+  TelemetrySensor * sensor = &g_model.telemetrySensors[idx-MIXSRC_FIRST_TELEM];
+  if (sensor->id == RSSI_ID) {
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+
 // TODO in maths
 uint32_t getDistFromEarthAxis(int32_t latitude)
 {

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -23,17 +23,31 @@
 TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
 uint8_t allowNewSensors;
 
-bool isFaiForbidden(source_t idx) {
+bool isFaiForbidden(source_t idx)
+{
   TelemetrySensor * sensor = &g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM)/3];
-  if (sensor->id == RSSI_ID) {
-    return false;
+
+  switch (telemetryProtocol) {
+    
+    case PROTOCOL_FRSKY_SPORT:
+      if (sensor->id == RSSI_ID) {
+        return false;
+      }
+      else if (sensor->id == BATT_ID) {
+        return false;
+      }
+      break;
+
+    case PROTOCOL_FRSKY_D:
+      if (sensor->id == D_RSSI_ID) {
+        return false;
+      }
+      else if (sensor->id == D_A1_ID) {
+        return false;
+      }
+      break;
   }
-  else if (sensor->id == BATT_ID) {
-    return false;
-  }
-  else{
-    return true;
-  }
+  return true;
 }
 
 // TODO in maths

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -47,6 +47,7 @@ bool isFaiForbidden(source_t idx)
       }
       break;
 
+#if defined(CROSSFIRE)
     case TELEM_PROTO_CROSSFIRE:
       if (sensor->id == RX_RSSI1_INDEX) {
         return false;
@@ -58,7 +59,7 @@ bool isFaiForbidden(source_t idx)
         return false;
       }
       break;
-
+#endif
   }
   return true;
 }

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -25,6 +25,10 @@ uint8_t allowNewSensors;
 
 bool isFaiForbidden(source_t idx)
 {
+  if (idx < MIXSRC_FIRST_TELEM) {
+    return false;
+  }
+  
   TelemetrySensor * sensor = &g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM)/3];
 
   switch (telemetryProtocol) {
@@ -48,7 +52,7 @@ bool isFaiForbidden(source_t idx)
       break;
 
 #if defined(CROSSFIRE)
-    case TELEM_PROTO_CROSSFIRE:
+    case PROTOCOL_PULSES_CROSSFIRE:
       if (sensor->id == RX_RSSI1_INDEX) {
         return false;
       }

--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -136,5 +136,6 @@ class TelemetryItem
 
 extern TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
 extern uint8_t allowNewSensors;
+bool isFaiForbidden(source_t idx);
 
 #endif // _TELEMETRY_SENSORS_H_


### PR DESCRIPTION
all sensors with exception of allowed sensors (see bellow) have their value set to 0 in FAI mode. LS, widgets, logs.. all aspect of OpenTX will keep seing those sensors, but with value of 0

the following sensors are allowed, and will not have their value 'zeroed':
FrSky Sport RSSI and RxBt
FrSky old telem RSSI and A1 (RxBt)
Crossfire RSSI1, RSSI2 and RxBt
and can therefore be used normaly in widget, LS,..

This fixes #3443 and more