### PR TITLE
support for CLI (over USB CDC) without DEBUG

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -701,6 +701,7 @@ int cliTest(const char ** argv)
   return 0;
 }
 
+#if defined(DEBUG)
 int cliTrace(const char ** argv)
 {
   if (!strcmp(argv[1], "on")) {
@@ -714,6 +715,7 @@ int cliTrace(const char ** argv)
   }
   return 0;
 }
+#endif
 
 int cliStackInfo(const char ** argv)
 {
@@ -1220,7 +1222,9 @@ const CliCommand cliCommands[] = {
   { "stackinfo", cliStackInfo, "" },
   { "meminfo", cliMemoryInfo, "" },
   { "test", cliTest, "new | std::exception | graphics | memspd" },
+#if defined(DEBUG)
   { "trace", cliTrace, "on | off" },
+#endif
   { "help", cliHelp, "[<command>]" },
   { "debugvars", cliDebugVars, "" },
   { "repeat", cliRepeat, "<interval> <command>" },

--- a/radio/src/targets/common/arm/stm32/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/CMakeLists.txt
@@ -39,7 +39,7 @@ set(FIRMWARE_TARGET_SRC
   ../common/arm/stm32/flash_driver.cpp
   )
 
-if(DEBUG)
+if(DEBUG OR CLI)
   set(STM32USB_SRC
     ${STM32USB_SRC}
     STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c


### PR DESCRIPTION
The title says it all. This enables the CLI over USB CDC, whereby DEBUG is not enabled, and thus TRACE is deactivated.

EDIT: tested on X10 only.