### PR TITLE
2.2 no avr

### DIFF
--- a/radio/util/Dockerfile
+++ b/radio/util/Dockerfile
@@ -13,12 +13,6 @@ RUN wget -q https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/+downl
     tar xjf gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2 && \
     mv gcc-arm-none-eabi-4_7-2013q3 /opt/gcc-arm-none-eabi
 
-RUN wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/g/gcc-avr/gcc-avr_4.7.2-2_amd64.deb && \
-    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/a/avr-libc/avr-libc_1.8.0-2_all.deb && \
-    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/b/binutils-avr/binutils-avr_2.24+Atmel3.4.4-1_amd64.deb && \
-    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/m/mpclib/libmpc2_0.9-4_amd64.deb && \
-    dpkg -i gcc-avr_4.7.2-2_amd64.deb libmpc2_0.9-4_amd64.deb avr-libc_1.8.0-2_all.deb binutils-avr_2.24+Atmel3.4.4-1_amd64.deb
-
 VOLUME ["/opentx"]
 
 ENV PATH $PATH:/opt/gcc-arm-none-eabi/bin:/opentx/code/radio/util

--- a/radio/util/Dockerfile
+++ b/radio/util/Dockerfile
@@ -13,10 +13,10 @@ RUN wget -q https://launchpad.net/gcc-arm-embedded/4.7/4.7-2013-q3-update/+downl
     tar xjf gcc-arm-none-eabi-4_7-2013q3-20130916-linux.tar.bz2 && \
     mv gcc-arm-none-eabi-4_7-2013q3 /opt/gcc-arm-none-eabi
 
-RUN wget -q http://ftp.de.debian.org/debian/pool/main/g/gcc-avr/gcc-avr_4.7.2-2_amd64.deb && \
-    wget -q http://ftp.de.debian.org/debian/pool/main/a/avr-libc/avr-libc_1.8.0-2_all.deb && \
-    wget -q http://ftp.de.debian.org/debian/pool/main/b/binutils-avr/binutils-avr_2.24+Atmel3.4.4-1_amd64.deb && \
-    wget -q http://ftp.de.debian.org/debian/pool/main/m/mpclib/libmpc2_0.9-4_amd64.deb && \
+RUN wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/g/gcc-avr/gcc-avr_4.7.2-2_amd64.deb && \
+    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/a/avr-libc/avr-libc_1.8.0-2_all.deb && \
+    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/b/binutils-avr/binutils-avr_2.24+Atmel3.4.4-1_amd64.deb && \
+    wget -q http://ftp.de.debian.org/debian-archive/debian/pool/main/m/mpclib/libmpc2_0.9-4_amd64.deb && \
     dpkg -i gcc-avr_4.7.2-2_amd64.deb libmpc2_0.9-4_amd64.deb avr-libc_1.8.0-2_all.deb binutils-avr_2.24+Atmel3.4.4-1_amd64.deb
 
 VOLUME ["/opentx"]


### PR DESCRIPTION
alternate PR to #6785

remove unused avr packages from 2.2 docker file, instead of fixing externally changed location.