### PR TITLE
Wismy/bt name fix

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -315,7 +315,7 @@ void Bluetooth::wakeup(void)
           *cur = '\0';
         }
         else {
-          cur = strAppend(cur, "Taranis-X9E");
+          cur = strAppend(cur, FLAVOUR);
         }
         writeString(command);
         state = BLUETOOTH_WAIT_TTM;
@@ -418,11 +418,7 @@ void Bluetooth::wakeup()
         *cur = '\0';
       }
       else {
-#if defined(PCBHORUS)
-        cur = strAppend(cur, "horus");
-#else
-        cur = strAppend(cur, "taranis");
-#endif
+        cur = strAppend(cur, FLAVOUR);
       }
       writeString(command);
       state = BLUETOOTH_STATE_NAME_SENT;

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -419,9 +419,9 @@ void Bluetooth::wakeup()
       }
       else {
 #if defined(PCBHORUS)
-        cur = strAppend(cur, "Horus");
+        cur = strAppend(cur, "horus");
 #else
-        cur = strAppend(cur, "Taranis");
+        cur = strAppend(cur, "taranis");
 #endif
       }
       writeString(command);

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -310,7 +310,7 @@ void Bluetooth::wakeup(void)
         uint8_t len = ZLEN(g_eeGeneral.bluetoothName);
         if (len > 0) {
           for (int i = 0; i < len; i++) {
-            *cur++ = zchar2char(g_eeGeneral.bluetoothName[i]);
+            *cur++ = char2lower(zchar2char(g_eeGeneral.bluetoothName[i]));
           }
           *cur = '\0';
         }
@@ -413,7 +413,7 @@ void Bluetooth::wakeup()
       uint8_t len = ZLEN(g_eeGeneral.bluetoothName);
       if (len > 0) {
         for (int i = 0; i < len; i++) {
-          *cur++ = zchar2char(g_eeGeneral.bluetoothName[i]);
+          *cur++ = char2lower(zchar2char(g_eeGeneral.bluetoothName[i]));
         }
         *cur = '\0';
       }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -432,6 +432,7 @@ extern struct t_inactivity inactivity;
 
 char hex2zchar(uint8_t hex);
 char zchar2char(int8_t idx);
+char char2lower(char c);
 int8_t char2zchar(char c);
 void str2zchar(char *dest, const char *src, int size);
 int zchar2str(char *dest, const char *src, int size);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -44,6 +44,15 @@ char zchar2char(int8_t idx)
   return ' ';
 }
 
+char char2lower(char c)
+{
+  if(c >= 'A' && c <= 'Z'){
+    return c+32;
+  }
+  else
+    return c;
+}
+
 int8_t char2zchar(char c)
 {
   if (c == '_') return 37;


### PR DESCRIPTION
Fixed the issue that bluetooth doesn't work if uppercase follows "AT+NAME" command.