### PR TITLE
Improve debug timer, add benchmarking via CLI

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1339,5 +1339,5 @@ void cliTask(void * pdata)
 
 void cliStart()
 {
-  cliTaskId = CoCreateTaskEx(cliTask, NULL, 10, &cliStack.stack[CLI_STACK_SIZE-1], CLI_STACK_SIZE, 1, false);
+  cliTaskId = CoCreateTaskEx(cliTask, NULL, CLI_TASK_PRIO, &cliStack.stack[CLI_STACK_SIZE-1], CLI_STACK_SIZE, 1, false);
 }

--- a/radio/src/cli.h
+++ b/radio/src/cli.h
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -29,7 +29,6 @@ extern uint8_t cliTracesEnabled;
 #include "fifo.h"
 extern Fifo<uint8_t, 256> cliRxFifo;
 #include "tasks_arm.h"
-#define CLI_STACK_SIZE                 1000
 extern OS_TID cliTaskId;
 extern TaskStack<CLI_STACK_SIZE> cliStack;
 #endif

--- a/radio/src/debug.cpp
+++ b/radio/src/debug.cpp
@@ -21,6 +21,12 @@
 #include "opentx.h"
 #include "stamp.h"
 #include <stdarg.h>
+#if defined(CPUARM)
+  #include <OsConfig.h>
+#endif
+#if !defined(SIMU) && (defined(STM32F2) || defined(PCBSKY9X))
+  #include "dwt.h"    // STM32F2 library and SKY9X SAM do not define DWT registers
+#endif
 
 #if defined(SIMU)
 traceCallbackFunc traceCallback = 0;
@@ -138,7 +144,7 @@ void dumpTraceBuffer()
     " notd",  // INT_OTG_FS_RX_NOT_DEVICE,
 #endif // #if defined(DEBUG_USB_INTERRUPTS)
   };
