### PR TITLE
do not invalidate filenames buffer on EVT_REFRESH

### DIFF
--- a/radio/src/gui/480x272/radio_sdmanager.cpp
+++ b/radio/src/gui/480x272/radio_sdmanager.cpp
@@ -194,7 +194,6 @@ bool menuRadioSdManager(event_t _event)
       // no break;
 
     case EVT_ENTRY_UP:
-    case EVT_REFRESH:
       REFRESH_FILES();
       break;
 

--- a/radio/src/gui/480x272/view_text.cpp
+++ b/radio/src/gui/480x272/view_text.cpp
@@ -50,6 +50,7 @@ bool menuTextView(event_t event)
       break;
 
     case EVT_KEY_FIRST(KEY_EXIT):
+      menuVerticalOffset = 0;
       popMenu();
       break;
   }


### PR DESCRIPTION
otherwise the filenames are reset to the end of list, whereby the indexes stay the same on [LONG ENTER] (pop-up menu).

This causes then funny things like that when scrolling further down the menu:
![IMG_0122](https://user-images.githubusercontent.com/1050031/64910047-41373b80-d713-11e9-83c1-4a897e189456.JPG)
