### PR TITLE
Add file name to model edit window title

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1260,7 +1260,7 @@ void MdiChild::openModelEditWindow(int row)
   gStopwatch.report("ModelEdit creation");
   ModelEdit * t = new ModelEdit(this, radioData, (row), firmware);
   gStopwatch.report("ModelEdit created");
-  t->setWindowTitle(tr("Editing model %1: ").arg(row+1) + QString(model.name));
+  t->setWindowTitle(tr("Editing model %1: ").arg(row+1) + QString(model.name) + QString("   (%1)").arg(userFriendlyCurrentFile()));
   connect(t, &ModelEdit::modified, this, &MdiChild::setModified);
   gStopwatch.report("STARTING MODEL EDIT");
   t->show();


### PR DESCRIPTION
Fixes #6057 to avoid doubt when editing models with same name from different files.

![screenshot from 2019-01-07 11-04-23](https://user-images.githubusercontent.com/15316949/50743519-27348780-126d-11e9-9bbf-e6787f9eda2f.png)
