### PR TITLE
Model print and compare user customisable style

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -244,6 +244,7 @@ set(companion_SRCS
   radionotfound.cpp
   wizarddata.cpp
   wizarddialog.cpp
+  styleeditdialog.cpp
   )
 
 set(companion_MOC_HDRS
@@ -275,6 +276,8 @@ set(companion_MOC_HDRS
   modelprinter.h
   multimodelprinter.h
   modelslist.h
+  styleeditdialog.h
+  helpers_html.h
   )
 
 set(companion_UIS
@@ -295,6 +298,7 @@ set(companion_UIS
   flashfirmwaredialog.ui
   flasheepromdialog.ui
   radionotfound.ui
+  styleeditdialog.ui
   )
 
 if(WIN32)

--- a/companion/src/companion.qrc
+++ b/companion/src/companion.qrc
@@ -235,6 +235,7 @@
     <file>images/library/10802.png</file>
     <file>themes/default/style.css</file>
     <file>themes/default/style-osx.css</file>
+    <file>themes/default/modelprt.css</file>
     <file>themes/monochrome/16/paintbrush.png</file>
     <file>themes/monochrome/16/open.png</file>
     <file>themes/monochrome/16/edit.png</file>

--- a/companion/src/comparedialog.cpp
+++ b/companion/src/comparedialog.cpp
@@ -23,6 +23,7 @@
 #include "appdata.h"
 #include "helpers.h"
 #include "modelslist.h"
+#include "styleeditdialog.h"
 #include <QPrinter>
 #include <QPrintDialog>
 
@@ -188,4 +189,11 @@ void CompareDialog::on_printFileButton_clicked()
     printer.setOutputFileName(filename);
     ui->textEdit->print(&printer);
   }
+}
+
+void CompareDialog::on_styleButton_clicked()
+{
+  StyleEditDialog *g = new StyleEditDialog(this, MODEL_PRINT_CSS);
+  if (g->exec() == QDialog::Accepted)
+    compare();
 }

--- a/companion/src/comparedialog.h
+++ b/companion/src/comparedialog.h
@@ -51,6 +51,7 @@ class CompareDialog : public QDialog
     void removeModelBtnClicked();
     void on_printButton_clicked();
     void on_printFileButton_clicked();
+    void on_styleButton_clicked();
 
   protected:
     virtual void closeEvent(QCloseEvent * event);

--- a/companion/src/comparedialog.ui
+++ b/companion/src/comparedialog.ui
@@ -43,6 +43,9 @@
        <property name="text">
         <string>To compare models, drag and drop them anywhere in this window.</string>
        </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item>
@@ -62,6 +65,13 @@
       <widget class="QPushButton" name="closeButton">
        <property name="text">
         <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="styleButton">
+       <property name="text">
+        <string>Style</string>
        </property>
       </widget>
      </item>

--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -151,7 +151,7 @@ bool Stylesheet::read(const QString & path)
     }
   }
   if (mResult)
-    mErrormsg = tr("Style sheet data successfully read from '%1'").arg(QDir::toNativeSeparators(path));
+    mErrormsg = tr("Style sheet data read from '%1'").arg(QDir::toNativeSeparators(path));
   else
     mErrormsg = tr("Style sheet data unable to be read from '%1'").arg(QDir::toNativeSeparators(path));
   qDebug() << mErrormsg;
@@ -167,30 +167,30 @@ bool Stylesheet::update()
     QDir dir;
     if (!dir.mkpath(mCustomPath))
       mErrormsg = tr("Cannot create folder '%1'").arg(QDir::toNativeSeparators(mCustomPath));
-    else
-      mErrormsg = tr("Created folder '%1'").arg(QDir::toNativeSeparators(mCustomPath));
   }
