### PR TITLE
telemetry simulator fixes

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -73,7 +73,7 @@ TelemetrySimulator::TelemetrySimulator(QWidget * parent, SimulatorInterface * si
 
 TelemetrySimulator::~TelemetrySimulator()
 {
-  timer.stop();
+  stopTelemetry();
   logTimer.stop();
   delete logPlayback;
   delete ui;
@@ -93,10 +93,10 @@ void TelemetrySimulator::onSimulatorStopped()
 void TelemetrySimulator::onSimulateToggled(bool isChecked)
 {
   if (isChecked) {
-    timer.start();
+    startTelemetry();
   }
   else {
-    timer.stop();
+    stopTelemetry();
   }
 }
 
@@ -1055,5 +1055,24 @@ void TelemetrySimulator::LogPlaybackController::setUiDataValues()
     else {
       // file is corrupt - shut down with open logs, or log format changed mid-day
     }
+  }
+}
+
+void TelemetrySimulator::startTelemetry()
+{
+  timer.start();
+}
+
+void TelemetrySimulator::stopTelemetry()
+{
+  timer.stop();
+
+  bool ok;
+  uint8_t buffer[FRSKY_SPORT_PACKET_SIZE] = {0};
+  generateSportPacket(buffer, ui->rssi_inst->text().toInt(&ok, 0) - 1, DATA_FRAME, RSSI_ID, 0);
+
+  if (ok) {
+    QByteArray ba((char *)buffer, FRSKY_SPORT_PACKET_SIZE);  
+    emit telemetryDataChanged(ba);
   }
 }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -912,7 +912,7 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
     lon = convertDegMin(lonLat[0]);
     lat = convertDegMin(lonLat[1]);
   }
-  return QString::number(lat) + ", " + QString::number(lon);
+  return QString::number(lat, 'f', 6) + ", " + QString::number(lon, 'f', 6);
 }
 
 void TelemetrySimulator::LogPlaybackController::updatePositionLabel(int32_t percentage)

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -205,6 +205,8 @@ class TelemetrySimulator : public QWidget
         uint32_t encodeDateTime(uint8_t yearOrHour, uint8_t monthOrMinute, uint8_t dayOrSecond, bool isDate);
     };  // GPSEmulator
 
+    void startTelemetry();
+    void stopTelemetry();
 };  // TelemetrySimulator
 
 #endif // _TELEMETRYSIMU_H_


### PR DESCRIPTION
- Trigger "telemetry lost" properly when "simulate" is ticked out or window is closed (RSSI=0).
- GPS precision fixed when read from CSV log file.