### PR TITLE
Prevent leftover network handles/threads after update checks.

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -80,8 +80,9 @@ const char * const OPENTX_COMPANION_DOWNLOAD_URL[] = {
 };
 
 MainWindow::MainWindow():
-  downloadDialog_forWait(NULL),
+  downloadDialog_forWait(nullptr),
   checkForUpdatesState(0),
+  networkManager(nullptr),
   windowsListActions(new QActionGroup(this))
 {
   // setUnifiedTitleAndToolBarOnMac(true);
@@ -252,39 +253,50 @@ QString MainWindow::getCompanionUpdateBaseUrl()
 
 void MainWindow::checkForUpdates()
 {
+  if (!checkForUpdatesState) {
+    closeUpdatesWaitDialog();
+    if (networkManager) {
+      networkManager->deleteLater();
+      networkManager = nullptr;
+    }
+    return;
+  }
+
   if (checkForUpdatesState & SHOW_DIALOG_WAIT) {
     checkForUpdatesState -= SHOW_DIALOG_WAIT;
     downloadDialog_forWait = new downloadDialog(NULL, tr("Checking for updates"));
     downloadDialog_forWait->show();
   }
 
+  if (networkManager)
+    disconnect(networkManager, 0, this, 0);
+  else
+    networkManager = new QNetworkAccessManager(this);
+
+  QUrl url;
   if (checkForUpdatesState & CHECK_COMPANION) {
     checkForUpdatesState -= CHECK_COMPANION;
-    // TODO why create each time a network manager?
-    networkManager = new QNetworkAccessManager(this);
-    connect(networkManager, SIGNAL(finished(QNetworkReply*)),this, SLOT(checkForCompanionUpdateFinished(QNetworkReply*)));
-    QUrl url(QString("%1/%2").arg(getCompanionUpdateBaseUrl()).arg(COMPANION_STAMP));
+    url.setUrl(QString("%1/%2").arg(getCompanionUpdateBaseUrl()).arg(COMPANION_STAMP));
+    connect(networkManager, &QNetworkAccessManager::finished, this, &MainWindow::checkForCompanionUpdateFinished);
     qDebug() << "Checking for Companion update " << url.url();
-    QNetworkRequest request(url);
-    request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
-    networkManager->get(request);
   }
   else if (checkForUpdatesState & CHECK_FIRMWARE) {
     checkForUpdatesState -= CHECK_FIRMWARE;
-    QString stamp = getCurrentFirmware()->getStampUrl();
+    const QString stamp = getCurrentFirmware()->getStampUrl();
     if (!stamp.isEmpty()) {
-      networkManager = new QNetworkAccessManager(this);
-      connect(networkManager, SIGNAL(finished(QNetworkReply*)), this, SLOT(checkForFirmwareUpdateFinished(QNetworkReply*)));
-      QUrl url(stamp);
+      url.setUrl(stamp);
+      connect(networkManager, &QNetworkAccessManager::finished, this, &MainWindow::checkForFirmwareUpdateFinished);
       qDebug() << "Checking for firmware update " << url.url();
-      QNetworkRequest request(url);
-      request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
-      networkManager->get(request);
     }
   }
-  else if (checkForUpdatesState==0) {
-    closeUpdatesWaitDialog();
+  if (!url.isValid()) {
+    checkForUpdates();
+    return;
   }
+
+  QNetworkRequest request(url);
+  request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
+  networkManager->get(request);
 }
 
 void MainWindow::onUpdatesError()
@@ -320,6 +332,7 @@ QString MainWindow::seekCodeString(const QByteArray & qba, const QString & label
 void MainWindow::checkForCompanionUpdateFinished(QNetworkReply * reply)
 {
   QByteArray qba = reply->readAll();
+  reply->deleteLater();
   QString version = seekCodeString(qba, "VERSION");
   if (version.isNull())
     return onUpdatesError();
@@ -431,6 +444,7 @@ void MainWindow::checkForFirmwareUpdateFinished(QNetworkReply * reply)
   bool ignore = false;
 
   QByteArray qba = reply->readAll();
+  reply->deleteLater();
   QString versionString = seekCodeString(qba, "VERSION");
   QString dateString = seekCodeString(qba, "DATE");
   if (versionString.isNull() || dateString.isNull())

--- a/companion/src/releasenotesfirmwaredialog.cpp
+++ b/companion/src/releasenotesfirmwaredialog.cpp
@@ -48,5 +48,6 @@ void ReleaseNotesFirmwareDialog::replyFinished(QNetworkReply * reply)
 {
   ui->textEditor->setHtml(reply->readAll());
   ui->textEditor->setOpenExternalLinks(true);
+  reply->deleteLater();
 }
 


### PR DESCRIPTION
Noticed this while checking the sound file handles issue.  From QNetworkManager [docs](http://doc.qt.io/qt-5/qnetworkaccessmanager.html#details):

>**Note**: After the request has finished, it is the responsibility of the user to delete the QNetworkReply object at an appropriate time.

Also cleans up multiple instances of QNetworkManager being created.

I think it's safe for 2.2.2 (and PR is against 2.2 branch), but should definitely go into 2.3 either way.