### PR TITLE
Do not display disabled trim on main views

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -105,8 +105,10 @@ void displayTrims(uint8_t phase)
     uint8_t att = ROUND;
     int16_t val = getTrimValue(phase, i);
 
+#if defined(CPUARM)
     if(getRawTrimValue(phase, i).mode == TRIM_MODE_NONE)
       continue;
+#endif
 
 #if !defined(CPUM64) || !defined(TELEMETRY_FRSKY)
     int16_t dir = val;

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -103,10 +103,9 @@ void displayTrims(uint8_t phase)
     uint8_t stickIndex = CONVERT_MODE(i);
     xm = x[stickIndex];
     uint8_t att = ROUND;
-    trim_t v = getRawTrimValue(phase, i);
-    int16_t val = v.value;
+    int16_t val = getTrimValue(phase, i);
 
-    if(v.mode == TRIM_MODE_NONE)
+    if(getRawTrimValue(phase, i).mode == TRIM_MODE_NONE)
       continue;
 
 #if !defined(CPUM64) || !defined(TELEMETRY_FRSKY)

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -103,7 +103,11 @@ void displayTrims(uint8_t phase)
     uint8_t stickIndex = CONVERT_MODE(i);
     xm = x[stickIndex];
     uint8_t att = ROUND;
-    int16_t val = getTrimValue(phase, i);
+    trim_t v = getRawTrimValue(phase, i);
+    int16_t val = v.value;
+
+    if(v.mode == TRIM_MODE_NONE)
+      continue;
 
 #if !defined(CPUM64) || !defined(TELEMETRY_FRSKY)
     int16_t dir = val;

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -93,12 +93,11 @@ void displayTrims(uint8_t phase)
     xm = x[stickIndex];
 
     uint32_t att = ROUND;
-    trim_t v = getRawTrimValue(phase, i);
-    int32_t trim = v.value;
+    int32_t trim = getTrimValue(phase, i);
     int32_t val = trim;
     bool exttrim = false;
     
-    if(v.mode == TRIM_MODE_NONE)
+    if(getRawTrimValue(phase, i).mode == TRIM_MODE_NONE)
       continue;
     
     if (val < TRIM_MIN || val > TRIM_MAX) {

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -94,7 +94,6 @@ void displayTrims(uint8_t phase)
 
     uint32_t att = ROUND;
     trim_t v = getRawTrimValue(phase, i);
-    
     int32_t trim = v.value;
     int32_t val = trim;
     bool exttrim = false;

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -93,9 +93,15 @@ void displayTrims(uint8_t phase)
     xm = x[stickIndex];
 
     uint32_t att = ROUND;
-    int32_t trim = getTrimValue(phase, i);
+    trim_t v = getRawTrimValue(phase, i);
+    
+    int32_t trim = v.value;
     int32_t val = trim;
     bool exttrim = false;
+    
+    if(v.mode == TRIM_MODE_NONE)
+      continue;
+    
     if (val < TRIM_MIN || val > TRIM_MAX) {
       exttrim = true;
     }

--- a/radio/src/gui/480x272/view_main.cpp
+++ b/radio/src/gui/480x272/view_main.cpp
@@ -51,7 +51,11 @@ void drawTrims(uint8_t flightMode)
     static uint8_t vert[4] = {0, 1, 1, 0};
     unsigned int stickIndex = CONVERT_MODE(i);
     coord_t xm = x[stickIndex];
-    int32_t trim = getTrimValue(flightMode, i);
+    trim_t v = getRawTrimValue(flightMode, i);
+    int32_t trim = v.value;
+
+    if(v.mode == TRIM_MODE_NONE)
+      continue;
 
     if (vert[i]) {
       if (g_model.extendedTrims == 1) {

--- a/radio/src/gui/480x272/view_main.cpp
+++ b/radio/src/gui/480x272/view_main.cpp
@@ -51,10 +51,10 @@ void drawTrims(uint8_t flightMode)
     static uint8_t vert[4] = {0, 1, 1, 0};
     unsigned int stickIndex = CONVERT_MODE(i);
     coord_t xm = x[stickIndex];
-    trim_t v = getRawTrimValue(flightMode, i);
-    int32_t trim = v.value;
+    int32_t trim = getTrimValue(flightMode, i);
 
-    if(v.mode == TRIM_MODE_NONE)
+
+    if(getRawTrimValue(flightMode, i).mode == TRIM_MODE_NONE)
       continue;
 
     if (vert[i]) {


### PR DESCRIPTION
Based on a disucssion on rocket chat

Individual trims that are desactivated by flight mode settings are not displayed on main views

![image](https://user-images.githubusercontent.com/5167938/41272428-59acd5de-6e15-11e8-9f63-f802ce63fac1.png)
