### PR TITLE
Use unique "usage" for reporting each analog value in usb HID code.

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -99,14 +99,14 @@ static uint8_t  USBD_HID_DataIn (void  *pdev, uint8_t epnum);
     uint8_t buttons1; //bit 0 - button 1, bit 1 - button 2, ..., mapped to channels 9-16, on if channel > 0
     uint8_t buttons2; // mapped to channels 17-24, on if channel > 0
     uint8_t buttons3; // mapped to channels 25-32, on if channel > 0
-    uint8_t X;  //analog value, mapped to channel 1
-    uint8_t Y;  //analog value, mapped to channel 2
-    uint8_t Z;  //analog value, mapped to channel 3
-    uint8_t Rx; //analog value, mapped to channel 4
-    uint8_t Ry  //analog value, mapped to channel 5
-    uint8_t Rz; //analog value, mapped to channel 6
-    uint8_t S1; //analog value, mapped to channel 7
-    uint8_t S2; //analog value, mapped to channel 8
+    uint16_t X;  //analog value, mapped to channel 1
+    uint16_t Y;  //analog value, mapped to channel 2
+    uint16_t Z;  //analog value, mapped to channel 3
+    uint16_t Rx; //analog value, mapped to channel 4
+    uint16_t Ry  //analog value, mapped to channel 5
+    uint16_t Rz; //analog value, mapped to channel 6
+    uint16_t S1; //analog value, mapped to channel 7
+    uint16_t S2; //analog value, mapped to channel 8
   }
 */ 
 __ALIGN_BEGIN static const uint8_t HID_JOYSTICK_ReportDesc[] __ALIGN_END =
@@ -131,7 +131,7 @@ __ALIGN_BEGIN static const uint8_t HID_JOYSTICK_ReportDesc[] __ALIGN_END =
     0x09, 0x34,                    //         USAGE (Ry)
     0x09, 0x35,                    //         USAGE (Rz)
     0x09, 0x36,                    //         USAGE (Slider)
-    0x09, 0x36,                    //         USAGE (Slider)
+    0x09, 0x37,                    //         USAGE (Dial)
     0x16, 0x00, 0x00,              //         LOGICAL_MINIMUM (0)
     0x26, 0xFF, 0x07,              //         LOGICAL_MAXIMUM (2047)
     0x75, 0x10,                    //         REPORT_SIZE (16)


### PR DESCRIPTION
Before my changes HID description used Slider report twice for two different values. On Linux this resulted in joystick with 7 instead of 8 analog channels and the last channel was somewhat affected by both pots that were mapped to channels 7 and 8.  Different HID/joystick drivers might have handled it differently. It somewhat makes sense, keyboard page has two different usage id for reporting left shift and right shift.

Tested on ArchLinux with XD9+.