### PR TITLE
Add RX numbers to CPN models list

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -534,7 +534,6 @@ void MdiChild::initModelsList()
   connect(modelsListModel, &QAbstractItemModel::dataChanged, this, &MdiChild::onDataChanged);
 
   ui->modelsList->setModel(modelsListModel);
-  ui->modelsList->header()->setVisible(!firmware->getCapability(Capability::HasModelCategories));
   if (IS_HORUS(board)) {
     ui->modelsList->setIndentation(20);
     // ui->modelsList->resetIndentation(); // introduced in next Qt versions ...
@@ -543,6 +542,14 @@ void MdiChild::initModelsList()
     ui->modelsList->setIndentation(0);
   }
   refresh();
+
+  if (firmware->getCapability(Capability::HasModelCategories)) {
+    ui->modelsList->header()->resizeSection(0, ui->modelsList->header()->sectionSize(0) * 2);   // pad out categories and model names
+    }
+  else {
+    ui->modelsList->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);           // minimise Index
+    ui->modelsList->header()->resizeSection(1, ui->modelsList->header()->sectionSize(1) * 1.5); // pad out model names
+  }
 }
 
 void MdiChild::refresh()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -545,7 +545,7 @@ void MdiChild::initModelsList()
 
   if (firmware->getCapability(Capability::HasModelCategories)) {
     ui->modelsList->header()->resizeSection(0, ui->modelsList->header()->sectionSize(0) * 2);   // pad out categories and model names
-    }
+  }
   else {
     ui->modelsList->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);           // minimise Index
     ui->modelsList->header()->resizeSection(1, ui->modelsList->header()->sectionSize(1) * 1.5); // pad out model names

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -755,11 +755,15 @@ bool TreeModel::isModelIdUnique(unsigned modelIdx)
   int cnt = 0;
   for (unsigned i=0; i<radioData->models.size(); i++) {
     ModelData & model = radioData->models[i];
-    for (unsigned j=0; j<CPN_MAX_MODULES; j++) {
-      if (!model.moduleData[j].protocol == PULSES_OFF && model.moduleData[j].modelId == modelIdx) {
-        cnt++;
+    if (!model.isEmpty()) {
+      for (unsigned j=0; j<CPN_MAX_MODULES; j++) {
+        if (model.moduleData[j].protocol != PULSES_OFF && model.moduleData[j].modelId == modelIdx) {
+          if (++cnt > 1) {
+            return false;
+          }
+        }
       }
     }
   }
-  return (cnt < 2 ? true : false);
+  return true;
 }

--- a/companion/src/modelslist.h
+++ b/companion/src/modelslist.h
@@ -146,6 +146,7 @@ class TreeModel : public QAbstractItemModel
 
   private:
     TreeItem * getItem(const QModelIndex & index) const;
+    bool isModelIdUnique(unsigned modelId);
 
     TreeItem * rootItem;
     RadioData * radioData;

--- a/companion/src/modelslist.h
+++ b/companion/src/modelslist.h
@@ -53,6 +53,8 @@ class TreeItem
     void setModelIndex(int value) { modelIndex = value; }
     int getCategoryIndex() const { return categoryIndex; }
     void setCategoryIndex(int value) { categoryIndex = value; }
+    void setHighlightRX(int value) { highlightRX = value; }
+    bool isHighlightRX() const { return highlightRX; }
 
     quint16 getFlags() const { return flags; }
     void setFlags(const quint16 & value) { flags = value; }
@@ -68,6 +70,7 @@ class TreeItem
     int categoryIndex;
     int modelIndex;
     quint16 flags;
+    bool highlightRX;
 };
 
 
@@ -152,6 +155,7 @@ class TreeModel : public QAbstractItemModel
     RadioData * radioData;
     int availableEEpromSize;
     MimeHeaderData mimeHeaderData;
+    bool hasCategories;
 };
 
 #endif // _MODELSLIST_H_


### PR DESCRIPTION
Enhancement #5088
Lists RX # even if not displayed/editable in model edit. This allows residual configuration to be visible which may be the cause of issues. Residual configuration possible from changing RX type and copying models.

\+ means # referenced by more than one model
\* means # references non-existent model

![screenshot from 2019-01-11 21-19-20](https://user-images.githubusercontent.com/15316949/51029565-d0bba600-15ea-11e9-8e34-1e70357134b4.png)

![screenshot from 2019-01-11 21-19-52](https://user-images.githubusercontent.com/15316949/51029571-d44f2d00-15ea-11e9-8c33-163f2918c099.png)
