### PR TITLE
Full 11 bit USB HID gamepad resolution and fixed offsets for compatibility

### DIFF
--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -151,10 +151,13 @@ void usbJoystickUpdate()
     //analog values
     //uint8_t * p = HID_Buffer + 1;
     for (int i = 0; i < 8; ++i) {
-      int16_t value = channelOutputs[i] / 8;
-      if ( value > 127 ) value = 127;
-      else if ( value < -127 ) value = -127;
-      HID_Buffer[i+3] = static_cast<int8_t>(value);
+
+      int16_t value = channelOutputs[i] + 1023;
+      if ( value > 2047 ) value = 2047;
+      else if ( value < 0 ) value = 0;
+      HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
+      HID_Buffer[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);
+
     }
     USBD_HID_SendReport(&USB_OTG_dev, HID_Buffer, HID_IN_PACKET);
   }

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -152,7 +152,7 @@ void usbJoystickUpdate()
     //uint8_t * p = HID_Buffer + 1;
     for (int i = 0; i < 8; ++i) {
 
-      int16_t value = channelOutputs[i] + 1023;
+      int16_t value = channelOutputs[i] + 1024;
       if ( value > 2047 ) value = 2047;
       else if ( value < 0 ) value = 0;
       HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -151,10 +151,13 @@ void usbJoystickUpdate()
     //analog values
     //uint8_t * p = HID_Buffer + 1;
     for (int i = 0; i < 8; ++i) {
-      int16_t value = channelOutputs[i] / 8;
-      if ( value > 127 ) value = 127;
-      else if ( value < -127 ) value = -127;
-      HID_Buffer[i+3] = static_cast<int8_t>(value);
+
+      int16_t value = channelOutputs[i] + 1024;
+      if ( value > 2047 ) value = 2047;
+      else if ( value < 0 ) value = 0;
+      HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
+      HID_Buffer[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);
+
     }
     USBD_HID_SendReport(&USB_OTG_dev, HID_Buffer, HID_IN_PACKET);
   }

--- a/radio/src/targets/common/arm/stm32/usbd_conf.h
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.h
@@ -47,7 +47,7 @@
 #define HID_IN_EP                    0x81
 #define HID_OUT_EP                   0x01
 
-#define HID_IN_PACKET                19//11
+#define HID_IN_PACKET                19
 #define HID_OUT_PACKET               9
 
 #define CDC_IN_EP                    0x81  /* EP1 for data IN */

--- a/radio/src/targets/common/arm/stm32/usbd_conf.h
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.h
@@ -47,7 +47,7 @@
 #define HID_IN_EP                    0x81
 #define HID_OUT_EP                   0x01
 
-#define HID_IN_PACKET                11
+#define HID_IN_PACKET                19
 #define HID_OUT_PACKET               9
 
 #define CDC_IN_EP                    0x81  /* EP1 for data IN */

--- a/radio/src/targets/common/arm/stm32/usbd_conf.h
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.h
@@ -47,7 +47,7 @@
 #define HID_IN_EP                    0x81
 #define HID_OUT_EP                   0x01
 
-#define HID_IN_PACKET                11
+#define HID_IN_PACKET                19//11
 #define HID_OUT_PACKET               9
 
 #define CDC_IN_EP                    0x81  /* EP1 for data IN */

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -132,9 +132,9 @@ __ALIGN_BEGIN static const uint8_t HID_JOYSTICK_ReportDesc[] __ALIGN_END =
     0x09, 0x35,                    //         USAGE (Rz)
     0x09, 0x36,                    //         USAGE (Slider)
     0x09, 0x36,                    //         USAGE (Slider)
-    0x15, 0x81,                    //         LOGICAL_MINIMUM (-127)
-    0x25, 0x7f,                    //         LOGICAL_MAXIMUM (127)
-    0x75, 0x08,                    //         REPORT_SIZE (8)
+    0x16, 0x00, 0x00,              //         LOGICAL_MINIMUM (0)
+    0x26, 0xFF, 0x07,              //         LOGICAL_MAXIMUM (2047)
+    0x75, 0x10,                    //         REPORT_SIZE (16)
     0x95, 0x08,                    //         REPORT_COUNT (8)
     0x81, 0x02,                    //         INPUT (Data,Var,Abs)
     0xc0,                          //       END_COLLECTION


### PR DESCRIPTION
This is a proposal to increase the usb gamepad resolution from 8 bit to the full 11 bit while improving compatibility for some games where you had to cut the range in half again.

The changes were tested on the taranis X9D+ and windows 10 with great results and should comply with the official USB HID standard.