### PR TITLE
Horus: add receiver number check

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -157,7 +157,7 @@ endforeach()
 set(SRC ${SRC} debug.cpp)
 
 if(${EEPROM} STREQUAL SDCARD)
-  set(SRC ${SRC} storage/storage_common.cpp storage/sdcard_raw.cpp)
+  set(SRC ${SRC} storage/storage_common.cpp storage/sdcard_raw.cpp storage/modelslist.cpp)
 elseif(${EEPROM} STREQUAL EEPROM_RLC)
   set(SRC ${SRC} storage/storage_common.cpp storage/eeprom_common.cpp storage/eeprom_rlc.cpp)
   add_definitions(-DEEPROM -DEEPROM_RLC)

--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -634,6 +634,46 @@ int cliTestMemorySpeed()
 
   return 0;
 }
+
+#include "storage/modelslist.h"
+using std::list;
+
+int cliTestModelsList()
+{
+  ModelsList modList;
+  modList.load();
+
+  int count=0;
+
+  serialPrint("Starting fetching RF data 100x...");
+  uint32_t start = (uint32_t)CoGetOSTime();
+
+  const list<ModelsCategory*>& cats = modList.getCategories();
+  while(1) {
+    for (list<ModelsCategory*>::const_iterator cat_it = cats.begin();
+         cat_it != cats.end(); ++cat_it) {
+
+      for (ModelsCategory::iterator mod_it = (*cat_it)->begin();
+           mod_it != (*cat_it)->end(); mod_it++) {
+
+        if (!(*mod_it)->fetchRfData()) {
+          serialPrint("Error while fetching RF data...");
+          return 0;
+        }
+
+        if (++count >= 100)
+          goto done;
+      }
+    }
+  }
+
+ done:
+  uint32_t actualRuntime = (uint32_t)CoGetOSTime() - start;
+  serialPrint("Done fetching %ix RF data: %d ms", count, actualRuntime*2);
+
+  return 0;
+}
+
 #endif   // #if defined(COLORLCD)
 
 int cliTest(const char ** argv)
@@ -650,6 +690,9 @@ int cliTest(const char ** argv)
   }
   else if (!strcmp(argv[1], "memspd")) {
     return cliTestMemorySpeed();
+  }
+  else if (!strcmp(argv[1], "modelslist")) {
+    return cliTestModelsList();
   }
 #endif
   else {

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -254,6 +254,8 @@ void menuModelSetup(event_t event)
   static uint8_t selectedPxxPower = g_model.moduleData[EXTERNAL_MODULE].pxx.power; //TODO could go to the reusable struct
 #endif
 
+  int8_t old_editMode = s_editMode;
+
 #if defined(PCBTARANIS)
   MENU_TAB({
     HEADER_LINE_COLUMNS
@@ -1105,9 +1107,14 @@ void menuModelSetup(event_t event)
                 if (checkIncDec_Ret) {
                   modelHeaders[g_eeGeneral.currModel].modelId[moduleIdx] = g_model.header.modelId[moduleIdx];
                 }
-              }
-              if (editMode==0 && event==EVT_KEY_BREAK(KEY_ENTER)) {
-                checkModelIdUnique(g_eeGeneral.currModel, moduleIdx);
+                else if (event == EVT_KEY_LONG(KEY_ENTER)) {
+                  killEvents(event);
+                  uint8_t newVal = findNextUnusedModelId(g_eeGeneral.currModel, moduleIdx);
+                  if (newVal != g_model.header.modelId[moduleIdx]) {
+                    modelHeaders[g_eeGeneral.currModel].modelId[moduleIdx] = g_model.header.modelId[moduleIdx] = newVal;
+                    storageDirty(EE_MODEL);
+                  }
+                }
               }
             }
             lcdDrawText(MODEL_SETUP_2ND_COLUMN+xOffsetBind, y, STR_MODULE_BIND, l_posHorz==1 ? attr : 0);
@@ -1503,6 +1510,30 @@ void menuModelSetup(event_t event)
     lcdDrawNumber(16+4*FW, 5*FH, TELEMETRY_RSSI(), BOLD);
   }
 #endif
