### PR TITLE
Allow HorusBT chip install on  X9E and X7 (non S)

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -75,7 +75,7 @@ char * bluetoothReadline(bool error_reset)
           TRACE("BT Reset...(%d)", bluetoothState);
           bluetoothDone();
           bluetoothState = BLUETOOTH_STATE_OFF;
-          bluetoothWakeupTime = get_tmr10ms() + 200; /* 1s */
+          bluetoothWakeupTime = get_tmr10ms() + 100; /* 1s */
           return NULL;
         }
         else {
@@ -263,7 +263,12 @@ void bluetoothWakeup()
     bluetoothWakeupTime = now + 10; /* 100ms */
   }
   else if (bluetoothState == BLUETOOTH_STATE_OFF) {
+#if defined(PCBHORUS)
+    bluetoothInit(BLUETOOTH_FACTORY_BAUDRATE);
+    bluetoothState = BLUETOOTH_STATE_FACTORY_BAUDRATE_INIT;
+#else
     bluetoothState = BLUETOOTH_STATE_BAUDRATE_SENT;
+#endif
   }
 
   if (bluetoothState != BLUETOOTH_STATE_OFF) {

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -20,15 +20,9 @@
 
 #include "opentx.h"
 
-#if defined(PCBX7) || defined(PCBHORUS) || defined(USEHORUSBT)
 #define BLUETOOTH_COMMAND_NAME         "AT+NAME"
 #define BLUETOOTH_ANSWER_NAME          "OK+"
 #define BLUETOOTH_COMMAND_BAUD_115200  "AT+BAUD115200"
-#else
-#define BLUETOOTH_COMMAND_NAME         "TTM:REN-"
-#define BLUETOOTH_ANSWER_NAME          "TTM:REN"
-#define BLUETOOTH_COMMAND_BAUD_115200  "TTM:BPS-115200"
-#endif
 
 #define BLUETOOTH_PACKET_SIZE          14
 #define BLUETOOTH_LINE_LENGTH          32
@@ -69,9 +63,6 @@ char * bluetoothReadline(bool error_reset)
 
   while (1) {
     if (!btRxFifo.pop(byte)) {
-#if defined(PCBX9E) && !defined(USEHORUSBT)     // X9E BT module can get unresponsive
-      TRACE("NO RESPONSE FROM BT MODULE");
-#endif
       return NULL;
     }
     TRACE_NOCRLF("%02X ", byte);
@@ -81,14 +72,10 @@ char * bluetoothReadline(bool error_reset)
         bluetoothBufferIndex = 0;
         TRACE("BT< %s", bluetoothBuffer);
         if (error_reset && !strcmp((char *)bluetoothBuffer, "ERROR")) {
-#if defined(PCBX9E)                           // X9E enter BT reset loop if following code is implemented
-          TRACE("BT error...");
-#else
           TRACE("BT Reset...");
           bluetoothDone();
           bluetoothState = BLUETOOTH_STATE_OFF;
-          bluetoothWakeupTime = get_tmr10ms() + 100; /* 1s */
-#endif
+          bluetoothWakeupTime = get_tmr10ms() + 200; /* 1s */
           return NULL;
         }
         else {
@@ -259,66 +246,6 @@ void bluetoothReceiveTrainer()
   }
 }
 
-#if defined(PCBX9E) && !defined(USEHORUSBT)
-void bluetoothWakeup(void)
-{
-  if (!g_eeGeneral.bluetoothMode) {
-    if (bluetoothState != BLUETOOTH_INIT) {
-      bluetoothDone();
-      bluetoothState = BLUETOOTH_INIT;
-    }
-  }
-  else {
-    static tmr10ms_t waitEnd = 0;
-    if (bluetoothState != BLUETOOTH_STATE_IDLE) {
-
-      if (bluetoothState == BLUETOOTH_INIT) {
-        bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE);
-        char command[32];
-        char * cur = strAppend(command, BLUETOOTH_COMMAND_NAME);
-        uint8_t len = ZLEN(g_eeGeneral.bluetoothName);
-        if (len > 0) {
-          for (int i = 0; i < len; i++) {
-            *cur++ = idx2char(g_eeGeneral.bluetoothName[i]);
-          }
-        }
-        else {
-          cur = strAppend(cur, "Taranis-X9E");
-        }
-        strAppend(cur, "\r\n");
-        bluetoothWriteString(command);
-        bluetoothState = BLUETOOTH_WAIT_TTM;
-        waitEnd = get_tmr10ms() + 25; // 250ms
-      }
-      else if (bluetoothState == BLUETOOTH_WAIT_TTM) {
-        if (get_tmr10ms() > waitEnd) {
-            char * line = bluetoothReadline();
-            if (strncmp(line, "OK+", 3)) {
-            bluetoothState = BLUETOOTH_STATE_IDLE;
-            }
-            else {
-              bluetoothInit(BLUETOOTH_FACTORY_BAUDRATE);
-              const char btMessage[] = "TTM:BPS-115200";
-              bluetoothWriteString(btMessage);
-              bluetoothState = BLUETOOTH_WAIT_BAUDRATE_CHANGE;
-              waitEnd = get_tmr10ms() + 250; // 2.5s
-            }
-          }
-        }
-      else if (bluetoothState == BLUETOOTH_WAIT_BAUDRATE_CHANGE) {
-        if (get_tmr10ms() > waitEnd) {
-          bluetoothState = BLUETOOTH_INIT;
-        }
-      }
-    }
-    else if (IS_BLUETOOTH_TRAINER()){
-      bluetoothState = BLUETOOTH_STATE_CONNECTED;
-      bluetoothWriteWakeup();
-      bluetoothSendTrainer();
-    }
-  }
-}
-#else // PCBX9E
 void bluetoothWakeup()
 {
   tmr10ms_t now = get_tmr10ms();
@@ -440,4 +367,3 @@ void bluetoothWakeup()
     }
   }
 }
