### PR TITLE
Reflow CRSF script splash for X7

### DIFF
--- a/radio/sdcard/taranis-x7/CROSSFIRE/crossfire.lua
+++ b/radio/sdcard/taranis-x7/CROSSFIRE/crossfire.lua
@@ -96,7 +96,8 @@ local function run(event)
   lcd.clear()
   lcd.drawScreenTitle("CROSSFIRE SETUP", 0, 0)
   if #devices == 0 then
-    lcd.drawText(24, 28, "Waiting for Crossfire devices...")
+    lcd.drawText(36, 24, "Waiting for")
+    lcd.drawText(16, 36, "Crossfire devices...")
   else
     for i=1, #devices do
       local attr = (lineIndex == i and INVERS or 0)


### PR DESCRIPTION
The Crossfire LUA script has a really bad UI on the X7, most of the devices' settings go off screen to the right. This PR fixes the splash screen (_"Waiting for Crossfire devices..."_) only.

![screen-2019-01-06-160542](https://user-images.githubusercontent.com/3594528/50737163-56dc8480-11c6-11e9-9292-ff0d1ddef5ee.png)
