### PR TITLE
Companion custom functions sound playback fixes

### DIFF
--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -98,11 +98,16 @@ static QString iconThemeFolder(int theme_set)
 
 CompanionIcon::CompanionIcon(const QString &baseimage)
 {
+  addImage(baseimage);
+}
+
+void CompanionIcon::addImage(const QString & baseimage, Mode mode, State state)
+{
   const QString theme = iconThemeFolder(g.theme());
-  addFile(":/themes/"+theme+"/16/"+baseimage, QSize(16,16));
-  addFile(":/themes/"+theme+"/24/"+baseimage, QSize(24,24));
-  addFile(":/themes/"+theme+"/32/"+baseimage, QSize(32,32));
-  addFile(":/themes/"+theme+"/48/"+baseimage, QSize(48,48));
+  addFile(":/themes/"+theme+"/16/"+baseimage, QSize(16,16), mode, state);
+  addFile(":/themes/"+theme+"/24/"+baseimage, QSize(24,24), mode, state);
+  addFile(":/themes/"+theme+"/32/"+baseimage, QSize(32,32), mode, state);
+  addFile(":/themes/"+theme+"/48/"+baseimage, QSize(48,48), mode, state);
 }
 
 

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -55,6 +55,7 @@ extern const QColor colors[CPN_MAX_CURVES];
 class CompanionIcon: public QIcon {
   public:
     CompanionIcon(const QString &baseimage);
+    void addImage(const QString &baseimage, Mode mode = Normal, State state = Off);
 };
 
 class GVarGroup: public QObject {

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -21,9 +21,10 @@
 #ifndef _CUSTOMFUNCTIONS_H_
 #define _CUSTOMFUNCTIONS_H_
 
-#include <QMediaPlayer>
 #include "modeledit.h"
 #include "eeprominterface.h"
+
+#include <QMediaPlayer>
 
 class RawSwitchFilterItemModel;
 class TimerEdit;
@@ -66,7 +67,9 @@ class CustomFunctionsPanel : public GenericPanel
     void fsw_customContextMenuRequested(QPoint pos);
     void refreshCustomFunction(int index, bool modified=false);
     void onChildModified();
-    void playMusic();
+    bool playSound(int index);
+    void stopSound(int index);
+    void toggleSound(bool play);
     void onMediaPlayerStateChanged(QMediaPlayer::State state);
     void onMediaPlayerError(QMediaPlayer::Error error);
     void fswDelete();
@@ -90,7 +93,7 @@ class CustomFunctionsPanel : public GenericPanel
     QCheckBox * fswtchParamGV[CPN_MAX_SPECIAL_FUNCTIONS];
     QDoubleSpinBox * fswtchParam[CPN_MAX_SPECIAL_FUNCTIONS];
     TimerEdit * fswtchParamTime[CPN_MAX_SPECIAL_FUNCTIONS];
-    QPushButton * playBT[CPN_MAX_SPECIAL_FUNCTIONS];
+    QToolButton * playBT[CPN_MAX_SPECIAL_FUNCTIONS];
     QComboBox * fswtchParamT[CPN_MAX_SPECIAL_FUNCTIONS];
     QComboBox * fswtchParamArmT[CPN_MAX_SPECIAL_FUNCTIONS];
     QCheckBox * fswtchEnable[CPN_MAX_SPECIAL_FUNCTIONS];


### PR DESCRIPTION
* Fix sound file locked after playback (fixes #5222, fixes #5997); 
* Refactor play button (fixes #4929);
* Fix possible crash when sound file locked from outside (eg. SDL in simu);
* Adds better feedback (error msg) when a file can't be opened (eg. locked or unreadable);

Tested in all supported OSs/compilers.

I did discover another related bug, this one on the simu firmware side, where it (I'm assuming SDL) doesn't close a file when it is used as background music, or if a file couldn't be played back for some other reason.  So the file remains locked and can no longer be played from CPN side either, which could lead to a CPN crash.  I prevented the crash and added an error message, but obviously it will be better to fix the root cause.  Seems to be only a Windows issue.

Also (first commit):
* App icons can have multiple images for representing different UI states (checked/active/etc) -- this is used for the checkable play/stop button.
