### PR TITLE
Xfire at 0 rssi

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -68,6 +68,9 @@ const CrossfireSensor & getCrossfireSensor(uint8_t id, uint8_t subId)
 
 void processCrossfireTelemetryValue(uint8_t index, int32_t value)
 {
+  if(!TELEMETRY_STREAMING())
+    return;
+
   const CrossfireSensor & sensor = crossfireSensors[index];
   setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id, 0, sensor.subId, value, sensor.unit, sensor.precision);
 }


### PR DESCRIPTION
> Reported by putimir :  💬 One thing, I noticed, regarding telemetry display, changed in this version: 
> 
> With the XF transmitter modules, you get some of the sensors from TX module in, even if not connected to a receiver, for example, TPWR and RQly. In previous OpenTX, these were getting in nicely and the telemetry display, as well as all the logical switches and functions were working as intended... 
> 
> Now these sensors come in intermittently, the displays are blinking, the LS are firing multiple times.... 
> 
> When the TX connects with an RX, these symptoms are gone, all the sensors, both from RX and TX are stable... 

With this fix, Xfire telem will behave like other telem, when there is no sign from the receiver (rssi = 0), the telemetry will stop streaming. It is a bit different from 2.2 behavior, but should not be an issue we think