### PR TITLE
Refactor simu startup and shutdown handling

### DIFF
--- a/radio/src/definitions.h
+++ b/radio/src/definitions.h
@@ -72,8 +72,7 @@ typedef __int24 int24_t;
 #else
   #define FORCEINLINE inline __attribute__ ((always_inline))
   #define NOINLINE    __attribute__ ((noinline))
-  #define SIMU_SLEEP(x)
-  #define SIMU_SLEEP_NORET(x)
+  #define SIMU_SLEEP(x)       true
   #define CONVERT_PTR_UINT(x) ((uint32_t)(x))
   #define CONVERT_UINT_PTR(x) ((uint32_t *)(x))
 #endif

--- a/radio/src/gui/common/colorlcd/widgets.cpp
+++ b/radio/src/gui/common/colorlcd/widgets.cpp
@@ -82,6 +82,7 @@ void runFatalErrorScreen(const char * message)
       uint32_t pwr_check = pwrCheck();
       if (pwr_check == e_power_off) {
         boardOff();
+        return;  // only happens in SIMU, required for proper shutdown
       }
       else if (pwr_check == e_power_press) {
         refresh = true;
@@ -89,7 +90,6 @@ void runFatalErrorScreen(const char * message)
       else if (pwr_check == e_power_on && refresh) {
         break;
       }
-      SIMU_SLEEP_NORET(1);
     }
   }
 }

--- a/radio/src/io/bootloader_flash.cpp
+++ b/radio/src/io/bootloader_flash.cpp
@@ -61,7 +61,8 @@ void bootloaderFlash(const char * filename)
       flashWrite(CONVERT_UINT_PTR(FIRMWARE_ADDRESS+i+j), (uint32_t *)(buffer+j));
     }
     drawProgressBar(STR_WRITING, i, BOOTLOADER_SIZE);
