### PR TITLE
Turn backlight on for switch warning

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -971,6 +971,7 @@ void doSplash()
 #endif
 
   if (SPLASH_NEEDED()) {
+    backlightOn();
     drawSplash();
 
 #if !defined(CPUARM)

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -721,6 +721,7 @@ void checkSwitches()
     }
 
     LED_ERROR_BEGIN();
+    backlightOn();
 
     // first - display warning
 #if defined(PCBTARANIS) || defined(PCBHORUS)


### PR DESCRIPTION
SW do not turn backlight on when other do.
Also enables backlight for splash screen.

This (kinda) fixes #5959 