### PR TITLE
[X10] mute audio when fifo buffer is empty

### DIFF
--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -792,13 +792,19 @@ void AudioQueue::wakeup()
     if (size > 0) {
       // TRACE("pushing buffer %p", buffer);
       buffer->size = size;
+
 #if defined(SOFTWARE_VOLUME)
-      for(uint32_t i=0; i<buffer->size; ++i) {
-        int32_t tmpSample = (int32_t) ((uint32_t) (buffer->data[i]) - AUDIO_DATA_SILENCE);  // conversion from uint16_t
-        buffer->data[i] = (int16_t) (((tmpSample * currentSpeakerVolume) / VOLUME_LEVEL_MAX) + AUDIO_DATA_SILENCE);
+      if (currentSpeakerVolume > 0) {
+          for(uint32_t i=0; i<buffer->size; ++i) {
+              int32_t tmpSample = (int32_t) ((uint32_t) (buffer->data[i]) - AUDIO_DATA_SILENCE);  // conversion from uint16_t
+              buffer->data[i] = (int16_t) (((tmpSample * currentSpeakerVolume) / VOLUME_LEVEL_MAX) + AUDIO_DATA_SILENCE);
+          }
+
+          buffersFifo.audioPushBuffer();
       }
-#endif
+#else
       buffersFifo.audioPushBuffer();
+#endif
     }
     else {
       // break the endless loop

--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -795,7 +795,7 @@ void AudioQueue::wakeup()
 
 #if defined(SOFTWARE_VOLUME)
       if (currentSpeakerVolume > 0) {
-        for(uint32_t i=0; i<buffer->size; ++i) {
+        for (uint32_t i=0; i<buffer->size; ++i) {
           int32_t tmpSample = (int32_t) ((uint32_t) (buffer->data[i]) - AUDIO_DATA_SILENCE);  // conversion from uint16_t
           buffer->data[i] = (int16_t) (((tmpSample * currentSpeakerVolume) / VOLUME_LEVEL_MAX) + AUDIO_DATA_SILENCE);
         }

--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -795,12 +795,11 @@ void AudioQueue::wakeup()
 
 #if defined(SOFTWARE_VOLUME)
       if (currentSpeakerVolume > 0) {
-          for(uint32_t i=0; i<buffer->size; ++i) {
-              int32_t tmpSample = (int32_t) ((uint32_t) (buffer->data[i]) - AUDIO_DATA_SILENCE);  // conversion from uint16_t
-              buffer->data[i] = (int16_t) (((tmpSample * currentSpeakerVolume) / VOLUME_LEVEL_MAX) + AUDIO_DATA_SILENCE);
-          }
-
-          buffersFifo.audioPushBuffer();
+        for(uint32_t i=0; i<buffer->size; ++i) {
+          int32_t tmpSample = (int32_t) ((uint32_t) (buffer->data[i]) - AUDIO_DATA_SILENCE);  // conversion from uint16_t
+          buffer->data[i] = (int16_t) (((tmpSample * currentSpeakerVolume) / VOLUME_LEVEL_MAX) + AUDIO_DATA_SILENCE);
+        }
+        buffersFifo.audioPushBuffer();
       }
 #else
       buffersFifo.audioPushBuffer();

--- a/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
@@ -51,6 +51,17 @@ void dacInit()
   dacTimerInit();
 
   GPIO_InitTypeDef GPIO_InitStructure;
+
+#if defined(PCBX10)
+  GPIO_InitStructure.GPIO_Pin = AUDIO_MUTE_GPIO_PIN;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+  GPIO_Init(AUDIO_MUTE_GPIO, &GPIO_InitStructure);
+  GPIO_SetBits(AUDIO_MUTE_GPIO, AUDIO_MUTE_GPIO_PIN);
+#endif
+
   GPIO_InitStructure.GPIO_Pin = AUDIO_OUTPUT_GPIO_PIN;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AN;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
@@ -83,6 +94,10 @@ void audioConsumeCurrentBuffer()
 
     nextBuffer = audioQueue.buffersFifo.getNextFilledBuffer();
     if (nextBuffer) {
+#if defined(PCBX10)
+      // un-mute
+      GPIO_ResetBits(AUDIO_MUTE_GPIO, AUDIO_MUTE_GPIO_PIN);
+#endif
       AUDIO_DMA_Stream->CR &= ~DMA_SxCR_EN ;                              // Disable DMA channel
       AUDIO_DMA->HIFCR = DMA_HIFCR_CTCIF5 | DMA_HIFCR_CHTIF5 | DMA_HIFCR_CTEIF5 | DMA_HIFCR_CDMEIF5 | DMA_HIFCR_CFEIF5 ; // Write ones to clear bits
       AUDIO_DMA_Stream->M0AR = CONVERT_PTR_UINT(nextBuffer->data);
@@ -91,6 +106,12 @@ void audioConsumeCurrentBuffer()
       DAC->SR = DAC_SR_DMAUDR1 ;                      // Write 1 to clear flag
       DAC->CR |= DAC_CR_EN1 | DAC_CR_DMAEN1 ;                 // Enable DAC
     }
+#if defined(PCBX10)
+    else {
+      // mute
+      GPIO_SetBits(AUDIO_MUTE_GPIO, AUDIO_MUTE_GPIO_PIN);
+    }
+#endif
   }
 }
 

--- a/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
@@ -52,7 +52,7 @@ void dacInit()
 
   GPIO_InitTypeDef GPIO_InitStructure;
 
-#if defined(PCBX10)
+#if defined(AUDIO_MUTE_GPIO_PIN)
   GPIO_InitStructure.GPIO_Pin = AUDIO_MUTE_GPIO_PIN;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
@@ -94,7 +94,7 @@ void audioConsumeCurrentBuffer()
 
     nextBuffer = audioQueue.buffersFifo.getNextFilledBuffer();
     if (nextBuffer) {
-#if defined(PCBX10)
+#if defined(AUDIO_MUTE_GPIO_PIN)
       // un-mute
       GPIO_ResetBits(AUDIO_MUTE_GPIO, AUDIO_MUTE_GPIO_PIN);
 #endif
@@ -106,7 +106,7 @@ void audioConsumeCurrentBuffer()
       DAC->SR = DAC_SR_DMAUDR1 ;                      // Write 1 to clear flag
       DAC->CR |= DAC_CR_EN1 | DAC_CR_DMAEN1 ;                 // Enable DAC
     }
-#if defined(PCBX10)
+#if defined(AUDIO_MUTE_GPIO_PIN)
     else {
       // mute
       GPIO_SetBits(AUDIO_MUTE_GPIO, AUDIO_MUTE_GPIO_PIN);


### PR DESCRIPTION
Fixes #5561 by muting the X10 audio amplifier when no sound is being played. On targets with SOFTWARE_VOLUME, no audio is pushed to the queue when volume is muted.

This has been tested on X10 only.