-#elif defined(PCBTARANIS) 
+#elif defined(PCBTARANIS)
   const char * const interruptNames[INT_LAST] = {
     "Tick ",   // INT_TICK,
     "5ms  ",   // INT_5MS,
@@ -202,32 +208,54 @@ void CoTaskSwitchHook(uint8_t taskID)
 
 #endif // #if defined(DEBUG_TASKS)
 
-#if defined(DEBUG_TIMERS)
+#if defined(CPUARM)
+/*
+   DebugTimer
+*/
+
+// TODO: Use RTOS abstraction layer once ready.
+#define RTOS_GET_TICKS()         CoGetOSTime()
+#define RTOS_TICKS_1US           (CFG_CPU_FREQ / CFG_SYSTICK_FREQ / (CFG_CPU_FREQ / 1000000))  // RTOS timer ticks per 1us
+#ifdef SIMU
+  #define SYSTEM_GET_TICKS()     simuTimerMicros()                // returns 1us increments
+  #define SYSTEM_TICKS_1US       (1)
+#else
+  #define SYSTEM_GET_TICKS()     (DWT->CYCCNT)                    // use cycle counter
+  #define SYSTEM_TICKS_1US       (CFG_CPU_FREQ / 1000000)         // number of system ticks in 1us
+#endif
+#define SYSTEM_TICKS_MAX_US      (0xFFFFFFFF / SYSTEM_TICKS_1US)  // longest possible time span using systicks (must fit into uint32)
 
 void DebugTimer::start()
 {
-  _start_hiprec = getTmr2MHz();
-  _start_loprec = get_tmr10ms();
+  start_loprec = RTOS_GET_TICKS();
+  start_hiprec = SYSTEM_GET_TICKS();
 }
 
-void DebugTimer::stop()
+debug_timer_t DebugTimer::stop()
 {
-  // getTmr2MHz is 16 bit timer, resolution 0.5us, max measurable value 32.7675 milli seconds
-  // tmr10ms_t tmr10ms = get_tmr10ms(); 32 bit timer, resolution 10ms, max measurable value: 42949672.95 s = 1.3 years
-  // if time difference is bigger than 30ms, then use low resolution timer
-  // otherwise use high resolution
-  if ((_start_hiprec == 0) && (_start_loprec == 0)) return;
-
-  last = get_tmr10ms() - _start_loprec;  //use low precision timer
-  if (last < 3) {
-    //use high precision
-    last = (uint16_t)(getTmr2MHz() - _start_hiprec) / 2;
-  }
-  else {
-    last *= 10000ul; //adjust unit to 1us
-  }
-  evalStats(); 
+  // The DWT cycle count timer is 32b with a maximum span depending on CPU frequency (eg. ~25.5s on F4 @ 168MHz, ~35.5s on F2 @ 120MHz).
+  // If time difference is larger than that, then we use the lower-resolution 64-bit RTOS timer (currently 2ms per tick, ~99 days total)
+  const uint32_t lpdlta = (RTOS_GET_TICKS() - start_loprec) * RTOS_TICKS_1US;
+  if (lpdlta > SYSTEM_TICKS_MAX_US)
+    last = lpdlta;
+  else
+    last = (SYSTEM_GET_TICKS() - start_hiprec) / SYSTEM_TICKS_1US;
+  evalStats();
+  return last;
 }
+
+void DebugTimer::evalStats()
+{
+  ++iter;
+  ttl += last;
+  if (min > last)
+    min = last;
+  if (max < last)
+    max = last;
+}
+#endif  // defined(CPUARM)
+
+#if defined(DEBUG_TIMERS)
 
 DebugTimer debugTimers[DEBUG_TIMERS_COUNT];
 

--- a/radio/src/targets/sky9x/dwt.h
+++ b/radio/src/targets/sky9x/dwt.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#if defined(REVA)
+  #include "AT91SAM3S2.h"
+#else
+  #include "AT91SAM3S4.h"
+#endif
+#if !defined(SIMU)
+  #include "core_cm3.h"
+#endif
+
+
+/** \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  Control Register                          */
+  __IO uint32_t CYCCNT;                  /*!< Offset: 0x004 (R/W)  Cycle Count Register                      */
+  __IO uint32_t CPICNT;                  /*!< Offset: 0x008 (R/W)  CPI Count Register                        */
+  __IO uint32_t EXCCNT;                  /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register         */
+  __IO uint32_t SLEEPCNT;                /*!< Offset: 0x010 (R/W)  Sleep Count Register                      */
+  __IO uint32_t LSUCNT;                  /*!< Offset: 0x014 (R/W)  LSU Count Register                        */
+  __IO uint32_t FOLDCNT;                 /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register         */
+  __I  uint32_t PCSR;                    /*!< Offset: 0x01C (R/ )  Program Counter Sample Register           */
+  __IO uint32_t COMP0;                   /*!< Offset: 0x020 (R/W)  Comparator Register 0                     */
+  __IO uint32_t MASK0;                   /*!< Offset: 0x024 (R/W)  Mask Register 0                           */
+  __IO uint32_t FUNCTION0;               /*!< Offset: 0x028 (R/W)  Function Register 0                       */
+       uint32_t RESERVED0[1];
+  __IO uint32_t COMP1;                   /*!< Offset: 0x030 (R/W)  Comparator Register 1                     */
+  __IO uint32_t MASK1;                   /*!< Offset: 0x034 (R/W)  Mask Register 1                           */
+  __IO uint32_t FUNCTION1;               /*!< Offset: 0x038 (R/W)  Function Register 1                       */
+       uint32_t RESERVED1[1];
+  __IO uint32_t COMP2;                   /*!< Offset: 0x040 (R/W)  Comparator Register 2                     */
+  __IO uint32_t MASK2;                   /*!< Offset: 0x044 (R/W)  Mask Register 2                           */
+  __IO uint32_t FUNCTION2;               /*!< Offset: 0x048 (R/W)  Function Register 2                       */
+       uint32_t RESERVED2[1];
+  __IO uint32_t COMP3;                   /*!< Offset: 0x050 (R/W)  Comparator Register 3                     */
+  __IO uint32_t MASK3;                   /*!< Offset: 0x054 (R/W)  Mask Register 3                           */
+  __IO uint32_t FUNCTION3;               /*!< Offset: 0x058 (R/W)  Function Register 3                       */
+} DWT_Type;
+
+/* DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28                                          /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27                                          /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26                                          /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25                                          /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24                                          /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+
+#define DWT_CTRL_CYCEVTENA_Pos             22                                          /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
+
+#define DWT_CTRL_FOLDEVTENA_Pos            21                                          /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
+
+#define DWT_CTRL_LSUEVTENA_Pos             20                                          /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
+
+#define DWT_CTRL_SLEEPEVTENA_Pos           19                                          /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
+
+#define DWT_CTRL_EXCEVTENA_Pos             18                                          /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
+
+#define DWT_CTRL_CPIEVTENA_Pos             17                                          /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
+
+#define DWT_CTRL_EXCTRCENA_Pos             16                                          /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
+
+#define DWT_CTRL_PCSAMPLENA_Pos            12                                          /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
+
+#define DWT_CTRL_SYNCTAP_Pos               10                                          /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+
+#define DWT_CTRL_CYCTAP_Pos                 9                                          /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
+
+#define DWT_CTRL_POSTINIT_Pos               5                                          /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+
+#define DWT_CTRL_POSTPRESET_Pos             1                                          /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+
+#define DWT_CTRL_CYCCNTENA_Pos              0                                          /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL << DWT_CTRL_CYCCNTENA_Pos)           /*!< DWT CTRL: CYCCNTENA Mask */
+
+/* DWT CPI Count Register Definitions */
+#define DWT_CPICNT_CPICNT_Pos               0                                          /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL << DWT_CPICNT_CPICNT_Pos)           /*!< DWT CPICNT: CPICNT Mask */
+
+/* DWT Exception Overhead Count Register Definitions */
+#define DWT_EXCCNT_EXCCNT_Pos               0                                          /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL << DWT_EXCCNT_EXCCNT_Pos)           /*!< DWT EXCCNT: EXCCNT Mask */
+
+/* DWT Sleep Count Register Definitions */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL << DWT_SLEEPCNT_SLEEPCNT_Pos)       /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+
+/* DWT LSU Count Register Definitions */
+#define DWT_LSUCNT_LSUCNT_Pos               0                                          /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL << DWT_LSUCNT_LSUCNT_Pos)           /*!< DWT LSUCNT: LSUCNT Mask */
+
+/* DWT Folded-instruction Count Register Definitions */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0                                          /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL << DWT_FOLDCNT_FOLDCNT_Pos)         /*!< DWT FOLDCNT: FOLDCNT Mask */
+
+/* DWT Comparator Mask Register Definitions */
+#define DWT_MASK_MASK_Pos                   0                                          /*!< DWT MASK: MASK Position */
+#define DWT_MASK_MASK_Msk                  (0x1FUL << DWT_MASK_MASK_Pos)               /*!< DWT MASK: MASK Mask */
+
+/* DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_MATCHED_Pos           24                                          /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVADDR1_Pos        16                                          /*!< DWT FUNCTION: DATAVADDR1 Position */
+#define DWT_FUNCTION_DATAVADDR1_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR1_Pos)      /*!< DWT FUNCTION: DATAVADDR1 Mask */
+
+#define DWT_FUNCTION_DATAVADDR0_Pos        12                                          /*!< DWT FUNCTION: DATAVADDR0 Position */
+#define DWT_FUNCTION_DATAVADDR0_Msk        (0xFUL << DWT_FUNCTION_DATAVADDR0_Pos)      /*!< DWT FUNCTION: DATAVADDR0 Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10                                          /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_LNK1ENA_Pos            9                                          /*!< DWT FUNCTION: LNK1ENA Position */
+#define DWT_FUNCTION_LNK1ENA_Msk           (0x1UL << DWT_FUNCTION_LNK1ENA_Pos)         /*!< DWT FUNCTION: LNK1ENA Mask */
+
+#define DWT_FUNCTION_DATAVMATCH_Pos         8                                          /*!< DWT FUNCTION: DATAVMATCH Position */
+#define DWT_FUNCTION_DATAVMATCH_Msk        (0x1UL << DWT_FUNCTION_DATAVMATCH_Pos)      /*!< DWT FUNCTION: DATAVMATCH Mask */
+
+#define DWT_FUNCTION_CYCMATCH_Pos           7                                          /*!< DWT FUNCTION: CYCMATCH Position */
+#define DWT_FUNCTION_CYCMATCH_Msk          (0x1UL << DWT_FUNCTION_CYCMATCH_Pos)        /*!< DWT FUNCTION: CYCMATCH Mask */
+
+#define DWT_FUNCTION_EMITRANGE_Pos          5                                          /*!< DWT FUNCTION: EMITRANGE Position */
+#define DWT_FUNCTION_EMITRANGE_Msk         (0x1UL << DWT_FUNCTION_EMITRANGE_Pos)       /*!< DWT FUNCTION: EMITRANGE Mask */
+
+#define DWT_FUNCTION_FUNCTION_Pos           0                                          /*!< DWT FUNCTION: FUNCTION Position */
+#define DWT_FUNCTION_FUNCTION_Msk          (0xFUL << DWT_FUNCTION_FUNCTION_Pos)        /*!< DWT FUNCTION: FUNCTION Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+#define DWT_BASE            (0xE0001000UL)                            /*!< DWT Base Address                   */
+
+#define DWT                 ((DWT_Type       *)     DWT_BASE      )   /*!< DWT configuration struct           */
+

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -270,12 +270,12 @@ void tasksStart()
   cliStart();
 #endif
 
