### PR TITLE
Adapt multi safechecks to dual multi setup

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -870,7 +870,7 @@ void checkFailsafe()
 {
   for (int i=0; i<NUM_MODULES; i++) {
     if (isModuleMultimodule(i)) {
-      multiModuleStatus.requiresFailsafeCheck = true;
+      getMultiModuleStatus(i).requiresFailsafeCheck = true;
     }
     else if (isModuleFailsafeAvailable(i)) {
       ModuleData & moduleData = g_model.moduleData[i];

--- a/radio/src/telemetry/multi.cpp
+++ b/radio/src/telemetry/multi.cpp
@@ -160,6 +160,12 @@ static void processMultiStatusPacket(const uint8_t * data, uint8_t module)
   status.patch = data[4];
   status.lastUpdate = get_tmr10ms();
 
+  if (getMultiModuleStatus(module).requiresFailsafeCheck) {
+    getMultiModuleStatus(module).requiresFailsafeCheck = false;
+    if (getMultiModuleStatus(module).supportsFailsafe() &&  g_model.moduleData[EXTERNAL_MODULE].failsafeMode == FAILSAFE_NOT_SET)
+      POPUP_WARNING(STR_NO_FAILSAFE);
+  }
+
   if (wasBinding && !status.isBinding() && getMultiBindStatus(module) == MULTI_BIND_INITIATED)
     setMultiBindStatus(module, MULTI_BIND_FINISHED);
 }


### PR DESCRIPTION
Checks both multi if two are present, and display one warning if either or both module have a failsafe needing protocol and have it not set