### PR TITLE
Switch autobold

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -792,7 +792,7 @@ void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags, bool autoBold
 {
   char s[8];
   getSwitchPositionName(s, idx);
-  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
+  if (autoBold && idx != SWSRC_NONE && getSwitch(idx))
     flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -788,10 +788,12 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
   }
 }
 
-void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags)
+void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags, bool autoBold)
 {
   char s[8];
   getSwitchPositionName(s, idx);
+  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
+    flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/128x64/lcd.h
+++ b/radio/src/gui/128x64/lcd.h
@@ -124,7 +124,7 @@ void lcdDraw8bitsNumber(coord_t x, coord_t y, int8_t val);
 
 void putsModelName(coord_t x, coord_t y, char * name, uint8_t id, LcdFlags att);
 #if !defined(BOOT) // TODO not here ...
-void drawSwitch(coord_t x, coord_t y, swsrc_t swtch, LcdFlags att=0);
+void drawSwitch(coord_t x, coord_t y, swsrc_t swtch, LcdFlags att=0, bool autoBold = true);
 void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att=0);
 #endif
 void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags att=0);

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -509,7 +509,7 @@ void menuMainView(event_t event)
         if (SWITCH_EXISTS(i)) {
           getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
           getvalue_t sw = ((val < 0) ? 3 * i + 1 : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
-          drawSwitch(x[i], y[i], sw, 0);
+          drawSwitch(x[i], y[i], sw, 0, false);
         }
       }
       drawSmallSwitch(29, 5*FH+1, 4, SW_SF);
@@ -521,7 +521,7 @@ void menuMainView(event_t event)
         if (SWITCH_EXISTS(i)) {
           getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
           getvalue_t sw = ((val < 0) ? 3 * i + 1 : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
-          drawSwitch(x[i], y[i], sw, 0);
+          drawSwitch(x[i], y[i], sw, 0, false);
         }
       }
 #elif defined(PCBXLITES)
@@ -531,7 +531,7 @@ void menuMainView(event_t event)
         if (SWITCH_EXISTS(i)) {
           getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
           getvalue_t sw = ((val < 0) ? 3 * i + 1 : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
-          drawSwitch(x[i], y[i], sw, 0);
+          drawSwitch(x[i], y[i], sw, 0, false);
         }
       }
 #elif defined(PCBTARANIS)
@@ -545,7 +545,7 @@ void menuMainView(event_t event)
           }
           getvalue_t val = getValue(MIXSRC_FIRST_SWITCH+i);
           getvalue_t sw = ((val < 0) ? 3*i+1 : ((val == 0) ? 3*i+2 : 3*i+3));
-          drawSwitch(x, y, sw, 0);
+          drawSwitch(x, y, sw, 0, false);
         }
       }
 #else
@@ -557,7 +557,7 @@ void menuMainView(event_t event)
           x = 17*FW-1;
           y -= 3*FH;
         }
-        drawSwitch(x, y, sw, getSwitch(i) ? INVERS : 0);
+        drawSwitch(x, y, sw, getSwitch(i) ? INVERS : 0, false);
       }
 #endif
     }

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -697,7 +697,7 @@ void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags, bool autoBold
 {
   char s[8];
   getSwitchPositionName(s, idx);
-  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
+  if (autoBold && idx != SWSRC_NONE && getSwitch(idx))
     flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -693,13 +693,11 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
   }
 }
 