-  mixerTaskId = CoCreateTask(mixerTask, NULL, 5, &mixerStack.stack[MIXER_STACK_SIZE-1], MIXER_STACK_SIZE);
-  menusTaskId = CoCreateTask(menusTask, NULL, 10, &menusStack.stack[MENUS_STACK_SIZE-1], MENUS_STACK_SIZE);
+  mixerTaskId = CoCreateTask(mixerTask, NULL, MIXER_TASK_PRIO, &mixerStack.stack[MIXER_STACK_SIZE-1], MIXER_STACK_SIZE);
+  menusTaskId = CoCreateTask(menusTask, NULL, MENUS_TASK_PRIO, &menusStack.stack[MENUS_STACK_SIZE-1], MENUS_STACK_SIZE);
 
 #if !defined(SIMU)
   // TODO move the SIMU audio in this task
-  audioTaskId = CoCreateTask(audioTask, NULL, 7, &audioStack.stack[AUDIO_STACK_SIZE-1], AUDIO_STACK_SIZE);
+  audioTaskId = CoCreateTask(audioTask, NULL, AUDIO_TASK_PRIO, &audioStack.stack[AUDIO_STACK_SIZE-1], AUDIO_STACK_SIZE);
 #endif
 
   audioMutex = CoCreateMutex();

