### PR TITLE
Remove -nostartfiles linker option from bootloader

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -112,7 +112,7 @@ remove_definitions(-DCLI)
 remove_definitions(-DUSB_SERIAL)
 add_definitions(-DBOOT)
 
-set(CMAKE_EXE_LINKER_FLAGS "-mcpu=${MCU} -mthumb -nostartfiles -lm -T${RADIO_SRC_DIRECTORY}/targets/${TARGET_DIR}/stm32_ramboot.ld -Wl,-Map=bootloader.map,--cref,--no-warn-mismatch,--gc-sections")
+set(CMAKE_EXE_LINKER_FLAGS "-mcpu=${MCU} -mthumb -lm -T${RADIO_SRC_DIRECTORY}/targets/${TARGET_DIR}/stm32_ramboot.ld -Wl,-Map=bootloader.map,--cref,--no-warn-mismatch,--gc-sections")
 
 add_executable(bootloader ${BOOTLOADER_SRC})
 add_dependencies(bootloader ${BITMAPS_TARGET} firmware_translations)

--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -73,7 +73,6 @@ set(BOOTLOADER_SRC
   ../usb_bsp.c
   ../usb_driver.cpp
   ../flash_driver.cpp
-  init.c
   boot.cpp
   bin_files.cpp
   )

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -527,7 +527,3 @@ int main()
 
   return 0;
 }
-
-#if defined(PCBHORUS)
-void *__dso_handle = 0;
-#endif

--- a/radio/src/targets/common/arm/stm32/bootloader/init.c
+++ b/radio/src/targets/common/arm/stm32/bootloader/init.c
@@ -1,4 +1,0 @@
-void _init (void)
-{
-  
-}


### PR DESCRIPTION
Disassembly of the _init and _fini in bootloader.elf  that come from the libc show that they only executing a nop, so almost identical (+a nop) to our own _init implementation in init.c