### PR TITLE
Disable pulse while model notes are displayed

### DIFF
--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -373,6 +373,7 @@ void drawStatusLine();
   void menuTextView(event_t event);
   void pushMenuTextView(const char *filename);
   void pushModelNotes();
+  void readModelNotes();
 #endif
 
 #define LABEL(...)                     (uint8_t)-1

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -244,7 +244,7 @@ swsrc_t editSwitch(coord_t x, coord_t y, swsrc_t value, LcdFlags attr, event_t e
 #endif
 
 void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event);
-  
+
 extern uint8_t s_curveChan;
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags);
 
@@ -296,6 +296,7 @@ extern char s_text_file[TEXT_FILENAME_MAXLEN];
 void menuTextView(event_t event);
 void pushMenuTextView(const char *filename);
 void pushModelNotes();
+void readModelNotes();
 
 void menuChannelsView(event_t event);
 

--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -66,8 +66,8 @@ void pushMenu(MenuHandlerFunc newMenu)
   TRACE("pushMenu(%d, %p)", menuLevel, newMenu);
 }
 
-void readModelNotes() {
-
+void readModelNotes()
+{
   LED_ERROR_BEGIN();
 
   strcpy(s_text_file, MODELS_PATH "/");

--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -80,7 +80,7 @@ void readModelNotes() {
 
   clearKeyEvents();
   event_t event = EVT_ENTRY;
-  while (event != EVT_KEY_BREAK(KEY_EXIT)) {
+  while (event != EVT_KEY_FIRST(KEY_EXIT)) {
     lcdRefreshWait();
     lcdClear();
     menuTextView(event);

--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -66,6 +66,32 @@ void pushMenu(MenuHandlerFunc newMenu)
   TRACE("pushMenu(%d, %p)", menuLevel, newMenu);
 }
 
+void readModelNotes() {
+
+  LED_ERROR_BEGIN();
+
+  strcpy(s_text_file, MODELS_PATH "/");
+  char *buf = strcat_currentmodelname(&s_text_file[sizeof(MODELS_PATH)]);
+  strcpy(buf, TEXT_EXT);
+  if (!isFileAvailable(s_text_file)) {
+    char *buf = strAppendFilename(&s_text_file[sizeof(MODELS_PATH)], g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
+    strcpy(buf, TEXT_EXT);
+  }
+
+  clearKeyEvents();
+  event_t event = EVT_ENTRY;
+  while (event != EVT_KEY_BREAK(KEY_EXIT)) {
+    lcdRefreshWait();
+    lcdClear();
+    menuTextView(event);
+    event = getEvent();
+    lcdRefresh();
+    wdt_reset();
+  }
+
+  LED_ERROR_END();
+}
+
 bool menuModelNotes(event_t event)
 {
   if (event == EVT_ENTRY) {

--- a/radio/src/gui/480x272/menus.h
+++ b/radio/src/gui/480x272/menus.h
@@ -505,6 +505,7 @@ extern void (*popupMenuHandler)(const char * result);
 extern char s_text_file[TEXT_FILENAME_MAXLEN];
 void pushMenuTextView(const char * filename);
 void pushModelNotes();
+void readModelNotes();
 
 #define LABEL(...)                     (uint8_t)-1
 

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -101,6 +101,27 @@ void readTextFile(int & lines_count)
 #define EVT_KEY_NEXT_LINE              EVT_KEY_FIRST(KEY_DOWN)
 #define EVT_KEY_PREVIOUS_LINE          EVT_KEY_FIRST(KEY_UP)
 #endif
+
+void readModelNotes() {
+
+  LED_ERROR_BEGIN();
+
+  strcpy(s_text_file, MODELS_PATH "/");
+  char *buf = strcat_modelname(&s_text_file[sizeof(MODELS_PATH)], g_eeGeneral.currModel);
+  strcpy(buf, TEXT_EXT);
+
+  clearKeyEvents();
+  event_t event = EVT_ENTRY;
+  while (event != EVT_KEY_BREAK(KEY_EXIT)) {
+    lcdRefreshWait();
+    lcdClear();
+    menuTextView(event);
+    event = getEvent();
+    lcdRefresh();
+  }
+
+  LED_ERROR_END();
+}
 
 void menuTextView(event_t event)
 {

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -102,8 +102,8 @@ void readTextFile(int & lines_count)
 #define EVT_KEY_PREVIOUS_LINE          EVT_KEY_FIRST(KEY_UP)
 #endif
 
-void readModelNotes() {
-
+void readModelNotes()
+{
   LED_ERROR_BEGIN();
 
   strcpy(s_text_file, MODELS_PATH "/");

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -118,6 +118,7 @@ void readModelNotes() {
     menuTextView(event);
     event = getEvent();
     lcdRefresh();
+    wdt_reset();
   }
 
   LED_ERROR_END();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1134,7 +1134,7 @@ void checkAll()
 
 #if defined(CPUARM)
   if (g_model.displayChecklist && modelHasNotes()) {
-    pushModelNotes();
+    readModelNotes();
   }
 #endif
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -72,17 +72,6 @@ void postModelLoad(bool alarms)
   AUDIO_FLUSH();
   flightReset(false);
 
-  if (pulsesStarted()) {
-#if defined(GUI)
-    if (alarms) {
-      checkAll();
-      PLAY_MODEL_NAME();
-    }
-#endif
-    resumePulses();
-  }
-
-
   customFunctionsReset();
 
   restoreTimers();
@@ -100,7 +89,15 @@ void postModelLoad(bool alarms)
   LOAD_MODEL_CURVES();
 
   resumeMixerCalculations();
-  // TODO pulses should be started after mixer calculations ...
+  if (pulsesStarted()) {
+#if defined(GUI)
+    if (alarms) {
+      checkAll();
+      PLAY_MODEL_NAME();
+    }
+#endif
+    resumePulses();
+  }
 
 #if defined(TELEMETRY_FRSKY)
   frskySendAlarms();


### PR DESCRIPTION
This keep pulses off while model notes are displayed. This allow users to writes things like "Don't forget to connect external antenna', or 'this model needs module xxx' before those module are turned on.

This works at  boot and also when changing model.

Unlike other warning, getting out of this one requires exit/rtn

This closes #5747