+
+  // some field just finished being edited
+  if (old_editMode > 0 && s_editMode == 0) {
+    switch(menuVerticalPosition) {
+#if defined(PCBTARANIS)
+    case ITEM_MODEL_INTERNAL_MODULE_BIND:
+      if (menuHorizontalPosition == 0)
+        checkModelIdUnique(g_eeGeneral.currModel, INTERNAL_MODULE);
+      break;
+#endif
+#if defined(PCBSKY9X)
+    case ITEM_MODEL_EXTRA_MODULE_BIND:
+      if (menuHorizontalPosition == 0)
+        checkModelIdUnique(g_eeGeneral.currModel, EXTRA_MODULE);
+      break;
+#endif
+#if defined(CPUARM)
+      case ITEM_MODEL_EXTERNAL_MODULE_BIND:
+      if (menuHorizontalPosition == 0)
+        checkModelIdUnique(g_eeGeneral.currModel, EXTERNAL_MODULE);
+      break;
+#endif
+    }
+  }
 }
 
 #if defined(CPUARM)

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -244,6 +244,7 @@ void onModelSelectMenu(const char * result)
     selectMode = MODE_SELECT_MODEL;
     setCurrentModel(currentCategory->size() - 1);
     modelslist.setCurrentModel(currentModel);
