### PR TITLE
Companion: use fixed width font for model checklist

### DIFF
--- a/companion/src/modeledit/checklistdialog.ui
+++ b/companion/src/modeledit/checklistdialog.ui
@@ -38,6 +38,11 @@
        <verstretch>1</verstretch>
       </sizepolicy>
      </property>
+     <property name="font">
+      <font>
+       <family>Monospace</family>
+      </font>
+     </property>
      <property name="verticalScrollBarPolicy">
       <enum>Qt::ScrollBarAsNeeded</enum>
      </property>


### PR DESCRIPTION
Radio uses fixed width font