### PR TITLE
Updated wizard Lua scripts.

### DIFF
--- a/radio/sdcard/horus/SCRIPTS/WIZARD/glider/wizard.lua
+++ b/radio/sdcard/horus/SCRIPTS/WIZARD/glider/wizard.lua
@@ -302,8 +302,8 @@ local function runTailConfig(event)
   if fields[1][5] == 2 then
     lcd.drawBitmap(ImgTail, 252, 100)
     lcd.drawBitmap(ImgTailRud, 340, 100)
-    drawMark(415, 150, "A")
-    drawMark(380, 120, "C")
+    drawMark(415, 150, "C")
+    drawMark(380, 120, "A")
     drawMark(390, 185, "B")
     lcd.drawFilledRectangle(40, 122, 100, 30, CUSTOM_COLOR)
     drawMark(152, 124, "A")
@@ -332,7 +332,7 @@ end
 local lineIndex
 local function drawNextLine(text, text2)
   lcd.drawText(40, lineIndex, text, TEXT_COLOR)
-  lcd.drawText(250, lineIndex, text2 + 1, TEXT_COLOR)
+  lcd.drawText(242, lineIndex, ": CH" .. text2 + 1, TEXT_COLOR)
   lineIndex = lineIndex + 20
 end
 
@@ -354,35 +354,35 @@ local function runConfigSummary(event)
   lineIndex = 40
   -- motors
   if(MotorFields[1][5] == 1) then
-    drawNextLine("Motor channel :", MotorFields[2][5])
+    drawNextLine("Motor channel", MotorFields[2][5])
   end
   -- ail
   if(AilFields[1][5] == 1) then
-    drawNextLine("Aileron channel :",AilFields[2][5])
+    drawNextLine("Aileron channel",AilFields[2][5])
   elseif (AilFields[1][5] == 2) then
-    drawNextLine("Aileron Right channel :",AilFields[2][5])
-    drawNextLine("Aileron Left channel :",AilFields[3][5])
+    drawNextLine("Aileron Right channel",AilFields[2][5])
+    drawNextLine("Aileron Left channel",AilFields[3][5])
   end
   -- flaps
   if(FlapsFields[1][5] == 1) then
-    drawNextLine("Flaps channel :",FlapsFields[2][5])
+    drawNextLine("Flaps channel",FlapsFields[2][5])
   elseif (FlapsFields[1][5] == 2) then
-    drawNextLine("Flaps Right channel :",FlapsFields[2][5])
-    drawNextLine("Flaps Left channel :",FlapsFields[3][5])
+    drawNextLine("Flaps Right channel",FlapsFields[2][5])
+    drawNextLine("Flaps Left channel",FlapsFields[3][5])
   end
   -- tail
   if(TailFields[1][5] == 0) then
-    drawNextLine("Elevator channel :",TailFields[2][5])
+    drawNextLine("Elevator channel",TailFields[2][5])
   elseif (TailFields[1][5] == 1) then
-    drawNextLine("Elevator channel :",TailFields[2][5])
-    drawNextLine("Rudder channel :",TailFields[3][5])
+    drawNextLine("Elevator channel",TailFields[2][5])
+    drawNextLine("Rudder channel",TailFields[3][5])
   elseif (TailFields[1][5] == 2) then
-    drawNextLine("Elevator Left channel :",TailFields[2][5])
-    drawNextLine("Rudder channel :",TailFields[3][5])
-    drawNextLine("Elevator Right channel :",TailFields[4][5])
+    drawNextLine("Elevator Right channel",TailFields[2][5])
+    drawNextLine("Rudder channel",TailFields[3][5])
+    drawNextLine("Elevator Left channel",TailFields[4][5])
   elseif (TailFields[1][5] == 3) then
-    drawNextLine("V-Tail Right :", TailFields[2][5])
-    drawNextLine("V-Tail Left :", TailFields[3][5])
+    drawNextLine("V-Tail Right", TailFields[2][5])
+    drawNextLine("V-Tail Left", TailFields[3][5])
   end
   local result = runFieldsPage(event)
   if(fields[1][5] == 1 and edit == false) then
@@ -433,9 +433,9 @@ local function createModel(event)
     addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
   elseif (TailFields[1][5] == 2) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