-#endif

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -22,7 +22,7 @@
 
 #define BLUETOOTH_COMMAND_NAME         "AT+NAME"
 #define BLUETOOTH_ANSWER_NAME          "OK+"
-#define BLUETOOTH_COMMAND_BAUD_115200  "AT+BAUD115200"
+#define BLUETOOTH_COMMAND_BAUD_115200  "AT+BAUD4"
 
 #define BLUETOOTH_PACKET_SIZE          14
 #define BLUETOOTH_LINE_LENGTH          32
@@ -71,8 +71,8 @@ char * bluetoothReadline(bool error_reset)
         bluetoothBuffer[bluetoothBufferIndex-1] = '\0';
         bluetoothBufferIndex = 0;
         TRACE("BT< %s", bluetoothBuffer);
-        if (error_reset && !strcmp((char *)bluetoothBuffer, "ERROR")) {
-          TRACE("BT Reset...");
+        if ((error_reset && !strcmp((char *)bluetoothBuffer, "ERROR")) && (bluetoothState > BLUETOOTH_STATE_BAUDRATE_INIT)) {
+          TRACE("BT Reset...(%d)", bluetoothState);
           bluetoothDone();
           bluetoothState = BLUETOOTH_STATE_OFF;
           bluetoothWakeupTime = get_tmr10ms() + 200; /* 1s */
@@ -263,8 +263,7 @@ void bluetoothWakeup()
     bluetoothWakeupTime = now + 10; /* 100ms */
   }
   else if (bluetoothState == BLUETOOTH_STATE_OFF) {
-    bluetoothInit(BLUETOOTH_FACTORY_BAUDRATE);
-    bluetoothState = BLUETOOTH_STATE_FACTORY_BAUDRATE_INIT;
+    bluetoothState = BLUETOOTH_STATE_BAUDRATE_SENT;
   }
 
   if (bluetoothState != BLUETOOTH_STATE_OFF) {
@@ -277,7 +276,7 @@ void bluetoothWakeup()
   if (bluetoothState == BLUETOOTH_STATE_FACTORY_BAUDRATE_INIT) {
     bluetoothWriteString("AT+BAUD4\r\n");
     bluetoothState = BLUETOOTH_STATE_BAUDRATE_SENT;
-    bluetoothWakeupTime = now + 10; /* 100ms */
+    bluetoothWakeupTime = now + 100; /* 1s */
   }
   else if (bluetoothState == BLUETOOTH_STATE_BAUDRATE_SENT) {
     bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE);

--- a/radio/src/bluetooth.h
+++ b/radio/src/bluetooth.h
@@ -19,11 +19,6 @@
  */
 
 enum BluetoothStates {
-#if defined(PCBX9E) && !defined(USEHORUSBT)
-    BLUETOOTH_INIT,
-    BLUETOOTH_WAIT_TTM,
-    BLUETOOTH_WAIT_BAUDRATE_CHANGE,
-#endif
     BLUETOOTH_STATE_OFF,
     BLUETOOTH_STATE_FACTORY_BAUDRATE_INIT,
     BLUETOOTH_STATE_BAUDRATE_SENT,
@@ -44,10 +39,7 @@ enum BluetoothStates {
 
 #define LEN_BLUETOOTH_ADDR             16
 
-#if defined(PCBX7) || defined(PCBXLITE)
 extern uint8_t btChipPresent;
-#endif
-
 extern volatile uint8_t bluetoothState;
 extern char bluetoothLocalAddr[LEN_BLUETOOTH_ADDR+1];
 extern char bluetoothDistantAddr[LEN_BLUETOOTH_ADDR+1];

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -266,7 +266,7 @@ int getSwitchWarningsCount()
 #define INTERNAL_MODULE_CHANNELS_ROWS     IF_INTERNAL_MODULE_ON(1)
 #define PORT_CHANNELS_ROWS(x)             (x==INTERNAL_MODULE ? INTERNAL_MODULE_CHANNELS_ROWS : (x==EXTERNAL_MODULE ? EXTERNAL_MODULE_CHANNELS_ROWS : 1))
 
-#if defined(BLUETOOTH) && defined(USEHORUSBT)
+#if defined(BLUETOOTH)
   #define TRAINER_LINE1_BLUETOOTH_M_ROWS    ((bluetoothDistantAddr[0] == 0 || bluetoothState == BLUETOOTH_STATE_CONNECTED) ? (uint8_t)0 : (uint8_t)1)
   #define TRAINER_LINE1_ROWS                (g_model.trainerMode == TRAINER_MODE_SLAVE ? (uint8_t)1 : (g_model.trainerMode == TRAINER_MODE_MASTER_BLUETOOTH ? TRAINER_LINE1_BLUETOOTH_M_ROWS : (g_model.trainerMode == TRAINER_MODE_SLAVE_BLUETOOTH ? (uint8_t)1 : HIDDEN_ROW)))
   #define TRAINER_LINE2_ROWS                (g_model.trainerMode == TRAINER_MODE_SLAVE ? (uint8_t)2 : HIDDEN_ROW)
@@ -751,7 +751,7 @@ void menuModelSetup(event_t event)
           g_model.trainerMode = checkIncDec(event, g_model.trainerMode, 0, TRAINER_MODE_MAX(), EE_MODEL, isTrainerModeAvailable);
         }
         break;
-        
+
 #if defined(BLUETOOTH)
       case ITEM_MODEL_TRAINER_BLUETOOTH:
         if (g_model.trainerMode == TRAINER_MODE_MASTER_BLUETOOTH) {
@@ -903,7 +903,7 @@ void menuModelSetup(event_t event)
       lcdDrawTextAlignedLeft(y, STR_TRAINER);
       break;
 
-#if defined(BLUETOOTH) && defined(USEHORUSBT)
+#if defined(BLUETOOTH)
     case ITEM_MODEL_TRAINER_LINE1:
       if (g_model.trainerMode == TRAINER_MODE_MASTER_BLUETOOTH) {
         if (attr) {

--- a/radio/src/gui/212x64/radio_hardware.cpp
+++ b/radio/src/gui/212x64/radio_hardware.cpp
@@ -54,8 +54,13 @@ enum menuRadioHwItems {
   CASE_PCBX9E(ITEM_RADIO_HARDWARE_SP)
   CASE_PCBX9E(ITEM_RADIO_HARDWARE_SQ)
   CASE_PCBX9E(ITEM_RADIO_HARDWARE_SR)
-  CASE_BLUETOOTH(ITEM_RADIO_HARDWARE_BLUETOOTH_MODE)
-  CASE_BLUETOOTH(ITEM_RADIO_HARDWARE_BLUETOOTH_NAME)
+  #if defined(BLUETOOTH)
+    ITEM_RADIO_HARDWARE_BLUETOOTH_MODE,
+    ITEM_RADIO_HARDWARE_BLUETOOTH_PAIRING_CODE,
+    ITEM_RADIO_HARDWARE_BLUETOOTH_LOCAL_ADDR,
+    ITEM_RADIO_HARDWARE_BLUETOOTH_DISTANT_ADDR,
+    ITEM_RADIO_HARDWARE_BLUETOOTH_NAME,
+  #endif
   ITEM_RADIO_HARDWARE_UART3_MODE,
   ITEM_RADIO_HARDWARE_JITTER_FILTER,
   ITEM_RADIO_HARDWARE_MAX
@@ -77,8 +82,8 @@ enum menuRadioHwItems {
   #define SWITCHES_ROWS  NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1, NAVIGATION_LINE_BY_LINE|1
 #endif
 
-#if defined(BLUETOOTH) && defined(USEHORUSBT)
-  #define BLUETOOTH_ROWS 0, uint8_t(g_eeGeneral.bluetoothMode == BLUETOOTH_OFF ? -1 : 0),
+#if defined(BLUETOOTH)
+  #define BLUETOOTH_ROWS uint8_t(btChipPresent ? 0 : HIDDEN_ROW), uint8_t(g_eeGeneral.bluetoothMode == BLUETOOTH_TELEMETRY ? -1 : HIDDEN_ROW), uint8_t(g_eeGeneral.bluetoothMode == BLUETOOTH_OFF ? HIDDEN_ROW : -1), uint8_t(g_eeGeneral.bluetoothMode == BLUETOOTH_OFF ? HIDDEN_ROW : -1), uint8_t(g_eeGeneral.bluetoothMode == BLUETOOTH_OFF ? HIDDEN_ROW : 0),
 #else
   #define BLUETOOTH_ROWS
 #endif
@@ -198,19 +203,37 @@ void menuRadioHardware(event_t event)
         break;
       }
 
-#if defined(BLUETOOTH) && defined(USEHORUSBT)
-        case ITEM_RADIO_HARDWARE_BLUETOOTH_MODE:
-          lcdDrawText(INDENT_WIDTH, y, STR_BLUETOOTH);
-          lcdDrawTextAtIndex(HW_SETTINGS_COLUMN, y, STR_BLUETOOTH_MODES, g_eeGeneral.bluetoothMode, attr);
-          if (attr) {
-            g_eeGeneral.bluetoothMode = checkIncDecGen(event, g_eeGeneral.bluetoothMode, BLUETOOTH_OFF, BLUETOOTH_TRAINER);
-          }
-          break;
+#if defined(BLUETOOTH)
+      case ITEM_RADIO_HARDWARE_BLUETOOTH_MODE:
+        lcdDrawTextAlignedLeft(y, STR_BLUETOOTH);
+        lcdDrawTextAtIndex(HW_SETTINGS_COLUMN, y, STR_BLUETOOTH_MODES, g_eeGeneral.bluetoothMode, attr);
+        if ((g_eeGeneral.bluetoothMode != BLUETOOTH_OFF) && !btChipPresent) {
+          g_eeGeneral.bluetoothMode = BLUETOOTH_OFF;
+        }
+        if (attr) {
+          g_eeGeneral.bluetoothMode = checkIncDecGen(event, g_eeGeneral.bluetoothMode, BLUETOOTH_OFF, BLUETOOTH_TRAINER);
+        }
+        break;
 
-        case ITEM_RADIO_HARDWARE_BLUETOOTH_NAME:
-          lcdDrawText(INDENT_WIDTH, y, STR_NAME);
-          editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.bluetoothName, LEN_BLUETOOTH_NAME, event, attr);
-          break;
+      case ITEM_RADIO_HARDWARE_BLUETOOTH_PAIRING_CODE:
+        lcdDrawTextAlignedLeft(y, STR_BLUETOOTH_PIN_CODE);
+        lcdDrawText(HW_SETTINGS_COLUMN, y, "0000");
+        break;
+
+      case ITEM_RADIO_HARDWARE_BLUETOOTH_LOCAL_ADDR:
+        lcdDrawTextAlignedLeft(y, STR_BLUETOOTH_LOCAL_ADDR);
+        lcdDrawText(HW_SETTINGS_COLUMN, y, bluetoothLocalAddr[0] == '\0' ? "---" : bluetoothLocalAddr);
+        break;
+
+      case ITEM_RADIO_HARDWARE_BLUETOOTH_DISTANT_ADDR:
+        lcdDrawTextAlignedLeft(y, STR_BLUETOOTH_DIST_ADDR);
+        lcdDrawText(HW_SETTINGS_COLUMN, y, bluetoothDistantAddr[0] == '\0' ? "---" : bluetoothDistantAddr);
+        break;
+
+      case ITEM_RADIO_HARDWARE_BLUETOOTH_NAME:
+        lcdDrawText(INDENT_WIDTH, y, STR_NAME);
+        editName(HW_SETTINGS_COLUMN, y, g_eeGeneral.bluetoothName, LEN_BLUETOOTH_NAME, event, attr);
+        break;
 #endif
 
       case ITEM_RADIO_HARDWARE_UART3_MODE:

--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -563,12 +563,10 @@ bool isTrainerModeAvailable(int mode)
 {
   if (IS_EXTERNAL_MODULE_ENABLED() && (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE || mode == TRAINER_MODE_MASTER_CPPM_EXTERNAL_MODULE))
     return false;
-#if defined(USEHORUSBT)
-  else if (mode == TRAINER_MODE_MASTER_BATTERY_COMPARTMENT)
-#else
-  else if (mode == TRAINER_MODE_MASTER_BLUETOOTH || mode == TRAINER_MODE_MASTER_BATTERY_COMPARTMENT || mode == TRAINER_MODE_SLAVE_BLUETOOTH)
-#endif
+#if defined(BLUETOOTH)
+  else if (g_eeGeneral.bluetoothMode != BLUETOOTH_TRAINER && (mode == TRAINER_MODE_MASTER_BLUETOOTH || mode == TRAINER_MODE_SLAVE_BLUETOOTH))
     return false;
+#endif
   else
     return true;
 }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2662,8 +2662,9 @@ int main()
 
   boardInit();
 
-#if defined(PCBX7)
-  bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE);   //BT is turn on for a brief period to differentiate X7 and X7S
+#if defined(PCBX7) || defined(PCBX9E)
+  bluetoothInit(BLUETOOTH_FACTORY_BAUDRATE);   //BT is turn on for a brief period to differentiate X7 and X7S and to allow X9E with Horus BT chip
+  bluetoothWriteString("AT+BAUD4\r\n");
 #endif
 
 #if defined(GUI) && !defined(PCBTARANIS) && !defined(PCBHORUS)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -155,12 +155,6 @@
   #define CASE_SDCARD(x)
 #endif
 
-#if defined(BLUETOOTH) && !(defined(PCBX9E) && !defined(USEHORUSBT))
-  #define CASE_BLUETOOTH(x) x,
-#else
-  #define CASE_BLUETOOTH(x)
-#endif
-
 #if defined(HELI)
   #define CASE_HELI(x) x,
 #else
@@ -203,7 +197,7 @@
   #define CASE_PCBX9E(x)
 #endif
 
-#if defined(BLUETOOTH) && !(defined(PCBX9E) && !defined(USEHORUSBT))
+#if defined(BLUETOOTH)
   #define CASE_BLUETOOTH(x) x,
 #else
   #define CASE_BLUETOOTH(x)
@@ -234,13 +228,8 @@
 #define IS_FAI_FORBIDDEN(idx) (IS_FAI_ENABLED() && idx >= MIXSRC_FIRST_TELEM)
 
 #if defined(BLUETOOTH)
-#if defined(X9E) && !defined(USEHORUSBT)
-  #define IS_BLUETOOTH_TRAINER()       (g_model.trainerMode == TRAINER_MODE_SLAVE_BLUETOOTH)
-  #define IS_SLAVE_TRAINER()           (g_model.trainerMode == TRAINER_MODE_SLAVE)
-#else
   #define IS_BLUETOOTH_TRAINER()       (g_model.trainerMode == TRAINER_MODE_MASTER_BLUETOOTH || g_model.trainerMode == TRAINER_MODE_SLAVE_BLUETOOTH)
   #define IS_SLAVE_TRAINER()           (g_model.trainerMode == TRAINER_MODE_SLAVE || g_model.trainerMode == TRAINER_MODE_SLAVE_BLUETOOTH)
-#endif
 #else
   #define IS_BLUETOOTH_TRAINER()       false
   #define IS_SLAVE_TRAINER()           (g_model.trainerMode == TRAINER_MODE_SLAVE)

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -23,8 +23,12 @@
 Fifo<uint8_t, 64> btTxFifo;
 Fifo<uint8_t, 64> btRxFifo;
 
-#if defined(PCBX7) || defined(PCBXLITE)
+#if defined(PCBX7) || defined(PCBXLITE) || defined(PCBX9E)
+#if defined(SIMU)
+uint8_t btChipPresent = 1;
+#else
 uint8_t btChipPresent = 0;
+#endif
 #endif
 
 enum BluetoothWriteState
@@ -109,7 +113,7 @@ extern "C" void BT_USART_IRQHandler(void)
     USART_ClearITPendingBit(BT_USART, USART_IT_RXNE);
     uint8_t byte = USART_ReceiveData(BT_USART);
     btRxFifo.push(byte);
-#if defined(PCBX7) || defined(PCBXLITE)
+#if defined(PCBX7) || defined(PCBXLITE) || defined(PCBX9E)
     if (!btChipPresent) {   //This is to differentiate X7 and X7S
       btChipPresent = 1;
       bluetoothDone();

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -598,11 +598,8 @@ void serial2Stop(void);
 
 // BT driver
 #define BLUETOOTH_DEFAULT_BAUDRATE      115200
-#if defined(PCBX9E) && !defined(USEHORUSBT)
-#define BLUETOOTH_FACTORY_BAUDRATE     9600
-#else
-#define BLUETOOTH_FACTORY_BAUDRATE      57600
-#endif
+#define BLUETOOTH_FACTORY_BAUDRATE      115200
+
 void bluetoothInit(uint32_t baudrate);
 void bluetoothWriteWakeup(void);
 uint8_t bluetoothIsWriting(void);

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -598,7 +598,11 @@ void serial2Stop(void);
 
 // BT driver
 #define BLUETOOTH_DEFAULT_BAUDRATE      115200
-#define BLUETOOTH_FACTORY_BAUDRATE      115200
+#if defined(PCBHORUS)
+#define BLUETOOTH_FACTORY_BAUDRATE      57600
+#else
+#define BLUETOOTH_FACTORY_BAUDRATE      9600
+#endif
 
 void bluetoothInit(uint32_t baudrate);
 void bluetoothWriteWakeup(void);


### PR DESCRIPTION
This allows users to had a Horus chip to X9E and X7. Added chip should be activated even with their default 9600 bps

Somewhat tested, but need further tests.

THIS COMPLETELY WIPES previous unused X9E BT handling