### PR TITLE
Logs : log all switches based on hardware config

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -791,7 +791,7 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -696,7 +696,7 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -290,7 +290,7 @@ void putsModelName(coord_t x, coord_t y, char * name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -28,13 +28,11 @@ uint8_t logDelay;
 void writeHeader();
 
 #if defined(PCBTARANIS) || defined(PCBHORUS)
-  #define GET_2POS_STATE(sw) (switchState(SW_ ## sw ## 0) ? -1 : 1)
+#define GET_SWITCH_STATE(sw)  (getValue(MIXSRC_FIRST_SWITCH+sw) < 0 ? -1 : getValue(MIXSRC_FIRST_SWITCH+sw) > 0 ? 1 : 0)
 #else
-  #define GET_2POS_STATE(sw) (switchState(SW_ ## sw) ? -1 : 1)
-#endif
-
+#define GET_2POS_STATE(sw) (switchState(SW_ ## sw) ? -1 : 1)
 #define GET_3POS_STATE(sw) (switchState(SW_ ## sw ## 0) ? -1 : (switchState(SW_ ## sw ## 2) ? 1 : 0))
-
+#endif
 
 void logsInit()
 {
@@ -166,18 +164,18 @@ void writeHeader()
     }
     f_putc(',', &g_oLogFile);
   }
-#if defined(PCBX7)
-  #define STR_SWITCHES_LOG_HEADER  "SA,SB,SC,SD,SF,SH"
-#elif defined(PCBXLITE)
-  #define STR_SWITCHES_LOG_HEADER  "SA,SB,SC,SD"
-#elif defined(PCBXLITES)
-  #define STR_SWITCHES_LOG_HEADER  "SA,SB,SC,SD,SE,SF"
-#elif defined(PCBX9LITE)
-  #define STR_SWITCHES_LOG_HEADER  "SA,SB,SC,SE,SF"
-#else
-  #define STR_SWITCHES_LOG_HEADER  "SA,SB,SC,SD,SE,SF,SG,SH"
-#endif
-  f_puts(STR_SWITCHES_LOG_HEADER ",LSW,", &g_oLogFile);
+
+  for(uint8_t i=0; i<NUM_SWITCHES; i++) {
+    if (SWITCH_EXISTS(i)) {
+      char s[LEN_SWITCH_NAME + 2];
+      char * temp;
+      temp = getSwitchName(s, SWSRC_FIRST_SWITCH + i * 3);
+      *temp++ = ',';
+      *temp = '\0';
+      f_puts(s, &g_oLogFile);
+    }
+  }
+  f_puts("LSW,", &g_oLogFile);
 #else
   f_puts("Rud,Ele,Thr,Ail,P1,P2,P3,THR,RUD,ELE,3POS,AIL,GEA,TRN,", &g_oLogFile);
 #endif
@@ -272,46 +270,13 @@ void logsWrite()
         f_printf(&g_oLogFile, "%d,", calibratedAnalogs[i]);
       }
 
