### PR TITLE
fixes #5988

### DIFF
--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -801,6 +801,9 @@ void AudioQueue::wakeup()
         }
         buffersFifo.audioPushBuffer();
       }
+      else {
+        break;
+      }
 #else
       buffersFifo.audioPushBuffer();
 #endif


### PR DESCRIPTION
Tested on X-Lite (hardware) and X10 simu.

To be able to test properly, just use whatever MP3 file you have, convert it (`sox file.mp3 -b 16 -r 16000 -c 1 out.wav`) and set that wav as the background music. Then turn the volume ON/OFF with a poti.