### PR TITLE
Reset backlight timer on rotary encoder (keys mode)

### DIFF
--- a/radio/src/targets/horus/keys_driver.cpp
+++ b/radio/src/targets/horus/keys_driver.cpp
@@ -71,6 +71,10 @@ void checkRotaryEncoder()
     else {
       ++rotencValue[0];
     }
+#if !defined(BOOT)
+    if (g_eeGeneral.backlightMode & e_backlight_mode_keys)
+      backlightOn();
+#endif
   }
 }
 

--- a/radio/src/targets/taranis/keys_driver.cpp
+++ b/radio/src/targets/taranis/keys_driver.cpp
@@ -126,6 +126,11 @@ void checkRotaryEncoder()
       ++rotencValue[0];
     }
     rotencPosition = newpos;
+#if !defined(BOOT)
+    if (g_eeGeneral.backlightMode & e_backlight_mode_keys) {
+      backlightOn();
+    }
+#endif
   }
 }
 #endif


### PR DESCRIPTION
I guess the rotary encoder can be consider a "key" as well.