-// TODO: use hardware config to populate
-#if defined(PCBX9LITE)
-      f_printf(&g_oLogFile, "%d,%d,%d,%d,0x%08X%08X,",
-          GET_3POS_STATE(SA),
-          GET_3POS_STATE(SB),
-          GET_3POS_STATE(SC),
-          GET_2POS_STATE(SD),
-          GET_2POS_STATE(SE),
-          getLogicalSwitchesStates(32),
-          getLogicalSwitchesStates(0));
-#elif defined(PCBXLITE)
-      f_printf(&g_oLogFile, "%d,%d,%d,%d,0x%08X%08X,",
-          GET_3POS_STATE(SA),
-          GET_3POS_STATE(SB),
-          GET_3POS_STATE(SC),
-          GET_3POS_STATE(SD),
-          getLogicalSwitchesStates(32),
-          getLogicalSwitchesStates(0));
-#elif defined(PCBX7)
-      f_printf(&g_oLogFile, "%d,%d,%d,%d,%d,%d,0x%08X%08X,",
-          GET_3POS_STATE(SA),
-          GET_3POS_STATE(SB),
-          GET_3POS_STATE(SC),
-          GET_3POS_STATE(SD),
-          GET_2POS_STATE(SF),
-          GET_2POS_STATE(SH),
-          getLogicalSwitchesStates(32),
-          getLogicalSwitchesStates(0));
-#elif defined(PCBTARANIS) || defined(PCBHORUS)
-      f_printf(&g_oLogFile, "%d,%d,%d,%d,%d,%d,%d,%d,0x%08X%08X,",
-          GET_3POS_STATE(SA),
-          GET_3POS_STATE(SB),
-          GET_3POS_STATE(SC),
-          GET_3POS_STATE(SD),
-          GET_3POS_STATE(SE),
-          GET_2POS_STATE(SF),
-          GET_3POS_STATE(SG),
-          GET_2POS_STATE(SH),
-          getLogicalSwitchesStates(32),
-          getLogicalSwitchesStates(0));
+#if defined(PCBTARANIS) || defined(PCBHORUS)
+      for(uint8_t i=0; i<NUM_SWITCHES; i++) {
+        if (SWITCH_EXISTS(i)) {
+          f_printf(&g_oLogFile, "%d,", GET_SWITCH_STATE(i));
+        }
+      }
+      f_printf(&g_oLogFile, "0x%08X%08X,", getLogicalSwitchesStates(32), getLogicalSwitchesStates(0));
 #else
       f_printf(&g_oLogFile, "%d,%d,%d,%d,%d,%d,%d,",
           GET_2POS_STATE(THR),

--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -167,11 +167,10 @@ void writeHeader()
 
   for(uint8_t i=0; i<NUM_SWITCHES; i++) {
     if (SWITCH_EXISTS(i)) {
-      char s[LEN_SWITCH_NAME + 2];
+      char s[LEN_SWITCH_NAME + 2] = {0};
       char * temp;
       temp = getSwitchName(s, SWSRC_FIRST_SWITCH + i * 3);
-      *temp++ = ',';
-      *temp = '\0';
+      *temp = ',';
       f_puts(s, &g_oLogFile);
     }
   }

--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -28,10 +28,10 @@ uint8_t logDelay;
 void writeHeader();
 
 #if defined(PCBTARANIS) || defined(PCBHORUS)
-#define GET_SWITCH_STATE(sw)  (getValue(MIXSRC_FIRST_SWITCH+sw) < 0 ? -1 : getValue(MIXSRC_FIRST_SWITCH+sw) > 0 ? 1 : 0)
+  #define GET_SWITCH_STATE(sw)  (getValue(MIXSRC_FIRST_SWITCH+sw) < 0 ? -1 : getValue(MIXSRC_FIRST_SWITCH+sw) > 0 ? 1 : 0)
 #else
-#define GET_2POS_STATE(sw) (switchState(SW_ ## sw) ? -1 : 1)
-#define GET_3POS_STATE(sw) (switchState(SW_ ## sw ## 0) ? -1 : (switchState(SW_ ## sw ## 2) ? 1 : 0))
+  #define GET_2POS_STATE(sw) (switchState(SW_ ## sw) ? -1 : 1)
+  #define GET_3POS_STATE(sw) (switchState(SW_ ## sw ## 0) ? -1 : (switchState(SW_ ## sw ## 2) ? 1 : 0))
 #endif
 
 void logsInit()

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -241,6 +241,7 @@ char * getGVarString(char * dest, int idx)
   return dest;
 }
 
+#if !defined(PCBSKY9X)
 char * getSwitchName(char * dest, swsrc_t idx)
 {
   div_t swinfo = switchInfo(idx);
@@ -267,6 +268,7 @@ char * getSwitchName(char * dest, swsrc_t idx)
   }
   return dest;
 }
+#endif
 
 char * getSwitchString(char * dest, swsrc_t idx)
 {

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -241,6 +241,33 @@ char * getGVarString(char * dest, int idx)
   return dest;
 }
 