--- a/radio/src/tasks_arm.h
+++ b/radio/src/tasks_arm.h
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -30,7 +30,12 @@ extern "C" {
 #define MENUS_STACK_SIZE       2000
 #define MIXER_STACK_SIZE       500
 #define AUDIO_STACK_SIZE       500
-#define BLUETOOTH_STACK_SIZE   500
+#define CLI_STACK_SIZE         1000
+
+#define MIXER_TASK_PRIO        5
+#define AUDIO_TASK_PRIO        7
+#define MENUS_TASK_PRIO        10
+#define CLI_TASK_PRIO          10
 
 #if defined(_MSC_VER)
 #define _ALIGNED(x) __declspec(align(x))


### PR DESCRIPTION
Use DWT cycle counter for longer high-precision timer (~25.5s on F4 @ 168MHz, ~35.5s on F2 @ 120MHz).
Use CoGetOSTime() for higher-resolution low-precision timer (2ms vs. 10ms).
DebugTimer is now always available on CPUARM (does not add any size unless it is used in the code).

This does compile of SKY9X but I'm not sure the DWT cycle counter is actually enabled on there... no way to test.

Benchmarking routines with example included.  Here's an example of the output (times are in [us]):

```
>bench fstat 10

!! Starting: f_stat with vs. w/out FILINFO  [10 iterations]

++ [with ] iter: 1; elapsed: 6286;
++ [with ] iter: 2; elapsed: 6285;
++ [with ] iter: 3; elapsed: 6285;
++ [with ] iter: 4; elapsed: 6286;
++ [with ] iter: 5; elapsed: 6285;
++ [with ] iter: 6; elapsed: 6285;
++ [with ] iter: 7; elapsed: 6285;
++ [with ] iter: 8; elapsed: 6286;
++ [with ] iter: 9; elapsed: 6286;
++ [with ] iter: 10; elapsed: 6285;
== [with ]: iterations: 10;  avg: 6285;  min: 6285;  max: 6286;  ttl: 62854;

++ [w/out] iter: 1; elapsed: 6287;
++ [w/out] iter: 2; elapsed: 6283;
++ [w/out] iter: 3; elapsed: 6283;
++ [w/out] iter: 4; elapsed: 6283;
++ [w/out] iter: 5; elapsed: 6282;
++ [w/out] iter: 6; elapsed: 6283;
++ [w/out] iter: 7; elapsed: 6283;
++ [w/out] iter: 8; elapsed: 6283;
++ [w/out] iter: 9; elapsed: 6283;
++ [w/out] iter: 10; elapsed: 6283;
== [w/out]: iterations: 10;  avg: 6283;  min: 6282;  max: 6287;  ttl: 62833;

Comparison report: f_stat with vs. w/out FILINFO  [10 iterations]
         test deltas :      avg (percent  chng);           total (percent  chng);
  [w/out] vs [with ] :       -2 (  0.03% bettr);             -21 (  0.03% bettr);

```
I'll be posting some more interesting results later/elsewhere.

Please note the new PR tag... :)