### PR TITLE
Display FlySky VOLTS values as signed integers

### DIFF
--- a/radio/src/telemetry/flysky_ibus.cpp
+++ b/radio/src/telemetry/flysky_ibus.cpp
@@ -103,6 +103,9 @@ static void processFlySkySensor(const uint8_t *packet)
       else if (id == FS_ID_TEMP)
         // Temperature sensors have 40 degree offset
         value -= 400;
+      else if (sensor->unit == UNIT_VOLTS)
+        // Voltage types are signed 16bit integers
+        value = (int16_t)value;
       setTelemetryValue(TELEM_PROTO_FLYSKY_IBUS, id, 0, instance, value, sensor->unit, sensor->precision);
       return;
     }


### PR DESCRIPTION
As discussed in #6246 

Standard AFHDS2A protocol transmits all values as 2 raw bytes
and a stock FS-i6 transmitter shows voltage type values properly
as signed. This change interprets all UNIT_VOLTS FlySky telemetry
items as being signed 16-bit values so their display matches the
values displayed on stock FS-i6 and FS-i6X receivers.

Signed-off-by: Bryan Mayland <bmayland@capnbry.net>