### PR TITLE
Clean up PWM stick reads, remove double averaging

### DIFF
--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -409,7 +409,7 @@ uint16_t getAnalogValue(uint8_t index);
 #endif
 
 #if NUM_PWMSTICKS > 0
-extern uint8_t sticks_pwm_disabled;
+extern bool sticks_pwm_disabled;
 #define STICKS_PWM_ENABLED()          (sticks_pwm_disabled == false)
 void sticksPwmInit(void);
 void sticksPwmRead(uint16_t * values);

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -445,7 +445,7 @@ enum Analogs {
 
 #if defined(PCBXLITE)
   #define NUM_PWMSTICKS                 4
-  extern uint8_t sticks_pwm_disabled;
+  extern bool sticks_pwm_disabled;
   #define STICKS_PWM_ENABLED()         (sticks_pwm_disabled == false)
   void sticksPwmInit(void);
   void sticksPwmRead(uint16_t * values);


### PR DESCRIPTION
We already do averaging in the normal anaIn/getADC().
Also according to Mike's and my own research we don't need the averaging.

Tested on two X-Lites with PMW sticks