### PR TITLE
Fix multi dsm channel count/max

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -396,7 +396,7 @@ int ModulePanel::getMaxChannelCount()
       return 6;
     case PULSES_MULTIMODULE:
       if (module.multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2)
-        return 6;
+        return 12;
       else
         return 16;
       break;
@@ -766,6 +766,7 @@ void ModulePanel::onMultiProtocolChanged(int index)
     if (module.multi.customProto)
       maxSubTypes=8;
     module.subType = std::min(module.subType, maxSubTypes -1);
+    module.channelsCount = getMaxChannelCount();
     update();
     emit modified();
     lock = false;


### PR DESCRIPTION
- max chan for multi dsm is 12 (as oposed to dsm hack module : 6)
- on multi change, set channelCount to max (was already done for non multi protocol change)

This fixes #6989