-    SIMU_SLEEP(30/*ms*/);
+    if (!SIMU_SLEEP(30/*ms*/))
+      break;
   }
 
   if (unlocked) {

--- a/radio/src/io/frsky_sport.cpp
+++ b/radio/src/io/frsky_sport.cpp
@@ -123,7 +123,7 @@ void sportProcessUpdatePacket(uint8_t * packet)
 bool sportWaitState(SportUpdateState state, int timeout)
 {
 #if defined(SIMU)
-  SIMU_SLEEP_NORET(1);
+  SIMU_SLEEP(1);
   return true;
 #else
   watchdogSuspend(timeout / 10);

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -198,12 +198,7 @@ bool clearKeyEvents()
 #endif
 
   while (keyDown()) {
-
-#if defined(SIMU)
-    SIMU_SLEEP_NORET(1/*ms*/);
-#else
     wdt_reset();
-#endif
 
 #if !defined(BOOT)
     if ((get_tmr10ms() - start) >= 300) {  // wait no more than 3 seconds
@@ -222,13 +217,7 @@ void clearKeyEvents()
 {
   // loop until all keys are up
   while (keyDown()) {
-
-#if defined(SIMU)
-    SIMU_SLEEP(1/*ms*/);
-#else
     wdt_reset();
-#endif
-
 #if defined(PCBSTD) && defined(ROTARY_ENCODER_NAVIGATION) && !defined(TELEMETREZ)
     rotencPoll();
 #endif

--- a/radio/src/storage/eeprom_raw.cpp
+++ b/radio/src/storage/eeprom_raw.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -63,16 +63,12 @@ uint8_t eepromWriteBuffer[EEPROM_BUFFER_SIZE] __DMA;
 
 void eepromWaitReadStatus()
 {
-  while (eepromReadStatus() == 0) {
-    SIMU_SLEEP(5/*ms*/);
-  }
+  while (eepromReadStatus() == 0 && SIMU_SLEEP(5/*ms*/)) { }
 }
 
 void eepromWaitTransferComplete()
 {
-  while (!eepromIsTransferComplete()) {
-    SIMU_SLEEP(5/*ms*/);
-  }
+  while (!eepromIsTransferComplete() && SIMU_SLEEP(5/*ms*/)) { }
 }
 
 void eepromEraseBlock(uint32_t address, bool blocking=true)

--- a/radio/src/storage/eeprom_rlc.cpp
+++ b/radio/src/storage/eeprom_rlc.cpp
@@ -958,7 +958,8 @@ void eepromBackup()
     eepromReadBlock(buffer, i, 1024);
     f_write(&file, buffer, 1024, &count);
     drawProgressBar(STR_WRITING, i, EEPROM_SIZE);
-    SIMU_SLEEP(100/*ms*/);
+    if (!SIMU_SLEEP(100/*ms*/))
+      break;
   }
 
   f_close(&file);

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -842,7 +842,6 @@ void checkSwitches()
 
     wdt_reset();
 
-    SIMU_SLEEP(1);
 #if defined(CPUARM)
     CoTickDelay(10);
 #endif

--- a/radio/src/targets/9x/board.h
+++ b/radio/src/targets/9x/board.h
@@ -131,8 +131,13 @@ void boardInit(void);
 #endif
 
 // Power driver (none)
+#if !defined(SIMU)
 #define pwrCheck()                 (e_power_on)
 #define pwrOff()
+#else
+uint8_t pwrCheck();
+void pwrOff();
+#endif
 #define UNEXPECTED_SHUTDOWN()      (mcusr & (1 << WDRF))
 
 // Trainer driver

--- a/radio/src/targets/gruvin9x/board.cpp
+++ b/radio/src/targets/gruvin9x/board.cpp
@@ -147,9 +147,10 @@ ISR(USART1_RX_vect)
 }
 #endif
 
+#if !defined(SIMU)
 uint8_t pwrCheck()
 {
-#if !defined(SIMU) && !defined(REV0)
+#if !defined(REV0)
   if ((PING & 0b00000010) && (~PINL & 0b01000000))
     return e_power_off;
 #endif
@@ -162,6 +163,7 @@ void pwrOff()
   PORTL = 0x7f;
 #endif
 }
+#endif // !defined(SIMU)
 
 uint8_t keyDown()
 {

--- a/radio/src/targets/mega2560/board.cpp
+++ b/radio/src/targets/mega2560/board.cpp
@@ -88,20 +88,19 @@ void boardInit()
 #endif // !SIMU               
 }              
 
-
+#if !defined(SIMU)
 uint8_t pwrCheck()
 {
-#if !defined(SIMU)
   if ((~PINH & 0b00100000) && (~PINH & 0b01000000))
-  return e_power_off;
-#endif          
-  return e_power_on;  
-}      
+    return e_power_off;
+  return e_power_on;
+}
 
 void pwrOff()
 {
   PORTH &= ~0x10;   // PortH-4 set to 0
 }
+#endif // !defined(SIMU)
 
 uint8_t keyDown()
 {

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -90,7 +90,7 @@ QString OpenTxSimulator::name()
 bool OpenTxSimulator::isRunning()
 {
   QMutexLocker lckr(&m_mtxSimuMain);
-  return (bool)main_thread_running;
+  return simuIsRunning();
 }
 
 void OpenTxSimulator::init()

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -348,21 +348,25 @@ extern uint32_t Master_frequency;
 
 extern uint8_t portb, portc, porth, dummyport;
 extern uint16_t dummyport16;
-extern uint8_t main_thread_running;
+
+extern uint8_t simu_start_mode;
 extern char * main_thread_error;
+
+#define OPENTX_START_DEFAULT_ARGS  simu_start_mode
 
 #define getADC()
 #define GET_ADC_IF_MIXER_NOT_RUNNING()
 #define getADC_bandgap()
 
-#define SIMU_SLEEP(x) do { if (!main_thread_running) return; sleep(x/*ms*/); } while (0)
-#define SIMU_SLEEP_NORET(x) do { sleep(x/*ms*/); } while (0)
+#define SIMU_SLEEP(x)       simuSleep(x)
 
 uint64_t simuTimerMicros(void);
 
 void simuInit();
 void StartSimu(bool tests=true, const char * sdPath = 0, const char * settingsPath = 0);
 void StopSimu();
+bool simuIsRunning();
+bool simuSleep(uint32_t ms);
 
 void simuSetKey(uint8_t key, bool state);
 void simuSetTrim(uint8_t trim, bool state);

--- a/radio/src/tasks_arm.cpp
+++ b/radio/src/tasks_arm.cpp
@@ -116,20 +116,20 @@ void mixerTask(void * pdata)
 
   while(1) {
 
-#if defined(SIMU)
-    if (main_thread_running == 0)
-      return;
-#endif
-
 #if defined(SBUS)
     processSbusInput();
 #endif
 
     CoTickDelay(1);
 
+#if defined(SIMU)
+    if (pwrCheck() == e_power_off)
+      return;
+#else
     if (isForcePowerOffRequested()) {
       pwrOff();
     }
+#endif
 
     uint32_t now = CoGetOSTime();
     bool run = false;
@@ -242,11 +242,6 @@ void menusTask(void * pdata)
     }
 
     resetForcePowerOffRequest();
-
-#if defined(SIMU)
-    if (main_thread_running == 0)
-      break;
-#endif
   }
 
 #if defined(PCBX9E)


### PR DESCRIPTION
 * Use `pwrCheck()` as primary control point for shutdown, centralizes thread control in `simpgmspace` module;
 * Remove `main_thread_running` in favor of separate variables for startup mode and shutdown flag;
 * Don't start a thread for ARM startup, just run `simuMain()` directly (the thread just exits anyway);
 * Refactor `SIMU_SLEEP()` macro, and remove all unnecessary uses of it, also remove `SIMU_SLEEP_NORET`;
 * Add `startType` param to `opentxStart()` to control splash and startup checks;
 * Fixes backlight never turning off in simulator with "SWITCH" power button type (`pwrPressed()` was always `true`);
 * Fixes simu shutdown when model checklist is displayed at startup;
 * Adds stubs to possibly simulate a "soft" power button in the future.

There's a bunch of annoying AVR exceptions... I will make a cleaner one for 2.3.