### PR TITLE
Fix disappearing mixer lines after an invalid line is removed.

### DIFF
--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -72,8 +72,8 @@ class MixesPanel : public ModelPanel
     void mixersDeleteList(QList<int> list);
     QList<int> createMixListFromSelected();
     void setSelectedByMixList(QList<int> list);
-    bool AddMixerLine(int dest);
-    QString getMixerText(int dest, bool * new_ch);
+    void AddMixerLine(int dest);
+    QString getMixerText(int dest, bool newChannel);
 };
 
 #endif // _MIXES_H_


### PR DESCRIPTION
If source is invalid after a line is edited and saved, all the following mixer lines (on all channels) are hidden (they're not deleted, you can still see them if the model is printed).  As brought up by @kilrah  on chat.

This also brings the display functions (update, addMixerLine, and getMixerText) in line with Inputs code which I recently modified.