### PR TITLE
No longer use deprecated qt5_use_modules

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -309,7 +309,6 @@ qt5_wrap_ui(companion_SRCS ${companion_UIS})
 qt5_wrap_cpp(companion_SRCS ${companion_MOC_HDRS})
 
 add_executable(${COMPANION_NAME} MACOSX_BUNDLE ${WIN_EXECUTABLE_TYPE} ${companion_SRCS} ${icon_RC})
-qt5_use_modules(${COMPANION_NAME} Core Widgets Network)
 target_link_libraries(${COMPANION_NAME} PRIVATE generaledit modeledit qcustomplot shared ${CPN_COMMON_LIB})
 
 PrintTargetReport("${COMPANION_NAME}")

--- a/companion/src/generaledit/CMakeLists.txt
+++ b/companion/src/generaledit/CMakeLists.txt
@@ -28,5 +28,4 @@ qt5_wrap_ui(generaledit_SRCS ${generaledit_UIS})
 qt5_wrap_cpp(generaledit_SRCS ${generaledit_HDRS})
 
 add_library(generaledit ${generaledit_SRCS})
-qt5_use_modules(generaledit Widgets Xml Multimedia)
-target_link_libraries(generaledit PRIVATE ${CPN_COMMON_LIB})
+target_link_libraries(generaledit PRIVATE ${CPN_COMMON_LIB} Qt5::Multimedia)

--- a/companion/src/modeledit/CMakeLists.txt
+++ b/companion/src/modeledit/CMakeLists.txt
@@ -60,5 +60,4 @@ qt5_wrap_ui(modeledit_SRCS ${modeledit_UIS})
 qt5_wrap_cpp(modeledit_SRCS ${modeledit_HDRS})
 
 add_library(modeledit ${modeledit_SRCS})
-qt5_use_modules(modeledit Widgets Xml Multimedia)
-target_link_libraries(modeledit PRIVATE ${CPN_COMMON_LIB})
+target_link_libraries(modeledit PRIVATE ${CPN_COMMON_LIB} Qt5::Multimedia)

--- a/companion/src/storage/CMakeLists.txt
+++ b/companion/src/storage/CMakeLists.txt
@@ -27,5 +27,4 @@ foreach(name ${storage_NAMES})
 endforeach()
 
 add_library(storage ${storage_SRCS})
-qt5_use_modules(storage Core Xml Widgets)
 target_link_libraries(storage PRIVATE ${CPN_COMMON_LIB})

--- a/companion/src/thirdparty/qcustomplot/CMakeLists.txt
+++ b/companion/src/thirdparty/qcustomplot/CMakeLists.txt
@@ -9,4 +9,4 @@ set(qcustomplot_HDRS
 qt5_wrap_cpp(qcustomplot_SRCS ${qcustomplot_HDRS})
 
 add_library(qcustomplot ${qcustomplot_SRCS})
-qt5_use_modules(qcustomplot Widgets PrintSupport)
+target_link_libraries(qcustomplot PRIVATE ${CPN_COMMON_LIB} Qt5::Widgets Qt5::PrintSupport)

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -36,8 +36,7 @@ if(Qt5Widgets_FOUND)
   add_library(${SIMULATOR_TARGET} SHARED ${SIMULATOR_SRC})
   add_dependencies(${SIMULATOR_TARGET} ${FIRMWARE_DEPENDENCIES})
   target_compile_definitions(${SIMULATOR_TARGET} PUBLIC ${APP_COMMON_DEFINES})  # set in top-level CMakeLists
-  target_link_libraries(${SIMULATOR_TARGET} ${SDL_LIBRARY})
-  qt5_use_modules(${SIMULATOR_TARGET} Core)
+  target_link_libraries(${SIMULATOR_TARGET} ${SDL_LIBRARY} Qt5::Core)
   add_custom_target(libsimulator DEPENDS ${SIMULATOR_TARGET})
 
   # Prepare the "all-simu-libs" target to build simulator libraries for *every* supported PCB type (PCB_TYPES list)

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -38,9 +38,8 @@ if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
   use_cxx11()  # ensure gnu++11 in CXX_FLAGS with CMake < 3.1
 
   add_executable(gtests EXCLUDE_FROM_ALL ${TEST_SRC_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/location.h ${RADIO_SRC} ../targets/simu/simpgmspace.cpp ../targets/simu/simueeprom.cpp ../targets/simu/simufatfs.cpp)
-  qt5_use_modules(gtests Core Widgets)
   add_dependencies(gtests ${FIRMWARE_DEPENDENCIES} gtests-lib)
-  target_link_libraries(gtests gtests-lib pthread)
+  target_link_libraries(gtests gtests-lib pthread Qt5::Core Qt5::Widgets)
   message(STATUS "Added optional gtests target")
 else()
   message(WARNING "WARNING: gtests target will not be available (check that GTEST_INCDIR, GTEST_SRCDIR, and Qt5Widgets are configured).")


### PR DESCRIPTION
QT 5.11 finally removes the qt5_use_modules macro.
Instead target_link_libraries with the Qt5::Lib added should be used.
Since we already use that in one place, it should work everywhere. Since
the common companion lib already depends on Core, widges and multimedia
components that link against it, also implicitly link against those
libraries.