### PR TITLE
Rework Horus BL handling

### DIFF
--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -360,7 +360,8 @@ bool menuRadioSetup(event_t event)
 
       case ITEM_SETUP_BACKLIGHT_MODE:
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_MODE);
-        g_eeGeneral.backlightMode = editChoice(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, e_backlight_mode_off, e_backlight_mode_on, attr, event);
+        if (attr & INVERS) g_eeGeneral.backlightMode = checkIncDec(event, g_eeGeneral.backlightMode, e_backlight_mode_keys, e_backlight_mode_on, (menuVerticalPositions[0] == 0) ? EE_MODEL : EE_GENERAL);
+        lcdDrawTextAtIndex(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, attr);
         break;
 
       case ITEM_SETUP_FLASH_BEEP:

--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -360,7 +360,7 @@ bool menuRadioSetup(event_t event)
 
       case ITEM_SETUP_BACKLIGHT_MODE:
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_MODE);
-        if (attr & INVERS) g_eeGeneral.backlightMode = checkIncDec(event, g_eeGeneral.backlightMode, e_backlight_mode_keys, e_backlight_mode_on, (menuVerticalPositions[0] == 0) ? EE_MODEL : EE_GENERAL);
+        if (attr & INVERS) g_eeGeneral.backlightMode = checkIncDec(event, g_eeGeneral.backlightMode, e_backlight_mode_keys, e_backlight_mode_on, EE_GENERAL);
         lcdDrawTextAtIndex(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, attr);
         break;
 

--- a/radio/src/targets/horus/backlight_driver.cpp
+++ b/radio/src/targets/horus/backlight_driver.cpp
@@ -31,7 +31,7 @@ void backlightInit()
   GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
   GPIO_Init(BACKLIGHT_GPIO, &GPIO_InitStructure);
   GPIO_PinAFConfig(BACKLIGHT_GPIO, BACKLIGHT_GPIO_PinSource, BACKLIGHT_GPIO_AF);
-  
+
   // TIMER init
 #if defined(PCBX12S)
   if (IS_HORUS_PROD()) {
@@ -77,4 +77,11 @@ void backlightEnable(uint8_t dutyCycle)
 #elif defined(PCBX10)
   BACKLIGHT_TIMER->CCR3 = BACKLIGHT_LEVEL_MAX - dutyCycle;
 #endif
+
+  if (dutyCycle == 0) {
+    BACKLIGHT_TIMER->BDTR &= ~TIM_BDTR_MOE;
+  }
+  else if ((BACKLIGHT_TIMER->BDTR & TIM_BDTR_MOE) == 0) {
+    BACKLIGHT_TIMER->BDTR |= TIM_BDTR_MOE;
+  }
 }

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -466,7 +466,6 @@ void backlightEnable(uint8_t dutyCycle);
 #endif
 #define BACKLIGHT_ENABLE()    backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX-g_eeGeneral.backlightBright)
 #define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : (g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) ? 0 : g_eeGeneral.blOffBright)
-
 #define isBacklightEnabled()  true
 
 #if !defined(SIMU)

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -465,7 +465,8 @@ void backlightEnable(uint8_t dutyCycle);
 #define BACKLIGHT_LEVEL_MIN   46
 #endif
 #define BACKLIGHT_ENABLE()    backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX-g_eeGeneral.backlightBright)
-#define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : g_eeGeneral.blOffBright)
+#define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : (g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) ? 0 : g_eeGeneral.blOffBright)
+
 #define isBacklightEnabled()  true
 
 #if !defined(SIMU)


### PR DESCRIPTION
- OFF mode is not available for Horus anymore, as it makes no sense for a radio that requires BL
- if OFF brightness is set to the very mimium, then BL is turned off during off periods

This fixes #5621 and fixes #5403