### PR TITLE
Fix some issues with Inputs editor

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -151,7 +151,7 @@ QVector<const MixData *> ModelData::mixes(int channel) const
   return result;
 }
 
-void ModelData::removeInput(const int idx)
+void ModelData::removeInput(const int idx, bool clearName)
 {
   unsigned int chn = expoData[idx].chn;
 
@@ -159,15 +159,8 @@ void ModelData::removeInput(const int idx)
   expoData[CPN_MAX_EXPOS-1].clear();
 
   //also remove input name if removing last line for this input
-  bool found = false;
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
-    if (expoData[i].mode==0) continue;
-    if (expoData[i].chn==chn) {
-      found = true;
-      break;
-    }
-  }
-  if (!found) inputNames[chn][0] = 0;
+  if (clearName && !expos(chn).size())
+    inputNames[chn][0] = 0;
 }
 
 void ModelData::clearInputs()

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -136,7 +136,7 @@ class ModelData {
     void convert(RadioDataConversionState & cstate);
 
     ExpoData * insertInput(const int idx);
-    void removeInput(const int idx);
+    void removeInput(const int idx, bool clearName = true);
 
     bool isInputValid(const unsigned int idx) const;
     bool hasExpos(uint8_t inputIdx) const;

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -37,6 +37,7 @@ class InputsPanel : public ModelPanel
 
   private slots:
     void clearExpos();
+    void moveExpoList(bool down);
     void moveExpoUp();
     void moveExpoDown();
     void mimeExpoDropped(int index, const QMimeData *data, Qt::DropAction action);
@@ -50,6 +51,7 @@ class InputsPanel : public ModelPanel
     void exposDuplicate();
     void expoOpen(QListWidgetItem *item = NULL);
     void expoAdd();
+    void maybeCopyInputName(int srcChan, int destChan);
 
   private:
     bool expoInserted;
@@ -59,15 +61,15 @@ class InputsPanel : public ModelPanel
 
     int getExpoIndex(unsigned int dch);
     bool gm_insertExpo(int idx);
-    void gm_deleteExpo(int index);
+    void gm_deleteExpo(int index, bool clearName = true);
     void gm_openExpo(int index);
     int gm_moveExpo(int idx, bool dir);
-    void exposDeleteList(QList<int> list);
+    void exposDeleteList(QList<int> list, bool clearName = true);
     QList<int> createExpoListFromSelected();
     void setSelectedByExpoList(QList<int> list);
     void pasteExpoMimeData(const QMimeData * mimeData, int destIdx);
-    bool AddInputLine(int dest);
-    QString getInputText(int dest, bool * new_ch);
+    void AddInputLine(int dest);
+    QString getInputText(int dest, bool newChan);
 
 };
 


### PR DESCRIPTION
 * Fix "ghost" input names being left over when moving items (closes #5740); 
 * Cut/paste and moving item(s) will now also copy the input name(s) in some cases (see below);
 * Clean up some code and potential crashes with out-of-range indices.

Copying the input names is a little tricky... I set it up so that in all cases it will only copy/move a name if destination input channel is nameless AND source input becomes empty after the operation.  Specifically, it will (or should) not duplicate names.  So if you copy/paste a line to a new channel, the name will not carry over.  If you cut/paste a line and the source input channel now has no entries, the name WILL carry over (if the destination channel is nameless).  Same for moving an item with move up/down or drag-move.

One noticeable side-effect is when you Cut an item, the input name will remain with the old input channel until you paste the clipboard.  It actually provides a decent place marker showing where the line was cut from, so it's not too awkward.  If you don't paste the cut item anywhere, then the "ghost" name will remain until that input channel is edited again.