### PR TITLE
fixed gvar display when precision is used.

### DIFF
--- a/radio/src/gui/480x272/model_gvars.cpp
+++ b/radio/src/gui/480x272/model_gvars.cpp
@@ -157,13 +157,14 @@ bool menuModelGVars(event_t event)
       gvar_t v = fm->gvars[i];
 
       LcdFlags attr = RIGHT | ((sub == i && menuHorizontalPosition == j) ? (s_editMode > 0 ? BLINK | INVERS : INVERS) : 0);
-      if (j == curfm)
-        attr |= BOLD;
       coord_t x = GVARS_FM_COLUMN(j);
       coord_t yval = y;
       if (v <= GVAR_MAX && (g_model.gvars[i].prec > 0 || abs(v) >= 1000 || ( abs(v) >= 100 && g_model.gvars[i].unit > 0))) {
         attr |= SMLSIZE;
         yval += 3;
+      }
+      else if (j == curfm) {
+        attr |= BOLD;
       }
       if (v <= GVAR_MAX && g_model.gvars[i].unit > 0) {
         x -= 9;


### PR DESCRIPTION
Issue:
<img width="219" alt="Screen Shot 2019-09-14 at 19 12 55" src="https://user-images.githubusercontent.com/1050031/64911925-42269800-d728-11e9-875f-ede25e3f4b64.png">
<img width="260" alt="Screen Shot 2019-09-14 at 19 12 42" src="https://user-images.githubusercontent.com/1050031/64911929-45218880-d728-11e9-8a5f-58af5ceb19b6.png">

Now, as we don't have a small font that can be made bold, it is just small in this case.