### PR TITLE
Rework BL behavior for Horus

### DIFF
--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -360,8 +360,7 @@ bool menuRadioSetup(event_t event)
 
       case ITEM_SETUP_BACKLIGHT_MODE:
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_MODE);
-        if (attr & INVERS) g_eeGeneral.backlightMode = checkIncDec(event, g_eeGeneral.backlightMode, e_backlight_mode_keys, e_backlight_mode_on, EE_GENERAL);
-        lcdDrawTextAtIndex(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, attr);
+        g_eeGeneral.backlightMode = editChoice(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, e_backlight_mode_off, e_backlight_mode_on, attr, event);
         break;
 
       case ITEM_SETUP_FLASH_BEEP:

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -465,7 +465,7 @@ void backlightEnable(uint8_t dutyCycle);
 #define BACKLIGHT_LEVEL_MIN   46
 #endif
 #define BACKLIGHT_ENABLE()    backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX-g_eeGeneral.backlightBright)
-#define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : (g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) ? 0 : g_eeGeneral.blOffBright)
+#define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright)
 #define isBacklightEnabled()  true
 
 #if !defined(SIMU)


### PR DESCRIPTION
We have got feedback that some user need OFF mode for Horus, since they use it in conjunction with a BL special function to switch between 'night' and 'day' mode.

So with this change, the behavior is  the following for Horus:

- mode OFF : screen nevers turn completely off, it goes to min backlight (5 for x12, 45 for x10)
- mode keys/controls : if off setting is set to absolute min, then screen goes fully dark