### PR TITLE
fixed file descriptor leaks in radio tools

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -116,6 +116,7 @@ void menuRadioTools(event_t event)
       if (isRadioScriptTool(fno.fname))
         addRadioScriptTool(index++, path);
     }
+    f_closedir(&dir);
   }
 #endif
 

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1131,10 +1131,11 @@ bool readToolName(char * toolName, const char * filename)
     return "Error opening file";
   }
 
-  if (f_read(&file, &buffer, sizeof(buffer), &count) != FR_OK) {
-    f_close(&file);
+  FRESULT res = f_read(&file, &buffer, sizeof(buffer), &count);
+  f_close(&file);
+
+  if (res != FR_OK)
     return false;
-  }
 
   const char * tns = "TNS|";
   auto * start = std::search(buffer, buffer + sizeof(buffer), tns, tns + 4);


### PR DESCRIPTION
It is not really clear if this is really what is seen in #6716. I have spotted another memory related issue which could be related as well:

```
simulator(92124,0x7fff938bb380) malloc: *** error for object 0x10b569178: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
Process 92124 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00007fff5afc3b66 libsystem_kernel.dylib`__pthread_kill + 10
libsystem_kernel.dylib`__pthread_kill:
->  0x7fff5afc3b66 <+10>: jae    0x7fff5afc3b70            ; <+20>
    0x7fff5afc3b68 <+12>: movq   %rax, %rdi
    0x7fff5afc3b6b <+15>: jmp    0x7fff5afbaae9            ; cerror_nocancel
    0x7fff5afc3b70 <+20>: retq   
Target 0: (simulator) stopped.
(lldb) bt
error: libsimulation.a(debugoutput.cpp.o) :: Class 'QIODevice' has a base class 'QObject' which does not have a complete definition.
error: libsimulation.a(debugoutput.cpp.o) :: Try compiling the source file with -fstandalone-debug.
error: libsimulation.a(debugoutput.cpp.o) :: Class 'QComboBox' has a base class 'QWidget' which does not have a complete definition.
error: libsimulation.a(debugoutput.cpp.o) :: Try compiling the source file with -fstandalone-debug.
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fff5afc3b66 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff5b18e080 libsystem_pthread.dylib`pthread_kill + 333
    frame #2: 0x00007fff5af1f1ae libsystem_c.dylib`abort + 127
    frame #3: 0x00007fff5b028b58 libsystem_malloc.dylib`szone_error + 596
    frame #4: 0x00007fff5b01d69a libsystem_malloc.dylib`tiny_malloc_from_free_list + 1155
    frame #5: 0x00007fff5b01c443 libsystem_malloc.dylib`szone_malloc_should_clear + 422
    frame #6: 0x00007fff5b01c241 libsystem_malloc.dylib`malloc_zone_malloc + 103
    frame #7: 0x00007fff5b01b5bf libsystem_malloc.dylib`malloc + 24
    frame #8: 0x000000010186224d QtCore`QArrayData::allocate(unsigned long, unsigned long, unsigned long, QFlags<QArrayData::AllocationOption>) + 141
    frame #9: 0x00000001013e4a33 QtGui`QTextEngine::shapeText(int) const + 1779
    frame #10: 0x00000001013fcf22 QtGui`QTextLine::layout_helper(int) + 802
    frame #11: 0x0000000100f045c6 QtWidgets`QPlainTextDocumentLayout::layoutBlock(QTextBlock const&) + 406
    frame #12: 0x0000000100f0431a QtWidgets`QPlainTextDocumentLayout::blockBoundingRect(QTextBlock const&) const + 74
    frame #13: 0x0000000100f05f48 QtWidgets`___lldb_unnamed_symbol2516$$QtWidgets + 440
    frame #14: 0x0000000100f3699b QtWidgets`___lldb_unnamed_symbol2856$$QtWidgets + 123
    frame #15: 0x0000000100f38486 QtWidgets`QWidgetTextControl::cursorRect(QTextCursor const&) const + 86
    frame #16: 0x0000000100f08c5a QtWidgets`QPlainTextEdit::cursorRect() const + 58
    frame #17: 0x0000000100f07800 QtWidgets`___lldb_unnamed_symbol2527$$QtWidgets + 64
    frame #18: 0x0000000100f0dcc4 QtWidgets`___lldb_unnamed_symbol2541$$QtWidgets + 36
    frame #19: 0x0000000100f39d10 QtWidgets`QWidgetTextControl::moveCursor(QTextCursor::MoveOperation, QTextCursor::MoveMode) + 96
    frame #20: 0x00000001001116a1 simulator`DebugOutput::processBytesReceived(this=0x00000001021f1b70) at debugoutput.cpp:182
    frame #21: 0x0000000100114f1e simulator`QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (DebugOutput::*)()>::call(f=80 14 11 00 01 00 00 00 00 00 00 00 00 00 00 00, o=0x00000001021f1b70, arg=0x000000010c706c10)(), DebugOutput*, void**) at qobjectdefs_impl.h:152
    frame #22: 0x0000000100114e93 simulator`void QtPrivate::FunctionPointer<void (DebugOutput::*)()>::call<QtPrivate::List<>, void>(f=80 14 11 00 01 00 00 00 00 00 00 00 00 00 00 00, o=0x00000001021f1b70, arg=0x000000010c706c10)(), DebugOutput*, void**) at qobjectdefs_impl.h:185
    frame #23: 0x0000000100114dc6 simulator`QtPrivate::QSlotObject<void (DebugOutput::*)(), QtPrivate::List<>, void>::impl(which=1, this_=0x000000010218d260, r=0x00000001021f1b70, a=0x000000010c706c10, ret=0x0000000000000000) at qobjectdefs_impl.h:414
    frame #24: 0x0000000101a46ba1 QtCore`QObject::event(QEvent*) + 753
    frame #25: 0x0000000100d8a3ea QtWidgets`QWidget::event(QEvent*) + 4746
    frame #26: 0x0000000100d4d9fd QtWidgets`QApplicationPrivate::notify_helper(QObject*, QEvent*) + 269
    frame #27: 0x0000000100d4ee02 QtWidgets`QApplication::notify(QObject*, QEvent*) + 594
    frame #28: 0x0000000101a1ccc4 QtCore`QCoreApplication::notifyInternal2(QObject*, QEvent*) + 212
    frame #29: 0x0000000101a1defe QtCore`QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) + 878
    frame #30: 0x00000001023b5009 libqcocoa.dylib`___lldb_unnamed_symbol658$$libqcocoa.dylib + 313
    frame #31: 0x00000001023b5778 libqcocoa.dylib`___lldb_unnamed_symbol670$$libqcocoa.dylib + 40
    frame #32: 0x00007fff32f60d41 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    frame #33: 0x00007fff3301a75c CoreFoundation`__CFRunLoopDoSource0 + 108
    frame #34: 0x00007fff32f437a0 CoreFoundation`__CFRunLoopDoSources0 + 208
    frame #35: 0x00007fff32f42c1d CoreFoundation`__CFRunLoopRun + 1293
    frame #36: 0x00007fff32f42483 CoreFoundation`CFRunLoopRunSpecific + 483
    frame #37: 0x00007fff3222cd96 HIToolbox`RunCurrentEventLoopInMode + 286
    frame #38: 0x00007fff3222cb06 HIToolbox`ReceiveNextEventCommon + 613
    frame #39: 0x00007fff3222c884 HIToolbox`_BlockUntilNextEventMatchingListInModeWithFilter + 64
    frame #40: 0x00007fff304dca73 AppKit`_DPSNextEvent + 2085
    frame #41: 0x00007fff30c72e34 AppKit`-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3044
    frame #42: 0x00007fff304d1885 AppKit`-[NSApplication run] + 764
    frame #43: 0x00000001023b44f3 libqcocoa.dylib`___lldb_unnamed_symbol651$$libqcocoa.dylib + 2579
    frame #44: 0x0000000101a1813f QtCore`QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) + 431
    frame #45: 0x0000000101a1d2d2 QtCore`QCoreApplication::exec() + 130
    frame #46: 0x0000000100007820 simulator`main(argc=1, argv=0x00007ffeefbff8c8) at simulator.cpp:352
    frame #47: 0x00007fff5ae73015 libdyld.dylib`start + 1
    frame #48: 0x00007fff5ae73015 libdyld.dylib`start + 1
```