### PR TITLE
Rework 128 timer to better leverage tiny space

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -193,7 +193,7 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
       if(negative)
         lcdDrawText(lcdLastLeftPos, y, "-", att | negative);
     }
-    else if (timerState.val < 359940) { // display HHhMM
+    else if (timerState.val < 99 * 60 * 60 + 59 * 60) { // display HHhMM
       div_t qr = div(abs(timerState.val) / 60, 60);
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0, 2);
       lcdDrawText(lcdLastLeftPos, y, "h", att);

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -185,7 +185,7 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
     const TimerState & timerState = timersStates[index];
     const uint8_t negative = (timerState.val<0 ? BLINK | INVERS : 0);
     LcdFlags att = RIGHT | DBLSIZE;
-    if (timerState.val < 3600) { // display MM:SS
+    if (timerState.val < 60 * 60) { // display MM:SS
       div_t qr = div(abs(timerState.val), 60);
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0 | negative, 2);
       lcdDrawText(lcdLastLeftPos, y, ":", att|BLINK | negative);
@@ -193,12 +193,12 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
       if(negative)
         lcdDrawText(lcdLastLeftPos, y, "-", att | negative);
     }
-    else if (timerState.val < 99 * 60 * 60 + 59 * 60) { // display HHhMM
+    else if (timerState.val < (99 * 60 * 60) + (59 * 60) { // display HHhMM
       div_t qr = div(abs(timerState.val) / 60, 60);
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0, 2);
       lcdDrawText(lcdLastLeftPos, y, "h", att);
       lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att);
-      if(negative)
+      if (negative)
         lcdDrawText(lcdLastLeftPos, y, "-", att);
     }
     else {  //display HHHH for crazy large persistent timers

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -190,7 +190,7 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0 | negative, 2);
       lcdDrawText(lcdLastLeftPos, y, ":", att|BLINK | negative);
       lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att | negative);
-      if(negative)
+      if (negative)
         lcdDrawText(lcdLastLeftPos, y, "-", att | negative);
     }
     else if (timerState.val < (99 * 60 * 60) + (59 * 60) { // display HHhMM

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -180,11 +180,31 @@ void displayTrims(uint8_t phase)
 void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
 {
   const TimerData & timer = g_model.timers[index];
+
   if (timer.mode) {
     const TimerState & timerState = timersStates[index];
     const uint8_t negative = (timerState.val<0 ? BLINK | INVERS : 0);
-    LcdFlags att = RIGHT | DBLSIZE | negative;
-    drawTimer(x, y, timerState.val, att, att);
+    LcdFlags att = RIGHT | DBLSIZE;
+    if (timerState.val < 3600) { // display MM:SS
+      div_t qr = div(abs(timerState.val), 60);
+      lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0 | negative, 2);
+      lcdDrawText(lcdLastLeftPos, y, ":", att|BLINK | negative);
+      lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att | negative);
+      if(negative)
+        lcdDrawText(lcdLastLeftPos, y, "-", att | negative);
+    }
+    else if (timerState.val < 359940) { // display HHhMM
+      div_t qr = div(abs(timerState.val) / 60, 60);
+      lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0, 2);
+      lcdDrawText(lcdLastLeftPos, y, "h", att);
+      lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att);
+      if(negative)
+        lcdDrawText(lcdLastLeftPos, y, "-", att);
+    }
+    else {  //display HHHH for crazy large persistent timers
+      lcdDrawText(x - 5, y, "h", att);
+      lcdDrawNumber(lcdLastLeftPos, y, timerState.val / 3600, att);
+    }
     uint8_t xLabel = (negative ? x-56 : x-49);
     uint8_t len = zlen(timer.name, LEN_TIMER_NAME);
     if (len > 0) {


### PR DESCRIPTION
Some users display persistent timers on main view, leading to issue given the tiny space allowed.

This change will display MM:SS for timer under 1 hour

It will then display HH:MM for timer lower than 99h59

Then just the number of hours for timers above that

This fixes #6945