### PR TITLE
Allow power-off while model checklist is displayed during startup.

### DIFF
--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -80,7 +80,7 @@ void readModelNotes()
 
   clearKeyEvents();
   event_t event = EVT_ENTRY;
-  while (event != EVT_KEY_FIRST(KEY_EXIT) && pwrCheck() != e_power_off) {
+  while (event != EVT_KEY_FIRST(KEY_EXIT) && pwrCheck() < e_power_off) {
     lcdRefreshWait();
     lcdClear();
     menuTextView(event);

--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -80,7 +80,7 @@ void readModelNotes()
 
   clearKeyEvents();
   event_t event = EVT_ENTRY;
-  while (event != EVT_KEY_FIRST(KEY_EXIT)) {
+  while (event != EVT_KEY_FIRST(KEY_EXIT) && pwrCheck() != e_power_off) {
     lcdRefreshWait();
     lcdClear();
     menuTextView(event);

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -112,7 +112,7 @@ void readModelNotes()
 
   clearKeyEvents();
   event_t event = EVT_ENTRY;
-  while (event != EVT_KEY_BREAK(KEY_EXIT)) {
+  while (event != EVT_KEY_BREAK(KEY_EXIT) && pwrCheck() != e_power_off) {
     lcdRefreshWait();
     lcdClear();
     menuTextView(event);

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -112,7 +112,7 @@ void readModelNotes()
 
   clearKeyEvents();
   event_t event = EVT_ENTRY;
-  while (event != EVT_KEY_BREAK(KEY_EXIT) && pwrCheck() != e_power_off) {
+  while (event != EVT_KEY_BREAK(KEY_EXIT) && pwrCheck() < e_power_off) {
     lcdRefreshWait();
     lcdClear();
     menuTextView(event);


### PR DESCRIPTION
I've got no way to test it with `PWR_BUTTON_PRESS`.  Seems to work fine otherwise.

This does nothing for Simu[lator] as of yet (it will still hang), but I do have another patch coming up for that.