### PR TITLE
Add string type to lua widget inputs

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1360,6 +1360,7 @@ const luaR_value_entry opentxConstants[] = {
   { "SHADOWED", SHADOWED },
   { "COLOR", ZoneOption::Color },
   { "BOOL", ZoneOption::Bool },
+  { "STRING", ZoneOption::String },
   { "CUSTOM_COLOR", CUSTOM_COLOR },
   { "TEXT_COLOR", TEXT_COLOR },
   { "TEXT_BGCOLOR", TEXT_BGCOLOR },


### PR DESCRIPTION
Allow thinghs like

```
local options = {
  { "Option1", SOURCE, 1 },
  { "Option2", VALUE, 1000 },
  { "Option3", COLOR, RED },
  { "Option4", STRING, "NAME" },
  { "Shadow", BOOL, 0 }
}
```

I'm unsure if STRING or TEXT should be used tho

This closes #5545