### PR TITLE
[2.3] telemetry simulator fixes/improvement

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -447,6 +447,32 @@ void TelemetrySimulator::generateTelemetryFrame()
   }
 }
 
+void TelemetrySimulator::startTelemetry()
+{
+  timer.start();
+}
+
+void TelemetrySimulator::stopTelemetry()
+{
+  timer.stop();
+
+  bool ok = (ui && ui->rssi_inst);
+
+  int id = 0;
+  if (ok) {
+    id = ui->rssi_inst->text().toInt(&ok, 0);
+  }
+
+  if (!ok)
+    return;
+
+  uint8_t buffer[FRSKY_SPORT_PACKET_SIZE] = {0};
+  generateSportPacket(buffer, id - 1, DATA_FRAME, RSSI_ID, 0);
+
+  QByteArray ba((char *)buffer, FRSKY_SPORT_PACKET_SIZE);
+  emit telemetryDataChanged(ba);
+}
+
 uint32_t TelemetrySimulator::FlvssEmulator::encodeCellPair(uint8_t cellNum, uint8_t firstCellNo, double cell1, double cell2)
 {
   uint16_t cell1Data = cell1 * 500.0;
@@ -1055,24 +1081,5 @@ void TelemetrySimulator::LogPlaybackController::setUiDataValues()
     else {
       // file is corrupt - shut down with open logs, or log format changed mid-day
     }
-  }
-}
-
-void TelemetrySimulator::startTelemetry()
-{
-  timer.start();
-}
-
-void TelemetrySimulator::stopTelemetry()
-{
-  timer.stop();
-
-  bool ok;
-  uint8_t buffer[FRSKY_SPORT_PACKET_SIZE] = {0};
-  generateSportPacket(buffer, ui->rssi_inst->text().toInt(&ok, 0) - 1, DATA_FRAME, RSSI_ID, 0);
-
-  if (ok) {
-    QByteArray ba((char *)buffer, FRSKY_SPORT_PACKET_SIZE);  
-    emit telemetryDataChanged(ba);
   }
 }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -73,7 +73,7 @@ TelemetrySimulator::TelemetrySimulator(QWidget * parent, SimulatorInterface * si
 
 TelemetrySimulator::~TelemetrySimulator()
 {
-  timer.stop();
+  stopTelemetry();
   logTimer.stop();
   delete logPlayback;
   delete ui;
@@ -93,10 +93,10 @@ void TelemetrySimulator::onSimulatorStopped()
 void TelemetrySimulator::onSimulateToggled(bool isChecked)
 {
   if (isChecked) {
-    timer.start();
+    startTelemetry();
   }
   else {
-    timer.stop();
+    stopTelemetry();
   }
 }
 
@@ -1055,5 +1055,24 @@ void TelemetrySimulator::LogPlaybackController::setUiDataValues()
     else {
       // file is corrupt - shut down with open logs, or log format changed mid-day
     }
+  }
+}
+
+void TelemetrySimulator::startTelemetry()
+{
+  timer.start();
+}
+
+void TelemetrySimulator::stopTelemetry()
+{
+  timer.stop();
+
+  bool ok;
+  uint8_t buffer[FRSKY_SPORT_PACKET_SIZE] = {0};
+  generateSportPacket(buffer, ui->rssi_inst->text().toInt(&ok, 0) - 1, DATA_FRAME, RSSI_ID, 0);
+
+  if (ok) {
+    QByteArray ba((char *)buffer, FRSKY_SPORT_PACKET_SIZE);  
+    emit telemetryDataChanged(ba);
   }
 }

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -456,12 +456,11 @@ void TelemetrySimulator::stopTelemetry()
 {
   timer.stop();
 
-  bool ok = (ui && ui->rssi_inst);
+  if (ui && ui->rssi_inst)
+    return;
 
-  int id = 0;
-  if (ok) {
-    id = ui->rssi_inst->text().toInt(&ok, 0);
-  }
+  bool ok = false;
+  int id = ui->rssi_inst->text().toInt(&ok, 0);
 
   if (!ok)
     return;

--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -912,7 +912,7 @@ QString TelemetrySimulator::LogPlaybackController::convertGPS(QString input)
     lon = convertDegMin(lonLat[0]);
     lat = convertDegMin(lonLat[1]);
   }
-  return QString::number(lat) + ", " + QString::number(lon);
+  return QString::number(lat, 'f', 6) + ", " + QString::number(lon, 'f', 6);
 }
 
 void TelemetrySimulator::LogPlaybackController::updatePositionLabel(int32_t percentage)

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -205,6 +205,8 @@ class TelemetrySimulator : public QWidget
         uint32_t encodeDateTime(uint8_t yearOrHour, uint8_t monthOrMinute, uint8_t dayOrSecond, bool isDate);
     };  // GPSEmulator
 
+    void startTelemetry();
+    void stopTelemetry();
 };  // TelemetrySimulator
 
 #endif // _TELEMETRYSIMU_H_

--- a/companion/src/simulation/telemetrysimu.h
+++ b/companion/src/simulation/telemetrysimu.h
@@ -69,6 +69,8 @@ class TelemetrySimulator : public QWidget
     void onReplayRateChanged(int value);
     void refreshSensorRatios();
     void generateTelemetryFrame();
+    void startTelemetry();
+    void stopTelemetry();
 
   protected:
 
@@ -204,9 +206,6 @@ class TelemetrySimulator : public QWidget
         uint32_t encodeLatLon(double latLon, bool isLat);
         uint32_t encodeDateTime(uint8_t yearOrHour, uint8_t monthOrMinute, uint8_t dayOrSecond, bool isDate);
     };  // GPSEmulator
-
-    void startTelemetry();
-    void stopTelemetry();
 };  // TelemetrySimulator
 
 #endif // _TELEMETRYSIMU_H_


### PR DESCRIPTION
This is basically the rebased version of #6013 on top of 2.3.

**Fix:**
- fixes GPS precision (6 digits now).

**Improvement:**
- send RSSI=0 when the telemetry simulator is stopped.

This changes the behaviour of the telemetry simulator a bit, and makes it a tad more consistent with the behaviour observed in the radio simulator with respect to telemetry.

When the radio simulator starts, no telemetry is received, which is equivalent to the physical radio when no receiver is plugged. When the telemetry simulator is started by checking the "Simulate" checkbox, telemetry packets are sent, and the radio simulator now behaves as if the receiver had been plugged.

When however the telemetry simulator is disabled by unchecking "Simulate", it would previously just stop sending telemetry packets, without setting RSSI to 0, so that the radio would think that the receiver was still plugged, whereby no RSSI telemetry packets were sent nor received. This does not really happen for real, as the FrSky modules do send RSSI packets even if the receiver is not plugged (however with 0 in case no receiver is present).

This patch basically mirrors the behaviour of the FrSky module by sending one last RSSI=0 packet when:
- telemetry simulator window is closed.
- "Simulate" is unchecked.

Please note that it will effectively trigger a "Telemetry lost" message, just like it would when you unplug the receiver. Previously, you would only hear "Sensor lost" after a while, but the telemetry was still official "ON", albeit no packets were received.
