### PR TITLE
Invert direction of X9E wheel in the Crossfire devices menu

### DIFF
--- a/radio/sdcard/taranis-x9/CROSSFIRE/crossfire.lua
+++ b/radio/sdcard/taranis-x9/CROSSFIRE/crossfire.lua
@@ -87,9 +87,9 @@ local function run(event)
     return 2
   elseif event == EVT_EXIT_BREAK then
     return 2
-  elseif event == EVT_PLUS_FIRST or event == EVT_PLUS_REPT or event == EVT_ROT_LEFT then
+  elseif event == EVT_PLUS_FIRST or event == EVT_PLUS_REPT or event == EVT_ROT_RIGHT then
     selectDevice(1)
-  elseif event == EVT_MINUS_FIRST or event == EVT_MINUS_REPT or event == EVT_ROT_RIGHT then
+  elseif event == EVT_MINUS_FIRST or event == EVT_MINUS_REPT or event == EVT_ROT_LEFT then
     selectDevice(-1)
   end
 


### PR DESCRIPTION
The wheel direction taken in devices menu was different from the direction taken in the device detail menu. This patch makes sure that turning the X9E wheel to the right consistently moves down in the Crossfire menus everywhere.