-    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
+    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
   elseif (TailFields[1][5] == 3) then
     addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
     addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", 50, 1)

--- a/radio/sdcard/horus/SCRIPTS/WIZARD/glider/wizard.lua
+++ b/radio/sdcard/horus/SCRIPTS/WIZARD/glider/wizard.lua
@@ -258,7 +258,7 @@ local function runFlapsConfig(event)
 end
 
 local TailFields = {
-  {50, 50, COMBO, 1, 1, { "1 channel for Elevator, no Rudder", "One chan for Elevator, one for Rudder", "Two chans for Elevator, one for Rudder", "V Tail"} },
+  {50, 50, COMBO, 1, 1, { "1 channel for Elevator, no Rudder", "One channel for Elevator, one for Rudder", "Two channels for Elevator, one for Rudder", "V Tail"} },
   {50, 127, COMBO, 1, 1, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --ele
   {50, 167, COMBO, 1, 3, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --rud
   {50, 207, COMBO, 0, 5, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --ele2
@@ -354,38 +354,35 @@ local function runConfigSummary(event)
   lineIndex = 40
   -- motors
   if(MotorFields[1][5] == 1) then
-    drawNextLine("Motor chan :", MotorFields[2][5])
-  elseif (MotorFields[1][5] == 2) then
-    drawNextLine("Motor 1 chan :", MotorFields[2][5])
-    drawNextLine("Motor 2 chan :", MotorFields[3][5])
+    drawNextLine("Motor channel :", MotorFields[2][5])
   end
   -- ail
   if(AilFields[1][5] == 1) then
-    drawNextLine("Aileron chan :",AilFields[2][5])
+    drawNextLine("Aileron channel :",AilFields[2][5])
   elseif (AilFields[1][5] == 2) then
-    drawNextLine("Aileron 1 chan :",AilFields[2][5])
-    drawNextLine("Aileron 2 chan :",AilFields[3][5])
+    drawNextLine("Aileron Right channel :",AilFields[2][5])
+    drawNextLine("Aileron Left channel :",AilFields[3][5])
   end
   -- flaps
   if(FlapsFields[1][5] == 1) then
-    drawNextLine("Flaps chan :",FlapsFields[2][5])
+    drawNextLine("Flaps channel :",FlapsFields[2][5])
   elseif (FlapsFields[1][5] == 2) then
-    drawNextLine("Flaps 1 chan :",FlapsFields[2][5])
-    drawNextLine("Flaps 2 chan :",FlapsFields[3][5])
+    drawNextLine("Flaps Right channel :",FlapsFields[2][5])
+    drawNextLine("Flaps Left channel :",FlapsFields[3][5])
   end
   -- tail
   if(TailFields[1][5] == 0) then
-    drawNextLine("Elevator chan :",TailFields[2][5])
+    drawNextLine("Elevator channel :",TailFields[2][5])
   elseif (TailFields[1][5] == 1) then
-    drawNextLine("Elevator chan :",TailFields[2][5])
-    drawNextLine("Rudder chan :",TailFields[3][5])
+    drawNextLine("Elevator channel :",TailFields[2][5])
+    drawNextLine("Rudder channel :",TailFields[3][5])
   elseif (TailFields[1][5] == 2) then
-    drawNextLine("Elevator 1 chan :",TailFields[2][5])
-    drawNextLine("Rudder chan :",TailFields[3][5])
-    drawNextLine("Elevator 2 chan :",TailFields[4][5])
+    drawNextLine("Elevator Left channel :",TailFields[2][5])
+    drawNextLine("Rudder channel :",TailFields[3][5])
+    drawNextLine("Elevator Right channel :",TailFields[4][5])
   elseif (TailFields[1][5] == 3) then
-    drawNextLine("V-Tail elevator :", TailFields[2][5])
-    drawNextLine("V-Tail rudder :", TailFields[3][5])
+    drawNextLine("V-Tail Right :", TailFields[2][5])
+    drawNextLine("V-Tail Left :", TailFields[3][5])
   end
   local result = runFieldsPage(event)
   if(fields[1][5] == 1 and edit == false) then
@@ -414,23 +411,20 @@ local function createModel(event)
   -- motor
   if(MotorFields[1][5] == 1) then
     addMix(MotorFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor")
-  elseif (MotorFields[1][5] == 2) then
-    addMix(MotorFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor1")
-    addMix(MotorFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor2")
   end
   -- Ailerons
   if(AilFields[1][5] == 1) then
     addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif (AilFields[1][5] == 2) then
-    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
-    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
+    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR")
+    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL", -100)
   end
   -- Flaps
   if(FlapsFields[1][5] == 1) then
     addMix(FlapsFields[2][5], MIXSRC_SA, "Flaps")
   elseif (FlapsFields[1][5] == 2) then
-    addMix(FlapsFields[2][5], MIXSRC_SA, "FlapsL")
-    addMix(FlapsFields[3][5], MIXSRC_SA, "FlapsR")
+    addMix(FlapsFields[2][5], MIXSRC_SA, "FlapsR")
+    addMix(FlapsFields[3][5], MIXSRC_SA, "FlapsL")
   end
   -- Tail
   if(TailFields[1][5] == 0) then
@@ -443,10 +437,10 @@ local function createModel(event)
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
     addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
   elseif (TailFields[1][5] == 3) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", 50, 1)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", -50, 1)
   end
   lcd.drawText(70, 90, "Model successfully created !", TEXT_COLOR)
   lcd.drawText(100, 130, "Press RTN to exit", TEXT_COLOR)

--- a/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
+++ b/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
@@ -258,7 +258,7 @@ local function runFlapsConfig(event)
 end
 
 local TailFields = {
-  {50, 50, COMBO, 1, 1, { "1 channel for Elevator, no Rudder", "One chan for Elevator, one for Rudder", "Two chans for Elevator, one for Rudder", "V Tail"} },
+  {50, 50, COMBO, 1, 1, { "1 channel for Elevator, no Rudder", "One channel for Elevator, one for Rudder", "Two channels for Elevator, one for Rudder", "V Tail"} },
   {50, 127, COMBO, 1, 1, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --ele
   {50, 167, COMBO, 1, 3, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --rud
   {50, 207, COMBO, 0, 5, { "CH1", "CH2", "CH3", "CH4", "CH5", "CH6", "CH7", "CH8" } }, --ele2
@@ -354,38 +354,35 @@ local function runConfigSummary(event)
   lineIndex = 40
   -- motors
   if(MotorFields[1][5] == 1) then
-    drawNextLine("Motor chan :", MotorFields[2][5])
-  elseif (MotorFields[1][5] == 2) then
-    drawNextLine("Motor 1 chan :", MotorFields[2][5])
-    drawNextLine("Motor 2 chan :", MotorFields[3][5])
+    drawNextLine("Motor channel :", MotorFields[2][5])
   end
   -- ail
   if(AilFields[1][5] == 1) then
-    drawNextLine("Aileron chan :",AilFields[2][5])
+    drawNextLine("Aileron channel :",AilFields[2][5])
   elseif (AilFields[1][5] == 2) then
-    drawNextLine("Aileron 1 chan :",AilFields[2][5])
-    drawNextLine("Aileron 2 chan :",AilFields[3][5])
+    drawNextLine("Aileron Right channel :",AilFields[2][5])
+    drawNextLine("Aileron Left channel :",AilFields[3][5])
   end
   -- flaps
   if(FlapsFields[1][5] == 1) then
-    drawNextLine("Flaps chan :",FlapsFields[2][5])
+    drawNextLine("Flaps channel :",FlapsFields[2][5])
   elseif (FlapsFields[1][5] == 2) then
-    drawNextLine("Flaps 1 chan :",FlapsFields[2][5])
-    drawNextLine("Flaps 2 chan :",FlapsFields[3][5])
+    drawNextLine("Flaps Right channel :",FlapsFields[2][5])
+    drawNextLine("Flaps Left channel :",FlapsFields[3][5])
   end
   -- tail
   if(TailFields[1][5] == 0) then
-    drawNextLine("Elevator chan :",TailFields[2][5])
+    drawNextLine("Elevator channel :",TailFields[2][5])
   elseif (TailFields[1][5] == 1) then
-    drawNextLine("Elevator chan :",TailFields[2][5])
-    drawNextLine("Rudder chan :",TailFields[3][5])
+    drawNextLine("Elevator channel :",TailFields[2][5])
+    drawNextLine("Rudder channel :",TailFields[3][5])
   elseif (TailFields[1][5] == 2) then
-    drawNextLine("Elevator 1 chan :",TailFields[2][5])
-    drawNextLine("Rudder chan :",TailFields[3][5])
-    drawNextLine("Elevator 2 chan :",TailFields[4][5])
+    drawNextLine("Elevator Right channel :",TailFields[2][5])
+    drawNextLine("Rudder channel :",TailFields[3][5])
+    drawNextLine("Elevator Left channel :",TailFields[4][5])
   elseif (TailFields[1][5] == 3) then
-    drawNextLine("V-Tail elevator :", TailFields[2][5])
-    drawNextLine("V-Tail rudder :", TailFields[3][5])
+    drawNextLine("V-Tail Right :", TailFields[2][5])
+    drawNextLine("V-Tail Left :", TailFields[3][5])
   end
   local result = runFieldsPage(event)
   if(fields[1][5] == 1 and edit == false) then
@@ -414,23 +411,20 @@ local function createModel(event)
   -- motor
   if(MotorFields[1][5] == 1) then
     addMix(MotorFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor")
-  elseif (MotorFields[1][5] == 2) then
-    addMix(MotorFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor1")
-    addMix(MotorFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(2), "Motor2")
   end
   -- Ailerons
   if(AilFields[1][5] == 1) then
     addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif (AilFields[1][5] == 2) then
-    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
-    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
+    addMix(AilFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR")
+    addMix(AilFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL", -100)
   end
   -- Flaps
   if(FlapsFields[1][5] == 1) then
     addMix(FlapsFields[2][5], MIXSRC_SA, "Flaps")
   elseif (FlapsFields[1][5] == 2) then
-    addMix(FlapsFields[2][5], MIXSRC_SA, "FlapsL")
-    addMix(FlapsFields[3][5], MIXSRC_SA, "FlapsR")
+    addMix(FlapsFields[2][5], MIXSRC_SA, "FlapsR")
+    addMix(FlapsFields[3][5], MIXSRC_SA, "FlapsL")
   end
   -- Tail
   if(TailFields[1][5] == 0) then
@@ -439,14 +433,14 @@ local function createModel(event)
     addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "Elev")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
   elseif (TailFields[1][5] == 2) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
     addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")
-    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevR")
+    addMix(TailFields[4][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "ElevL")
   elseif (TailFields[1][5] == 3) then
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
-    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
-    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
+    addMix(TailFields[2][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", 50, 1)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
+    addMix(TailFields[3][5], MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", -50, 1)
   end
   lcd.drawText(70, 90, "Model successfully created !", TEXT_COLOR)
   lcd.drawText(100, 130, "Press RTN to exit", TEXT_COLOR)

--- a/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
+++ b/radio/sdcard/horus/SCRIPTS/WIZARD/plane/wizard.lua
@@ -332,7 +332,7 @@ end
 local lineIndex
 local function drawNextLine(text, text2)
   lcd.drawText(40, lineIndex, text, TEXT_COLOR)
-  lcd.drawText(250, lineIndex, text2 + 1, TEXT_COLOR)
+  lcd.drawText(242, lineIndex, ": CH" .. text2 + 1, TEXT_COLOR)
   lineIndex = lineIndex + 20
 end
 
@@ -354,35 +354,35 @@ local function runConfigSummary(event)
   lineIndex = 40
   -- motors
   if(MotorFields[1][5] == 1) then
-    drawNextLine("Motor channel :", MotorFields[2][5])
+    drawNextLine("Motor channel", MotorFields[2][5])
   end
   -- ail
   if(AilFields[1][5] == 1) then
-    drawNextLine("Aileron channel :",AilFields[2][5])
+    drawNextLine("Aileron channel",AilFields[2][5])
   elseif (AilFields[1][5] == 2) then
-    drawNextLine("Aileron Right channel :",AilFields[2][5])
-    drawNextLine("Aileron Left channel :",AilFields[3][5])
+    drawNextLine("Aileron Right channel",AilFields[2][5])
+    drawNextLine("Aileron Left channel",AilFields[3][5])
   end
   -- flaps
   if(FlapsFields[1][5] == 1) then
-    drawNextLine("Flaps channel :",FlapsFields[2][5])
+    drawNextLine("Flaps channel",FlapsFields[2][5])
   elseif (FlapsFields[1][5] == 2) then
-    drawNextLine("Flaps Right channel :",FlapsFields[2][5])
-    drawNextLine("Flaps Left channel :",FlapsFields[3][5])
+    drawNextLine("Flaps Right channel",FlapsFields[2][5])
+    drawNextLine("Flaps Left channel",FlapsFields[3][5])
   end
   -- tail
   if(TailFields[1][5] == 0) then
-    drawNextLine("Elevator channel :",TailFields[2][5])
+    drawNextLine("Elevator channel",TailFields[2][5])
   elseif (TailFields[1][5] == 1) then
-    drawNextLine("Elevator channel :",TailFields[2][5])
-    drawNextLine("Rudder channel :",TailFields[3][5])
+    drawNextLine("Elevator channel",TailFields[2][5])
+    drawNextLine("Rudder channel",TailFields[3][5])
   elseif (TailFields[1][5] == 2) then
-    drawNextLine("Elevator Right channel :",TailFields[2][5])
-    drawNextLine("Rudder channel :",TailFields[3][5])
-    drawNextLine("Elevator Left channel :",TailFields[4][5])
+    drawNextLine("Elevator Right channel",TailFields[2][5])
+    drawNextLine("Rudder channel",TailFields[3][5])
+    drawNextLine("Elevator Left channel",TailFields[4][5])
   elseif (TailFields[1][5] == 3) then
-    drawNextLine("V-Tail Right :", TailFields[2][5])
-    drawNextLine("V-Tail Left :", TailFields[3][5])
+    drawNextLine("V-Tail Right", TailFields[2][5])
+    drawNextLine("V-Tail Left", TailFields[3][5])
   end
   local result = runFieldsPage(event)
   if(fields[1][5] == 1 and edit == false) then

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
@@ -311,6 +311,7 @@ end
 
 local function drawNextLine(x, y, label, channel)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+48, y, ":", 0);
   lcd.drawSource(x+52, y, MIXSRC_CH1+channel, 0)
   y = y + 8
   if y > 50 then

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
@@ -327,12 +327,12 @@ local function drawConfirmationMenu()
   lcd.drawText(48, 1, "Ready to go?", 0);
   lcd.drawFilledRectangle(0, 0, LCD_W, 9, 0)
   if engineMode == 1 then
-    x, y = drawNextLine(x, y, "Thr:", thrCH1)
+    x, y = drawNextLine(x, y, "Throttle", thrCH1)
   end
-  x, y = drawNextLine(x, y, "Ele L:", elevCH1)
-  x, y = drawNextLine(x, y, "Ele R:", elevCH2)
+  x, y = drawNextLine(x, y, "Elevon L", elevCH1)
+  x, y = drawNextLine(x, y, "Elevon R", elevCH2)
   if rudderMode == 1 then
-    drawNextLine(x, y, "Rudder:", rudCH1)
+    drawNextLine(x, y, "Rudder", rudCH1)
   end
   lcd.drawText(48, LCD_H-8, "[Enter Long] to confirm", 0);
   lcd.drawFilledRectangle(0, LCD_H-9, LCD_W, 9, 0)

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
@@ -165,8 +165,8 @@ end
 -- Init function
 local function init()
   thrCH1 = defaultChannel(2)
-  rollCH1 = defaultChannel(3)
-  yawCH1 = defaultChannel(0)
+  rollCH1 = defaultChannel(0)
+  yawCH1 = defaultChannel(3)
   pitchCH1 = defaultChannel(1)
   local ver, radio, maj, minor, rev = getVersion()
   if string.match(radio, "x7") then
@@ -352,15 +352,15 @@ local function drawConfirmationMenu()
   lcd.clear()
   lcd.drawText(0, 1, "Ready to go?", 0);
   lcd.drawFilledRectangle(0, 0, LCD_W, 9, 0)
-  x, y = drawNextLine(x, y, "Throttle:", thrCH1)
-  x, y = drawNextLine(x, y, "Roll:", rollCH1)
-  x, y = drawNextLine(x, y, "Pitch:", pitchCH1)
-  x, y = drawNextLine(x, y, "Yaw:", yawCH1)
+  x, y = drawNextLine(x, y, "Throttle", thrCH1)
+  x, y = drawNextLine(x, y, "Roll", rollCH1)
+  x, y = drawNextLine(x, y, "Pitch", pitchCH1)
+  x, y = drawNextLine(x, y, "Yaw", yawCH1)
   local x = 72
   local y = 12
-  x, y = drawNextSWLine(x, y, "Arm:", armSW1)
-  x, y = drawNextSWLine(x, y, "Mode:", modeSW1)
-  x, y = drawNextSWLine(x, y, "Beeper:", beeperSW1)
+  x, y = drawNextSWLine(x, y, "Arm", armSW1)
+  x, y = drawNextSWLine(x, y, "Mode", modeSW1)
+  x, y = drawNextSWLine(x, y, "Beeper", beeperSW1)
   lcd.drawText(0, LCD_H-8, "[Enter Long] to confirm", 0);
   lcd.drawFilledRectangle(0, LCD_H-9, LCD_W, 9, 0)
   fieldsMax = 0

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
@@ -326,6 +326,7 @@ end
 -- Confirmation Menu
 local function drawNextLine(x, y, label, channel)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+46, y, ":", 0);
   lcd.drawSource(x+50, y, MIXSRC_CH1+channel, 0)
   y = y + 8
   if y > 50 then
@@ -337,6 +338,7 @@ end
 
 local function drawNextSWLine(x, y, label, switch)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+38, y, ":", 0);
   lcd.drawText(x+42, y, switches[switch], 0)
   y = y + 8
   if y > 50 then

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
@@ -429,6 +429,7 @@ end
 -- Confirmation Menu
 local function drawNextLine(x, y, label, channel)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+26, y, ":", 0);
   lcd.drawSource(x+30, y, MIXSRC_CH1+channel, 0)
   y = y + 8
   if y > 50 then

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
@@ -502,8 +502,8 @@ local function applySettings()
   if aileronsMode == 1 then
     addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif aileronsMode == 2 then
-    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
-    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
+    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL", -100)
+    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR")
   end
   if flapsMode == 1 then
     addMix(flapsCH1, MIXSRC_SA, "Flap")
@@ -519,9 +519,9 @@ local function applySettings()
   end
   if tailMode == 3 then
     addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
-    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
+    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", -50, 1)
     addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
-    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
+    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", 50, 1)
   else
     if tailMode > 0 then
       addMix(rudCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/delta.lua
@@ -338,10 +338,10 @@ local function drawConfirmationMenu()
   if engineMode == 1 then
     x, y = drawNextLine(x, y, "Throttle", thrCH1)
   end
-  x, y = drawNextLine(x, y, "Elev L", elevCH1)
-  x, y = drawNextLine(x, y, "Elev R", elevCH2)
+  x, y = drawNextLine(x, y, "Elevon L", elevCH1)
+  x, y = drawNextLine(x, y, "Elevon R", elevCH2)
   if rudderMode == 1 then
-    drawNextLine(x, y, "Rudder:", rudCH1)
+    drawNextLine(x, y, "Rudder", rudCH1)
   end
   lcd.drawText(48, LCD_H-8, "Long [ENT] to confirm", 0);
   lcd.drawFilledRectangle(0, LCD_H-9, LCD_W, 9, 0)

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/multi.lua
@@ -20,8 +20,8 @@ local ROLL_PAGE = 1
 local PITCH_PAGE = 2
 local YAW_PAGE = 3
 local ARM_PAGE = 4
-local MODE_PAGE = 5
-local BEEPER_PAGE = 6
+local BEEPER_PAGE = 5
+local MODE_PAGE = 6
 local CONFIRMATION_PAGE = 7
 
 -- Navigation variables
@@ -340,6 +340,7 @@ end
 -- Confirmation Menu
 local function drawNextCHLine(x, y, label, channel)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+48, y, ":", 0);
   lcd.drawSource(x+52, y, MIXSRC_CH1+channel, 0)
   y = y + 8
   if y > 50 then
@@ -351,6 +352,7 @@ end
 
 local function drawNextSWLine(x, y, label, switch)
   lcd.drawText(x, y, label, 0);
+  lcd.drawText(x+76, y, ":", 0);
   lcd.drawText(x+80, y, switches[switch], 0)
   y = y + 8
   if y > 50 then
@@ -366,15 +368,15 @@ local function drawConfirmationMenu()
   lcd.clear()
   lcd.drawText(48, 1, "Ready to go?", 0);
   lcd.drawFilledRectangle(0, 0, LCD_W, 9, 0)
-  x, y = drawNextCHLine(x, y, "Throttle:", thrCH1)
-  x, y = drawNextCHLine(x, y, "Roll:", rollCH1)
-  x, y = drawNextCHLine(x, y, "Pitch:", pitchCH1)
-  x, y = drawNextCHLine(x, y, "Yaw:", yawCH1)
+  x, y = drawNextCHLine(x, y, "Throttle", thrCH1)
+  x, y = drawNextCHLine(x, y, "Roll", rollCH1)
+  x, y = drawNextCHLine(x, y, "Pitch", pitchCH1)
+  x, y = drawNextCHLine(x, y, "Yaw", yawCH1)
   x = 95
   y = 12
-  x, y = drawNextSWLine(x, y, "Arm switch:", armSW1)
-  x, y = drawNextSWLine(x, y, "Mode switch:", modeSW1)
-  x, y = drawNextSWLine(x, y, "Beeper switch:", beeperSW1)
+  x, y = drawNextSWLine(x, y, "Arm switch", armSW1)
+  x, y = drawNextSWLine(x, y, "Beeper switch", beeperSW1)
+  x, y = drawNextSWLine(x, y, "Mode switch", modeSW1)
   lcd.drawText(48, LCD_H-8, "[Enter Long] to confirm", 0);
   lcd.drawFilledRectangle(0, LCD_H-9, LCD_W, 9, 0)
   lcd.drawPixmap(LCD_W-18, 0, "confirm-tick.bmp")
@@ -396,7 +398,7 @@ end
 local function applySettings()
   model.defaultInputs()
   model.deleteMixes()
-  addMix(thrCH1,   MIXSRC_FIRST_INPUT+defaultChannel(2), "Throttle")
+  addMix(thrCH1,   MIXSRC_FIRST_INPUT+defaultChannel(2), "Engine")
   addMix(rollCH1,  MIXSRC_FIRST_INPUT+defaultChannel(3), "Roll")
   addMix(yawCH1,   MIXSRC_FIRST_INPUT+defaultChannel(0), "Yaw")
   addMix(pitchCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "Pitch")

--- a/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/WIZARD/plane.lua
@@ -509,8 +509,8 @@ local function applySettings()
   if aileronsMode == 1 then
     addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "Ail")
   elseif aileronsMode == 2 then
-    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL")
-    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR", -100)
+    addMix(ailCH1, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilL", -100)
+    addMix(ailCH2, MIXSRC_FIRST_INPUT+defaultChannel(3), "AilR")
   end
   if flapsMode == 1 then
     addMix(flapsCH1, MIXSRC_SA, "Flaps")
@@ -526,9 +526,9 @@ local function applySettings()
   end
   if tailMode == 3 then
     addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleL", 50)
-    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", 50, 1)
+    addMix(eleCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudL", -50, 1)
     addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(1), "V-EleR", 50)
-    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", -50, 1)
+    addMix(eleCH2, MIXSRC_FIRST_INPUT+defaultChannel(0), "V-RudR", 50, 1)
   else
     if tailMode > 0 then
       addMix(rudCH1, MIXSRC_FIRST_INPUT+defaultChannel(0), "Rudder")


### PR DESCRIPTION
- Some cosmetic changes (Left/Right instead 1/2).
- Swap Left/Right when it didn't match the displayed image.
- Added ":" in the summary menu of the X9 multi-copter wizard.
- Removed "2 motors" in the Horus wizard (not used).
- Fixed some inconsistency for Delta & V-Tail mixing. Now all radio's wizards will generate the same mixes.
- Shifted the char ":" for X7 wizards (cosmetic).
- Shorten some mixes name (reduce to 6 chars).
- Longer and more meaningful field names, when the screen radio allows it.
- Cosmetic change for Horus summary page in order to be consistent with X7/X9 wizard (moved ":" + take benefit of larger screen by adding "CH") .
- Fixed Horus glider wizard: tail configuration was reversed compared to the plane wizard (right & left were swapped).