+char * getSwitchName(char * dest, swsrc_t idx)
+{
+  div_t swinfo = switchInfo(idx);
+  if (ZEXIST(g_eeGeneral.switchNames[swinfo.quot])) {
+    dest += zchar2str(dest, g_eeGeneral.switchNames[swinfo.quot], LEN_SWITCH_NAME);
+    // TODO tous zchar2str
+  }
+  else {
+    *dest++ = 'S';
+#if defined(PCBX7)
+    if (swinfo.quot >= 5)
+        *dest++ = 'H' + swinfo.quot - 5;
+      else if (swinfo.quot == 4)
+#if defined(RADIO_T12)
+        *dest++ = 'G';
+#else
+        *dest++ = 'F';
+#endif
+      else
+        *dest++ = 'A'+swinfo.quot;
+#else
+    *dest++ = 'A' + swinfo.quot;
+#endif
+  }
+  return dest;
+}
+
 char * getSwitchString(char * dest, swsrc_t idx)
 {
   if (idx == SWSRC_NONE) {
@@ -267,27 +294,7 @@ char * getSwitchString(char * dest, swsrc_t idx)
   #define IDX_ON_IN_STR_VSWITCHES      (IDX_TRIMS_IN_STR_VSWITCHES+SWSRC_LAST_TRIM-SWSRC_FIRST_TRIM+1)
   if (idx <= SWSRC_LAST_SWITCH) {
     div_t swinfo = switchInfo(idx);
-    if (ZEXIST(g_eeGeneral.switchNames[swinfo.quot])) {
-      s += zchar2str(s, g_eeGeneral.switchNames[swinfo.quot], LEN_SWITCH_NAME);
-      // TODO tous zchar2str
-    }
-    else {
-      *s++ = 'S';
-#if defined(PCBX7)
-      if (swinfo.quot >= 5)
-        *s++ = 'H' + swinfo.quot - 5;
-      else if (swinfo.quot == 4)
-#if defined(RADIO_T12)
-        *s++ = 'G';
-#else
-        *s++ = 'F';
-#endif
-      else
-        *s++ = 'A'+swinfo.quot;
-#else
-      *s++ = 'A' + swinfo.quot;
-#endif
-    }
+    s = getSwitchName(s, idx);
     *s++ = "\300-\301"[swinfo.rem];
     *s = '\0';
   }

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -270,7 +270,7 @@ char * getSwitchName(char * dest, swsrc_t idx)
 }
 #endif
 
-char * getSwitchString(char * dest, swsrc_t idx)
+char * getSwitchPositionName(char * dest, swsrc_t idx)
 {
   if (idx == SWSRC_NONE) {
     return getStringAtIndex(dest, STR_VSWITCHES, 0);
@@ -405,7 +405,7 @@ char * getSourceString(char * dest, mixsrc_t idx)
     }
   }
   else if (idx <= MIXSRC_LAST_LOGICAL_SWITCH) {
-    getSwitchString(dest, SWSRC_SW1 + idx - MIXSRC_SW1);
+    getSwitchPositionName(dest, SWSRC_SW1 + idx - MIXSRC_SW1);
   }
   else if (idx <= MIXSRC_LAST_TRAINER) {
     strAppendStringWithIndex(dest, STR_PPM_TRAINER, idx - MIXSRC_FIRST_TRAINER + 1);

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -36,6 +36,7 @@ char * getTimerString(char * dest, int32_t tme, uint8_t hours=0);
 char * getCurveString(char * dest, int idx);
 char * getGVarString(char * dest, int idx);
 char * getSwitchString(char * dest, swsrc_t idx);
+char * getSwitchName(char * dest, swsrc_t idx);
 char * getSourceString(char * dest, mixsrc_t idx);
 #endif
 

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -35,7 +35,7 @@ char * strAppendStringWithIndex(char * dest, const char * s, int idx);
 char * getTimerString(char * dest, int32_t tme, uint8_t hours=0);
 char * getCurveString(char * dest, int idx);
 char * getGVarString(char * dest, int idx);
-char * getSwitchString(char * dest, swsrc_t idx);
+char * getSwitchPositionName(char * dest, swsrc_t idx);
 char * getSwitchName(char * dest, swsrc_t idx);
 char * getSourceString(char * dest, mixsrc_t idx);
 #endif


### PR DESCRIPTION
- Display either user defined switch name if exist or predefined siwtch name in column header
- Logs all switches available based on hardwrae configuration
- No more (ugly) per radio predefinition
- This also fixes the issue where X9Lite logs cannot be read by Companion
- This fixes #6612 

Sample from X9E testing

`Date,Time,Rud,Ele,Thr,Ail,F1,F2,F3,F4,S1,S2,LS,RS,SA,SB,SC,SD,SE,SF,SG,SH,SO,SP,aaa,LSW,TxBat(V)
2019-08-10,17:28:16.960,0,0,-1024,0,0,0,0,0,0,0,0,0,-1,-1,-1,-1,-1,-1,-1,1,1,1,0,0x0000000000000000,10.6
2019-08-10,17:28:17.820,0,0,-1024,0,0,0,0,0,0,0,0,0,-1,-1,-1,-1,-1,-1,-1,1,1,1,0,0x0000000000000000,10.6`