### PR TITLE
Add support for retrieving model ID over CRSF

### DIFF
--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -46,3 +46,30 @@ uint8_t createCrossfireChannelsFrame(uint8_t * frame, int16_t * pulses)
   *buf++ = crc8(crc_start, 23);
   return buf - frame;
 }
+
+uint8_t createCrossfireModelConfigFrame(uint8_t * frame, uint8_t port)
+{
+  uint8_t * buf = frame;
+  *buf++ = MODULE_ADDRESS;
+  uint8_t * crc_start = buf;
+  *buf++ = MODEL_CONFIG_ID;
+  // For future-proofing, clients should treat the model ID as an opaque
+  // byte sequence. First byte indicates its length, then the actual ID
+  // follows.
+  *buf++ = 1;
+  *buf++ = g_model.header.modelId[port];
+  // Model name
+  for (int i=0; g_model.header.name[i]; i++) {
+    *buf++ = idx2char(g_model.header.name[i]);
+  }
+  *buf++ = '\0';
+
+  // Set size
+  // 1(ID) + 1(MODEL_ID SIZE) + 1(MODEL_ID) + STRLEN(NAME)+1(NAME) + 1(CRC)
+  uint8_t frame_size = buf - frame - 2 + 1;
+  *(frame + 1) = frame_size;
+
+  *buf++ = crc8(crc_start, frame_size - 1);
+
+  return buf - frame;
+}

--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -30,6 +30,7 @@ TrainerPulsesData trainerPulsesData __DMA;
 
 #if defined(CROSSFIRE)
 uint8_t createCrossfireChannelsFrame(uint8_t * frame, int16_t * pulses);
+uint8_t createCrossfireModelConfigFrame(uint8_t * frame, uint8_t port);
 #endif
 
 uint8_t getRequiredProtocol(uint8_t port)
@@ -199,7 +200,13 @@ void setupPulses(uint8_t port)
         else
 #endif
         {
-          len = createCrossfireChannelsFrame(crossfire, &channelOutputs[g_model.moduleData[port].channelsStart]);
+          if (isCrossfireModelConfigPending()) {
+            len = createCrossfireModelConfigFrame(crossfire, port);
+            crossfireModelConfigSent();
+          }
+          else {
+            len = createCrossfireChannelsFrame(crossfire, &channelOutputs[g_model.moduleData[port].channelsStart]);
+          }
         }
         sportSendBuffer(crossfire, len);
       }

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -47,6 +47,8 @@ const CrossfireSensor crossfireSensors[] = {
   {0,              0, "UNKNOWN",        UNIT_RAW,           0},
 };
 
+static bool crossfireModelConfigPending = false;
+
 const CrossfireSensor & getCrossfireSensor(uint8_t id, uint8_t subId)
 {
   if (id == LINK_ID)
@@ -160,6 +162,9 @@ void processCrossfireTelemetryFrame()
       }
       break;
     }
+    case REQUEST_MODEL_CONFIG_ID:
+      crossfireModelConfigPending = true;
+      break;
 
 #if defined(LUA)
     default:
@@ -177,6 +182,16 @@ void processCrossfireTelemetryFrame()
 bool isCrossfireOutputBufferAvailable()
 {
   return outputTelemetryBufferSize == 0;
+}
+
+bool isCrossfireModelConfigPending()
+{
+  return crossfireModelConfigPending;
+}
+
+void crossfireModelConfigSent()
+{
+  crossfireModelConfigPending = false;
 }
 
 void processCrossfireTelemetryData(uint8_t data)
@@ -200,7 +215,8 @@ void processCrossfireTelemetryData(uint8_t data)
     telemetryRxBufferCount = 0;
   }
 
-  if (telemetryRxBufferCount > 4) {
+  // 4 bytes of data is the size of an empty frame
+  if (telemetryRxBufferCount >= 4) {
     uint8_t length = telemetryRxBuffer[1];
     if (length + 2 == telemetryRxBufferCount) {
       processCrossfireTelemetryFrame();

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -33,6 +33,8 @@
 #define CHANNELS_ID                    0x16
 #define ATTITUDE_ID                    0x1E
 #define FLIGHT_MODE_ID                 0x21
+#define REQUEST_MODEL_CONFIG_ID        0x26
+#define MODEL_CONFIG_ID                0x27
 #define PING_DEVICES_ID                0x28
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
@@ -76,6 +78,8 @@ enum CrossfireSensorIndexes {
 void processCrossfireTelemetryData(uint8_t data);
 void crossfireSetDefault(int index, uint8_t id, uint8_t subId);
 bool isCrossfireOutputBufferAvailable();
+bool isCrossfireModelConfigPending();
+void crossfireModelConfigSent();
 
 #if SPORT_MAX_BAUDRATE < 400000
 const uint32_t CROSSFIRE_BAUDRATES[] = {


### PR DESCRIPTION
Add 2 frames types:

- REQUEST_MODEL_CONFIG_ID sent from the TX to the radio to request
the model configuration. Empty.
- MODEL_CONFIG_ID sent from the radio to the TX. Contains the number
of bytes of the model ID followed by the ID itself and the
null-terminated model name.

For retrieving the model ID, the TX sends REQUEST_MODEL_CONFIG_ID,
which makes the radio send MODEL_CONFIG_ID rather than CHANNELS_ID
in the next cycle. This allows the TX to only ask for the model ID
when it needs it without loosing a control cycle periodically.