### PR TITLE
Companion AVR removal - stage 1.

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -467,12 +467,12 @@ void AppPreferencesDialog::onFirmwareOptionChanged(bool state)
     return;
 
   // This de-selects any mutually exlusive options (that is, members of the same QList<Option> list).
-  const QList<QList<Option> > & fwOpts = getBaseFirmware()->opts;
-  for (const QList<Option> & opts : fwOpts) {
-    for (const Option & opt : opts) {
+  const Firmware::OptionsList & fwOpts = getBaseFirmware()->optionGroups();
+  for (const Firmware::OptionsGroup & optGrp : fwOpts) {
+    for (const Firmware::Option & opt : optGrp) {
       if (cb->text() == opt.name) {
         QCheckBox *ocb = nullptr;
-        foreach(const Option & other, opts)
+        foreach(const Firmware::Option & other, optGrp)
           if (other.name != opt.name && (ocb = optionsCheckBoxes.value(other.name, nullptr)))
             ocb->setChecked(false);
         return;
@@ -498,7 +498,7 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
   updateLock = true;
 
   ui->langCombo->clear();
-  for (const char *lang : baseFw->languages) {
+  for (const char *lang : baseFw->languageList()) {
     ui->langCombo->addItem(lang);
     if (currLang == lang) {
       ui->langCombo->setCurrentIndex(ui->langCombo->count() - 1);
@@ -521,8 +521,8 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
 
   int index = 0;
   QWidget * prevFocus = ui->langCombo;
-  for (const QList<Option> &opts : qAsConst(baseFw->opts)) {
-    for (const Option &opt : opts) {
+  for (const Firmware::OptionsGroup &optGrp : baseFw->optionGroups()) {
+    for (const Firmware::Option &opt : optGrp) {
       QCheckBox * cb = new QCheckBox(ui->profileTab);
       cb->setText(opt.name);
       cb->setToolTip(opt.tooltip);
@@ -530,7 +530,7 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
       ui->optionsLayout->addWidget(cb, index / 4, index % 4);
       QWidget::setTabOrder(prevFocus, cb);
       // connect to duplicates check handler if this option is part of a group
-      if (opts.size() > 1)
+      if (optGrp.size() > 1)
         connect(cb, &QCheckBox::toggled, this, &AppPreferencesDialog::onFirmwareOptionChanged);
       optionsCheckBoxes.insert(opt.name, cb);
       prevFocus = cb;

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -31,15 +31,15 @@
 
 AppPreferencesDialog::AppPreferencesDialog(QWidget * parent) :
   QDialog(parent),
+  ui(new Ui::AppPreferencesDialog),
   updateLock(false),
-  mainWinHasDirtyChild(false),
-  ui(new Ui::AppPreferencesDialog)
+  mainWinHasDirtyChild(false)
 {
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("apppreferences.png"));
 
   initSettings();
-  connect(ui->downloadVerCB, SIGNAL(currentIndexChanged(int)), this, SLOT(baseFirmwareChanged()));
+  connect(ui->downloadVerCB, SIGNAL(currentIndexChanged(int)), this, SLOT(onBaseFirmwareChanged()));
   connect(ui->opt_appDebugLog, &QCheckBox::toggled, this, &AppPreferencesDialog::toggleAppLogSettings);
   connect(ui->opt_fwTraceLog, &QCheckBox::toggled, this, &AppPreferencesDialog::toggleAppLogSettings);
 
@@ -111,7 +111,7 @@ void AppPreferencesDialog::accept()
     profile.name(ui->profileNameLE->text());
 
   bool fwchange = false;
-  Firmware * newFw = getFirmwareVariant();
+  Firmware * newFw = getFirmwareVariant();  // always !null
   // If a new fw type has been choosen, several things need to reset
   if (Firmware::getCurrentVariant()->getId() != newFw->getId()) {
     // check if we're going to be converting to a new radio type and there are unsaved files in the main window
@@ -288,7 +288,7 @@ void AppPreferencesDialog::initSettings()
     }
   }
 
-  baseFirmwareChanged();
+  onBaseFirmwareChanged();
 }
 
 void AppPreferencesDialog::on_libraryPathButton_clicked()
@@ -435,81 +435,47 @@ void AppPreferencesDialog::on_clearImageButton_clicked()
   ui->SplashFileName->clear();
 }
 
-
-void AppPreferencesDialog::showVoice(bool show)
+void AppPreferencesDialog::onBaseFirmwareChanged()
 {
-  ui->voiceLabel->setVisible(show);
-  ui->voiceCombo->setVisible(show);
+  populateFirmwareOptions(getBaseFirmware());
 }
 
-void AppPreferencesDialog::baseFirmwareChanged()
+Firmware *AppPreferencesDialog::getBaseFirmware() const
 {
-  QString selected_firmware = ui->downloadVerCB->currentData().toString();
-
-  foreach(Firmware * firmware, Firmware::getRegisteredFirmwares()) {
-    if (firmware->getId() == selected_firmware) {
-      populateFirmwareOptions(firmware);
-      break;
-    }
-  }
+  return Firmware::getFirmwareForId(ui->downloadVerCB->currentData().toString());
 }
 
-Firmware * AppPreferencesDialog::getFirmwareVariant()
+Firmware * AppPreferencesDialog::getFirmwareVariant() const
 {
-  QString selected_firmware = ui->downloadVerCB->currentData().toString();
+  QString id = ui->downloadVerCB->currentData().toString();
 
-  foreach(Firmware * firmware, Firmware::getRegisteredFirmwares()) {
-    QString id = firmware->getId();
-    if (id == selected_firmware) {
-      foreach(QCheckBox *cb, optionsCheckBoxes) {
-        if (cb->isChecked()) {
-          id += "-" + cb->text();
-        }
-      }
-
-      if (voice && voice->isChecked()) {
-        id += "-tts" + ui->voiceCombo->currentText();
-      }
-
-      if (ui->langCombo->count()) {
-        id += "-" + ui->langCombo->currentText();
-      }
-
-      return Firmware::getFirmwareForId(id);
-    }
+  foreach(QCheckBox *cb, optionsCheckBoxes.values()) {
+    if (cb->isChecked())
+      id += "-" + cb->text();
   }
 
-  // Should never occur...
-  return Firmware::getDefaultVariant();
+  if (ui->langCombo->count())
+    id += "-" + ui->langCombo->currentText();
+
+  return Firmware::getFirmwareForId(id);
 }
 
-void AppPreferencesDialog::firmwareOptionChanged(bool state)
+void AppPreferencesDialog::onFirmwareOptionChanged(bool state)
 {
   QCheckBox *cb = qobject_cast<QCheckBox*>(sender());
-  if (cb == voice) {
-    showVoice(voice->isChecked());
-  }
-  Firmware * firmware=NULL;
-  if (cb && state) {
-    QVariant selected_firmware = ui->downloadVerCB->currentData();
-    foreach(firmware, Firmware::getRegisteredFirmwares()) {
-      if (firmware->getId() == selected_firmware) {
-        foreach(QList<Option> opts, firmware->opts) {
-          foreach(Option opt, opts) {
-            if (cb->text() == opt.name) {
-              foreach(Option other, opts) {
-                if (other.name != opt.name) {
-                  foreach(QCheckBox *ocb, optionsCheckBoxes) {
-                    if (ocb->text() == other.name) {
-                      ocb->setChecked(false);
-                    }
-                  }
-                }
-              }
-              return;
-            }
-          }
-        }
+  if (!(cb && state))
+    return;
+
+  // This de-selects any mutually exlusive options (that is, members of the same QList<Option> list).
+  const QList<QList<Option> > & fwOpts = getBaseFirmware()->opts;
+  for (const QList<Option> & opts : fwOpts) {
+    for (const Option & opt : opts) {
+      if (cb->text() == opt.name) {
+        QCheckBox *ocb = nullptr;
+        foreach(const Option & other, opts)
+          if (other.name != opt.name && (ocb = optionsCheckBoxes.value(other.name, nullptr)))
+            ocb->setChecked(false);
+        return;
       }
     }
   }
@@ -525,68 +491,56 @@ void AppPreferencesDialog::toggleAppLogSettings()
 
 void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
 {
-  const Firmware * parent = firmware->getFirmwareBase();
+  const Firmware * baseFw = firmware->getFirmwareBase();
+  QStringList currVariant = Firmware::getCurrentVariant()->getId().split('-');
+  const QString currLang = ui->langCombo->count() ? ui->langCombo->currentText() : currVariant.last();
 
   updateLock = true;
 
-  QString id = Firmware::getCurrentVariant()->getId();
   ui->langCombo->clear();
-  foreach(const char *lang, parent->languages) {
+  for (const char *lang : baseFw->languages) {
     ui->langCombo->addItem(lang);
-    if (id.endsWith(lang)) {
+    if (currLang == lang) {
       ui->langCombo->setCurrentIndex(ui->langCombo->count() - 1);
     }
   }
 
-  voice = NULL; // we will search for a voice checkbox
+  if (optionsCheckBoxes.size()) {
+    currVariant.clear();
+    QMutableMapIterator<QString, QCheckBox *> it(optionsCheckBoxes);
+    while (it.hasNext()) {
+      it.next();
+      QCheckBox * cb = it.value();
+      if (cb->isChecked())
+        currVariant.append(it.key());    // keep previous selections
+      ui->optionsLayout->removeWidget(cb);
+      cb->deleteLater();
+      it.remove();
+    }
+  }
 
   int index = 0;
-  QWidget * prevFocus = ui->voiceCombo;
-  foreach(QList<Option> opts, parent->opts) {
-    foreach(Option opt, opts) {
-      if (index >= optionsCheckBoxes.size()) {
-        QCheckBox * checkbox = new QCheckBox(ui->profileTab);
-        ui->optionsLayout->addWidget(checkbox, optionsCheckBoxes.count()/4, optionsCheckBoxes.count()%4, 1, 1);
-        optionsCheckBoxes.push_back(checkbox);
-        connect(checkbox, SIGNAL(toggled(bool)), this, SLOT(firmwareOptionChanged(bool)));
-        if (prevFocus) {
-          QWidget::setTabOrder(prevFocus, checkbox);
-        }
-      }
-
-      QCheckBox *cb = optionsCheckBoxes.at(index++);
-      if (cb) {
-        cb->show();
-        cb->setText(opt.name);
-        cb->setToolTip(opt.tooltip);
-        cb->setCheckState(id.contains(opt.name) ? Qt::Checked : Qt::Unchecked);
-        if (opt.name == QString("voice")) {
-          voice = cb;
-        }
-        prevFocus = cb;
-      }
+  QWidget * prevFocus = ui->langCombo;
+  for (const QList<Option> &opts : qAsConst(baseFw->opts)) {
+    for (const Option &opt : opts) {
+      QCheckBox * cb = new QCheckBox(ui->profileTab);
+      cb->setText(opt.name);
+      cb->setToolTip(opt.tooltip);
+      cb->setChecked(currVariant.contains(opt.name));
+      ui->optionsLayout->addWidget(cb, index / 4, index % 4);
+      QWidget::setTabOrder(prevFocus, cb);
+      // connect to duplicates check handler if this option is part of a group
+      if (opts.size() > 1)
+        connect(cb, &QCheckBox::toggled, this, &AppPreferencesDialog::onFirmwareOptionChanged);
+      optionsCheckBoxes.insert(opt.name, cb);
+      prevFocus = cb;
+      ++index;
     }
   }
-
-  for (; index<optionsCheckBoxes.size(); index++) {
-    QCheckBox *cb = optionsCheckBoxes.at(index);
-    cb->hide();
-    cb->setCheckState(Qt::Unchecked);
-  }
-
-  ui->voiceCombo->clear();
-  foreach(const char *lang, parent->ttslanguages) {
-    ui->voiceCombo->addItem(lang);
-    if (id.contains(QString("-tts%1").arg(lang))) {
-      ui->voiceCombo->setCurrentIndex(ui->voiceCombo->count() - 1);
-    }
-  }
-
-  showVoice(voice && voice->isChecked());
 
   // TODO: Remove once splash replacement supported on Horus
   // NOTE: 480x272 image causes issues on screens <800px high, needs a solution like scrolling once reinstated
-  if (IS_HORUS(parent->getBoard())) {
+  if (IS_HORUS(baseFw->getBoard())) {
     ui->widget_splashImage->hide();
     ui->SplashFileName->setText("");
   }
@@ -597,7 +551,7 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
   }
 
   updateLock = false;
-  QTimer::singleShot(50, this, SLOT(shrink()));
+  QTimer::singleShot(50, this, &AppPreferencesDialog::shrink);
 }
 
 void AppPreferencesDialog::shrink()

--- a/companion/src/apppreferencesdialog.h
+++ b/companion/src/apppreferencesdialog.h
@@ -49,26 +49,10 @@ class AppPreferencesDialog : public QDialog
     void firmwareProfileChanged();
     void firmwareProfileAboutToChange(bool saveFiles = true);
 
-  private:
-    QList<QCheckBox *> optionsCheckBoxes;
-    bool updateLock;
-    bool mainWinHasDirtyChild;
-    void showVoice(bool);
-    void showVoice();
-    void hideVoice();
-    void populateLocale();
-    void populateFirmwareOptions(const Firmware *);
-    Firmware * getFirmwareVariant();
-    QCheckBox * voice;
-
-    Ui::AppPreferencesDialog *ui;
-    void initSettings();
-    bool displayImage(const QString & fileName);
-
   protected slots:
     void shrink();
-    void baseFirmwareChanged();
-    void firmwareOptionChanged(bool state);
+    void onBaseFirmwareChanged();
+    void onFirmwareOptionChanged(bool state);
     void toggleAppLogSettings();
 
     void on_libraryPathButton_clicked();
@@ -87,6 +71,18 @@ class AppPreferencesDialog : public QDialog
     void on_joystickChkB_clicked();
     void on_joystickcalButton_clicked();
 #endif
+
+  private:
+    void initSettings();
+    void populateFirmwareOptions(const Firmware *);
+    Firmware * getBaseFirmware() const;
+    Firmware * getFirmwareVariant() const;
+    bool displayImage(const QString & fileName);
+
+    Ui::AppPreferencesDialog *ui;
+    QMap<QString, QCheckBox *> optionsCheckBoxes;
+    bool updateLock;
+    bool mainWinHasDirtyChild;
 };
 
 #endif // _APPPREFERENCESDIALOG_H_

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>863</width>
-    <height>673</height>
+    <width>741</width>
+    <height>668</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,16 +26,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
@@ -52,24 +42,37 @@
        <string>Radio Profile</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
-       <item row="8" column="2" colspan="2">
-        <widget class="QPushButton" name="sdPathButton">
-         <property name="text">
-          <string>Select Folder</string>
+       <item row="5" column="1">
+        <widget class="QWidget" name="optionsWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
+         <layout class="QGridLayout" name="optionsLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="horizontalSpacing">
+           <number>5</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>4</number>
+          </property>
+         </layout>
         </widget>
        </item>
-       <item row="9" column="2" colspan="2">
-        <widget class="QPushButton" name="ProfilebackupPathButton">
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="4">
+       <item row="7" column="0" colspan="4">
         <widget class="QWidget" name="widget_splashImage" native="true">
          <layout class="QGridLayout" name="gridLayout_5">
           <property name="leftMargin">
@@ -183,27 +186,18 @@
          </layout>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="16" column="1">
+        <widget class="QCheckBox" name="burnFirmware">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
          <property name="text">
-          <string>Profile Name</string>
+          <string>Offer to write FW to Tx after download</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="profileNameLE"/>
        </item>
        <item row="1" column="0" colspan="4">
         <widget class="Line" name="line_8">
@@ -218,319 +212,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <family>Sans Serif</family>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Radio Type</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="downloadVerCB">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="langLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Menu Language</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,1">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
-         </property>
-         <item>
-          <widget class="QComboBox" name="langCombo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="voiceLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <family>Sans Serif</family>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Voice Language</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="voiceCombo">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Set voice language.
-May be different from firmware language</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Build Options</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="4">
-        <widget class="Line" name="splashSeparator">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="sdPathLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>SD Structure path</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QLineEdit" name="sdPath">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="profilebackupPathLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Backup folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLineEdit" name="profilebackupPath">
-         <property name="toolTip">
-          <string>If set it will override the application general setting</string>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QCheckBox" name="pbackupEnable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>if set, will override general backup enable</string>
-         </property>
-         <property name="text">
-          <string>Enable automatic backup before writing firmware</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>General Settings</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QLabel" name="lblGeneralSettings">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string notr="true">General Settings Label</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default Stick Mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1">
-        <widget class="QComboBox" name="stickmodeCB">
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="whatsThis">
-          <string>Mode selection:
-
-Mode 1:
-  Left stick:  Elevator, Rudder
-  Right stick:  Throttle, Aileron
-
-Mode 2:
-  Left stick:  Throttle, Rudder
-  Right stick:  Elevator, Aileron
-
-Mode 3:
-  Left stick:  Elevator, Aileron
-  Right stick:  Throttle, Rudder
-
-Mode 4:
-  Left stick:  Throttle, Aileron
-  Right stick:  Elevator, Rudder
-
-</string>
-         </property>
-         <property name="currentIndex">
-          <number>1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Mode 1 (RUD ELE THR AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 2 (RUD THR ELE AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 3 (AIL ELE THR RUD)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 4 (AIL THR ELE RUD)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="label_13">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default Channel Order</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QComboBox" name="channelorderCB">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -666,7 +348,30 @@ Mode 4:
          </item>
         </widget>
        </item>
-       <item row="14" column="1">
+       <item row="2" column="1">
+        <widget class="QComboBox" name="downloadVerCB">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Build Options</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1">
         <widget class="QCheckBox" name="renameFirmware">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -679,8 +384,56 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
-        <widget class="QCheckBox" name="burnFirmware">
+       <item row="9" column="2" colspan="2">
+        <widget class="QPushButton" name="sdPathButton">
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Profile Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="profileNameLE"/>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="profilebackupPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Backup folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QLabel" name="lblGeneralSettings">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
@@ -688,24 +441,11 @@ Mode 4:
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Offer to write FW to Tx after download</string>
+          <string notr="true">General Settings Label</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="7" column="0" colspan="4">
+       <item row="8" column="0" colspan="4">
         <widget class="QLabel" name="label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -724,34 +464,240 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QWidget" name="optionsWidget" native="true">
+       <item row="13" column="0">
+        <widget class="QLabel" name="label_14">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <layout class="QGridLayout" name="optionsLayout">
-          <property name="leftMargin">
-           <number>0</number>
+         <property name="text">
+          <string>Default Stick Mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="1">
+        <widget class="QComboBox" name="stickmodeCB">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="whatsThis">
+          <string>Mode selection:
+
+Mode 1:
+  Left stick:  Elevator, Rudder
+  Right stick:  Throttle, Aileron
+
+Mode 2:
+  Left stick:  Throttle, Rudder
+  Right stick:  Elevator, Aileron
+
+Mode 3:
+  Left stick:  Elevator, Aileron
+  Right stick:  Throttle, Rudder
+
+Mode 4:
+  Left stick:  Throttle, Aileron
+  Right stick:  Elevator, Rudder
+
+</string>
+         </property>
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Mode 1 (RUD ELE THR AIL)</string>
           </property>
-          <property name="topMargin">
-           <number>0</number>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 2 (RUD THR ELE AIL)</string>
           </property>
-          <property name="rightMargin">
-           <number>0</number>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 3 (AIL ELE THR RUD)</string>
           </property>
-          <property name="bottomMargin">
-           <number>0</number>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 4 (AIL THR ELE RUD)</string>
           </property>
-          <property name="horizontalSpacing">
-           <number>5</number>
-          </property>
-          <property name="verticalSpacing">
-           <number>4</number>
-          </property>
-         </layout>
+         </item>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Default Channel Order</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QCheckBox" name="pbackupEnable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>if set, will override general backup enable</string>
+         </property>
+         <property name="text">
+          <string>Enable automatic backup before writing firmware</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="4">
+        <widget class="Line" name="splashSeparator">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLineEdit" name="profilebackupPath">
+         <property name="toolTip">
+          <string>If set it will override the application general setting</string>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="sdPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>SD Structure path</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="2" colspan="2">
+        <widget class="QPushButton" name="ProfilebackupPathButton">
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>General Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <family>Sans Serif</family>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Radio Type</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="langLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Menu Language</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLineEdit" name="sdPath">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="langCombo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
         </widget>
        </item>
       </layout>
@@ -1464,14 +1410,22 @@ Mode 4:
      </widget>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>profileNameLE</tabstop>
   <tabstop>downloadVerCB</tabstop>
-  <tabstop>langCombo</tabstop>
-  <tabstop>voiceCombo</tabstop>
   <tabstop>sdPath</tabstop>
   <tabstop>sdPathButton</tabstop>
   <tabstop>profilebackupPath</tabstop>

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -140,8 +140,11 @@ const int Boards::getFlashSize(Type board)
   }
 }
 
-const SwitchInfo Boards::getSwitchInfo(Board::Type board, unsigned index)
+const SwitchInfo Boards::getSwitchInfo(Board::Type board, int index)
 {
+  if (index < 0)
+    return {SWITCH_NOT_AVAILABLE, CPN_STR_UNKNOWN_ITEM};
+
   if (IS_TARANIS_XLITE(board)) {
     const Board::SwitchInfo switches[] = {
       {SWITCH_3POS,   "SA"},
@@ -202,7 +205,7 @@ const SwitchInfo Boards::getSwitchInfo(Board::Type board, unsigned index)
       return switches[index];
   }
 
-  return {SWITCH_NOT_AVAILABLE, "???"};
+  return {SWITCH_NOT_AVAILABLE, CPN_STR_UNKNOWN_ITEM};
 }
 
 const int Boards::getCapability(Board::Type board, Board::Capability capability)
@@ -301,9 +304,12 @@ const QString Boards::getAxisName(int index)
     return tr("Unknown");
 }
 
-const QString Boards::getAnalogInputName(Board::Type board, unsigned index)
+const QString Boards::getAnalogInputName(Board::Type board, int index)
 {
-  if ((int)index < getBoardCapability(board, Board::Sticks)) {
+  if (index < 0)
+    return CPN_STR_UNKNOWN_ITEM;
+
+  if (index < getBoardCapability(board, Board::Sticks)) {
     const QString sticks[] = {
       tr("Rud"),
       tr("Ele"),
@@ -376,7 +382,7 @@ const QString Boards::getAnalogInputName(Board::Type board, unsigned index)
       return pots[index];
   }
 
-  return "???";
+  return CPN_STR_UNKNOWN_ITEM;
 }
 
 const bool Boards::isBoardCompatible(Type board1, Type board2)

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -179,8 +179,6 @@ class Boards
 
 // temporary aliases for transition period, use Boards class instead.
 #define getBoardCapability(b__, c__)   Boards::getCapability(b__, c__)
-#define getEEpromSize(b__)             Boards::getEEpromSize(b__)
-#define getSwitchInfo(b__, i__)        Boards::getSwitchInfo(b__, i__)
 
 #define IS_9X(board)                   (board==Board::BOARD_STOCK || board==Board::BOARD_M128)
 #define IS_STOCK(board)                (board==Board::BOARD_STOCK)

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -157,18 +157,18 @@ class Boards
     const uint32_t getFourCC() const { return getFourCC(m_boardType); }
     const int getEEpromSize() const { return getEEpromSize(m_boardType); }
     const int getFlashSize() const { return getFlashSize(m_boardType); }
-    const Board::SwitchInfo getSwitchInfo(unsigned index) const { return getSwitchInfo(m_boardType, index); }
+    const Board::SwitchInfo getSwitchInfo(int index) const { return getSwitchInfo(m_boardType, index); }
     const int getCapability(Board::Capability capability) const { return getCapability(m_boardType, capability); }
-    const QString getAnalogInputName(unsigned index) const { return getAnalogInputName(m_boardType, index); }
+    const QString getAnalogInputName(int index) const { return getAnalogInputName(m_boardType, index); }
     const bool isBoardCompatible(Board::Type board2) const { return isBoardCompatible(m_boardType, board2); }
 
     static uint32_t getFourCC(Board::Type board);
     static const int getEEpromSize(Board::Type board);
     static const int getFlashSize(Board::Type board);
-    static const Board::SwitchInfo getSwitchInfo(Board::Type board, unsigned index);
+    static const Board::SwitchInfo getSwitchInfo(Board::Type board, int index);
     static const int getCapability(Board::Type board, Board::Capability capability);
     static const QString getAxisName(int index);
-    static const QString getAnalogInputName(Board::Type board, unsigned index);
+    static const QString getAnalogInputName(Board::Type board, int index);
     static const bool isBoardCompatible(Board::Type board1, Board::Type board2);
     static const QString getBoardName(Board::Type board);
 

--- a/companion/src/firmwares/eeprominterface.cpp
+++ b/companion/src/firmwares/eeprominterface.cpp
@@ -142,25 +142,13 @@ Firmware * Firmware::getFirmwareForId(const QString & id)
   return defaultVariant;
 }
 
-void Firmware::addOption(const char *option, QString tooltip, uint32_t variant)
-{
-  Option options[] = { { option, tooltip, variant }, { NULL } };
-  addOptions(options);
-}
-
-void Firmware::addOption(const Option & option)
-{
-  Option options[] = { option, { NULL } };
-  addOptions(options);
-}
-
 unsigned int Firmware::getVariantNumber()
 {
   unsigned int result = 0;
   const Firmware * base = getFirmwareBase();
   QStringList options = id.mid(base->getId().length()+1).split("-", QString::SkipEmptyParts);
   foreach(QString option, options) {
-    foreach(QList<Option> group, base->opts) {
+    foreach(OptionsGroup group, base->opts) {
       foreach(Option opt, group) {
         if (opt.name == option) {
           result += opt.variant;
@@ -171,21 +159,27 @@ unsigned int Firmware::getVariantNumber()
   return result;
 }
 
-void Firmware::addLanguage(const char *lang)
+void Firmware::addLanguage(const char * lang)
 {
   languages.push_back(lang);
 }
 
-void Firmware::addTTSLanguage(const char *lang)
+//void Firmware::addTTSLanguage(const char * lang)
+//{
+//  ttslanguages.push_back(lang);
+//}
+
+void Firmware::addOption(const char * option, const QString & tooltip, unsigned variant)
 {
-  ttslanguages.push_back(lang);
+  addOption(Option(option, tooltip, variant));
 }
 
-void Firmware::addOptions(Option options[])
+void Firmware::addOption(const Option & option)
 {
-  QList<Option> opts;
-  for (int i=0; options[i].name; i++) {
-    opts.push_back(options[i]);
-  }
-  this->opts.push_back(opts);
+  addOptionsGroup({option});
+}
+
+void Firmware::addOptionsGroup(const OptionsGroup & options)
+{
+  this->opts.append(options);
 }

--- a/companion/src/firmwares/eeprominterface.cpp
+++ b/companion/src/firmwares/eeprominterface.cpp
@@ -148,6 +148,12 @@ void Firmware::addOption(const char *option, QString tooltip, uint32_t variant)
   addOptions(options);
 }
 
+void Firmware::addOption(const Option & option)
+{
+  Option options[] = { option, { NULL } };
+  addOptions(options);
+}
+
 unsigned int Firmware::getVariantNumber()
 {
   unsigned int result = 0;

--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -418,8 +418,6 @@ inline int calcRESXto100(int x)
   return divRoundClosest(x*100, 1024);
 }
 
-#define CHECK_IN_ARRAY(T, index) ((unsigned int)index < DIM(T) ? T[(unsigned int)index] : CPN_STR_UNKNOWN_ITEM)
-
 extern QList<EEPROMInterface *> eepromInterfaces;
 
 

--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -244,40 +244,37 @@ enum EepromLoadErrors {
   NUM_ERRORS
 };
 
-struct Option {
-  const char * name;
-  QString tooltip;
-  uint32_t variant;
-};
-
 class Firmware
 {
   Q_DECLARE_TR_FUNCTIONS(Firmware)
 
   public:
-    Firmware(const QString & id, const QString & name, Board::Type board):
-      id(id),
-      name(name),
-      board(board),
-      variantBase(0),
-      base(NULL),
-      eepromInterface(NULL)
-    {
-    }
+    struct Option {
+      const char * name = nullptr;
+      QString tooltip;
+      unsigned variant = 0;
 
-    Firmware(Firmware * base, const QString & id, const QString & name, Board::Type board):
+      explicit Option(const char * name, const QString & description, unsigned variant = 0) :
+        name(name), tooltip(description), variant(variant) { }
+    };
+    typedef QList<Option> OptionsGroup;
+    typedef QList<OptionsGroup> OptionsList;
+
+
+    explicit Firmware(const QString & id, const QString & name, Board::Type board) :
+      Firmware(nullptr, id, name, board)
+    { }
+
+    explicit Firmware(Firmware * base, const QString & id, const QString & name, Board::Type board) :
       id(id),
       name(name),
       board(board),
       variantBase(0),
       base(base),
-      eepromInterface(NULL)
-    {
-    }
+      eepromInterface(nullptr)
+    { }
 
-    virtual ~Firmware()
-    {
-    }
+    virtual ~Firmware() { }
 
     inline const Firmware * getFirmwareBase() const
     {
@@ -288,15 +285,15 @@ class Firmware
 
     unsigned int getVariantNumber();
 
-    virtual void addLanguage(const char *lang);
+    virtual void addLanguage(const char * lang);
 
-    virtual void addTTSLanguage(const char *lang);
+    //virtual void addTTSLanguage(const char * lang);
 
-    virtual void addOption(const char *option, QString tooltip="", uint32_t variant=0);
+    virtual void addOption(const char * option, const QString & tooltip = QString(), unsigned variant = 0);
 
-    virtual void addOption(const Option &option);
+    virtual void addOption(const Option & option);
 
-    virtual void addOptions(Option options[]);
+    virtual void addOptionsGroup(const OptionsGroup & options);
 
     virtual QString getStampUrl() = 0;
 
@@ -327,6 +324,16 @@ class Firmware
     QString getId() const
     {
       return id;
+    }
+
+    QList<const char *> languageList() const
+    {
+      return languages;
+    }
+
+    OptionsList optionGroups() const
+    {
+      return opts;
     }
 
     virtual int getCapability(Capability) = 0;
@@ -370,12 +377,6 @@ class Firmware
       currentVariant = value;
     }
 
-  public:
-    QList<const char *> languages;
-    QList<const char *> ttslanguages;
-    QList< QList<Option> > opts;
-
-
   protected:
     QString id;
     QString name;
@@ -383,14 +384,13 @@ class Firmware
     unsigned int variantBase;
     Firmware * base;
     EEPROMInterface * eepromInterface;
+    QList<const char *> languages;
+    //QList<const char *> ttslanguages;
+    OptionsList opts;
 
     static QVector<Firmware *> registeredFirmwares;
     static Firmware * defaultVariant;
     static Firmware * currentVariant;
-
-  private:
-    Firmware();
-
 };
 
 inline Firmware * getCurrentFirmware()
@@ -421,8 +421,6 @@ inline int calcRESXto100(int x)
 #define CHECK_IN_ARRAY(T, index) ((unsigned int)index < DIM(T) ? T[(unsigned int)index] : CPN_STR_UNKNOWN_ITEM)
 
 extern QList<EEPROMInterface *> eepromInterfaces;
-
-bool loadFile(RadioData & radioData, const QString & filename);
 
 
 #endif // _EEPROMINTERFACE_H_

--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -294,6 +294,8 @@ class Firmware
 
     virtual void addOption(const char *option, QString tooltip="", uint32_t variant=0);
 
+    virtual void addOption(const Option &option);
+
     virtual void addOptions(Option options[]);
 
     virtual QString getStampUrl() = 0;

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -28,29 +28,30 @@
 
 QString removeAccents(const QString & str)
 {
-  QString result = str;
-
   // UTF-8 ASCII Table
-  const QString tA[] = { "á", "â", "ã", "à", "ä" };
-  const QString tE[] = { "é", "è", "ê", "ě" };
-  const QString tI[] = { "í" };
-  const QString tO[] = { "ó", "ô", "õ", "ö" };
-  const QString tU[] = { "ú", "ü" };
-  const QString tC[] = { "ç" };
-  const QString tY[] = { "ý" };
-  const QString tS[] = { "š" };
-  const QString tR[] = { "ř" };
+  static const QHash<QString, QVariant> map = {
+    {"a", QRegularExpression("[áâãàä]")},
+    {"A", QRegularExpression("[ÁÂÃÀÄ]")},
+    {"e", QRegularExpression("[éèêě]")},
+    {"E", QRegularExpression("[ÉÈÊĚ]")},
+    {"o", QRegularExpression("[óôõö]")},
+    {"O", QRegularExpression("[ÓÔÕÖ]")},
+    {"u", QRegularExpression("[úü]")},
+    {"U", QRegularExpression("[ÚÜ]")},
+    {"i", "í"}, {"I", "Í"},
+    {"c", "ç"}, {"C", "Ç"},
+    {"y", "ý"}, {"Y", "Ý"},
+    {"s", "š"}, {"S", "Š"},
+    {"r", "ř"}, {"R", "Ř"}
+  };
 
-  for (unsigned int i = 0; i < DIM(tA); i++) result.replace(tA[i], "a");
-  for (unsigned int i = 0; i < DIM(tE); i++) result.replace(tE[i], "e");
-  for (unsigned int i = 0; i < DIM(tI); i++) result.replace(tI[i], "i");
-  for (unsigned int i = 0; i < DIM(tO); i++) result.replace(tO[i], "o");
-  for (unsigned int i = 0; i < DIM(tU); i++) result.replace(tU[i], "u");
-  for (unsigned int i = 0; i < DIM(tC); i++) result.replace(tC[i], "c");
-  for (unsigned int i = 0; i < DIM(tY); i++) result.replace(tY[i], "y");
-  for (unsigned int i = 0; i < DIM(tS); i++) result.replace(tS[i], "s");
-  for (unsigned int i = 0; i < DIM(tR); i++) result.replace(tR[i], "r");
-
+  QString result(str);
+  for (QHash<QString, QVariant>::const_iterator it = map.cbegin(), en = map.cend(); it != en; ++it) {
+    if (it.value().canConvert<QRegularExpression>())
+      result.replace(it.value().toRegularExpression(), it.key());
+    else
+      result.replace(it.value().toString(), it.key());
+  }
   return result;
 }
 

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1075,92 +1075,78 @@ void addOpenTxCommonOptions(OpenTxFirmware * firmware)
   firmware->addOptions(fai_options);
 }
 
-void addFrskyRfOptions(OpenTxFirmware * firmware)
+void addOpenTxRfOptions(OpenTxFirmware * firmware, bool mm, bool eu, bool flex)
 {
-  Option rf_options[] = {{"eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015")},
-                         {"flexr9m", QCoreApplication::translate("Firmware", "Enable non certified firmwares")},
-                         {NULL}};
-  firmware->addOptions(rf_options);
+  Option opt_eu = {"eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015")};
+  Option opt_fl = {"flexr9m", QCoreApplication::translate("Firmware", "Enable non certified firmwares")};
+  Option opt_mm = {"multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module")};
+  if (mm)
+    firmware->addOption(opt_mm);
+  if (eu && flex) {
+    Option options[] = { opt_eu, opt_fl, { NULL } };
+    firmware->addOptions(options);
+  }
+  else if (eu) {
+    firmware->addOption(opt_eu);
+  }
+}
+
+void addOpenTxFontOptions(OpenTxFirmware * firmware)
+{
+  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
+}
+
+void addOpenTxArm9xOptions(OpenTxFirmware * firmware)
+{
+  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable HELI menu and cyclic mix support"));
+  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
+  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
+  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
+  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
+  //firmware->addOption("bluetooth", QCoreApplication::translate("Firmware", "Bluetooth interface"));
+  addOpenTxRfOptions(firmware, true, true, false);
+  addOpenTxFontOptions(firmware);
+  addOpenTxCommonOptions(firmware);
 }
 
 void addOpenTxFrskyOptions(OpenTxFirmware * firmware)
 {
   addOpenTxCommonOptions(firmware);
-  firmware->addOption("multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module"));
   firmware->addOption("noheli", QCoreApplication::translate("Firmware", "Disable HELI menu and cyclic mix support"));
   firmware->addOption("nogvars", QCoreApplication::translate("Firmware", "Disable Global variables"));
   firmware->addOption("lua", QCoreApplication::translate("Firmware", "Enable Lua custom scripts screen"));
   firmware->addOption("luac", QCoreApplication::translate("Firmware", "Enable Lua compiler"));
-  addFrskyRfOptions(firmware);
+  addOpenTxRfOptions(firmware, true, true, true);
 }
 
 void addOpenTxTaranisOptions(OpenTxFirmware * firmware)
 {
+  firmware->addOption("internalppm", QCoreApplication::translate("Firmware", "Support for PPM internal module hack"));
   addOpenTxFrskyOptions(firmware);
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-}
-
-void addOpenTxLcdOptions(OpenTxFirmware * firmware)
-{
-  Option lcd_options[] = {
-    {"ST7565P",     QCoreApplication::translate("Firmware", "ST7565P LCD or compatible")},
-    {"ST7565R",     QCoreApplication::translate("Firmware", "ST7565R LCD or compatible")},
-    {"ERC12864FSF", QCoreApplication::translate("Firmware", "ERC12864FSF LCD")},
-    {"ST7920",      QCoreApplication::translate("Firmware", "ST7920 LCD")},
-    {"KS108",       QCoreApplication::translate("Firmware", "KS108 LCD")},
-    {NULL}
-  };
-  firmware->addOptions(lcd_options);
-}
-
-void addOpenTxVoiceOptions(OpenTxFirmware * firmware)
-{
-  Option voice_options[] = {
-    {"WTV20",     	QCoreApplication::translate("Firmware", "WTV20 voice module")},
-    {"JQ6500", 		QCoreApplication::translate("Firmware", "JQ6500 voice module")},
-    {NULL}
-  };
-  firmware->addOptions(voice_options);
+  addOpenTxFontOptions(firmware);
 }
 
 QList<OpenTxEepromInterface *> opentxEEpromInterfaces;
 
-void registerOpenTxFirmware(OpenTxFirmware * firmware)
+void registerOpenTxFirmware(OpenTxFirmware * firmware, bool deprecated = false)
 {
   OpenTxEepromInterface * eepromInterface = new OpenTxEepromInterface(firmware);
   firmware->setEEpromInterface(eepromInterface);
   opentxEEpromInterfaces.push_back(eepromInterface);
   eepromInterfaces.push_back(eepromInterface);
-  Firmware::addRegisteredFirmware(firmware);
+  if (!deprecated)
+    Firmware::addRegisteredFirmware(firmware);
 }
 
 void registerOpenTxFirmwares()
 {
   OpenTxFirmware * firmware;
 
-  Option ext_options[] = {{"frsky",      QCoreApplication::translate("Firmware", "Support for frsky telemetry mod"),  FRSKY_VARIANT},
-                          {"telemetrez", QCoreApplication::translate("Firmware", "Support for telemetry easy board"), FRSKY_VARIANT},
-                          {"jeti",       QCoreApplication::translate("Firmware", "Support for jeti telemetry mod"),       0},
-                          {"ardupilot",  QCoreApplication::translate("Firmware", "Support for receiving ardupilot data"), 0},
-                          {"nmea",       QCoreApplication::translate("Firmware", "Support for receiving NMEA data"),      0},
-                          {"mavlink",    QCoreApplication::translate("Firmware", "Support for MAVLINK devices"),      MAVLINK_VARIANT},
-                          {NULL}};
-  Option extr_options[] = {{"frsky",     QCoreApplication::translate("Firmware", "Support for frsky telemetry mod"), FRSKY_VARIANT},
-                           {"jeti",      QCoreApplication::translate("Firmware", "Support for jeti telemetry mod"),       0},
-                           {"ardupilot", QCoreApplication::translate("Firmware", "Support for receiving ardupilot data"), 0},
-                           {"nmea",      QCoreApplication::translate("Firmware", "Support for receiving NMEA data"),      0},
-                           {"mavlink",   QCoreApplication::translate("Firmware", "Support for MAVLINK devices"),     MAVLINK_VARIANT},
-                           {NULL}};
-  Option nav_options[] = {{"rotenc",    QCoreApplication::translate("Firmware", "Rotary Encoder use in menus navigation")},
-                          {"potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation")},
-                          {NULL}};
-  Option dsm2_options[] = {{"DSM2",    QCoreApplication::translate("Firmware", "Support for DSM2 modules"),                                  0},
-                           {"DSM2PPM", QCoreApplication::translate("Firmware", "Support for DSM2 modules using ppm instead of true serial"), 0},
-                           {NULL}};
-
   /* FrSky Taranis X9D+ board */
   firmware = new OpenTxFirmware("opentx-x9d+", QCoreApplication::translate("Firmware", "FrSky Taranis X9D+"), BOARD_TARANIS_X9DP);
-  firmware->addOption("internalppm", QCoreApplication::translate("Firmware", "Support for PPM internal module hack"));
   firmware->addOption("noras", QCoreApplication::translate("Firmware", "Disable RAS (SWR)"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
@@ -1168,7 +1154,6 @@ void registerOpenTxFirmwares()
   /* FrSky Taranis X9D board */
   firmware = new OpenTxFirmware("opentx-x9d", QCoreApplication::translate("Firmware", "FrSky Taranis X9D"), BOARD_TARANIS_X9D);
   firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Haptic module installed"));
-  firmware->addOption("internalppm", QCoreApplication::translate("Firmware", "Support for PPM internal module hack"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
@@ -1176,19 +1161,20 @@ void registerOpenTxFirmwares()
   firmware = new OpenTxFirmware("opentx-x9e", QCoreApplication::translate("Firmware", "FrSky Taranis X9E"), BOARD_TARANIS_X9E);
   firmware->addOption("shutdownconfirm", QCoreApplication::translate("Firmware", "Confirmation before radio shutdown"));
   firmware->addOption("horussticks", QCoreApplication::translate("Firmware", "Horus gimbals installed (Hall sensors)"));
-  firmware->addOption("internalppm", QCoreApplication::translate("Firmware", "Support for PPM internal module hack"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X7 board */
   firmware = new OpenTxFirmware("opentx-x7", QCoreApplication::translate("Firmware", "FrSky Taranis X7 / X7S"), BOARD_TARANIS_X7);
-  addOpenTxTaranisOptions(firmware);
+  addOpenTxFrskyOptions(firmware);
+  addOpenTxFontOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X-Lite board */
   firmware = new OpenTxFirmware("opentx-xlite", QCoreApplication::translate("Firmware", "FrSky Taranis X-Lite"), BOARD_TARANIS_XLITE);
   // firmware->addOption("stdr9m", QCoreApplication::translate("Firmware", "Use JR-sized R9M module"));
-  addOpenTxTaranisOptions(firmware);
+  addOpenTxFrskyOptions(firmware);
+  addOpenTxFontOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X10 board */
@@ -1196,7 +1182,7 @@ void registerOpenTxFirmwares()
   addOpenTxFrskyOptions(firmware);
   registerOpenTxFirmware(firmware);
 
-  /* FrSky Horus board */
+  /* FrSky X12 (Horus) board */
   firmware = new OpenTxFirmware("opentx-x12s", QCoreApplication::translate("Firmware", "FrSky Horus X12S"), BOARD_X12S);
   addOpenTxFrskyOptions(firmware);
   firmware->addOption("pcbdev", QCoreApplication::translate("Firmware", "Use ONLY with first DEV pcb version"));
@@ -1204,246 +1190,30 @@ void registerOpenTxFirmwares()
 
   /* 9XR-Pro */
   firmware = new OpenTxFirmware("opentx-9xrpro", QCoreApplication::translate("Firmware", "Turnigy 9XR-PRO"), BOARD_9XRPRO);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable HELI menu and cyclic mix support"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-//  firmware->addOption("bluetooth", QCoreApplication::translate("Firmware", "Bluetooth interface"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  firmware->addOption("multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module"));
-  firmware->addOption("eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
-
-  /* 9XR board with M128 chip */
-  firmware = new OpenTxFirmware("opentx-9xr128", QCoreApplication::translate("Firmware", "Turnigy 9XR with m128 chip"), BOARD_M128);
-  firmware->addOptions(extr_options);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QCoreApplication::translate("Firmware", "No splash screen"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("audio", QCoreApplication::translate("Firmware", "Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QCoreApplication::translate("Firmware", "Support for DSM2 modules"));
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QCoreApplication::translate("Firmware", "Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write Progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
-
-  /* 9XR board */
-  firmware = new OpenTxFirmware("opentx-9xr", QCoreApplication::translate("Firmware", "Turnigy 9XR"), BOARD_STOCK);
-  firmware->addOptions(extr_options);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QCoreApplication::translate("Firmware", "No splash screen"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("audio", QCoreApplication::translate("Firmware", "Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QCoreApplication::translate("Firmware", "Support for DSM2 modules"));
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QCoreApplication::translate("Firmware", "Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write Progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("nowshh", QCoreApplication::translate("Firmware", "No Winged Shadow How High support"));
-  firmware->addOption("novario", QCoreApplication::translate("Firmware", "No vario support"));
-  firmware->addOption("nogps", QCoreApplication::translate("Firmware", "No GPS support"));
-  firmware->addOption("nogauges", QCoreApplication::translate("Firmware", "No gauges in the custom telemetry screen"));
-  firmware->addOption("stickrev", QCoreApplication::translate("Firmware", "Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
-
-  /* 9x board */
-  firmware = new OpenTxFirmware("opentx-9x", QCoreApplication::translate("Firmware", "9X with stock board"), BOARD_STOCK);
-  firmware->addOptions(ext_options);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QCoreApplication::translate("Firmware", "No splash screen"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("audio", QCoreApplication::translate("Firmware", "Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QCoreApplication::translate("Firmware", "Support for DSM2 modules"));
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOptions(nav_options);
-  firmware->addOption("sp22", QCoreApplication::translate("Firmware", "SmartieParts 2.2 Backlight support"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QCoreApplication::translate("Firmware", "Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("nowshh", QCoreApplication::translate("Firmware", "No Winged Shadow How High support"));
-  firmware->addOption("novario", QCoreApplication::translate("Firmware", "No vario support"));
-  firmware->addOption("nogps", QCoreApplication::translate("Firmware", "No GPS support"));
-  firmware->addOption("nogauges", QCoreApplication::translate("Firmware", "No gauges in the custom telemetry screen"));
-  firmware->addOption("fasoffset", QCoreApplication::translate("Firmware", "Allow compensating for offset errors in FrSky FAS current sensors"));
-  firmware->addOption("stickrev", QCoreApplication::translate("Firmware", "Add support for reversing stick inputs (e.g. needed for FrSky gimbals)"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
-
-  /* 9x board with M128 chip */
-  firmware = new OpenTxFirmware("opentx-9x128", QCoreApplication::translate("Firmware", "9X with stock board and m128 chip"), BOARD_M128);
-  firmware->addOptions(ext_options);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nosplash", QCoreApplication::translate("Firmware", "No splash screen"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("audio", QCoreApplication::translate("Firmware", "Support for radio modified with regular speaker"));
-  firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Used if you have modified your radio with haptic mode"));
-  // NOT TESTED firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOption("DSM2", QCoreApplication::translate("Firmware", "Support for DSM2 modules"));
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOptions(nav_options);
-  firmware->addOption("sp22", QCoreApplication::translate("Firmware", "SmartieParts 2.2 Backlight support"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("thrtrace", QCoreApplication::translate("Firmware", "Enable the throttle trace in Statistics"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write Progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
+  addOpenTxArm9xOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* ar9x board */
   firmware = new OpenTxFirmware("opentx-ar9x", QCoreApplication::translate("Firmware", "9X with AR9X board"), BOARD_AR9X);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable HELI menu and cyclic mix support"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
+  addOpenTxArm9xOptions(firmware);
   firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-//  firmware->addOption("bluetooth", QCoreApplication::translate("Firmware", "Bluetooth interface"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-//  firmware->addOption("rtc", QCoreApplication::translate("Firmware", "Optional RTC added"));
-//  firmware->addOption("volume", QCoreApplication::translate("Firmware", "i2c volume control added"));
-  firmware->addOption("multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module"));
-  firmware->addOption("eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015"));
-  addOpenTxCommonOptions(firmware);
+  //firmware->addOption("rtc", QCoreApplication::translate("Firmware", "Optional RTC added"));
+  //firmware->addOption("volume", QCoreApplication::translate("Firmware", "i2c volume control added"));
   registerOpenTxFirmware(firmware);
 
   /* Sky9x board */
   firmware = new OpenTxFirmware("opentx-sky9x", QCoreApplication::translate("Firmware", "9X with Sky9x board"), BOARD_SKY9X);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable HELI menu and cyclic mix support"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
+  addOpenTxArm9xOptions(firmware);
   firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-//  firmware->addOption("bluetooth", QCoreApplication::translate("Firmware", "Bluetooth interface"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  firmware->addOption("multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module"));
-  firmware->addOption("eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015"));
-  addOpenTxCommonOptions(firmware);
   registerOpenTxFirmware(firmware);
 
-  /* Gruvin9x board */
-  firmware = new OpenTxFirmware("opentx-gruvin9x", QCoreApplication::translate("Firmware", "9X with Gruvin9x board"), BOARD_GRUVIN9X);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("sdcard", QCoreApplication::translate("Firmware", "Support for SD memory card"));
-  firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOptions(dsm2_options);
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write Progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
-
-  /* MEGA2560 board */
-  firmware = new OpenTxFirmware("opentx-mega2560", QCoreApplication::translate("Firmware", "DIY MEGA2560 radio"), BOARD_MEGA2560);
-  addOpenTxLcdOptions(firmware);
-  firmware->addOption("PWR", QCoreApplication::translate("Firmware", "Power management by soft-off circuitry"));
-  firmware->addOptions(ext_options);
-  firmware->addOption("PXX", QCoreApplication::translate("Firmware", "Support of FrSky PXX protocol"));
-  firmware->addOptions(dsm2_options);
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable heli menu and cyclic mix support"));
-  firmware->addOption("templates", QCoreApplication::translate("Firmware", "Enable TEMPLATES menu"));
-  firmware->addOption("nofp", QCoreApplication::translate("Firmware", "No flight modes"));
-  firmware->addOption("nocurves", QCoreApplication::translate("Firmware", "Disable curves menus"));
-  firmware->addOption("sdcard", QCoreApplication::translate("Firmware", "Support for SD memory card"));
-  firmware->addOption("audio", QCoreApplication::translate("Firmware", "Support for radio modified with regular speaker"));
-  //firmware->addOption("voice", QCoreApplication::translate("Firmware", "Used if you have modified your radio with voice mode"));
-  addOpenTxVoiceOptions(firmware);
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Used if you have modified your radio with haptic mode"));
-  firmware->addOption("ppmca", QCoreApplication::translate("Firmware", "PPM center adjustment in limits"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("symlimits", QCoreApplication::translate("Firmware", "Symetrical Limits"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  firmware->addOption("pgbar", QCoreApplication::translate("Firmware", "EEprom write Progress bar"));
-  firmware->addOption("imperial", QCoreApplication::translate("Firmware", "Imperial units"));
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
-  addOpenTxCommonOptions(firmware);
-  registerOpenTxFirmware(firmware);
+  // These are kept only for import purposes, marked as deprecated to hide from UI.
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-9xr",      Firmware::tr("Turnigy 9XR"),                       BOARD_STOCK),    true);
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-9xr128",   Firmware::tr("Turnigy 9XR with m128 chip"),        BOARD_M128),     true);
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-9x",       Firmware::tr("9X with stock board"),               BOARD_STOCK),    true);
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-9x128",    Firmware::tr("9X with stock board and m128 chip"), BOARD_M128),     true);
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-gruvin9x", Firmware::tr("9X with Gruvin9x board"),            BOARD_GRUVIN9X), true);
+  registerOpenTxFirmware(new OpenTxFirmware("opentx-mega2560", Firmware::tr("DIY MEGA2560 radio"),                BOARD_MEGA2560), true);
 
   Firmware::setDefaultVariant(Firmware::getFirmwareForId("opentx-x9d+"));
   Firmware::setCurrentVariant(Firmware::getDefaultVariant());

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1067,19 +1067,19 @@ QString OpenTxFirmware::getStampUrl()
 
 void addOpenTxCommonOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("ppmus", QCoreApplication::translate("Firmware", "Channel values displayed in us"));
-  firmware->addOption("nooverridech", QCoreApplication::translate("Firmware", "No OverrideCH functions available"));
-  Option fai_options[] = {{"faichoice", QCoreApplication::translate("Firmware", "Possibility to enable FAI MODE (no telemetry) at field")},
-                          {"faimode",   QCoreApplication::translate("Firmware", "FAI MODE (no telemetry) always enabled")},
+  firmware->addOption("ppmus", Firmware::tr("Channel values displayed in us"));
+  firmware->addOption("nooverridech", Firmware::tr("No OverrideCH functions available"));
+  Option fai_options[] = {{"faichoice", Firmware::tr("Possibility to enable FAI MODE (no telemetry) at field")},
+                          {"faimode",   Firmware::tr("FAI MODE (no telemetry) always enabled")},
                           {NULL}};
   firmware->addOptions(fai_options);
 }
 
 void addOpenTxRfOptions(OpenTxFirmware * firmware, bool mm, bool eu, bool flex)
 {
-  Option opt_eu = {"eu", QCoreApplication::translate("Firmware", "Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015")};
-  Option opt_fl = {"flexr9m", QCoreApplication::translate("Firmware", "Enable non certified firmwares")};
-  Option opt_mm = {"multimodule", QCoreApplication::translate("Firmware", "Support for the DIY-Multiprotocol-TX-Module")};
+  Option opt_eu = {"eu", Firmware::tr("Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015")};
+  Option opt_fl = {"flexr9m", Firmware::tr("Enable non certified firmwares")};
+  Option opt_mm = {"multimodule", Firmware::tr("Support for the DIY-Multiprotocol-TX-Module")};
   if (mm)
     firmware->addOption(opt_mm);
   if (eu && flex) {
@@ -1093,20 +1093,20 @@ void addOpenTxRfOptions(OpenTxFirmware * firmware, bool mm, bool eu, bool flex)
 
 void addOpenTxFontOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("sqt5font", QCoreApplication::translate("Firmware", "Use alternative SQT5 font"));
+  firmware->addOption("sqt5font", Firmware::tr("Use alternative SQT5 font"));
 }
 
 void addOpenTxArm9xOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("heli", QCoreApplication::translate("Firmware", "Enable HELI menu and cyclic mix support"));
-  firmware->addOption("gvars", QCoreApplication::translate("Firmware", "Global variables"), GVARS_VARIANT);
-  firmware->addOption("potscroll", QCoreApplication::translate("Firmware", "Pots use in menus navigation"));
-  firmware->addOption("autosource", QCoreApplication::translate("Firmware", "In model setup menus automatically set source by moving the control"));
-  firmware->addOption("autoswitch", QCoreApplication::translate("Firmware", "In model setup menus automatically set switch by moving the control"));
-  firmware->addOption("nographics", QCoreApplication::translate("Firmware", "No graphical check boxes and sliders"));
-  firmware->addOption("battgraph", QCoreApplication::translate("Firmware", "Battery graph"));
-  firmware->addOption("nobold", QCoreApplication::translate("Firmware", "Don't use bold font for highlighting active items"));
-  //firmware->addOption("bluetooth", QCoreApplication::translate("Firmware", "Bluetooth interface"));
+  firmware->addOption("heli", Firmware::tr("Enable HELI menu and cyclic mix support"));
+  firmware->addOption("gvars", Firmware::tr("Global variables"), GVARS_VARIANT);
+  firmware->addOption("potscroll", Firmware::tr("Pots use in menus navigation"));
+  firmware->addOption("autosource", Firmware::tr("In model setup menus automatically set source by moving the control"));
+  firmware->addOption("autoswitch", Firmware::tr("In model setup menus automatically set switch by moving the control"));
+  firmware->addOption("nographics", Firmware::tr("No graphical check boxes and sliders"));
+  firmware->addOption("battgraph", Firmware::tr("Battery graph"));
+  firmware->addOption("nobold", Firmware::tr("Don't use bold font for highlighting active items"));
+  //firmware->addOption("bluetooth", Firmware::tr("Bluetooth interface"));
   addOpenTxRfOptions(firmware, true, true, false);
   addOpenTxFontOptions(firmware);
   addOpenTxCommonOptions(firmware);
@@ -1115,16 +1115,16 @@ void addOpenTxArm9xOptions(OpenTxFirmware * firmware)
 void addOpenTxFrskyOptions(OpenTxFirmware * firmware)
 {
   addOpenTxCommonOptions(firmware);
-  firmware->addOption("noheli", QCoreApplication::translate("Firmware", "Disable HELI menu and cyclic mix support"));
-  firmware->addOption("nogvars", QCoreApplication::translate("Firmware", "Disable Global variables"));
-  firmware->addOption("lua", QCoreApplication::translate("Firmware", "Enable Lua custom scripts screen"));
-  firmware->addOption("luac", QCoreApplication::translate("Firmware", "Enable Lua compiler"));
+  firmware->addOption("noheli", Firmware::tr("Disable HELI menu and cyclic mix support"));
+  firmware->addOption("nogvars", Firmware::tr("Disable Global variables"));
+  firmware->addOption("lua", Firmware::tr("Enable Lua custom scripts screen"));
+  firmware->addOption("luac", Firmware::tr("Enable Lua compiler"));
   addOpenTxRfOptions(firmware, true, true, true);
 }
 
 void addOpenTxTaranisOptions(OpenTxFirmware * firmware)
 {
-  firmware->addOption("internalppm", QCoreApplication::translate("Firmware", "Support for PPM internal module hack"));
+  firmware->addOption("internalppm", Firmware::tr("Support for PPM internal module hack"));
   addOpenTxFrskyOptions(firmware);
   addOpenTxFontOptions(firmware);
 }
@@ -1146,65 +1146,65 @@ void registerOpenTxFirmwares()
   OpenTxFirmware * firmware;
 
   /* FrSky Taranis X9D+ board */
-  firmware = new OpenTxFirmware("opentx-x9d+", QCoreApplication::translate("Firmware", "FrSky Taranis X9D+"), BOARD_TARANIS_X9DP);
-  firmware->addOption("noras", QCoreApplication::translate("Firmware", "Disable RAS (SWR)"));
+  firmware = new OpenTxFirmware("opentx-x9d+", Firmware::tr("FrSky Taranis X9D+"), BOARD_TARANIS_X9DP);
+  firmware->addOption("noras", Firmware::tr("Disable RAS (SWR)"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky Taranis X9D board */
-  firmware = new OpenTxFirmware("opentx-x9d", QCoreApplication::translate("Firmware", "FrSky Taranis X9D"), BOARD_TARANIS_X9D);
-  firmware->addOption("haptic", QCoreApplication::translate("Firmware", "Haptic module installed"));
+  firmware = new OpenTxFirmware("opentx-x9d", Firmware::tr("FrSky Taranis X9D"), BOARD_TARANIS_X9D);
+  firmware->addOption("haptic", Firmware::tr("Haptic module installed"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky Taranis X9E board */
-  firmware = new OpenTxFirmware("opentx-x9e", QCoreApplication::translate("Firmware", "FrSky Taranis X9E"), BOARD_TARANIS_X9E);
-  firmware->addOption("shutdownconfirm", QCoreApplication::translate("Firmware", "Confirmation before radio shutdown"));
-  firmware->addOption("horussticks", QCoreApplication::translate("Firmware", "Horus gimbals installed (Hall sensors)"));
+  firmware = new OpenTxFirmware("opentx-x9e", Firmware::tr("FrSky Taranis X9E"), BOARD_TARANIS_X9E);
+  firmware->addOption("shutdownconfirm", Firmware::tr("Confirmation before radio shutdown"));
+  firmware->addOption("horussticks", Firmware::tr("Horus gimbals installed (Hall sensors)"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X7 board */
-  firmware = new OpenTxFirmware("opentx-x7", QCoreApplication::translate("Firmware", "FrSky Taranis X7 / X7S"), BOARD_TARANIS_X7);
+  firmware = new OpenTxFirmware("opentx-x7", Firmware::tr("FrSky Taranis X7 / X7S"), BOARD_TARANIS_X7);
   addOpenTxFrskyOptions(firmware);
   addOpenTxFontOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X-Lite board */
-  firmware = new OpenTxFirmware("opentx-xlite", QCoreApplication::translate("Firmware", "FrSky Taranis X-Lite"), BOARD_TARANIS_XLITE);
-  // firmware->addOption("stdr9m", QCoreApplication::translate("Firmware", "Use JR-sized R9M module"));
+  firmware = new OpenTxFirmware("opentx-xlite", Firmware::tr("FrSky Taranis X-Lite"), BOARD_TARANIS_XLITE);
+  // firmware->addOption("stdr9m", Firmware::tr("Use JR-sized R9M module"));
   addOpenTxFrskyOptions(firmware);
   addOpenTxFontOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X10 board */
-  firmware = new OpenTxFirmware("opentx-x10", QCoreApplication::translate("Firmware", "FrSky Horus X10 / X10S"), BOARD_X10);
+  firmware = new OpenTxFirmware("opentx-x10", Firmware::tr("FrSky Horus X10 / X10S"), BOARD_X10);
   addOpenTxFrskyOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* FrSky X12 (Horus) board */
-  firmware = new OpenTxFirmware("opentx-x12s", QCoreApplication::translate("Firmware", "FrSky Horus X12S"), BOARD_X12S);
+  firmware = new OpenTxFirmware("opentx-x12s", Firmware::tr("FrSky Horus X12S"), BOARD_X12S);
   addOpenTxFrskyOptions(firmware);
-  firmware->addOption("pcbdev", QCoreApplication::translate("Firmware", "Use ONLY with first DEV pcb version"));
+  firmware->addOption("pcbdev", Firmware::tr("Use ONLY with first DEV pcb version"));
   registerOpenTxFirmware(firmware);
 
   /* 9XR-Pro */
-  firmware = new OpenTxFirmware("opentx-9xrpro", QCoreApplication::translate("Firmware", "Turnigy 9XR-PRO"), BOARD_9XRPRO);
+  firmware = new OpenTxFirmware("opentx-9xrpro", Firmware::tr("Turnigy 9XR-PRO"), BOARD_9XRPRO);
   addOpenTxArm9xOptions(firmware);
   registerOpenTxFirmware(firmware);
 
   /* ar9x board */
-  firmware = new OpenTxFirmware("opentx-ar9x", QCoreApplication::translate("Firmware", "9X with AR9X board"), BOARD_AR9X);
+  firmware = new OpenTxFirmware("opentx-ar9x", Firmware::tr("9X with AR9X board"), BOARD_AR9X);
   addOpenTxArm9xOptions(firmware);
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
-  //firmware->addOption("rtc", QCoreApplication::translate("Firmware", "Optional RTC added"));
-  //firmware->addOption("volume", QCoreApplication::translate("Firmware", "i2c volume control added"));
+  firmware->addOption("dblkeys", Firmware::tr("Enable resetting values by pressing up and down at the same time"));
+  //firmware->addOption("rtc", Firmware::tr("Optional RTC added"));
+  //firmware->addOption("volume", Firmware::tr("i2c volume control added"));
   registerOpenTxFirmware(firmware);
 
   /* Sky9x board */
-  firmware = new OpenTxFirmware("opentx-sky9x", QCoreApplication::translate("Firmware", "9X with Sky9x board"), BOARD_SKY9X);
+  firmware = new OpenTxFirmware("opentx-sky9x", Firmware::tr("9X with Sky9x board"), BOARD_SKY9X);
   addOpenTxArm9xOptions(firmware);
-  firmware->addOption("dblkeys", QCoreApplication::translate("Firmware", "Enable resetting values by pressing up and down at the same time"));
+  firmware->addOption("dblkeys", Firmware::tr("Enable resetting values by pressing up and down at the same time"));
   registerOpenTxFirmware(firmware);
 
   // These are kept only for import purposes, marked as deprecated to hide from UI.

--- a/companion/src/firmwares/opentx/opentxinterface.h
+++ b/companion/src/firmwares/opentx/opentxinterface.h
@@ -106,19 +106,6 @@ class OpenTxFirmware: public Firmware
       addLanguage("pl");
       addLanguage("pt");
       addLanguage("se");
-
-      addTTSLanguage("en");
-      addTTSLanguage("cz");
-      addTTSLanguage("de");
-      addTTSLanguage("es");
-      addTTSLanguage("fr");
-      addTTSLanguage("hu");
-      addTTSLanguage("it");
-      addTTSLanguage("nl");
-      addTTSLanguage("pl");
-      addTTSLanguage("pt");
-      addTTSLanguage("se");
-      addTTSLanguage("sk");
     }
 
     virtual Firmware * getFirmwareVariant(const QString & id);

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -77,7 +77,7 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
           if (generalSettings)
             swName = QString(generalSettings->switchName[qr.quot]);
           if (swName.isEmpty())
-            swName = getSwitchInfo(board, qr.quot).name;
+            swName = Boards::getSwitchInfo(board, qr.quot).name;
           return swName + directionIndicators.at(qr.rem > -1 && qr.rem < directionIndicators.size() ? qr.rem : 1);
         }
         else {

--- a/companion/src/macros.h
+++ b/companion/src/macros.h
@@ -21,17 +21,18 @@
 #ifndef _MACROS_H_
 #define _MACROS_H_
 
+#include "constants.h"
 #include <QDataStream>
 #include <iterator>
 
-// #define DIM(arr) (sizeof((arr))/sizeof((arr)[0]))
-// new way for c++11
-#define DIM(arr__)   ((size_t)(std::end((arr__)) - std::begin((arr__))))
+#define DIM(arr__)   (std::end(arr__) - std::begin(arr__))
 
 #ifndef CONCATENATE
   #define CONCATENATE_IMPL(A, B)   A ## B
   #define CONCATENATE(A, B)        CONCATENATE_IMPL(A, B)
 #endif
+
+#define CHECK_IN_ARRAY(T, index) ((index) >= 0 && int(index) < DIM(T) ? T[(index)] : CPN_STR_UNKNOWN_ITEM)
 
 #define CREATE_ENUM_STREAM_OPS3(functype, type, datatype) \
 	functype QDataStream& operator << (QDataStream &out, type &e) { return out << (datatype&)e; } \

--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -161,6 +161,8 @@ class MainWindow : public QMainWindow
     bool readEepromFromRadio(const QString & filename);
     bool readFirmwareFromRadio(const QString & filename);
 
+    bool checkProfileRadioExists(int profId);
+
     QMdiArea *mdiArea;
     QSignalMapper *windowMapper;
 

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -241,7 +241,7 @@ bool SimulatorWidget::setStartupData(const QByteArray & dataSource, bool fromFil
   }
   // Assume a byte array of radio data was passed, load it.
   else if (!dataSource.isEmpty()) {
-    ret = firmware->getEEpromInterface()->load(simuData, (uint8_t *)dataSource.constData(), getEEpromSize(m_board));
+    ret = firmware->getEEpromInterface()->load(simuData, (uint8_t *)dataSource.constData(), Boards::getEEpromSize(m_board));
     startupData = dataSource;  // save the data for start()
   }
   // we're :-(
@@ -374,7 +374,7 @@ bool SimulatorWidget::saveTempData()
             fh.close();
         }
 
-        if (!firmware->getEEpromInterface()->load(radioData, (uint8_t *)startupData.constData(), getEEpromSize(m_board))) {
+        if (!firmware->getEEpromInterface()->load(radioData, (uint8_t *)startupData.constData(), Boards::getEEpromSize(m_board))) {
           error = tr("Error saving data: could not get data from simulator interface.");
         }
         else {
@@ -489,7 +489,7 @@ void SimulatorWidget::onSimulatorStopped()
   m_heartbeatTimer.invalidate();
 
   if (simulator && !simulator->isRunning() && saveTempRadioData) {
-    startupData.fill(0, getEEpromSize(m_board));
+    startupData.fill(0, Boards::getEEpromSize(m_board));
     simulator->readRadioData(startupData);
   }
 }


### PR DESCRIPTION
So far the main change is removal of AVR radio types from the selectable radios list in Profiles.  The base AVR firmwares are kept to allow import/conversions from those radios.

This adds a popup warning msg if selected profile uses an unavailable radio type (both at startup and when switching profiles). The warning simply prompts the user to update the profile... nothing is changed until user edits/deletes it.  At this point user could technically still open/edit an AVR radio file, though this will presumably need to change going forward.

Otherwise mostly refactoring stuff.