### PR TITLE
add boot version tag to taranis bootloader

### DIFF
--- a/radio/src/targets/taranis/stm32_ramboot.ld
+++ b/radio/src/targets/taranis/stm32_ramboot.ld
@@ -47,6 +47,7 @@ SECTIONS
   {
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
+    KEEP(*(.version))
     KEEP(*(.bootversiondata))
     . = ALIGN(4);      /* Align the start of the text part */
     *(.text)           /* .text sections (code) */


### PR DESCRIPTION
Allows for detecting the bootloader at the beginning of firmware.

fixes #5826