### PR TITLE
3djc/xlite sf nav

### DIFF
--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -139,7 +139,7 @@ void onCustomFunctionsMenu(const char * result)
     storageDirty(eeFlags);
   }
 }
-#endif // CPUARM
+#endif // PCBTARANIS
 
 void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomFunctionsContext * functionsContext)
 {
@@ -155,7 +155,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 #if defined(PCBXLITE)
   if (menuHorizontalPosition==0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
     killEvents(KEY_ENTER);
-    if (IS_SHIFT_PRESSED()) {
+    if (IS_SHIFT_PRESSED()) { // ENT LONG on xlite brings up switch type menu, so this menu is activated with SHIT + ENT LONG
 #else
   if (menuHorizontalPosition<0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
 #endif
@@ -180,7 +180,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 #if defined(PCBXLITE)
   }
 #endif
-#endif // PCBX7
+#endif // PCBTARANIS
 
   for (uint8_t i=0; i<NUM_BODY_LINES; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + i*FH;

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -103,7 +103,7 @@ void onAdjustGvarSourceLongEnterPress(const char * result)
 
 void onCustomFunctionsMenu(const char * result)
 {
-  int sub = menuVerticalPosition;
+  int sub = menuVerticalPosition - HEADER_LINE;
   CustomFunctionData * cfn;
   uint8_t eeFlags;
 

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -70,7 +70,7 @@ void onCustomFunctionsFileSelectionMenu(const char * result)
 }
 #endif // CPUARM && SDCARD
 
-#if defined(PCBX7)
+#if defined(PCBTARANIS)
 
 void onAdjustGvarSourceLongEnterPress(const char * result)
 {
@@ -151,8 +151,14 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
   uint8_t eeFlags = EE_MODEL;
 #endif
 
-#if defined(PCBX7)
+#if defined(PCBTARANIS)
+#if defined(PCBXLITE)
+  if (menuHorizontalPosition==0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
+    killEvents(KEY_ENTER);
+    if (IS_SHIFT_PRESSED()) {
+#else
   if (menuHorizontalPosition<0 && event==EVT_KEY_LONG(KEY_ENTER) && !READ_ONLY()) {
+#endif
     killEvents(event);
     CustomFunctionData *cfn = &functions[sub];
     if (!CFN_EMPTY(cfn))
@@ -171,6 +177,9 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
     }
     POPUP_MENU_START(onCustomFunctionsMenu);
   }
+#if defined(PCBXLITE)
+  }
+#endif
 #endif // PCBX7
 
   for (uint8_t i=0; i<NUM_BODY_LINES; i++) {

--- a/radio/src/gui/128x64/navigation.cpp
+++ b/radio/src/gui/128x64/navigation.cpp
@@ -438,7 +438,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
 
 #if defined(PCBXLITE)
   if (i_flags & INCDEC_SOURCE) {
-    if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    if (event == EVT_KEY_LONG(KEY_ENTER) && !IS_SHIFT_PRESSED()) {
       killEvents(event);
       checkIncDecSelection = MIXSRC_NONE;
 
@@ -487,7 +487,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
     }
   }
   else if (i_flags & INCDEC_SWITCH) {
-    if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    if (event == EVT_KEY_LONG(KEY_ENTER) && !IS_SHIFT_PRESSED()) {
       killEvents(event);
       checkIncDecSelection = SWSRC_NONE;
       if (i_min <= SWSRC_FIRST_SWITCH && i_max >= SWSRC_LAST_SWITCH)       POPUP_MENU_ADD_ITEM(STR_MENU_SWITCHES);
@@ -896,7 +896,12 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc * menuTab, uint8_t
   menuHorizontalPosition = l_posHorz;
 }
 #else
+#if defined(PCBXLITE)
+#define MAXCOL_RAW(row)                (horTab ? pgm_read_byte(horTab+min(row, (vertpos_t)horTabMax)) : (const uint8_t)0)
+#define MAXCOL(row)                    (MAXCOL_RAW(row) >= HIDDEN_ROW ? MAXCOL_RAW(row) : (const uint8_t)(MAXCOL_RAW(row) & (~NAVIGATION_LINE_BY_LINE)))
+#else
 #define MAXCOL(row)                    (horTab ? pgm_read_byte(horTab+min(row, (vertpos_t)horTabMax)) : (const uint8_t)0)
+#endif
 #define POS_HORZ_INIT(posVert)         0
 
 void check(event_t event, uint8_t curr, const MenuHandlerFunc *menuTab, uint8_t menuTabSize, const pm_uint8_t *horTab, uint8_t horTabMax, vertpos_t maxrow)


### PR DESCRIPTION
Fix SF nav:
- exiting the screen left or right make it appear on the other side
- Long Ent + SHIFT on first column bring copy/paste/clear menu
- no more cursor lost on right when cfn is empty