-void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags)
+void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags, bool autoBold)
 {
   char s[8];
   getSwitchPositionName(s, idx);
-  if(idx < SWSRC_FIRST_LOGICAL_SWITCH)
-    flags |= (idx && getSwitch(idx)) ? BOLD : 0;
-  else if(idx <= SWSRC_LAST_LOGICAL_SWITCH && getSwitch(idx))
+  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
     flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -697,6 +697,10 @@ void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags)
 {
   char s[8];
   getSwitchPositionName(s, idx);
+  if(idx < SWSRC_FIRST_LOGICAL_SWITCH)
+    flags |= (idx && getSwitch(idx)) ? BOLD : 0;
+  else if(idx <= SWSRC_LAST_LOGICAL_SWITCH && getSwitch(idx))
+    flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/212x64/lcd.h
+++ b/radio/src/gui/212x64/lcd.h
@@ -118,7 +118,7 @@ void lcdDrawNumber(coord_t x, coord_t y, int32_t val, LcdFlags mode, uint8_t len
 void lcdDrawNumber(coord_t x, coord_t y, int32_t val, LcdFlags mode=0);
 
 void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att);
-void drawSwitch(coord_t x, coord_t y, int32_t swtch, LcdFlags att=0);
+void drawSwitch(coord_t x, coord_t y, int32_t swtch, LcdFlags att=0, bool autoBold = true);
 void putsStickName(coord_t x, coord_t y, uint8_t idx, LcdFlags att=0);
 void drawSource(coord_t x, coord_t y, uint32_t idx, LcdFlags att=0);
 void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags att=0);

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -532,7 +532,7 @@ void menuMainView(event_t event)
       if (SWITCH_EXISTS(i)) {
         getvalue_t val = getValue(MIXSRC_FIRST_SWITCH+i);
         getvalue_t sw = ((val < 0) ? 3*i+1 : ((val == 0) ? 3*i+2 : 3*i+3));
-        drawSwitch((g_model.view == VIEW_INPUTS) ? (index<4 ? 8*FW+1 : 23*FW+2) : (index<4 ? 3*FW+1 : 8*FW-2), (index%4)*FH+3*FH, sw, 0);
+        drawSwitch((g_model.view == VIEW_INPUTS) ? (index<4 ? 8*FW+1 : 23*FW+2) : (index<4 ? 3*FW+1 : 8*FW-2), (index%4)*FH+3*FH, sw, 0, false);
         index++;
       }
     }

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -283,10 +283,12 @@ void putsModelName(coord_t x, coord_t y, char * name, uint8_t id, LcdFlags att)
   }
 }
 
-void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags)
+void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags, bool autoBold)
 {
   char s[8];
   getSwitchPositionName(s, idx);
+  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
+    flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -287,7 +287,7 @@ void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags, bool autoBold
 {
   char s[8];
   getSwitchPositionName(s, idx);
-  if(autoBold && idx != SWSRC_NONE && getSwitch(idx))
+  if (autoBold && idx != SWSRC_NONE && getSwitch(idx))
     flags |= BOLD;
   lcdDrawText(x, y, s, flags);
 }

--- a/radio/src/gui/480x272/lcd.h
+++ b/radio/src/gui/480x272/lcd.h
@@ -147,7 +147,7 @@ void drawTimer(coord_t x, coord_t y, int32_t tme, LcdFlags att=0);
 
 void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att);
 void putsStickName(coord_t x, coord_t y, uint8_t idx, LcdFlags att=0);
-void drawSwitch(coord_t x, coord_t y, swsrc_t swtch, LcdFlags flags=0);
+void drawSwitch(coord_t x, coord_t y, swsrc_t swtch, LcdFlags flags=0, bool autoBold = true);
 void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att=0);
 void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags att=0);
 void drawTimerMode(coord_t x, coord_t y, swsrc_t mode, LcdFlags att=0);

--- a/radio/src/tests/lcd.cpp
+++ b/radio/src/tests/lcd.cpp
@@ -259,7 +259,7 @@ TEST(Lcd, Dblsize)
 TEST(Lcd, DrawSwitch)
 {
   lcdClear();
-  drawSwitch(0,  10, SWSRC_SA0, 0);
+  drawSwitch(0,  10, SWSRC_SA0, 0, false);
   drawSwitch(30, 10, SWSRC_SA0, SMLSIZE);
   // drawSwitch(60, 10, SWSRC_SA0, MIDSIZE); missing arrows in this font
   drawSwitch(90, 10, SWSRC_SA0, DBLSIZE);


### PR DESCRIPTION
Display switches (in general, logical switches too) in bold when in the selected position / logical state

This superseedes : #6918

This closes #6812