### PR TITLE
Potential fix for #5895

### DIFF
--- a/radio/src/gui/480x272/themes/darkblue.cpp
+++ b/radio/src/gui/480x272/themes/darkblue.cpp
@@ -136,7 +136,7 @@ class DarkblueTheme: public Theme
 
       delete calibHorus;
 #if defined(PCBX10)
-      if(ANALOGS_PWM_ENABLED()) {
+      if(STICKS_PWM_ENABLED()) {
         calibHorus = BitmapBuffer::load(getThemePath("X10S.bmp"));
       }
       else {

--- a/radio/src/gui/480x272/themes/default.cpp
+++ b/radio/src/gui/480x272/themes/default.cpp
@@ -175,7 +175,7 @@ class DefaultTheme: public Theme
 
       delete calibHorus;
 #if defined(PCBX10)
-      if(ANALOGS_PWM_ENABLED()) {
+      if(STICKS_PWM_ENABLED()) {
         calibHorus = BitmapBuffer::load(getThemePath("X10S.bmp"));
       }
       else {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2627,10 +2627,6 @@ void opentxInit(OPENTX_INIT_ARGS)
     backlightOn();
   }
 
-#if NUM_PWMANALOGS > 0
-  analogPwmCheck();
-#endif
-
   if (!unexpectedShutdown) {
     opentxStart();
   }

--- a/radio/src/targets/common/arm/stm32/adc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/adc_driver.cpp
@@ -46,9 +46,9 @@
   const int8_t ana_direction[NUM_ANALOGS] = {1,-1,1,-1,  1,1,0,   1,1,  1};
 #endif
 
-#if NUM_PWMANALOGS > 0
-  #define FIRST_ANALOG_ADC             (ANALOGS_PWM_ENABLED() ? NUM_PWMANALOGS : 0)
-  #define NUM_ANALOGS_ADC              (ANALOGS_PWM_ENABLED() ? (NUM_ANALOGS - NUM_PWMANALOGS) : NUM_ANALOGS)
+#if NUM_PWMSTICKS > 0
+  #define FIRST_ANALOG_ADC             (STICKS_PWM_ENABLED() ? NUM_PWMSTICKS : 0)
+  #define NUM_ANALOGS_ADC              (STICKS_PWM_ENABLED() ? (NUM_ANALOGS - NUM_PWMSTICKS) : NUM_ANALOGS)
 #elif defined(PCBX9E)
   #define FIRST_ANALOG_ADC             0
   #define NUM_ANALOGS_ADC              10
@@ -93,7 +93,7 @@ void adcInit()
   ADC_MAIN->SQR1 = (NUM_ANALOGS_ADC-1) << 20; // bits 23:20 = number of conversions
 
 #if defined(PCBX10)
-  if (ANALOGS_PWM_ENABLED()) {
+  if (STICKS_PWM_ENABLED()) {
     ADC_MAIN->SQR2 = (ADC_CHANNEL_EXT1<<0) + (ADC_CHANNEL_EXT2<<5); // conversions 7 and more
     ADC_MAIN->SQR3 = (ADC_CHANNEL_POT1<<0) + (ADC_CHANNEL_POT2<<5) + (ADC_CHANNEL_POT3<<10) + (ADC_CHANNEL_SLIDER1<<15) + (ADC_CHANNEL_SLIDER2<<20) + (ADC_CHANNEL_BATT<<25); // conversions 1 to 6
   }
@@ -105,7 +105,7 @@ void adcInit()
   ADC_MAIN->SQR2 = (ADC_CHANNEL_POT4<<0) + (ADC_CHANNEL_SLIDER3<<5) + (ADC_CHANNEL_SLIDER4<<10) + (ADC_CHANNEL_BATT<<15); // conversions 7 and more
   ADC_MAIN->SQR3 = (ADC_CHANNEL_STICK_LH<<0) + (ADC_CHANNEL_STICK_LV<<5) + (ADC_CHANNEL_STICK_RV<<10) + (ADC_CHANNEL_STICK_RH<<15) + (ADC_CHANNEL_POT2<<20) + (ADC_CHANNEL_POT3<<25); // conversions 1 to 6
 #elif defined(PCBXLITE)
-  if (ANALOGS_PWM_ENABLED()) {
+  if (STICKS_PWM_ENABLED()) {
     ADC_MAIN->SQR2 = 0;
     ADC_MAIN->SQR3 = (ADC_CHANNEL_POT1<<0) + (ADC_CHANNEL_POT2<<5) + (ADC_CHANNEL_BATT<<10);
   }
@@ -149,9 +149,9 @@ void adcInit()
   ADC_EXT_DMA_Stream->FCR = DMA_SxFCR_DMDIS | DMA_SxFCR_FTH_0;
 #endif
 
-#if NUM_PWMANALOGS > 0
-  if (ANALOGS_PWM_ENABLED()) {
-    analogPwmInit();
+#if NUM_PWMSTICKS > 0
+  if (STICKS_PWM_ENABLED()) {
+    sticksPwmInit();
   }
 #endif
 }
@@ -211,9 +211,9 @@ void adcRead()
     adcValues[x] = temp[x] >> 2;
   }
 
-#if NUM_PWMANALOGS > 0
-  if (ANALOGS_PWM_ENABLED()) {
-    analogPwmRead(adcValues);
+#if NUM_PWMSTICKS > 0
+  if (STICKS_PWM_ENABLED()) {
+    sticksPwmRead(adcValues);
   }
 #endif
 }

--- a/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
@@ -22,14 +22,14 @@
 
 #define TIMESAMPLE_COUNT 6
 
-uint8_t analogs_pwm_disabled = 0;
+uint8_t sticks_pwm_disabled = 0;
 volatile uint32_t pwm_interrupt_count;
 volatile uint8_t  timer_capture_states[4];
 volatile uint32_t timer_capture_rising_time[4];
 volatile uint32_t timer_capture_values[4][TIMESAMPLE_COUNT];
 volatile uint8_t  timer_capture_indexes[4];
 
-void analogPwmInit()
+void sticksPwmInit()
 {
   GPIO_InitTypeDef GPIO_InitStructure;
   GPIO_InitStructure.GPIO_Pin = PWM_GPIOA_PINS;
@@ -121,7 +121,7 @@ extern "C" void PWM_IRQHandler(void)
   }
 }
 
-void analogPwmRead(uint16_t * values)
+void sticksPwmRead(uint16_t * values)
 {
   uint32_t tmp[4];
 
@@ -145,15 +145,4 @@ void analogPwmRead(uint16_t * values)
   values[1] = tmp[1];
   values[2] = tmp[3];
   values[3] = tmp[2];
-}
-
-void analogPwmCheck()
-{
-  // I have ~1860 interrupts with only one stick
-  if (pwm_interrupt_count < 1000) {
-    analogs_pwm_disabled = true;
-#if !defined(SIMU)
-    adcInit();
-#endif
-  }
 }

--- a/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
@@ -101,10 +101,10 @@ extern "C" void PWM_IRQHandler(void)
   for (int i=0; i<4; i++) {
     if (PWM_TIMER->SR & (TIM_DIER_CC1IE << i)) {
       uint32_t capture = TIM_GetCapture(i);
+      pwm_interrupt_count++;
       if (timer_capture_states[i] != 0) {
         uint32_t value = diff_with_16bits_overflow(timer_capture_rising_time[i], capture);
         if (value < 10000) {
-          pwm_interrupt_count++;
           timer_capture_values[i][timer_capture_indexes[i]++] = value;
           timer_capture_indexes[i] %= TIMESAMPLE_COUNT;
         }

--- a/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
@@ -101,7 +101,7 @@ extern "C" void PWM_IRQHandler(void)
   for (int i=0; i<4; i++) {
     if (PWM_TIMER->SR & (TIM_DIER_CC1IE << i)) {
       uint32_t capture = TIM_GetCapture(i);
-      pwm_interrupt_count++;
+      pwm_interrupt_count++; // overflow may happen but we only use this to detect PWM / ADC on radio startup
       if (timer_capture_states[i] != 0) {
         uint32_t value = diff_with_16bits_overflow(timer_capture_rising_time[i], capture);
         if (value < 10000) {

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -28,8 +28,8 @@ if (PCB STREQUAL X10)
   set(TARGET_SRC
     ${TARGET_SRC}
     ../common/arm/stm32/audio_dac_driver.cpp
-    ../common/arm/stm32/analog_adc_driver.cpp
-    ../common/arm/stm32/analog_pwm_driver.cpp
+    ../common/arm/stm32/adc_driver.cpp
+    ../common/arm/stm32/sticks_pwm_driver.cpp
     )
 
   set(BITMAPS_TARGET x10_bitmaps)

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -197,6 +197,15 @@ void boardInit()
   memset(&g_FATFS_Obj, 0, sizeof(g_FATFS_Obj));
 
   keysInit();
+
+#if NUM_PWMSTICKS > 0
+  sticksPwmInit();
+  delay_ms(20);
+  if (pwm_interrupt_count < 32) {
+    sticks_pwm_disabled = true;
+  }
+#endif
+
   adcInit();
   lcdInit();
   backlightInit();

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -339,10 +339,10 @@ void watchdogInit(unsigned int duration);
 #define NUM_XPOTS                      NUM_POTS
 #if defined(PCBX10)
   #define NUM_SLIDERS                  2
-  #define NUM_PWMANALOGS               4
+  #define NUM_PWMSTICKS                4
 #else
   #define NUM_SLIDERS                  4
-  #define NUM_PWMANALOGS               0
+  #define NUM_PWMSTICKS                0
 #endif
 enum Analogs {
   STICK1,
@@ -408,12 +408,11 @@ uint16_t getAnalogValue(uint8_t index);
   #define NUM_DUMMY_ANAS               0
 #endif
 
-#if NUM_PWMANALOGS > 0
-extern uint8_t analogs_pwm_disabled;
-#define ANALOGS_PWM_ENABLED()          (analogs_pwm_disabled == false)
-void analogPwmInit(void);
-void analogPwmRead(uint16_t * values);
-void analogPwmCheck();
+#if NUM_PWMSTICKS > 0
+extern uint8_t sticks_pwm_disabled;
+#define STICKS_PWM_ENABLED()          (sticks_pwm_disabled == false)
+void sticksPwmInit(void);
+void sticksPwmRead(uint16_t * values);
 extern volatile uint32_t pwm_interrupt_count;
 #endif
 

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -219,7 +219,7 @@
   #define PWM_IRQHandler                TIM5_IRQHandler
   #define PWM_IRQn                      TIM5_IRQn
   #define PWM_GPIOA_PINS                (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3)
-  #define ADC_GPIOA_PINS                (ANALOGS_PWM_ENABLED() ? 0 : (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3))
+  #define ADC_GPIOA_PINS                (STICKS_PWM_ENABLED() ? 0 : (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3))
   #define ADC_GPIOC_PINS                (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3)
   #define ADC_GPIOF_PINS                (GPIO_Pin_6 | GPIO_Pin_7) // | GPIO_Pin_8 | GPIO_Pin_9)
   #define ADC_CHANNEL_STICK_LH          ADC_Channel_0   // ADC3_IN0

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -169,13 +169,13 @@ set(TARGET_SRC
   backlight_driver.cpp
   extmodule_driver.cpp
   ../common/arm/stm32/audio_dac_driver.cpp
-  ../common/arm/stm32/analog_adc_driver.cpp
+  ../common/arm/stm32/adc_driver.cpp
   )
 
 if(PCB STREQUAL XLITE)
   set(TARGET_SRC
     ${TARGET_SRC}
-    ../common/arm/stm32/analog_pwm_driver.cpp
+    ../common/arm/stm32/sticks_pwm_driver.cpp
     )
 endif()
 

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -178,7 +178,7 @@ void boardInit()
 
 #if NUM_PWMSTICKS > 0
   sticksPwmInit();
-  delay_ms(40);
+  delay_ms(20);
   if (pwm_interrupt_count < 32) {
     sticks_pwm_disabled = true;
   }

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -174,6 +174,7 @@ void boardInit()
 #endif
 
   keysInit();
+  delaysInit();
 
 #if NUM_PWMSTICKS > 0
   sticksPwmInit();
@@ -184,7 +185,6 @@ void boardInit()
 #endif
 
   adcInit();
-  delaysInit();
   lcdInit(); // delaysInit() must be called before
   audioInit();
   init2MhzTimer();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -178,7 +178,7 @@ void boardInit()
 
 #if NUM_PWMSTICKS > 0
   sticksPwmInit();
-  delay_ms(20);
+  delay_ms(40);
   if (pwm_interrupt_count < 32) {
     sticks_pwm_disabled = true;
   }

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -174,6 +174,15 @@ void boardInit()
 #endif
 
   keysInit();
+
+#if NUM_PWMSTICKS > 0
+  sticksPwmInit();
+  delay_ms(20);
+  if (pwm_interrupt_count < 32) {
+    sticks_pwm_disabled = true;
+  }
+#endif
+
   adcInit();
   delaysInit();
   lcdInit(); // delaysInit() must be called before
@@ -252,9 +261,6 @@ void boardInit()
   else {
     pwrInit();
     backlightInit();
-#if NUM_PWMANALOGS > 0
-    delay_ms(730);
-#endif
   }
 #if defined(TOPLCD_GPIO)
   toplcdInit();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -253,7 +253,7 @@ void boardInit()
     pwrInit();
     backlightInit();
 #if NUM_PWMANALOGS > 0
-    delay_ms(650);
+    delay_ms(730);
 #endif
   }
 #if defined(TOPLCD_GPIO)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -252,6 +252,9 @@ void boardInit()
   else {
     pwrInit();
     backlightInit();
+#if NUM_PWMANALOGS > 0
+    delay_ms(650);
+#endif
   }
 #if defined(TOPLCD_GPIO)
   toplcdInit();

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -444,12 +444,11 @@ enum Analogs {
 #define NUM_DUMMY_ANAS                  0
 
 #if defined(PCBXLITE)
-  #define NUM_PWMANALOGS                4
-  extern uint8_t analogs_pwm_disabled;
-  #define ANALOGS_PWM_ENABLED()         (analogs_pwm_disabled == false)
-  void analogPwmInit(void);
-  void analogPwmRead(uint16_t * values);
-  void analogPwmCheck();
+  #define NUM_PWMSTICKS                 4
+  extern uint8_t sticks_pwm_disabled;
+  #define STICKS_PWM_ENABLED()         (sticks_pwm_disabled == false)
+  void sticksPwmInit(void);
+  void sticksPwmRead(uint16_t * values);
   extern volatile uint32_t pwm_interrupt_count;
   #define NUM_TRIMS_KEYS                4
 #else

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -477,7 +477,7 @@
   #define PWM_IRQHandler                TIM5_IRQHandler
   #define PWM_IRQn                      TIM5_IRQn
   #define PWM_GPIOA_PINS                (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3)
-  #define ADC_GPIOA_PINS                (ANALOGS_PWM_ENABLED() ? 0 : (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3))
+  #define ADC_GPIOA_PINS                (STICKS_PWM_ENABLED() ? 0 : (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3))
   #define ADC_GPIOC_PINS                (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2)
   #define ADC_CHANNEL_STICK_RV          ADC_Channel_0  // ADC1_IN0
   #define ADC_CHANNEL_STICK_RH          ADC_Channel_1  // ADC1_IN1


### PR DESCRIPTION
Reboot from bootloader or watchdog reset isn't subjected to PWR_PRESS_DURATION_MIN and so doesn't leave enough time to count enough transitions to switch to PWM gimbal mode.

Would be better to instead adjust the minimum number of transitions to the smallest possible reliable detection threshold to avoid an unnecessary delay in case of WDT reset. 

Needs to be checked on X7S, unless the PWM frequency is different in theory someone with PWM gimbals should currently have the same problem. Horus might get away with it due to longer boot time... or again it's just that Xlite PWM is much slower.