### PR TITLE
Disable trainer signal based input when trainer signal is lost

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -157,8 +157,7 @@ void applyExpos(int16_t * anas, uint8_t mode, uint8_t ovwrIdx, int16_t ovwrValue
       continue;
     if (ed->flightModes & (1<<mixerCurrentFlightMode))
       continue;
-    if (ed->srcRaw >= MIXSRC_FIRST_TRAINER && ed->srcRaw <= MIXSRC_LAST_TRAINER
-        && !IS_TRAINER_INPUT_VALID())
+    if (ed->srcRaw >= MIXSRC_FIRST_TRAINER && ed->srcRaw <= MIXSRC_LAST_TRAINER && !IS_TRAINER_INPUT_VALID())
       continue;
     if (getSwitch(ed->swtch)) {
       int32_t v;

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -157,6 +157,9 @@ void applyExpos(int16_t * anas, uint8_t mode, uint8_t ovwrIdx, int16_t ovwrValue
       continue;
     if (ed->flightModes & (1<<mixerCurrentFlightMode))
       continue;
+    if (ed->srcRaw >= MIXSRC_FIRST_TRAINER && ed->srcRaw <= MIXSRC_LAST_TRAINER
+        && !IS_TRAINER_INPUT_VALID())
+      continue;
     if (getSwitch(ed->swtch)) {
       int32_t v;
       if (ed->srcRaw == ovwrIdx) {


### PR DESCRIPTION
This is based on what is already done today in the mixers. However, it is much easier to have the trainer channels inserted in the inputs as in the mixers, especially when many mixers are used to run the model.

Example:
![IMG_7823](https://user-images.githubusercontent.com/1050031/66260982-40e80880-e7c6-11e9-8966-076dfadf2669.JPG)

Here, as soon as the trainer input is lost, the master's input (`SA`) will be used instead of the `TR5` even if `SH` is pulled.