### PR TITLE
[X7] fix #5911 and bmp loading

### DIFF
--- a/radio/src/gui/128x64/bmp.cpp
+++ b/radio/src/gui/128x64/bmp.cpp
@@ -129,10 +129,11 @@ uint8_t * lcdLoadBitmap(uint8_t * bmp, const char * filename, uint8_t width, uin
 
   memset(dest, 0, BITMAP_BUFFER_SIZE(w, h) - 2);
 
-  uint8_t rowSize = (w + 7) / 8;
+  uint8_t rowSize;
 
   switch (depth) {
     case 1:
+      rowSize = ((w + 31) / 32) * 4;
       for (int8_t i=h-1; i>=0; i--) {
         result = f_read(&bmpFile, buf, rowSize, &read);
         if (result != FR_OK || read != rowSize) {

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -922,15 +922,34 @@ void lcdDraw1bitBitmap(coord_t x, coord_t y, const uint8_t * img, uint8_t idx, L
   const uint8_t * q = img;
   uint8_t w = *q++;
   uint8_t hb = ((*q++) + 7) / 8;
+  uint8_t yShift = y % 8;
+
   bool inv = (att & INVERS) ? true : (att & BLINK ? BLINK_ON_PHASE : false);
+
   q += idx*w*hb;
+
   for (uint8_t yb = 0; yb < hb; yb++) {
+
     uint8_t *p = &displayBuf[(y / 8 + yb) * LCD_W + x];
+
     for (coord_t i=0; i<w; i++){
-      uint8_t b = *q++;
+
+      uint8_t b = inv ? ~(*q++) : *q++;
+      
       if (p < DISPLAY_END) {
-        *p++ = inv ? ~b : b;
+
+        if (!yShift) {
+          *p = b;
+        }
+        else {
+          *p = (*p & ((1 << yShift) - 1)) | (b << yShift);
+
+          if (p + LCD_W < DISPLAY_END) {
+            p[LCD_W] = (p[LCD_W] & (0xFF >> yShift)) | (b >> (8 - yShift));
+          }
+        }
       }
+      p++;
     }
   }
 }

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -541,7 +541,7 @@ Draw a bitmap at (x,y)
 
 @param name (string) full path to the bitmap on SD card (i.e. “/IMAGES/test.bmp”)
 
-@notice Only available on Taranis X9 series. Maximum image size if 106 x 64 pixels (width x height).
+@notice Maximum image size is [display width / 2] x [display height] pixels.
 
 @status current Introduced in 2.0.0
 */


### PR DESCRIPTION
Tested with this script:
```lua
y=12

local function runFunc(event)

  lcd.clear()
  lcd.drawText(1,1,"drawPixmap() example", 0)
  lcd.drawPixmap(24, y, "/delta.bmp")

  if event == EVT_VIRTUAL_NEXT then
     y = y + 1
  elseif event == EVT_VIRTUAL_PREVIOUS then
     y = y - 1
  end
  return 0
end

return { run=runFunc }
```

and this bitmap (github does not take bmp files...):
[delta.bmp.zip](https://github.com/opentx/opentx/files/3567183/delta.bmp.zip)

closes #5911 