+    modelslist.onNewModelCreated(currentModel, &g_model);
 #if defined(LUA)
     chainMenu(menuModelWizard);
 #endif

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -255,9 +255,8 @@ void onModelSelectMenu(const char * result)
     if (findNextFileIndex(duplicatedFilename, LEN_MODEL_FILENAME, MODELS_PATH)) {
       sdCopyFile(currentModel->modelFilename, MODELS_PATH, duplicatedFilename, MODELS_PATH);
       ModelCell* dup_model = modelslist.addModel(currentCategory, duplicatedFilename);
-      dup_model->setRfData(&g_model);
-      unsigned int index = currentCategory->size() - 1;
-      setCurrentModel(index);
+      dup_model->fetchRfData();
+      setCurrentModel(currentCategory->size() - 1);
     }
     else {
       POPUP_WARNING("Invalid File");

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -101,66 +101,15 @@ enum MenuModelSetupItems {
 
 void checkModelIdUnique(uint8_t moduleIdx)
 {
-  ModelCell* mod_cell = modelslist.getCurrentModel();
-  if (!mod_cell || !mod_cell->valid_rfData) {
-    TRACE("!mod_cell || !mod_cell->valid_rfData");
-    return;
-  }
-
-  uint8_t modelId = mod_cell->modelId[moduleIdx];
-  uint8_t type = mod_cell->moduleData[moduleIdx].type;
-  uint8_t rfProtocol = mod_cell->moduleData[moduleIdx].rfProtocol;
-
-  uint8_t additionalOnes = 0;
   char* warn_buf = reusableBuffer.msgbuf.msg;
-  char* curr = warn_buf;
-  curr[0] = 0;
 
-  const std::list<ModelsCategory*>& cats = modelslist.getCategories();
-  std::list<ModelsCategory*>::const_iterator cat_it = cats.begin();
-  for (;cat_it != cats.end(); cat_it++) {
-    for (ModelsCategory::const_iterator it = (*cat_it)->begin(); it != (*cat_it)->end(); it++) {
-      if (mod_cell == *it)
-        continue;
-
-      if (!(*it)->valid_rfData)
-        continue;
-
-      if ((type != MODULE_TYPE_NONE) &&
-          (type       == (*it)->moduleData[moduleIdx].type) &&
-          (rfProtocol == (*it)->moduleData[moduleIdx].rfProtocol) &&
-          (modelId    == (*it)->modelId[moduleIdx])) {
-
-        // Hit found!
-        const char* modelName = (*it)->modelName;
-        const char* modelFilename = (*it)->modelFilename;
-
-        // you cannot rely exactly on WARNING_LINE_LEN so using WARNING_LINE_LEN-2 (-2 for the ",")
-        if ((WARNING_LINE_LEN - 4 - (curr - warn_buf)) > LEN_MODEL_NAME) {
-          if (warn_buf[0] != 0)
-            curr = strAppend(curr, ", ");
-          if (modelName[0] == 0) {
-            curr = strAppendFilename(curr, modelFilename, strlen(modelFilename));
-          }
-          else
-            curr = strAppend(curr, modelName, LEN_MODEL_NAME);
-        }
-        else {
-          additionalOnes++;
-        }
-      }
+  // cannot rely exactly on WARNING_LINE_LEN so using WARNING_LINE_LEN-2
+  size_t warn_buf_len = sizeof(reusableBuffer.msgbuf.msg) - WARNING_LINE_LEN - 2;
+  if (!modelslist.isModelIdUnique(moduleIdx,warn_buf,warn_buf_len)) {
+    if (warn_buf[0] != 0) {
+      POPUP_WARNING(STR_MODELIDUSED);
+      SET_WARNING_INFO(warn_buf, sizeof(reusableBuffer.msgbuf.msg), 0);
     }
-  }
-
-  if (additionalOnes) {
-    curr = strAppend(curr, " (+");
-    curr = strAppendUnsigned(curr, additionalOnes);
-    curr = strAppend(curr, ")");
-  }
-
-  if (warn_buf[0] != 0) {
-    POPUP_WARNING(STR_MODELIDUSED);
-    SET_WARNING_INFO(warn_buf, sizeof(reusableBuffer.msgbuf.msg), 0);
   }
 }
 
@@ -962,6 +911,14 @@ bool menuModelSetup(event_t event)
             if (attr && l_posHorz==0) {
               if (s_editMode>0) {
                 CHECK_INCDEC_MODELVAR_ZERO(event, g_model.header.modelId[moduleIdx], MAX_RX_NUM(moduleIdx));
+                if (event == EVT_KEY_LONG(KEY_ENTER)) {
+                  killEvents(event);
+                  uint8_t newVal = modelslist.findNextUnusedModelId(moduleIdx);
+                  if (newVal != g_model.header.modelId[moduleIdx]) {
+                    g_model.header.modelId[moduleIdx] = newVal;
+                    storageDirty(EE_MODEL);
+                  }
+                }
               }
             }
             drawButton(MODEL_SETUP_2ND_COLUMN+xOffsetBind, y, STR_MODULE_BIND, (moduleFlag[moduleIdx] == MODULE_BIND ? BUTTON_ON : BUTTON_OFF) | (l_posHorz==1 ? attr : 0));

--- a/radio/src/gui/480x272/radio_sdmanager.cpp
+++ b/radio/src/gui/480x272/radio_sdmanager.cpp
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include "opentx.h"
+#include "storage/modelslist.h"
 
 #define REFRESH_FILES()        do { reusableBuffer.sdmanager.offset = 65535; currentBitmapIndex = -1; } while (0)
 #define NODE_TYPE(fname)       fname[SD_SCREEN_FILE_LENGTH+1]
@@ -126,6 +127,8 @@ void onSdManagerMenu(const char * result)
   }
   else if (result == STR_ASSIGN_BITMAP) {
     memcpy(g_model.header.bitmap, line, sizeof(g_model.header.bitmap));
+    if(modelslist.getCurrentModel())
+      modelslist.getCurrentModel()->resetBuffer();
     storageDirty(EE_MODEL);
   }
   else if (result == STR_ASSIGN_SPLASH) {

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -939,8 +939,9 @@ inline void resumeMixerCalculations()
 void generalDefault();
 void modelDefault(uint8_t id);
 
-#if defined(CPUARM)
+#if defined(CPUARM) && defined(EEPROM)
 void checkModelIdUnique(uint8_t index, uint8_t module);
+uint8_t findNextUnusedModelId(uint8_t index, uint8_t module);
 #endif
 
 #if defined(CPUARM)

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -22,6 +22,7 @@
 #define _SDCARD_H_
 
 #include "ff.h"
+#include "opentx.h"
 
 #define ROOT_PATH           "/"
 #define MODELS_PATH         ROOT_PATH "MODELS"      // no trailing slash = important

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -49,6 +49,11 @@ void ModelCell::setModelName(char* name)
   resetBuffer();
 }
 
+void ModelCell::setModelId(uint8_t moduleIdx, uint8_t id)
+{
+  modelId[moduleIdx] = id;
+}
+
 void ModelCell::resetBuffer()
 {
   if (buffer) {
@@ -534,7 +539,7 @@ uint8_t ModelsList::findNextUnusedModelId(uint8_t moduleIdx)
     }
   }
 
-  uint8_t new_id = 0;
+  uint8_t new_id = 1;
   uint8_t tst_mask = 1;
   for (;new_id < MAX_RX_NUM(moduleIdx); new_id++) {
     if (!(usedModelIds[new_id >> 3] & tst_mask)) {
@@ -547,4 +552,14 @@ uint8_t ModelsList::findNextUnusedModelId(uint8_t moduleIdx)
 
   // failed finding something...
   return 0;
+}
+
+void ModelsList::onNewModelCreated(ModelCell* cell, ModelData* model)
+{
+  cell->setModelName(model->header.name);
+  cell->setRfData(model);
+
+  uint8_t new_id = findNextUnusedModelId(INTERNAL_MODULE);
+  model->header.modelId[INTERNAL_MODULE] = new_id;
+  cell->setModelId(INTERNAL_MODULE, new_id);
 }

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -1,0 +1,429 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "modelslist.h"
+using std::list;
+
+ModelsList modelslist;
+
+ModelCell::ModelCell(const char * name)
+  : buffer(NULL), valid_rfData(false)
+{
+  strncpy(modelFilename, name, sizeof(modelFilename));
+  memset(modelName, 0, sizeof(modelName));
+}
+
+ModelCell::~ModelCell()
+{
+  resetBuffer();
+}
+
+void ModelCell::setModelName(char* name)
+{
+  zchar2str(modelName, name, LEN_MODEL_NAME);
+  if (modelName[0] == 0) {
+    char * tmp;
+    strncpy(modelName, modelFilename, LEN_MODEL_NAME);
+    tmp = (char *) memchr(modelName, '.',  LEN_MODEL_NAME);
+    if (tmp != NULL)
+      *tmp = 0;
+  }
+
+  resetBuffer();
+}
+
+void ModelCell::resetBuffer()
+{
+  if (buffer) {
+    delete buffer;
+    buffer = NULL;
+  }
+}
+
+const BitmapBuffer * ModelCell::getBuffer()
+{
+  if (!buffer) {
+    loadBitmap();
+  }
+  return buffer;
+}
+
+void ModelCell::loadBitmap()
+{
+  PACK(struct {
+    ModelHeader header;
+    TimerData timers[MAX_TIMERS];
+  }) partialmodel;
+  const char * error = NULL;
+
+  buffer = new BitmapBuffer(BMP_RGB565, MODELCELL_WIDTH, MODELCELL_HEIGHT);
+  if (buffer == NULL) {
+    return;
+  }
+
+  if (strncmp(modelFilename, g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME) == 0) {
+    memcpy(&partialmodel.header, &g_model.header, sizeof(partialmodel));
+  }
+  else {
+    error = readModel(modelFilename, (uint8_t *)&partialmodel.header, sizeof(partialmodel));
+  }
+
+  buffer->clear(TEXT_BGCOLOR);
+
+  if (error) {
+    buffer->drawText(5, 2, "(Invalid Model)", TEXT_COLOR);
+    buffer->drawBitmapPattern(5, 23, LBM_LIBRARY_SLOT, TEXT_COLOR);
+  }
+  else {
+    if (modelName[0] == 0)
+      setModelName(partialmodel.header.name);
+
+    char timer[LEN_TIMER_STRING];
+    buffer->drawSizedText(5, 2, modelName, LEN_MODEL_NAME, SMLSIZE|TEXT_COLOR);
+    getTimerString(timer, 0);
+    for (uint8_t i = 0; i < MAX_TIMERS; i++) {
+      if (partialmodel.timers[i].mode > 0 && partialmodel.timers[i].persistent) {
+        getTimerString(timer, partialmodel.timers[i].value);
+        break;
+      }
+    }
+    buffer->drawText(101, 40, timer, TEXT_COLOR);
+    for (int i=0; i<4; i++) {
+      buffer->drawBitmapPattern(104+i*11, 25, LBM_SCORE0, TITLE_BGCOLOR);
+    }
+    GET_FILENAME(filename, BITMAPS_PATH, partialmodel.header.bitmap, "");
+    const BitmapBuffer * bitmap = BitmapBuffer::load(filename);
+    if (bitmap) {
+      buffer->drawScaledBitmap(bitmap, 5, 24, 56, 32);
+      delete bitmap;
+    }
+    else {
+      buffer->drawBitmapPattern(5, 23, LBM_LIBRARY_SLOT, TEXT_COLOR);
+    }
+  }
+  buffer->drawSolidHorizontalLine(5, 19, 143, LINE_COLOR);
+}
+
+void ModelCell::save(FIL* file)
+{
+  f_puts(modelFilename, file);
+  f_putc('\n', file);
+}
+
+void ModelCell::setRfData(ModelData* model)
+{
+  for (uint8_t i = 0; i < NUM_MODULES; i++) {
+    modelId[i] = model->header.modelId[i];
+    setRfModuleData(i, &(model->moduleData[i]));
+    TRACE("<%s/%i> : %X,%X,%X",
+          strlen(modelName) ? modelName : modelFilename,
+          i, moduleData[i].type, moduleData[i].rfProtocol, modelId[i]);
+  }
+  valid_rfData = true;
+}
+
+void ModelCell::setRfModuleData(uint8_t moduleIdx, ModuleData* modData)
+{
+  moduleData[moduleIdx].type = modData->type;
+  if (modData->type != MODULE_TYPE_MULTIMODULE) {
+    moduleData[moduleIdx].rfProtocol = (uint8_t)modData->rfProtocol;
+  }
+  else {
+    // do we care here about MM_RF_CUSTOM_SELECTED? probably not...
+    moduleData[moduleIdx].rfProtocol = modData->getMultiProtocol(false);
+  }
+}
+
+bool ModelCell::fetchRfData()
+{
+  //TODO: use g_model in case fetching data for current model
+  //
+  char buf[256];
+  getModelPath(buf, modelFilename);
+
+  FIL      file;
+  uint16_t file_size;
+
+  const char* err = openFile(buf,&file,&file_size);
+  if (err) return false;
+
+  FSIZE_t start_offset = f_tell(&file);
+
+
+  UINT read;
+  if ((f_read(&file, buf, LEN_MODEL_NAME, &read) != FR_OK) || (read != LEN_MODEL_NAME))
+    goto error;
+
+  setModelName(buf);
+
+  // 1. fetch modelId: NUM_MODULES @ offsetof(ModelHeader, modelId)
+  // if (f_lseek(&file, start_offset + offsetof(ModelHeader, modelId)) != FR_OK)
+  //   goto error;
+  if ((f_read(&file, modelId, NUM_MODULES, &read) != FR_OK) || (read != NUM_MODULES))
+    goto error;
+
+  // 2. fetch ModuleData: sizeof(ModuleData)*NUM_MODULES @ offsetof(ModelData, moduleData)
+  if (f_lseek(&file, start_offset + offsetof(ModelData, moduleData)) != FR_OK)
+    goto error;
+
+  for(uint8_t i=0; i<NUM_MODULES; i++) {
+    ModuleData modData;
+    if ((f_read(&file, &modData, NUM_MODULES, &read) != FR_OK) || (read != NUM_MODULES))
+      goto error;
+
+    setRfModuleData(i, &modData);
+  }
+
+  valid_rfData = true;  
+  f_close(&file);
+  return true;
+  
+ error:
+  f_close(&file);
+  return false;  
+}
+
+ModelsCategory::ModelsCategory(const char * name)
+{
+  strncpy(this->name, name, sizeof(this->name));
+}
+
+ModelsCategory::~ModelsCategory()
+{
+  for (list<ModelCell *>::iterator it = begin(); it != end(); ++it) {
+    delete *it;
+  }
+}
+
+
+ModelCell * ModelsCategory::addModel(const char * name)
+{
+  ModelCell * result = new ModelCell(name);
+  push_back(result);
+  return result;
+}
+
+void ModelsCategory::removeModel(ModelCell * model)
+{
+  delete model;
+  remove(model);
+}
+
+void ModelsCategory::moveModel(ModelCell * model, int8_t step)
+{
+  ModelsCategory::iterator current = begin();
+  for (; current != end(); current++) {
+    if (*current == model) {
+      break;
+    }
+  }
+
+  ModelsCategory::iterator new_position = current;
+  if (step > 0) {
+    while (step >= 0 && new_position != end()) {
+      new_position++;
+      step--;
+    }
+  }
+  else {
+    while (step < 0 && new_position != begin()) {
+      new_position--;
+      step++;
+    }
+  }
+
+  insert(new_position, 1, *current);
+  erase(current);
+}
+
+void ModelsCategory::save(FIL * file)
+{
+  f_puts("[", file);
+  f_puts(name, file);
+  f_puts("]", file);
+  f_putc('\n', file);
+  for (list<ModelCell *>::iterator it = begin(); it != end(); ++it) {
+    (*it)->save(file);
+  }
+}
+
+ModelsList::ModelsList()
+{
+  init();
+}
+
+ModelsList::~ModelsList()
+{
+  clear();
+}
+
+void ModelsList::init()
+{
+  loaded = false;
+  currentCategory = NULL;
+  currentModel = NULL;
+  modelsCount = 0;
+}
+
+void ModelsList::clear()
+{
+  for (list<ModelsCategory *>::iterator it = categories.begin(); it != categories.end(); ++it) {
+    delete *it;
+  }
+  categories.clear();
+}
+
+bool ModelsList::load()
+{
+  char line[LEN_MODELS_IDX_LINE+1];
+  ModelsCategory * category = NULL;
+
+  if (loaded)
+    return true;
+
+  FRESULT result = f_open(&file, RADIO_MODELSLIST_PATH, FA_OPEN_EXISTING | FA_READ);
+  if (result == FR_OK) {
+    while (readNextLine(line, LEN_MODELS_IDX_LINE)) {
+      int len = strlen(line); // TODO could be returned by readNextLine
+      if (len > 2 && line[0] == '[' && line[len-1] == ']') {
+        line[len-1] = '\0';
+        category = new ModelsCategory(&line[1]);
+        categories.push_back(category);
+      }
+      else if (len > 0) {
+
+        //char* rf_data_str = cutModelFilename(line);
+        ModelCell * model = new ModelCell(line);
+        if (!category) {
+          category = new ModelsCategory("Models");
+          categories.push_back(category);
+        }
+        category->push_back(model);
+        if (!strncmp(line, g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME)) {
+          currentCategory = category;
+          currentModel = model;
+        }
+        //parseModulesData(model, rf_data_str);
+        //TRACE("model=<%s>, valid_rfData=<%i>",model->modelFilename,model->valid_rfData);
+        model->fetchRfData();
+        modelsCount += 1;
+      }
+    }
+    f_close(&file);
+
+    if (!getCurrentModel()) {
+      TRACE("currentModel is NULL");
+    }
+  }
+
+  if (categories.size() == 0) {
+    category = new ModelsCategory("Models");
+    categories.push_back(category);
+  }
+
+  loaded = true;
+  return true;
+}
+
+void ModelsList::save()
+{
+  FRESULT result = f_open(&file, RADIO_MODELSLIST_PATH, FA_CREATE_ALWAYS | FA_WRITE);
+  if (result != FR_OK) {
+    return;
+  }
+
+  for (list<ModelsCategory *>::iterator it = categories.begin(); it != categories.end(); ++it) {
+    (*it)->save(&file);
+  }
+
+  f_close(&file);
+}
+
+void ModelsList::setCurrentCategorie(ModelsCategory* cat)
+{
+  currentCategory = cat;
+}
+
+void ModelsList::setCurrentModel(ModelCell* cell)
+{
+  currentModel = cell;
+  if (!currentModel->valid_rfData)
+    currentModel->fetchRfData();
+}
+
+bool ModelsList::readNextLine(char * line, int maxlen)
+{
+  if (f_gets(line, maxlen, &file) != NULL) {
+    int curlen = strlen(line) - 1;
+    if (line[curlen] == '\n') { // remove unwanted chars if file was edited using windows
+      if (line[curlen - 1] == '\r') {
+        line[curlen - 1] = 0;
+      }
+      else {
+        line[curlen] = 0;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+ModelsCategory * ModelsList::createCategory()
+{
+  ModelsCategory * result = new ModelsCategory("Category");
+  categories.push_back(result);
+  save();
+  return result;
+}
+
+ModelCell * ModelsList::addModel(ModelsCategory * category, const char * name)
+{
+  ModelCell * result = category->addModel(name);
+  modelsCount++;
+  save();
+  return result;
+}
+
+void ModelsList::removeCategory(ModelsCategory * category)
+{
+  modelsCount -= category->size();
+  delete category;
+  categories.remove(category);
+}
+
+void ModelsList::removeModel(ModelsCategory * category, ModelCell * model)
+{
+  category->removeModel(model);
+  modelsCount--;
+  save();
+}
+
+void ModelsList::moveModel(ModelsCategory * category, ModelCell * model, int8_t step)
+{
+  category->moveModel(model, step);
+  save();
+}
+
+void ModelsList::moveModel(ModelCell * model, ModelsCategory * previous_category, ModelsCategory * new_category)
+{  
+  previous_category->remove(model);
+  new_category->push_back(model);
+  save();
+}

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -495,7 +495,7 @@ bool ModelsList::isModelIdUnique(uint8_t moduleIdx, char* warn_buf, size_t warn_
     curr = strAppend(curr, ")");
   }
 
-  return hit_found;
+  return !hit_found;
 }
 
 uint8_t ModelsList::findNextUnusedModelId(uint8_t moduleIdx)

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -116,8 +116,6 @@ public:
     return modelsCount;
   }
   
-  //void checkRfData();
-  
   bool readNextLine(char * line, int maxlen);
 
   ModelsCategory * createCategory();
@@ -127,6 +125,9 @@ public:
   void removeModel(ModelsCategory * category, ModelCell * model);
   void moveModel(ModelsCategory * category, ModelCell * model, int8_t step);
   void moveModel(ModelCell * model, ModelsCategory * previous_category, ModelsCategory * new_category);
+
+  bool isModelIdUnique(uint8_t moduleIdx, char* warn_buf, size_t warn_buf_len);
+  uint8_t findNextUnusedModelId(uint8_t moduleIdx);
 
 protected:
   FIL file;

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -54,15 +54,15 @@ public:
   void save(FIL* file);
 
   void setModelName(char* name);
+  void setRfData(ModelData* model);
 
+  void setModelId(uint8_t moduleIdx, uint8_t id);
+  void setRfModuleData(uint8_t moduleIdx, ModuleData* modData);
+
+  bool  fetchRfData();
   void  loadBitmap();
   const BitmapBuffer * getBuffer();
   void  resetBuffer();
-
-  bool fetchRfData();
-
-  void setRfData(ModelData* model);
-  void setRfModuleData(uint8_t moduleIdx, ModuleData* modData);
 };
 
 class ModelsCategory: public std::list<ModelCell *>
@@ -128,6 +128,8 @@ public:
 
   bool isModelIdUnique(uint8_t moduleIdx, char* warn_buf, size_t warn_buf_len);
   uint8_t findNextUnusedModelId(uint8_t moduleIdx);
+
+  void onNewModelCreated(ModelCell* cell, ModelData* model);
 
 protected:
   FIL file;

--- a/radio/src/storage/sdcard_raw.cpp
+++ b/radio/src/storage/sdcard_raw.cpp
@@ -66,10 +66,6 @@ const char * writeModel()
 {
   char path[256];
   getModelPath(path, g_eeGeneral.currModelFilename);
-
-  if (modelslist.getCurrentModel())
-    modelslist.getCurrentModel()->setRfData(&g_model);
-
   return writeFile(path, (uint8_t *)&g_model, sizeof(g_model));
 }
 

--- a/radio/src/storage/sdcard_raw.h
+++ b/radio/src/storage/sdcard_raw.h
@@ -26,6 +26,11 @@
 #define DEFAULT_CATEGORY         "Models"
 #define DEFAULT_MODEL_FILENAME   "model1.bin"
 
+// opens radio.bin or model file
+const char * openFile(const char * fullpath, FIL* file, uint16_t* size);
+
+void getModelPath(char * path, const char * filename);
+
 const char * readModel(const char * filename, uint8_t * buffer, uint32_t size);
 const char * loadModel(const char * filename, bool alarms=true);
 const char * createModel();

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -463,8 +463,10 @@ char * strAppendFilename(char * dest, const char * filename, const int size)
   memset(dest, 0, size);
   for (int i=0; i<size; i++) {
     char c = *filename++;
-    if (c == '\0' || c == '.')
+    if (c == '\0' || c == '.') {
+      *dest = 0;
       break;
+    }
     *dest++ = c;
   }
   return dest;

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -1056,7 +1056,11 @@
 #define TR_SET                         BUTTON("Set")
 #define TR_TRAINER                     "Trainer"
 #define TR_ANTENNAPROBLEM              CENTER "TX antenna problem!"
-#define TR_MODELIDUSED                 TR("ID used in:","Receiver ID used in:")
+#if defined(COLORLCD)
+  #define TR_MODELIDUSED               "ID used in:"
+#else
+  #define TR_MODELIDUSED               TR("ID used in:","Receiver ID used in:")
+#endif
 #define TR_MODULE                      INDENT "Module"
 #define TR_TELEMETRY_TYPE              TR("Type", "Telemetry type")
 #define TR_TELEMETRY_SENSORS           "Sensors"


### PR DESCRIPTION
Basically checks whether or not a receiver number is already used. In case it is, a warning is displayed.

Cases covered:
- check RX ID on any relevant change in module/proto/ID.
- assign a new free receiver ID on new model (internal RF).
- find the next free receiver ID while editing it (long press ENTER while editing).

The same features are now available as well on std LCD.