### PR TITLE
Improve some messsages

### DIFF
--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -704,7 +704,7 @@
 #define TR_BAR                         "Bar"
 #define TR_ALARM                       INDENT "Alarm"
 #define TR_USRDATA                     TR("UsrData", "User data")
-#define TR_BLADES                      INDENT "Blades"
+#define TR_BLADES                      INDENT "Blades/Poles"
 #define TR_SCREEN                      "Screen\001"
 #define TR_SOUND_LABEL                 "Sound"
 #define TR_LENGTH                      INDENT "Length"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -688,7 +688,7 @@
 #define TR_BAR                 "Bar"
 #define TR_ALARM               INDENT"Alarm"
 #define TR_USRDATA             "UsrData"
-#define TR_BLADES              INDENT"Blades"
+#define TR_BLADES              INDENT"Blades/Poles"
 #define TR_SCREEN              "Screen "
 #define TR_SOUND_LABEL         "Sound"
 #define TR_LENGTH              INDENT"Length"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -717,7 +717,7 @@
 #define TR_BAR                         "Barre"
 #define TR_ALARM                       INDENT "Alarme"
 #define TR_USRDATA                     "Données"
-#define TR_BLADES                      INDENT "Pales"
+#define TR_BLADES                      INDENT "Pales/Pôles"
 #define TR_SCREEN                      "Ecran "
 #define TR_SOUND_LABEL                 "Son"
 #define TR_LENGTH                      INDENT "Durée"


### PR DESCRIPTION
Add poles to blade string for easier understanding of ESC based sensors. This deals only with some languages as the other one already use localized strings.

Tested for all 3 UI sizes

We need to find best translation for : 
CZ : TR(INDENT"ListyVrt", INDENT"Listy vrtule")
DE: TR(INDENT "Prop", INDENT "Prop-Blätter")
ES:  INDENT"Palas"
IT: INDENT"Pale"
NL: "Bladen" (thats probaly wrong already with the missing INDENT
PL: " Łopaty śmigla" (same comment)
PT: INDENT"Helice"
SE: INDENT"Blad"