### PR TITLE
Turn on backlight on power press (but not on startup)

### DIFF
--- a/radio/src/targets/taranis/keys_driver.cpp
+++ b/radio/src/targets/taranis/keys_driver.cpp
@@ -149,7 +149,7 @@ void readKeysAndTrims()
     keys[index++].input(trims_input & i);
   }
 
-  if ((keys_input || trims_input) && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) {
+  if ((keys_input || trims_input || pwrPressed()) && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) {
     // on keypress turn the light on
     backlightOn();
   }


### PR DESCRIPTION
This makes power button to be considerend as a key as far as backlight is concerned.
On startup, the screen stay off, as per design choice (prevent battery drain in backpack for exemple)
This fixes #6089