-  QFile file(mCustomFile);
-  if (!file.open(QFile::WriteOnly | QFile::Text)) {
-    mErrormsg = tr("Cannot open file for writing '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
-  }
-  else {
-    QTextStream out(&file);
-    if (out.status()==QTextStream::Ok) {
-      out << mText;
-      if (!(out.status()==QTextStream::Ok)) {
-        mErrormsg = tr("Cannot write to file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
-        if (!file.flush()) {
-          mErrormsg = tr("Cannot flush buffer for file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+  if (path.exists()) {
+    QFile file(mCustomFile);
+    if (!file.open(QFile::WriteOnly | QFile::Text)) {
+      mErrormsg = tr("Cannot open file for writing '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+    }
+    else {
+      QTextStream out(&file);
+      if (out.status()==QTextStream::Ok) {
+        out << mText;
+        if (!(out.status()==QTextStream::Ok)) {
+          mErrormsg = tr("Cannot write to file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+          if (!file.flush()) {
+            mErrormsg = tr("Cannot flush buffer for file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+          }
+        }
+        else {
+          mResult = true;
+          mErrormsg = tr("Style sheet written to '%1'").arg(QDir::toNativeSeparators(mCustomFile));
         }
       }
-      else {
-        mResult = true;
-        mErrormsg = tr("Style sheet written to '%1'").arg(QDir::toNativeSeparators(mCustomFile));
-      }
     }
+    file.close();
   }
-  file.close();
   qDebug() << mErrormsg;
   return mResult;
 }
@@ -200,7 +200,7 @@ bool Stylesheet::deleteCustom()
   QFile file(mCustomFile);
   mResult = file.remove();
   if (mResult)
-    mErrormsg = tr("Custom style sheet successfully deleted: '%1'").arg(QDir::toNativeSeparators(mCustomFile));
+    mErrormsg = tr("Custom style sheet deleted: '%1'").arg(QDir::toNativeSeparators(mCustomFile));
   else
     mErrormsg = tr("Unable to delete custom style sheet: '%1'").arg(QDir::toNativeSeparators(mCustomFile));
   qDebug() << mErrormsg;

--- a/companion/src/helpers_html.cpp
+++ b/companion/src/helpers_html.cpp
@@ -18,7 +18,12 @@
  * GNU General Public License for more details.
  */
 
+#include "helpers.h"
 #include "helpers_html.h"
+#include <QStringList>
+#include <QDir>
+#include <QFile>
+#include <QTextStream>
 
 QString tdAlign(const QString & s, const QString & align, const QString & color, bool bold)
 {
@@ -80,3 +85,145 @@ QString doTableBlankRow()
 {
   return "<tr></tr>";
 }
+
+Stylesheet::Stylesheet(const QString & name):
+  mName(name)
+{
+  init();
+}
+
+Stylesheet::Stylesheet(const QString & name, const StyleType styleType):
+  mName(name)
+{
+  init();
+  mResult = load(styleType);
+}
+
+Stylesheet::~Stylesheet()
+{
+}
+
+void Stylesheet::init()
+{
+  mResult = false;
+  mErrormsg = "";
+  mText = "";
+  QStringList p = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+  mCustomPath = p[0];
+  mCustomFile = p[0] + "/" + mName;
+  mDefaultFile = THEMES_DEFAULT_PATH + mName;
+}
+
+bool Stylesheet::load(const StyleType styleType)
+{
+  mResult = false;
+  switch (styleType) {
+  case STYLE_TYPE_NONE:
+  case STYLE_TYPE_DEFAULT:
+    mResult = read(mDefaultFile);
+  case STYLE_TYPE_CUSTOM:
+    mResult = read(mCustomFile);
+  case STYLE_TYPE_EFFECTIVE:
+    mResult = read(mCustomFile);
+    if(!mResult)
+      mResult = read(mDefaultFile);
+  }
+  return mResult;
+}
+
+bool Stylesheet::read(const QString & path)
+{
+  mResult = false;
+  mText = "";
+
+  QFile file(path);
+  if (file.exists()) {
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+      QTextStream in(&file);
+      if (in.status()==QTextStream::Ok) {
+        mText = in.readAll();
+        if (in.status()==QTextStream::Ok)
+          mResult = true;
+        else
+          mText = "";
+      }
+      file.close();
+    }
+  }
+  if (mResult)
+    mErrormsg = tr("Style sheet data successfully read from '%1'").arg(QDir::toNativeSeparators(path));
+  else
+    mErrormsg = tr("Style sheet data unable to be read from '%1'").arg(QDir::toNativeSeparators(path));
+  qDebug() << mErrormsg;
+  return mResult;
+}
+
+bool Stylesheet::update()
+{
+  mResult = false;
+  mErrormsg = "";
+  QDir path(mCustomPath);
+  if (!path.exists()) {
+    QDir dir;
+    if (!dir.mkpath(mCustomPath))
+      mErrormsg = tr("Cannot create folder '%1'").arg(QDir::toNativeSeparators(mCustomPath));
+    else
+      mErrormsg = tr("Created folder '%1'").arg(QDir::toNativeSeparators(mCustomPath));
+  }
+  QFile file(mCustomFile);
+  if (!file.open(QFile::WriteOnly | QFile::Text)) {
+    mErrormsg = tr("Cannot open file for writing '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+  }
+  else {
+    QTextStream out(&file);
+    if (out.status()==QTextStream::Ok) {
+      out << mText;
+      if (!(out.status()==QTextStream::Ok)) {
+        mErrormsg = tr("Cannot write to file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+        if (!file.flush()) {
+          mErrormsg = tr("Cannot flush buffer for file '%1': Error: %2").arg(QDir::toNativeSeparators(mCustomFile), file.errorString());
+        }
+      }
+      else {
+        mResult = true;
+        mErrormsg = tr("Style sheet written to '%1'").arg(QDir::toNativeSeparators(mCustomFile));
+      }
+    }
+  }
+  file.close();
+  qDebug() << mErrormsg;
+  return mResult;
+}
+
+bool Stylesheet::deleteCustom()
+{
+  QFile file(mCustomFile);
+  mResult = file.remove();
+  if (mResult)
+    mErrormsg = tr("Custom style sheet successfully deleted: '%1'").arg(QDir::toNativeSeparators(mCustomFile));
+  else
+    mErrormsg = tr("Unable to delete custom style sheet: '%1'").arg(QDir::toNativeSeparators(mCustomFile));
+  qDebug() << mErrormsg;
+  return mResult;
+}
+
+QString Stylesheet::name()
+{
+  return mName;
+}
+
+QString Stylesheet::text()
+{
+  return mText;
+}
+
+void Stylesheet::setText(const QString & text)
+{
+  mText = text;
+}
+
+QString Stylesheet::errormsg()
+{
+  return mErrormsg;
+}
+

--- a/companion/src/helpers_html.h
+++ b/companion/src/helpers_html.h
@@ -21,8 +21,11 @@
 #ifndef _HELPERS_HTML_H_
 #define _HELPERS_HTML_H_
 
+#include <QObject>
 #include <QString>
-#include <QStringList>
+
+#define THEMES_DEFAULT_PATH   ":/themes/default/"
+#define MODEL_PRINT_CSS       "modelprt.css"
 
 QString tdAlign(const QString & s, const QString & align, const QString & color, bool bold);
 QString doTC(const QString & s, const QString & color = "", bool bold = false);
@@ -32,5 +35,40 @@ QString fv(const QString & name, const QString & value, const QString & color = 
 QString doTableCell(const QString & s, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
 QString doTableRow(const QStringList & strl, const unsigned int width = 0, const QString & align = "", const QString & color = "", bool bold = false);
 QString doTableBlankRow();
+
+class Stylesheet: public QObject
+{
+  Q_OBJECT
+
+  public:
+    enum StyleType {
+      STYLE_TYPE_NONE,
+      STYLE_TYPE_DEFAULT,
+      STYLE_TYPE_CUSTOM,
+      STYLE_TYPE_EFFECTIVE
+    };
+
+    Stylesheet(const QString & name);
+    Stylesheet(const QString & name, const StyleType styleType);
+    ~Stylesheet();
+    bool load(const StyleType styleType);
+    bool update();
+    bool deleteCustom();
+    QString name();
+    QString text();
+    QString errormsg();
+    void setText(const QString & text);
+
+  private:
+    bool mResult;
+    QString mErrormsg;
+    QString mName;
+    QString mText;
+    QString mCustomFile;
+    QString mCustomPath;
+    QString mDefaultFile;
+    void init();
+    bool read(const QString & filepath);
+};
 
 #endif // _HELPERS_HTML_H_

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -305,7 +305,7 @@ QString MultiModelPrinter::printSetup()
 
   MultiColumns columns(modelPrinterMap.size());
   columns.appendSectionTableStart();
-  ROWLABELCOMPARECELL(tr("Name"), 25, model->name, 75);
+  ROWLABELCOMPARECELL(tr("Name"), 20, model->name, 80);
   ROWLABELCOMPARECELL(tr("EEprom Size"), 0, modelPrinter->printEEpromSize(), 0);
   if (firmware->getCapability(ModelImage)) {
     ROWLABELCOMPARECELL(tr("Model Image"), 0, model->bitmap, 0);
@@ -328,18 +328,18 @@ QString MultiModelPrinter::printTimers()
   QString str;
   MultiColumns columns(modelPrinterMap.size());
   columns.appendSectionTableStart();
-  columns.appendRowHeader(QStringList() << tr("Timers") << tr("Time") << tr("Switch") << tr("Countdown") << tr("Minute call") << tr("Persistence"));
+  columns.appendRowHeader(QStringList() << tr("Timers") << tr("Time") << tr("Switch") << tr("Countdown") << tr("Min.call") << tr("Persist"));
 
   for (int i=0; i<firmware->getCapability(Timers); i++) {
     columns.appendRowStart();
     columns.appendCellStart(20, true);
     COMPARE(modelPrinter->printTimerName(i));
     columns.appendCellEnd(true);
-    COMPARECELL(modelPrinter->printTimerTimeValue(model->timers[i].val));
-    COMPARECELL(model->timers[i].mode.toString());
-    COMPARECELL(modelPrinter->printTimerCountdownBeep(model->timers[i].countdownBeep));
-    COMPARECELL(modelPrinter->printTimerMinuteBeep(model->timers[i].minuteBeep));
-    COMPARECELL(modelPrinter->printTimerPersistent(model->timers[i].persistent));
+    COMPARECELLWIDTH(modelPrinter->printTimerTimeValue(model->timers[i].val), 15);
+    COMPARECELLWIDTH(model->timers[i].mode.toString(), 15);
+    COMPARECELLWIDTH(modelPrinter->printTimerCountdownBeep(model->timers[i].countdownBeep), 15);
+    COMPARECELLWIDTH(modelPrinter->printTimerMinuteBeep(model->timers[i].minuteBeep), 15);
+    COMPARECELLWIDTH(modelPrinter->printTimerPersistent(model->timers[i].persistent), 20);
     columns.appendRowEnd();
   }
   columns.appendTableEnd();
@@ -354,10 +354,10 @@ QString MultiModelPrinter::printModules()
   columns.appendSectionTableStart();
   for (int i=0; i<firmware->getCapability(NumModules); i++) {
     columns.appendRowStart();
-    columns.appendCellStart(25, true);
+    columns.appendCellStart(20, true);
     COMPARE(modelPrinter->printModuleType(i));
     columns.appendCellEnd(true);
-    COMPARECELLWIDTH(modelPrinter->printModule(i), 75);
+    COMPARECELLWIDTH(modelPrinter->printModule(i), 80);
     columns.appendRowEnd();
   }
   if (firmware->getCapability(ModelTrainerEnable))
@@ -416,22 +416,22 @@ QString MultiModelPrinter::printFlightModes()
   {
     MultiColumns columns(modelPrinterMap.size());
     columns.appendSectionTableStart();
-    QStringList hd = QStringList() << tr("Flight mode") << tr("Switch") << tr("Fade IN") << tr("Fade OUT");
+    QStringList hd = QStringList() << tr("Flight mode") << tr("Switch") << tr("F.In") << tr("F.Out");
     for (int i=0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
       hd << RawSource(SOURCE_TYPE_TRIM, i).toString();
     }
     columns.appendRowHeader(hd);
-
+    int wd = 80/(getBoardCapability(getCurrentBoard(), Board::NumTrims) + 3);
     for (int i=0; i<firmware->getCapability(FlightModes); i++) {
       columns.appendRowStart();
-      columns.appendCellStart(0,true);
+      columns.appendCellStart(20,true);
       COMPARE(modelPrinter->printFlightModeName(i));
       columns.appendCellEnd(true);
-      COMPARECELL(modelPrinter->printFlightModeSwitch(model->flightModeData[i].swtch));
-      COMPARECELL(model->flightModeData[i].fadeIn);
-      COMPARECELL(model->flightModeData[i].fadeOut);
+      COMPARECELLWIDTH(modelPrinter->printFlightModeSwitch(model->flightModeData[i].swtch), wd);
+      COMPARECELLWIDTH(model->flightModeData[i].fadeIn, wd);
+      COMPARECELLWIDTH(model->flightModeData[i].fadeOut, wd);
       for (int k=0; k < getBoardCapability(getCurrentBoard(), Board::NumTrims); k++) {
-        COMPARECELL(modelPrinter->printTrim(i, k));
+        COMPARECELLWIDTH(modelPrinter->printTrim(i, k), wd);
       }
       columns.appendRowEnd();
     }
@@ -445,7 +445,7 @@ QString MultiModelPrinter::printFlightModes()
   if ((gvars && firmware->getCapability(GvarsFlightModes)) || firmware->getCapability(RotaryEncoders)) {
     MultiColumns columns(modelPrinterMap.size());
     columns.appendSectionTableStart();
-    QStringList hd = QStringList() << tr("Global variables");
+    QStringList hd = QStringList() << tr("Global vars");
     if (firmware->getCapability(GvarsFlightModes)) {
       for (int i=0; i<gvars; i++) {
         hd << tr("GV%1").arg(i+1);
@@ -455,11 +455,11 @@ QString MultiModelPrinter::printFlightModes()
       hd << tr("RE%1").arg(i+1);
     }
     columns.appendRowHeader(hd);
-
+    int wd = 80/gvars;
     if (firmware->getCapability(GvarsFlightModes)) {
-      columns.appendRowStart(tr("Name"));
+      columns.appendRowStart(tr("Name"), 20);
       for (int i=0; i<gvars; i++) {
-        COMPARECELL(model->gvarData[i].name);
+        COMPARECELLWIDTH(model->gvarData[i].name, wd);
       }
       columns.appendRowEnd();
       columns.appendRowStart(tr("Unit"));
@@ -526,7 +526,14 @@ QString MultiModelPrinter::printOutputs()
   if (firmware->getCapability(SYMLimits))
     hd << tr("Linear");
   columns.appendRowHeader(hd);
-
+  int cols = 4;
+  if (IS_HORUS_OR_TARANIS(firmware->getBoard()))
+    cols++;
+  if (firmware->getCapability(PPMCenter))
+    cols++;
+  if (firmware->getCapability(SYMLimits))
+    cols++;
+  int wd = 80/cols;
   for (int i=0; i<firmware->getCapability(Outputs); i++) {
     int count = 0;
     for (int k=0; k < modelPrinterMap.size(); k++)
@@ -534,21 +541,21 @@ QString MultiModelPrinter::printOutputs()
     if (!count)
       continue;
     columns.appendRowStart();
-    columns.appendCellStart(0, true);
+    columns.appendCellStart(20, true);
     COMPARE(modelPrinter->printChannelName(i));
     columns.appendCellEnd(true);
-    COMPARECELL(modelPrinter->printOutputOffset(i));
-    COMPARECELL(modelPrinter->printOutputMin(i));
-    COMPARECELL(modelPrinter->printOutputMax(i));
-    COMPARECELL(modelPrinter->printOutputRevert(i));
+    COMPARECELLWIDTH(modelPrinter->printOutputOffset(i), wd);
+    COMPARECELLWIDTH(modelPrinter->printOutputMin(i), wd);
+    COMPARECELLWIDTH(modelPrinter->printOutputMax(i), wd);
+    COMPARECELLWIDTH(modelPrinter->printOutputRevert(i), wd);
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-      COMPARECELL(modelPrinter->printOutputCurve(i));
+      COMPARECELLWIDTH(modelPrinter->printOutputCurve(i), wd);
     }
     if (firmware->getCapability(PPMCenter)) {
-      COMPARECELL(modelPrinter->printOutputPpmCenter(i));
+      COMPARECELLWIDTH(modelPrinter->printOutputPpmCenter(i), wd);
     }
     if (firmware->getCapability(SYMLimits)) {
-      COMPARECELL(modelPrinter->printOutputSymetrical(i));
+      COMPARECELLWIDTH(modelPrinter->printOutputSymetrical(i), wd);
     }
     columns.appendRowEnd();
   }
@@ -852,7 +859,6 @@ QString MultiModelPrinter::printSensors()
   int count = 0;
   columns.appendSectionTableStart();
   columns.appendRowHeader(QStringList() << tr("Name") << tr("Type") << tr("Parameters"));
-  //columns.appendRowHeader(QStringList() << tr("Name") << tr("Type") << tr("Formula/Source") << tr("Unit") << tr("Prec") << tr("Ratio") << tr("Ofst") << tr("A.Ofst") << tr("Fltr") << tr("Pers.") << tr("+ve") << tr("Log"));
   for (int i=0; i<CPN_MAX_SENSORS; ++i) {
     bool tsEmpty = true;
     for (int k=0; k < modelPrinterMap.size(); k++) {
@@ -864,12 +870,11 @@ QString MultiModelPrinter::printSensors()
     if (!tsEmpty) {
       count++;
       columns.appendRowStart();
-      columns.appendCellStart(15, true);
+      columns.appendCellStart(20, true);
       COMPARE(model->sensorData[i].nameToString(i));
       columns.appendCellEnd(true);
       COMPARECELLWIDTH(modelPrinter->printSensorTypeCond(i), 15);
-      COMPARECELLWIDTH(modelPrinter->printSensorParams(i), 70);
-      //COMPARESTRING("", modelPrinter->printSensorDetails(i), 0);
+      COMPARECELLWIDTH(modelPrinter->printSensorParams(i), 65);
       columns.appendRowEnd();
     }
   }

--- a/companion/src/multimodelprinter.h
+++ b/companion/src/multimodelprinter.h
@@ -51,7 +51,7 @@ class MultiModelPrinter: public QObject
         void append(int idx, const QString & str);
         template <class T> void append(int idx, T val);
         void beginCompare();
-        void endCompare(const QString & color = "black"); // was grey
+        void endCompare();
         void appendLineBreak();
         void appendSectionTableStart();
         void appendTableEnd();

--- a/companion/src/printdialog.cpp
+++ b/companion/src/printdialog.cpp
@@ -21,6 +21,7 @@
 #include "printdialog.h"
 #include "ui_printdialog.h"
 #include "helpers.h"
+#include "styleeditdialog.h"
 #include <QPrinter>
 #include <QPrintDialog>
 
@@ -31,13 +32,13 @@ PrintDialog::PrintDialog(QWidget *parent, Firmware * firmware, GeneralSettings &
   model(model),
   printfilename(filename),
   ui(new Ui::PrintDialog),
-  multimodelprinter(firmware)
+  multiModelPrinter(firmware)
 {
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("print.png"));
   setWindowTitle(model.name);
-  multimodelprinter.setModel(0, &model, &generalSettings);
-  ui->textEdit->setHtml(multimodelprinter.print(ui->textEdit->document()));
+  multiModelPrinter.setModel(0, &model, &generalSettings);
+  ui->textEdit->setHtml(multiModelPrinter.print(ui->textEdit->document()));
   if (!printfilename.isEmpty()) {
     printToFile();
     QTimer::singleShot(0, this, SLOT(autoClose()));
@@ -108,4 +109,11 @@ void PrintDialog::printToFile()
 void PrintDialog::autoClose()
 {
   this->close();
+}
+
+void PrintDialog::on_styleButton_clicked()
+{
+  StyleEditDialog *g = new StyleEditDialog(this, MODEL_PRINT_CSS);
+  if (g->exec() == QDialog::Accepted)
+    ui->textEdit->setHtml(multiModelPrinter.print(ui->textEdit->document()));
 }

--- a/companion/src/printdialog.ui
+++ b/companion/src/printdialog.ui
@@ -56,6 +56,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="styleButton">
+       <property name="text">
+        <string>Style</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="printButton">
        <property name="text">
         <string>Print</string>

--- a/companion/src/styleeditdialog.cpp
+++ b/companion/src/styleeditdialog.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "styleeditdialog.h"
+#include "ui_styleeditdialog.h"
+#include "helpers.h"
+
+StyleEditDialog::StyleEditDialog(QWidget * parent, const QString stylesheet):
+  QDialog(parent),
+  ui(new Ui::StyleEditDialog),
+  mStylesheet(stylesheet)
+{
+  ui->setupUi(this);
+  setWindowIcon(CompanionIcon("edit.png"));
+  if (!mStylesheet.load(Stylesheet::StyleType::STYLE_TYPE_EFFECTIVE))
+    QMessageBox::critical(this, tr("Style Sheet Editor"), tr("Cannot retrieve style %1\nError: %2").arg(mStylesheet.name(), mStylesheet.errormsg()));
+  QFont f;
+  f.setFamily("monospace");
+  f.setPointSize(10);
+  ui->pteStyle->setFont(f);
+  ui->pteStyle->setPlainText(mStylesheet.text());
+  connect(ui->pteStyle, SIGNAL(textChanged()), this, SLOT(changed()));
+  connect(ui->pbDefault, SIGNAL(clicked()), this, SLOT(resetToDefault()));
+  connect(ui->pbCancel, SIGNAL(clicked()), this, SLOT(reject()));
+  connect(ui->pbOK, SIGNAL(clicked()), this, SLOT(update()));
+}
+
+StyleEditDialog::~StyleEditDialog()
+{
+  delete ui;
+}
+
+void StyleEditDialog::changed()
+{
+  mDirty = true;
+}
+
+void StyleEditDialog::resetToDefault()
+{
+  mStylesheet.deleteCustom();   //  ignore result
+  if (!mStylesheet.load(Stylesheet::StyleType::STYLE_TYPE_DEFAULT))
+    QMessageBox::critical(this, tr("Style Sheet Editor"), tr("Cannot retrieve default style %1\nError: %2").arg(mStylesheet.name(), mStylesheet.errormsg()));
+  ui->pteStyle->setPlainText(mStylesheet.text());
+  mDirty = false;
+}
+
+void StyleEditDialog::update()
+{
+  if (mDirty) {
+    mStylesheet.setText(ui->pteStyle->toPlainText());
+    if (!mStylesheet.update())
+      QMessageBox::critical(this, tr("Style Sheet Editor"), tr("Cannot update custom style %1\nError: %2").arg(mStylesheet.name(), mStylesheet.errormsg()));
+  }
+  emit accept();
+}

--- a/companion/src/styleeditdialog.cpp
+++ b/companion/src/styleeditdialog.cpp
@@ -25,7 +25,8 @@
 StyleEditDialog::StyleEditDialog(QWidget * parent, const QString stylesheet):
   QDialog(parent),
   ui(new Ui::StyleEditDialog),
-  mStylesheet(stylesheet)
+  mStylesheet(stylesheet),
+  mDirty(false)
 {
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("edit.png"));

--- a/companion/src/styleeditdialog.h
+++ b/companion/src/styleeditdialog.h
@@ -18,43 +18,33 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _PRINTDIALOG_H_
-#define _PRINTDIALOG_H_
+#ifndef _STYLEEDITDIALOG_H_
+#define _STYLEEDITDIALOG_H_
 
+#include "helpers_html.h"
 #include <QtWidgets>
-#include "eeprominterface.h"
-#include "multimodelprinter.h"
 
 namespace Ui {
-  class PrintDialog;
+  class StyleEditDialog;
 }
 
-class PrintDialog : public QDialog
+class StyleEditDialog : public QDialog
 {
   Q_OBJECT
 
   public:
-    PrintDialog(QWidget * parent, Firmware * firmware, GeneralSettings & generalSettings, ModelData & model, const QString & filename="");
-    ~PrintDialog();
-    void closeEvent(QCloseEvent * event);
-
-    Firmware * firmware;
-    GeneralSettings & generalSettings;
-    ModelData & model;
-
-    QString printfilename;
-
-  protected:
-    Ui::PrintDialog *ui;
-    MultiModelPrinter multiModelPrinter;
-
-    void printToFile();
+    StyleEditDialog(QWidget * parent, const QString stylesheet);
+    ~StyleEditDialog();
 
   private slots:
-    void on_printButton_clicked();
-    void on_printFileButton_clicked();
-    void autoClose();
-    void on_styleButton_clicked();
+    void update();
+    void changed();
+    void resetToDefault();
+
+  private:
+    Ui::StyleEditDialog *ui;
+    Stylesheet mStylesheet;
+    bool mDirty;
 };
 
-#endif // _PRINTDIALOG_H_
+#endif // _STYLEEDITDIALOG_H_

--- a/companion/src/styleeditdialog.ui
+++ b/companion/src/styleeditdialog.ui
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StyleEditDialog</class>
+ <widget class="QDialog" name="StyleEditDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>630</width>
+    <height>373</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Style Sheet Editor</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>3</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QPlainTextEdit" name="pteStyle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAsNeeded</enum>
+     </property>
+     <property name="tabChangesFocus">
+      <bool>true</bool>
+     </property>
+     <property name="lineWrapMode">
+      <enum>QPlainTextEdit::NoWrap</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinimumSize</enum>
+     </property>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbDefault">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Reset to default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbCancel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbOK">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;OK</string>
+       </property>
+       <property name="shortcut">
+        <string/>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>This feature does not validate your changes and assumes you are familiar with CSS syntax for QT.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>pteStyle</tabstop>
+  <tabstop>pbOK</tabstop>
+  <tabstop>pbCancel</tabstop>
+  <tabstop>pbDefault</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/companion/src/themes/default/modelprt.css
+++ b/companion/src/themes/default/modelprt.css
@@ -1,0 +1,71 @@
+/*
+  User by Model Print and Compare
+
+  QT 5
+    1. Supports a subset of the HTML 4 and CSS 2.1 standards
+    2. Translates css to inline HTML which can lead to unexpected formatting
+
+  Reference Official QT 5 website https://doc.qt.io/qt-5/
+*/
+
+/*  overide environment defaults */
+p, table, td, th {
+  font-family: monospace;
+  font-size: 15px;
+  color: black;
+  font-style: normal;
+  font-weight: normal;
+}
+
+table {
+  border-style: solid;
+  border-color: grey;
+  border-width: 1px;
+}
+
+td, th {
+  margin: 0px;
+  padding: 1px;
+}
+
+/*  The style applied to section titles */
+.mpc-section-title {
+  color: black;
+  background-color: white;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: bold;
+}
+
+/*
+    These model compare differences style classes inherit field classes above
+
+    Notes:
+    1. The class is applied as <span class=...>some content</span>
+    2. It is strongly recommended customisation is limited to font attributes
+*/
+
+/*  model 1  */
+.mpc-diff1 {
+  color: green;
+/*
+  font-weight: bold;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: none;
+  background-color: white;
+*/
+}
+
+/*  model 2  */
+.mpc-diff2 {
+  color: red;
+/*
+  font-weight: bold;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: none;
+  background-color: white;
+*/
+}
+


### PR DESCRIPTION
New feature to allow users the ability to customise the print style via a stylesheet. The main use is for model compare to more clearly highlight differences.
A reuseable simple file editor has been included to manage the customisable file.
The default is a resource file to ensure it is kept in sync with the code and any QT changes. The initial stylesheet version replicates the code.
The customised file is stored in the OS application data folder so it persists across Companion versions.
QT 5 has a number of limitations when using stylesheets.

Fixes #5750 

Cosmetic layout fixes.