### PR TITLE
Allow minimizing the telemetry simulator window when un-docked.

### DIFF
--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -250,6 +250,8 @@ void SimulatorMainWindow::restoreUiState()
   toggleMenuBar(m_showMenubar);
   restoreGeometry(g.profile[m_radioProfileId].simulatorOptions().windowGeometry);
   restoreState(windowState, m_savedUiStateVersion);
+
+  setDockWidgetMinimizeHint(m_telemetryDockWidget);  // must be done after restore state
 }
 
 int SimulatorMainWindow::getExitStatus(QString * msg)
@@ -297,6 +299,7 @@ void SimulatorMainWindow::createDockWidgets()
     m_telemetryDockWidget->setWidget(telem);
     m_telemetryDockWidget->setObjectName("TELEMETRY_SIMULATOR");
     addTool(m_telemetryDockWidget, Qt::LeftDockWidgetArea, icon, QKeySequence(tr("F4")));
+    connect(m_telemetryDockWidget, &QDockWidget::topLevelChanged, [this](bool) { setDockWidgetMinimizeHint(m_telemetryDockWidget); });
   }
 
   if (!m_trainerDockWidget) {
@@ -464,6 +467,16 @@ void SimulatorMainWindow::toggleRadioDocked(bool dock)
   if (ui->actionDockRadio->isChecked() != dock)
     ui->actionDockRadio->setChecked(dock);
 
+}
+
+void SimulatorMainWindow::setDockWidgetMinimizeHint(QDockWidget * widget)
+{
+  if (widget->isFloating()) {
+    const bool wasVisible = widget->isVisible();
+    widget->setWindowFlags(Qt::CustomizeWindowHint | Qt::Window | Qt::WindowMinimizeButtonHint | Qt::WindowCloseButtonHint);
+    if (wasVisible)
+      widget->show();
+  }
 }
 
 void SimulatorMainWindow::openJoystickDialog(bool)

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -79,6 +79,7 @@ class SimulatorMainWindow : public QMainWindow
     void toggleMenuBar(bool show);
     void setRadioSizePolicy(int fixType);
     void toggleRadioDocked(bool dock);
+    void setDockWidgetMinimizeHint(QDockWidget * widget);
     void openJoystickDialog(bool);
     void showHelp(bool show);
 


### PR DESCRIPTION
**Needs testing on Mac and Linux.**  Incomplete tag until tested.