### PR TITLE
Mirror crossfire telem on serial

### DIFF
--- a/radio/src/targets/common/arm/stm32/serial2_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/serial2_driver.cpp
@@ -89,6 +89,12 @@ void serial2Init(unsigned int mode, unsigned int protocol)
 
   switch (mode) {
     case UART_MODE_TELEMETRY_MIRROR:
+#if defined(CROSSFIRE)
+      if (protocol == PROTOCOL_PULSES_CROSSFIRE) {
+        uart3Setup(CROSSFIRE_BAUDRATE, false);
+        break;
+      }
+#endif
       uart3Setup(FRSKY_SPORT_BAUDRATE, false);
       break;
 #if defined(DEBUG) || defined(CLI)

--- a/radio/src/targets/common/arm/stm32/serial2_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/serial2_driver.cpp
@@ -91,7 +91,7 @@ void serial2Init(unsigned int mode, unsigned int protocol)
     case UART_MODE_TELEMETRY_MIRROR:
 #if defined(CROSSFIRE)
       if (protocol == PROTOCOL_PULSES_CROSSFIRE) {
-        uart3Setup(CROSSFIRE_BAUDRATE, false);
+        uart3Setup(CROSSFIRE_TELEM_MIRROR_BAUDRATE, false);
         break;
       }
 #endif

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -181,8 +181,7 @@ bool isCrossfireOutputBufferAvailable()
 
 void processCrossfireTelemetryData(uint8_t data)
 {
-
-  #if defined(SERIAL2)
+#if defined(SERIAL2)
   if (g_eeGeneral.serial2Mode == UART_MODE_TELEMETRY_MIRROR) {
     serial2Putc(data);
   }

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -200,6 +200,12 @@ void processCrossfireTelemetryData(uint8_t data)
     telemetryRxBufferCount = 0;
   }
 
+#if defined(SERIAL2)
+  if (g_eeGeneral.serial2Mode == UART_MODE_TELEMETRY_MIRROR) {
+    serial2Putc(data);
+  }
+#endif
+
   if (telemetryRxBufferCount > 4) {
     uint8_t length = telemetryRxBuffer[1];
     if (length + 2 == telemetryRxBufferCount) {

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -181,6 +181,13 @@ bool isCrossfireOutputBufferAvailable()
 
 void processCrossfireTelemetryData(uint8_t data)
 {
+
+  #if defined(SERIAL2)
+  if (g_eeGeneral.serial2Mode == UART_MODE_TELEMETRY_MIRROR) {
+    serial2Putc(data);
+  }
+#endif
+
   if (telemetryRxBufferCount == 0 && data != RADIO_ADDRESS) {
     TRACE("[XF] address 0x%02X error", data);
     return;
@@ -199,12 +206,6 @@ void processCrossfireTelemetryData(uint8_t data)
     TRACE("[XF] array size %d error", telemetryRxBufferCount);
     telemetryRxBufferCount = 0;
   }
-
-#if defined(SERIAL2)
-  if (g_eeGeneral.serial2Mode == UART_MODE_TELEMETRY_MIRROR) {
-    serial2Putc(data);
-  }
-#endif
 
   if (telemetryRxBufferCount > 4) {
     uint8_t length = telemetryRxBuffer[1];

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -86,12 +86,13 @@ const uint8_t CROSSFIRE_PERIODS[] = {
   4,
   16,
 };
-#define CROSSFIRE_BAUDRATE             CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate]
-#define CROSSFIRE_PERIOD         CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]
+#define CROSSFIRE_BAUDRATE    CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate]
+#define CROSSFIRE_PERIOD      CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]
 #else
 #define CROSSFIRE_BAUDRATE             400000
 #define CROSSFIRE_PERIOD         4 // 4ms
 #endif
 
+#define CROSSFIRE_TELEM_MIRROR_BAUDRATE   115200
 
 #endif // _CROSSFIRE_H_


### PR DESCRIPTION
Output fixed at 115k (but fifo buffer is protected in case of overflow)

Users tested ok

This fixes #5357