### PR TITLE
Mixer scheduler

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -353,6 +353,7 @@ set(SRC
   strhelpers.cpp
   switches.cpp
   mixer.cpp
+  mixer_scheduler.cpp
   stamp.cpp
   timers.cpp
   trainer.cpp

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1621,7 +1621,7 @@ void menuModelSetup(event_t event)
         lcdDrawTextAlignedLeft(y, STR_MODULE_SYNC);
 
         char statusText[64];
-        getMultiSyncStatus(moduleIdx).getRefreshString(statusText);
+        getModuleSyncStatus(moduleIdx).getRefreshString(statusText);
         lcdDrawText(MODEL_SETUP_2ND_COLUMN, y, statusText);
         break;
       }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1321,7 +1321,7 @@ void menuModelSetup(event_t event)
     {
       lcdDrawTextAlignedLeft(y, STR_MODULE_SYNC);
       char statusText[64];
-      getMultiSyncStatus(EXTERNAL_MODULE).getRefreshString(statusText);
+      getModuleSyncStatus(EXTERNAL_MODULE).getRefreshString(statusText);
       lcdDrawText(MODEL_SETUP_2ND_COLUMN, y, statusText);
       break;
     }

--- a/radio/src/gui/480x272/model_setup.cpp
+++ b/radio/src/gui/480x272/model_setup.cpp
@@ -1737,7 +1737,7 @@ bool menuModelSetup(event_t event)
       lcdDrawText(MENUS_MARGIN_LEFT, y, STR_MODULE_SYNC);
 
       char statusText[64];
-      getMultiSyncStatus(moduleIdx).getRefreshString(statusText);
+      getModuleSyncStatus(moduleIdx).getRefreshString(statusText);
       lcdDrawText(MODEL_SETUP_2ND_COLUMN, y, statusText);
       break;
     }

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -249,7 +249,7 @@ inline uint8_t MULTIMODULE_HASOPTIONS(uint8_t moduleIdx)
 }
 
 #define MULTIMODULE_MODULE_ROWS(moduleIdx)      MULTIMODULE_PROTOCOL_KNOWN(moduleIdx) ? (uint8_t) 0 : HIDDEN_ROW, MULTIMODULE_PROTOCOL_KNOWN(moduleIdx) ? (uint8_t) 0 : HIDDEN_ROW, MULTI_DISABLE_CHAN_MAP_ROW(moduleIdx), // AUTOBIND, DISABLE TELEM, DISABLE CN.MAP
-#define MULTIMODULE_STATUS_ROWS(moduleIdx)      isModuleMultimodule(moduleIdx) ? TITLE_ROW : HIDDEN_ROW, (isModuleMultimodule(moduleIdx) && getMultiSyncStatus(moduleIdx).isValid()) ? TITLE_ROW : HIDDEN_ROW,
+#define MULTIMODULE_STATUS_ROWS(moduleIdx)      isModuleMultimodule(moduleIdx) ? TITLE_ROW : HIDDEN_ROW, (isModuleMultimodule(moduleIdx) && getModuleSyncStatus(moduleIdx).isValid()) ? TITLE_ROW : HIDDEN_ROW,
 #define MULTIMODULE_MODE_ROWS(moduleIdx)        (g_model.moduleData[moduleIdx].multi.customProto) ? (uint8_t) 3 : MULTIMODULE_HAS_SUBTYPE(moduleIdx) ? (uint8_t)2 : (uint8_t)1
 #define MULTIMODULE_SUBTYPE_ROWS(moduleIdx)     isModuleMultimodule(moduleIdx) ? MULTIMODULE_RFPROTO_COLUMNS(moduleIdx) : HIDDEN_ROW,
 #define MULTIMODULE_OPTIONS_ROW(moduleIdx)      (isModuleMultimodule(moduleIdx) && MULTIMODULE_HASOPTIONS(moduleIdx)) ? (uint8_t) 0: HIDDEN_ROW

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -161,6 +161,7 @@ inline uint8_t MODULE_CHANNELS_ROWS(int moduleIdx)
 
 
 #if defined(MULTIMODULE)
+
 inline uint8_t MULTI_DISABLE_CHAN_MAP_ROW(uint8_t moduleIdx)
 {
   if (!isModuleMultimodule(moduleIdx))

--- a/radio/src/mixer_scheduler.cpp
+++ b/radio/src/mixer_scheduler.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "opentx.h"
+#include "mixer_scheduler.h"
+
+#if !defined(SIMU)
+
+// Global trigger flag
+RTOS_FLAG_HANDLE mixerFlag;
+
+// Mixer schedule
+struct MixerSchedule {
+
+    // period in us
+    volatile uint16_t period;
+};
+
+static MixerSchedule mixerSchedules[NUM_MODULES];
+
+uint16_t getMixerSchedulerPeriod()
+{
+    if (mixerSchedules[INTERNAL_MODULE].period) {
+        return mixerSchedules[INTERNAL_MODULE].period;
+    }
+    else if (mixerSchedules[EXTERNAL_MODULE].period) {
+        return mixerSchedules[EXTERNAL_MODULE].period;
+    }
+    
+    return MIXER_SCHEDULER_DEFAULT_PERIOD_US;
+}
+
+void mixerSchedulerInit()
+{
+    RTOS_CREATE_FLAG(mixerFlag);
+    memset(mixerSchedules, 0, sizeof(mixerSchedules));
+}
+
+void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs)
+{
+    if ((periodUs > 0) && (periodUs < MIN_REFRESH_RATE)) {
+        periodUs = MIN_REFRESH_RATE;
+    }
+    else if ((periodUs > 0) && (periodUs > MAX_REFRESH_RATE)) {
+        periodUs = MAX_REFRESH_RATE;
+    }
+
+    mixerSchedules[moduleIdx].period = periodUs;
+}
+
+bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
+{
+    RTOS_CLEAR_FLAG(mixerFlag);
+    return RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
+}
+
+void mixerSchedulerISRTrigger()
+{
+    RTOS_ISR_SET_FLAG(mixerFlag);
+}
+
+#endif

--- a/radio/src/mixer_scheduler.cpp
+++ b/radio/src/mixer_scheduler.cpp
@@ -29,51 +29,51 @@ RTOS_FLAG_HANDLE mixerFlag;
 // Mixer schedule
 struct MixerSchedule {
 
-    // period in us
-    volatile uint16_t period;
+  // period in us
+  volatile uint16_t period;
 };
 
 static MixerSchedule mixerSchedules[NUM_MODULES];
 
 uint16_t getMixerSchedulerPeriod()
 {
-    if (mixerSchedules[INTERNAL_MODULE].period) {
-        return mixerSchedules[INTERNAL_MODULE].period;
-    }
-    else if (mixerSchedules[EXTERNAL_MODULE].period) {
-        return mixerSchedules[EXTERNAL_MODULE].period;
-    }
+  if (mixerSchedules[INTERNAL_MODULE].period) {
+    return mixerSchedules[INTERNAL_MODULE].period;
+  }
+  else if (mixerSchedules[EXTERNAL_MODULE].period) {
+    return mixerSchedules[EXTERNAL_MODULE].period;
+  }
     
-    return MIXER_SCHEDULER_DEFAULT_PERIOD_US;
+  return MIXER_SCHEDULER_DEFAULT_PERIOD_US;
 }
 
 void mixerSchedulerInit()
 {
-    RTOS_CREATE_FLAG(mixerFlag);
-    memset(mixerSchedules, 0, sizeof(mixerSchedules));
+  RTOS_CREATE_FLAG(mixerFlag);
+  memset(mixerSchedules, 0, sizeof(mixerSchedules));
 }
 
 void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs)
 {
-    if ((periodUs > 0) && (periodUs < MIN_REFRESH_RATE)) {
-        periodUs = MIN_REFRESH_RATE;
-    }
-    else if ((periodUs > 0) && (periodUs > MAX_REFRESH_RATE)) {
-        periodUs = MAX_REFRESH_RATE;
-    }
+  if ((periodUs > 0) && (periodUs < MIN_REFRESH_RATE)) {
+    periodUs = MIN_REFRESH_RATE;
+  }
+  else if ((periodUs > 0) && (periodUs > MAX_REFRESH_RATE)) {
+    periodUs = MAX_REFRESH_RATE;
+  }
 
-    mixerSchedules[moduleIdx].period = periodUs;
+  mixerSchedules[moduleIdx].period = periodUs;
 }
 
 bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
 {
-    RTOS_CLEAR_FLAG(mixerFlag);
-    return RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
+  RTOS_CLEAR_FLAG(mixerFlag);
+  return RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
 }
 
 void mixerSchedulerISRTrigger()
 {
-    RTOS_ISR_SET_FLAG(mixerFlag);
+  RTOS_ISR_SET_FLAG(mixerFlag);
 }
 
 #endif

--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -18,10 +18,16 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MIXER_SCHEDULER_DRIVER_H_
-#define _MIXER_SCHEDULER_DRIVER_H_
+#ifndef _MIXER_SCHEDULER_H_
+#define _MIXER_SCHEDULER_H_
+
+#define MIXER_SCHEDULER_DEFAULT_PERIOD_US 4000u // 4ms
+
+#define MIN_REFRESH_RATE      4000 /* us */
+#define MAX_REFRESH_RATE     25000 /* us */
 
 #if !defined(SIMU)
+
 // Call once to initialize the mixer scheduler
 void mixerSchedulerInit();
 
@@ -44,6 +50,12 @@ void mixerSchedulerEnableTrigger();
 // Disable the timer trigger
 void mixerSchedulerDisableTrigger();
 
+// Fetch the current scheduling period
+uint16_t getMixerSchedulerPeriod();
+
+// Trigger mixer from an ISR
+void mixerSchedulerISRTrigger();
+
 #else
 
 #define mixerSchedulerInit()
@@ -59,6 +71,9 @@ static inline bool mixerSchedulerWaitForTrigger(uint8_t timeout)
 
 #define mixerSchedulerEnableTrigger()
 #define mixerSchedulerDisableTrigger()
+
+#define getMixerSchedulerPeriod() (MIXER_SCHEDULER_DEFAULT_PERIOD_US)
+#define mixerSchedulerISRTrigger()
 
 #endif
 

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -491,7 +491,6 @@ extern uint8_t flightModeTransitionLast;
 void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms);
 void evalMixes(uint8_t tick10ms);
 void doMixerCalculations();
-void scheduleNextMixerCalculation(uint8_t module, uint16_t period_ms);
 
 void checkTrims();
 void perMain();

--- a/radio/src/pulses/dsm2.cpp
+++ b/radio/src/pulses/dsm2.cpp
@@ -76,7 +76,6 @@ void _send_1(uint8_t v)
 
   *extmodulePulsesData.dsm2.ptr++ = v - 1;
   extmodulePulsesData.dsm2.index += 1;
-  extmodulePulsesData.dsm2.rest -= v;
 }
 
 void sendByteDsm2(uint8_t b) // max 10 changes 0 10 10 10 10 1
@@ -101,9 +100,9 @@ void sendByteDsm2(uint8_t b) // max 10 changes 0 10 10 10 10 1
 void putDsm2Flush()
 {
   if (extmodulePulsesData.dsm2.index & 1)
-    *extmodulePulsesData.dsm2.ptr++ = extmodulePulsesData.dsm2.rest;
+    *extmodulePulsesData.dsm2.ptr++ = 60000;
   else
-    *(extmodulePulsesData.dsm2.ptr - 1) = extmodulePulsesData.dsm2.rest;
+    *(extmodulePulsesData.dsm2.ptr - 1) = 60000;
 }
 #endif
 
@@ -119,7 +118,6 @@ void setupPulsesDSM2()
   extmodulePulsesData.dsm2.serialBitCount = 0 ;
 #else
   extmodulePulsesData.dsm2.index = 0;
-  extmodulePulsesData.dsm2.rest = DSM2_PERIOD * 2000;
 #endif
 
   extmodulePulsesData.dsm2.ptr = extmodulePulsesData.dsm2.pulses;

--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -196,10 +196,8 @@ void setupPulsesMultiExternalModule()
   extmodulePulsesData.dsm2.serialByte = 0 ;
   extmodulePulsesData.dsm2.serialBitCount = 0 ;
 #else
-  extmodulePulsesData.dsm2.rest = getMultiSyncStatus(EXTERNAL_MODULE).getAdjustedRefreshRate();
   extmodulePulsesData.dsm2.index = 0;
 #endif
-
   extmodulePulsesData.dsm2.ptr = extmodulePulsesData.dsm2.pulses;
 
   setupPulsesMulti(EXTERNAL_MODULE);

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -283,6 +283,9 @@ void setupPulsesExternalModule(uint8_t protocol)
       ModuleSyncStatus& status = getModuleSyncStatus(EXTERNAL_MODULE);
       if (status.isValid())
         mixerSchedulerSetPeriod(EXTERNAL_MODULE, status.getAdjustedRefreshRate());
+      else
+        mixerSchedulerSetPeriod(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
+
       setupPulsesMultiExternalModule();
       break;
     }

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -21,6 +21,7 @@
 #include "opentx.h"
 #include "io/frsky_pxx2.h"
 #include "pulses/pxx2.h"
+#include "mixer_scheduler.h"
 
 uint8_t s_pulses_paused = 0;
 ModuleState moduleState[NUM_MODULES];
@@ -294,6 +295,8 @@ void setupPulsesExternalModule(uint8_t protocol)
 #endif
 
     default:
+      // external module stopped, set period to 0
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, 0);
       break;
   }
 }
@@ -352,6 +355,8 @@ static void enablePulsesInternalModule(uint8_t protocol)
       break;
 #endif
     default:
+      // internal module stopped, set internal period to 0 and start the scheduler
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, 0);
       mixerSchedulerStart();
       break;
   }

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -273,8 +273,13 @@ void setupPulsesExternalModule(uint8_t protocol)
 
 #if defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_MULTIMODULE:
+    {
+      ModuleSyncStatus& status = getModuleSyncStatus(EXTERNAL_MODULE);
+      if (status.isValid())
+        mixerSchedulerSetPeriod(EXTERNAL_MODULE, status.getAdjustedRefreshRate());
       setupPulsesMultiExternalModule();
       break;
+    }
 #endif
 
 #if defined(PPM)

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -267,8 +267,13 @@ void setupPulsesExternalModule(uint8_t protocol)
 
 #if defined(CROSSFIRE)
     case PROTOCOL_CHANNELS_CROSSFIRE:
+    {
+      ModuleSyncStatus& status = getModuleSyncStatus(EXTERNAL_MODULE);
+      if (status.isValid())
+        mixerSchedulerSetPeriod(EXTERNAL_MODULE, status.getAdjustedRefreshRate());
       setupPulsesCrossfire();
       break;
+    }
 #endif
 
 #if defined(MULTIMODULE)
@@ -394,6 +399,7 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(INTERNAL_MODULE_MULTI)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       setupPulsesMultiInternalModule();
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, MULTIMODULE_PERIOD);
       return true;
 #endif
 

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -352,6 +352,7 @@ static void enablePulsesInternalModule(uint8_t protocol)
       break;
 #endif
     default:
+      mixerSchedulerStart();
       break;
   }
 }

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -178,7 +178,7 @@ void enablePulsesExternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_DSM2_LP45:
     case PROTOCOL_CHANNELS_DSM2_DSM2:
     case PROTOCOL_CHANNELS_DSM2_DSMX:
-      extmoduleSerialStart(DSM2_BAUDRATE, DSM2_PERIOD * 2, false);
+      extmoduleSerialStart();
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, DSM2_PERIOD);
       break;
 #endif
@@ -204,14 +204,14 @@ void enablePulsesExternalModule(uint8_t protocol)
 
 #if defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_MULTIMODULE:
-      extmoduleSerialStart(MULTIMODULE_BAUDRATE, MULTIMODULE_PERIOD * 2, true);
+      extmoduleSerialStart();
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
       break;
 #endif
 
 #if defined(SBUS)
     case PROTOCOL_CHANNELS_SBUS:
-      extmoduleSerialStart(SBUS_BAUDRATE, SBUS_PERIOD_HALF_US, false);
+      extmoduleSerialStart();
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, SBUS_PERIOD);
       break;
 #endif
@@ -328,7 +328,7 @@ static void enablePulsesInternalModule(uint8_t protocol)
 #if defined(INTMODULE_HEARTBEAT)
       mixerSchedulerStop();
 #else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX2_PERIOD);
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_PERIOD);
       mixerSchedulerStart();
 #endif
       break;

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -317,7 +317,6 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       intmodulePulsesData.multi.initFrame();
       intmoduleSerialStart(MULTIMODULE_BAUDRATE, true, USART_Parity_Even, USART_StopBits_2, USART_WordLength_9b);
-      intmoduleTimerStart(MULTIMODULE_PERIOD);
       break;
 #endif
     default:

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -163,12 +163,14 @@ void enablePulsesExternalModule(uint8_t protocol)
 #if defined(PXX1)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       extmodulePxx1PulsesStart();
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, PXX_PULSES_PERIOD);
       break;
 #endif
 
 #if defined(PXX1) && defined(HARDWARE_EXTERNAL_MODULE_SIZE_SML)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       extmodulePxx1SerialStart();
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, EXTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -176,41 +178,48 @@ void enablePulsesExternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_DSM2_LP45:
     case PROTOCOL_CHANNELS_DSM2_DSM2:
     case PROTOCOL_CHANNELS_DSM2_DSMX:
-      extmoduleSerialStart(DSM2_BAUDRATE, DSM2_PERIOD * 2000, false);
+      extmoduleSerialStart(DSM2_BAUDRATE, DSM2_PERIOD * 2, false);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, DSM2_PERIOD);
       break;
 #endif
 
 #if defined(CROSSFIRE)
     case PROTOCOL_CHANNELS_CROSSFIRE:
       EXTERNAL_MODULE_ON();
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, CROSSFIRE_PERIOD);
       break;
 #endif
 
 #if defined(PXX2) && defined(EXTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX2_HIGHSPEED:
       extmoduleInvertedSerialStart(PXX2_HIGHSPEED_BAUDRATE);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, PXX2_PERIOD);
       break;
 
     case PROTOCOL_CHANNELS_PXX2_LOWSPEED:
       extmoduleInvertedSerialStart(PXX2_LOWSPEED_BAUDRATE);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, PXX2_PERIOD);
       break;
 #endif
 
 #if defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_MULTIMODULE:
-      extmoduleSerialStart(MULTIMODULE_BAUDRATE, MULTIMODULE_PERIOD * 2000, true);
+      extmoduleSerialStart(MULTIMODULE_BAUDRATE, MULTIMODULE_PERIOD * 2, true);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, 6666/*MULTIMODULE_PERIOD*/);
       break;
 #endif
 
 #if defined(SBUS)
     case PROTOCOL_CHANNELS_SBUS:
       extmoduleSerialStart(SBUS_BAUDRATE, SBUS_PERIOD_HALF_US, false);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, SBUS_PERIOD);
       break;
 #endif
 
 #if defined(PPM)
     case PROTOCOL_CHANNELS_PPM:
       extmodulePpmStart();
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, PPM_PERIOD(EXTERNAL_MODULE));
       break;
 #endif
 
@@ -295,12 +304,24 @@ static void enablePulsesInternalModule(uint8_t protocol)
 #if defined(PXX1) && !defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePxx1PulsesStart();
+#if defined(INTMODULE_HEARTBEAT)
+      mixerSchedulerStop();
+#else
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
+      mixerSchedulerStart();
+#endif
       break;
 #endif
 
 #if defined(PXX1) && defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       intmodulePxx1SerialStart();
+#if defined(INTMODULE_HEARTBEAT)
+      mixerSchedulerStop();
+#else
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
+      mixerSchedulerStart();
+#endif
       break;
 #endif
 
@@ -310,6 +331,13 @@ static void enablePulsesInternalModule(uint8_t protocol)
 #if defined(HARDWARE_INTERNAL_MODULE) && defined(INTERNAL_MODULE_PXX2) && defined(ACCESS_LIB)
       globalData.authenticationCount = 0;
 #endif
+
+#if defined(INTMODULE_HEARTBEAT)
+      mixerSchedulerStop();
+#else
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX2_PERIOD);
+      mixerSchedulerStart();
+#endif
       break;
 #endif
 
@@ -317,6 +345,7 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       intmodulePulsesData.multi.initFrame();
       intmoduleSerialStart(MULTIMODULE_BAUDRATE, true, USART_Parity_Even, USART_StopBits_2, USART_WordLength_9b);
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, MULTIMODULE_PERIOD);
       break;
 #endif
     default:

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -205,7 +205,7 @@ void enablePulsesExternalModule(uint8_t protocol)
 #if defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       extmoduleSerialStart(MULTIMODULE_BAUDRATE, MULTIMODULE_PERIOD * 2, true);
-      mixerSchedulerSetPeriod(EXTERNAL_MODULE, 6666/*MULTIMODULE_PERIOD*/);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
       break;
 #endif
 
@@ -234,14 +234,12 @@ void setupPulsesExternalModule(uint8_t protocol)
 #if defined(PXX1)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       extmodulePulsesData.pxx.setupFrame(EXTERNAL_MODULE);
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, PXX_PULSES_PERIOD);
       break;
 #endif
 
 #if defined(PXX1) && defined(HARDWARE_EXTERNAL_MODULE_SIZE_SML)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       extmodulePulsesData.pxx_uart.setupFrame(EXTERNAL_MODULE);
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, EXTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -249,14 +247,13 @@ void setupPulsesExternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX2_HIGHSPEED:
     case PROTOCOL_CHANNELS_PXX2_LOWSPEED:
       extmodulePulsesData.pxx2.setupFrame(EXTERNAL_MODULE);
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, PXX2_PERIOD);
       break;
 #endif
 
 #if defined(SBUS)
     case PROTOCOL_CHANNELS_SBUS:
       setupPulsesSbus();
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, SBUS_PERIOD);
+      mixerSchedulerSetPeriod(EXTERNAL_MODULE, SBUS_PERIOD);
       break;
 #endif
 
@@ -265,28 +262,24 @@ void setupPulsesExternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_DSM2_DSM2:
     case PROTOCOL_CHANNELS_DSM2_DSMX:
       setupPulsesDSM2();
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, DSM2_PERIOD);
       break;
 #endif
 
 #if defined(CROSSFIRE)
     case PROTOCOL_CHANNELS_CROSSFIRE:
       setupPulsesCrossfire();
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, CROSSFIRE_PERIOD);
       break;
 #endif
 
 #if defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       setupPulsesMultiExternalModule();
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
       break;
 #endif
 
 #if defined(PPM)
     case PROTOCOL_CHANNELS_PPM:
       setupPulsesPPMExternalModule();
-      scheduleNextMixerCalculation(EXTERNAL_MODULE, PPM_PERIOD(EXTERNAL_MODULE));
       break;
 #endif
 
@@ -359,16 +352,12 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(HARDWARE_INTERNAL_MODULE) && defined(PXX1) && !defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePulsesData.pxx.setupFrame(INTERNAL_MODULE);
-      scheduleNextMixerCalculation(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
       return true;
 #endif
 
 #if defined(PXX1) && defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       intmodulePulsesData.pxx_uart.setupFrame(INTERNAL_MODULE);
-#if !defined(INTMODULE_HEARTBEAT)
-      scheduleNextMixerCalculation(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
-#endif
       return true;
 #endif
 
@@ -377,13 +366,15 @@ bool setupPulsesInternalModule(uint8_t protocol)
     {
       bool result = intmodulePulsesData.pxx2.setupFrame(INTERNAL_MODULE);
       if (moduleState[INTERNAL_MODULE].mode == MODULE_MODE_SPECTRUM_ANALYSER || moduleState[INTERNAL_MODULE].mode == MODULE_MODE_POWER_METER) {
-        scheduleNextMixerCalculation(INTERNAL_MODULE, PXX2_TOOLS_PERIOD);
+        mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_TOOLS_PERIOD);
       }
-#if !defined(INTMODULE_HEARTBEAT)
       else {
-        scheduleNextMixerCalculation(INTERNAL_MODULE, PXX2_PERIOD);
-      }
+#if !defined(INTMODULE_HEARTBEAT)
+        mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_PERIOD);
+#else
+        mixerSchedulerSetPeriod(INTERNAL_MODULE, 0);
 #endif
+      }      
       return result;
     }
 #endif
@@ -391,14 +382,13 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(PCBTARANIS) && defined(INTERNAL_MODULE_PPM)
     case PROTOCOL_CHANNELS_PPM:
       setupPulsesPPMInternalModule();
-      scheduleNextMixerCalculation(INTERNAL_MODULE, PPM_PERIOD(INTERNAL_MODULE));
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, PPM_PERIOD(INTERNAL_MODULE));
       return true;
 #endif
 
 #if defined(INTERNAL_MODULE_MULTI)
     case PROTOCOL_CHANNELS_MULTIMODULE:
       setupPulsesMultiInternalModule();
-      scheduleNextMixerCalculation(INTERNAL_MODULE, MULTIMODULE_PERIOD);
       return true;
 #endif
 

--- a/radio/src/pulses/pulses.h
+++ b/radio/src/pulses/pulses.h
@@ -226,7 +226,6 @@ typedef Dsm2SerialPulsesData Dsm2PulsesData;
 PACK(struct Dsm2TimerPulsesData {
   pulse_duration_t pulses[MAX_PULSES_TRANSITIONS];
   pulse_duration_t * ptr;
-  uint16_t rest;
   uint8_t index;
 });
 typedef Dsm2TimerPulsesData Dsm2PulsesData;

--- a/radio/src/pulses/pulses.h
+++ b/radio/src/pulses/pulses.h
@@ -232,14 +232,14 @@ typedef Dsm2TimerPulsesData Dsm2PulsesData;
 #endif
 
 #define PPM_PERIOD_HALF_US(module)   ((g_model.moduleData[module].ppm.frameLength * 5 + 225) * 200) /*half us*/
-#define PPM_PERIOD(module)           (PPM_PERIOD_HALF_US(module) / 2000) /*ms*/
+#define PPM_PERIOD(module)           (PPM_PERIOD_HALF_US(module) / 2) /*us*/
 #define DSM2_BAUDRATE                125000
-#define DSM2_PERIOD                  22 /*ms*/
+#define DSM2_PERIOD                  22000 /*us*/
 #define SBUS_BAUDRATE                100000
 #define SBUS_PERIOD_HALF_US          ((g_model.moduleData[EXTERNAL_MODULE].sbus.refreshRate * 5 + 225) * 200) /*half us*/
-#define SBUS_PERIOD                  (SBUS_PERIOD_HALF_US / 2000) /*ms*/
+#define SBUS_PERIOD                  (SBUS_PERIOD_HALF_US / 2) /*us*/
 #define MULTIMODULE_BAUDRATE         100000
-#define MULTIMODULE_PERIOD           7 /*ms*/
+#define MULTIMODULE_PERIOD           7000 /*us*/
 
 #define CROSSFIRE_FRAME_MAXLEN         64
 PACK(struct CrossfirePulsesData {

--- a/radio/src/pulses/pxx.h
+++ b/radio/src/pulses/pxx.h
@@ -29,20 +29,20 @@
 
 #define PXX2_LOWSPEED_BAUDRATE             230400
 #define PXX2_HIGHSPEED_BAUDRATE            450000
-#define PXX2_PERIOD                        4 // 4ms
-#define PXX2_TOOLS_PERIOD                  1 // 1ms
+#define PXX2_PERIOD                        4000/*us*/
+#define PXX2_TOOLS_PERIOD                  1000/*us*/
 #define PXX2_FRAME_MAXLENGTH               64
 
-#define PXX_PULSES_PERIOD                  9/*ms*/
-#define EXTMODULE_PXX1_SERIAL_PERIOD       4/*ms*/
+#define PXX_PULSES_PERIOD                  9000/*us*/
+#define EXTMODULE_PXX1_SERIAL_PERIOD       4000/*us*/
 #define EXTMODULE_PXX1_SERIAL_BAUDRATE     420000
 
 #if defined(PXX_FREQUENCY_HIGH)
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   450000
-  #define INTMODULE_PXX1_SERIAL_PERIOD     4/*ms*/
+  #define INTMODULE_PXX1_SERIAL_PERIOD     4000/*us*/
 #else
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   115200
-  #define INTMODULE_PXX1_SERIAL_PERIOD     9/*ms*/
+  #define INTMODULE_PXX1_SERIAL_PERIOD     9000/*us*/
 #endif
 
 // Used by the Sky9x family boards

--- a/radio/src/pulses/sbus.cpp
+++ b/radio/src/pulses/sbus.cpp
@@ -55,7 +55,6 @@ static void _send_level(uint8_t v)
 
   *extmodulePulsesData.dsm2.ptr++ = v - 1;
   extmodulePulsesData.dsm2.index+=1;
-  extmodulePulsesData.dsm2.rest -=v;
 }
 
 void sendByteSbus(uint8_t b) // max 11 changes 0 10 10 10 10 P 1
@@ -113,7 +112,6 @@ void setupPulsesSbus()
   extmodulePulsesData.dsm2.serialByte = 0;
   extmodulePulsesData.dsm2.serialBitCount = 0;
 #else
-  extmodulePulsesData.dsm2.rest = SBUS_PERIOD_HALF_US;
   extmodulePulsesData.dsm2.index = 0;
 #endif
 

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -36,7 +36,9 @@ extern "C++" {
 
   typedef pthread_t RTOS_TASK_HANDLE;
   typedef pthread_mutex_t RTOS_MUTEX_HANDLE;
+
   typedef uint32_t RTOS_FLAG_HANDLE;
+
   typedef sem_t * RTOS_EVENT_HANDLE;
 
   extern uint64_t simuTimerMicros(void);
@@ -76,23 +78,24 @@ extern "C++" {
       pthread_mutex_unlock(&mutex);
   }
 
-  static inline void RTOS_CREATE_FLAG(uint32_t &flag)
+  static inline void RTOS_CREATE_FLAG(RTOS_FLAG_HANDLE flag)
   {
-    //TODO: use pthread condition
-    flag = 0;
   }
 
-  static inline void RTOS_SET_FLAG(uint32_t &flag)
+  static inline void RTOS_SET_FLAG(RTOS_FLAG_HANDLE flag)
   {
-    flag = 1;
   }
 
-  static inline void RTOS_CLEAR_FLAG(uint32_t &flag)
+  static inline void RTOS_CLEAR_FLAG(RTOS_FLAG_HANDLE flag)
   {
-    flag = 0;
   }
 
-  //TODO: #define RTOS_WAIT_FLAG(flag, timeout)
+  static inline bool RTOS_WAIT_FLAG(RTOS_FLAG_HANDLE flag, uint32_t timeout)
+  {
+    simuSleep(timeout);
+    return false;
+  }
+
   #define RTOS_ISR_SET_FLAG RTOS_SET_FLAG
 
   template<int SIZE>
@@ -241,7 +244,7 @@ template<int SIZE>
   #define RTOS_CREATE_FLAG(flag)        flag = CoCreateFlag(false, false)
   #define RTOS_SET_FLAG(flag)           (void)CoSetFlag(flag)
   #define RTOS_CLEAR_FLAG(flag)         (void)CoClearFlag(flag)
-  #define RTOS_WAIT_FLAG(flag,timeout)  CoWaitForSingleFlag(flag,timeout)
+  #define RTOS_WAIT_FLAG(flag,timeout)  (CoWaitForSingleFlag(flag,timeout) == E_TIMEOUT)
 
   static inline void RTOS_ISR_SET_FLAG(RTOS_FLAG_HANDLE flag)
   {

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -78,13 +78,22 @@ extern "C++" {
 
   static inline void RTOS_CREATE_FLAG(uint32_t &flag)
   {
-    flag = 0; // TODO: real flags (use semaphores?)
+    //TODO: use pthread condition
+    flag = 0;
   }
 
   static inline void RTOS_SET_FLAG(uint32_t &flag)
   {
     flag = 1;
   }
+
+  static inline void RTOS_CLEAR_FLAG(uint32_t &flag)
+  {
+    flag = 0;
+  }
+
+  //TODO: #define RTOS_WAIT_FLAG(flag, timeout)
+  #define RTOS_ISR_SET_FLAG RTOS_SET_FLAG
 
   template<int SIZE>
   class FakeTaskStack
@@ -146,6 +155,7 @@ template<int SIZE>
   {
     return (uint32_t)(simuTimerMicros() / 1000);
   }
+  
 #elif defined(RTOS_COOS)
 #ifdef __cplusplus
   extern "C" {
@@ -233,6 +243,15 @@ template<int SIZE>
   #define RTOS_CLEAR_FLAG(flag)         (void)CoClearFlag(flag)
   #define RTOS_WAIT_FLAG(flag,timeout)  (void)CoWaitForSingleFlag(flag,timeout)
 
+  static inline void RTOS_ISR_SET_FLAG(RTOS_FLAG_HANDLE flag)
+  {
+    CoEnterISR();
+    CoSchedLock();
+    isr_SetFlag(flag);
+    CoSchedUnlock();
+    CoExitISR();
+  }
+  
 #ifdef __cplusplus
   template<int SIZE>
   class TaskStack

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -241,7 +241,7 @@ template<int SIZE>
   #define RTOS_CREATE_FLAG(flag)        flag = CoCreateFlag(false, false)
   #define RTOS_SET_FLAG(flag)           (void)CoSetFlag(flag)
   #define RTOS_CLEAR_FLAG(flag)         (void)CoClearFlag(flag)
-  #define RTOS_WAIT_FLAG(flag,timeout)  (void)CoWaitForSingleFlag(flag,timeout)
+  #define RTOS_WAIT_FLAG(flag,timeout)  CoWaitForSingleFlag(flag,timeout)
 
   static inline void RTOS_ISR_SET_FLAG(RTOS_FLAG_HANDLE flag)
   {

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -230,6 +230,8 @@ template<int SIZE>
 
   #define RTOS_CREATE_FLAG(flag)        flag = CoCreateFlag(false, false)
   #define RTOS_SET_FLAG(flag)           (void)CoSetFlag(flag)
+  #define RTOS_CLEAR_FLAG(flag)         (void)CoClearFlag(flag)
+  #define RTOS_WAIT_FLAG(flag,timeout)  (void)CoWaitForSingleFlag(flag,timeout)
 
 #ifdef __cplusplus
   template<int SIZE>

--- a/radio/src/targets/common/arm/stm32/board_common.h
+++ b/radio/src/targets/common/arm/stm32/board_common.h
@@ -148,4 +148,6 @@ void delay_ms(uint32_t ms);
   GPIO_Init(GPIO, &GPIO_InitStructure); \
   GPIO_SetBits(GPIO, KEYS_ ## GPIO ## _PINS)
 
+#include "mixer_scheduler_driver.h"
+
 #endif

--- a/radio/src/targets/common/arm/stm32/board_common.h
+++ b/radio/src/targets/common/arm/stm32/board_common.h
@@ -148,6 +148,4 @@ void delay_ms(uint32_t ms);
   GPIO_Init(GPIO, &GPIO_InitStructure); \
   GPIO_SetBits(GPIO, KEYS_ ## GPIO ## _PINS)
 
-#include "mixer_scheduler_driver.h"
-
 #endif

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "opentx.h"
+#include "mixer_scheduler.h"
 
 volatile HeartbeatCapture heartbeatCapture;
 
@@ -65,13 +66,6 @@ void stop_intmodule_heartbeat()
   EXTI_Init(&EXTI_InitStructure);
 }
 
-// from mixer_scheduler_driver
-#if !defined(SIMU)
-void mixerScheduleISRTrigger();
-#else
-#define mixerScheduleISRTrigger()
-#endif
-
 void check_intmodule_heartbeat()
 {
   if (EXTI_GetITStatus(INTMODULE_HEARTBEAT_EXTI_LINE) != RESET) {
@@ -83,7 +77,7 @@ void check_intmodule_heartbeat()
     heartbeatCapture.count++;
     EXTI_ClearITPendingBit(INTMODULE_HEARTBEAT_EXTI_LINE);
 
-    mixerScheduleISRTrigger();
+    mixerSchedulerISRTrigger();
   }
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -65,6 +65,9 @@ void stop_intmodule_heartbeat()
   EXTI_Init(&EXTI_InitStructure);
 }
 
+// from mixer_scheduler_driver
+void mixerScheduleISRTrigger();
+
 void check_intmodule_heartbeat()
 {
   if (EXTI_GetITStatus(INTMODULE_HEARTBEAT_EXTI_LINE) != RESET) {
@@ -75,6 +78,8 @@ void check_intmodule_heartbeat()
 #endif
     heartbeatCapture.count++;
     EXTI_ClearITPendingBit(INTMODULE_HEARTBEAT_EXTI_LINE);
+
+    mixerScheduleISRTrigger();
   }
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -66,7 +66,11 @@ void stop_intmodule_heartbeat()
 }
 
 // from mixer_scheduler_driver
+#if !defined(SIMU)
 void mixerScheduleISRTrigger();
+#else
+#define mixerScheduleISRTrigger()
+#endif
 
 void check_intmodule_heartbeat()
 {

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -22,6 +22,8 @@
 
 #define MIXER_SCHEDULER_DEFAULT_PERIOD_US 4000u // 4ms
 
+#if !defined(SIMU)
+
 // Global trigger flag
 RTOS_FLAG_HANDLE mixerFlag;
 
@@ -94,7 +96,7 @@ void mixerSchedulerDisableTrigger()
 bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
 {
     RTOS_CLEAR_FLAG(mixerFlag);
-    return RTOS_WAIT_FLAG(mixerFlag, timeoutMs) == E_TIMEOUT;
+    return RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
 }
 
 void mixerScheduleISRTrigger()
@@ -113,3 +115,5 @@ extern "C" void MIXER_SCHEDULER_TIMER_IRQHandler(void)
     // trigger mixer start
     mixerScheduleISRTrigger();
 }
+
+#endif

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -91,10 +91,10 @@ void mixerSchedulerDisableTrigger()
     MIXER_SCHEDULER_TIMER->DIER &= ~TIM_DIER_UIE; // disable interrupt
 }
 
-void mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
+bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
 {
     RTOS_CLEAR_FLAG(mixerFlag);
-    RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
+    return RTOS_WAIT_FLAG(mixerFlag, timeoutMs) == E_TIMEOUT;
 }
 
 void mixerScheduleISRTrigger()

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -62,6 +62,8 @@ void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs)
 // Start scheduler with default period
 void mixerSchedulerStart()
 {
+    MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
+
     MIXER_SCHEDULER_TIMER->CR1   = TIM_CR1_URS; // do not generate interrupt on soft update
     MIXER_SCHEDULER_TIMER->PSC   = MIXER_SCHEDULER_TIMER_FREQ / 2000000 - 1; // 0.5uS (2Mhz)
     MIXER_SCHEDULER_TIMER->CCER  = 0;

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -26,49 +26,49 @@
 // Start scheduler with default period
 void mixerSchedulerStart()
 {
-    MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
+  MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
 
-    MIXER_SCHEDULER_TIMER->CR1   = TIM_CR1_URS; // do not generate interrupt on soft update
-    MIXER_SCHEDULER_TIMER->PSC   = MIXER_SCHEDULER_TIMER_FREQ / 2000000 - 1; // 0.5uS (2Mhz)
-    MIXER_SCHEDULER_TIMER->CCER  = 0;
-    MIXER_SCHEDULER_TIMER->CCMR1 = 0;
-    MIXER_SCHEDULER_TIMER->ARR   = 2 * getMixerSchedulerPeriod() - 1;
-    MIXER_SCHEDULER_TIMER->EGR   = TIM_EGR_UG;   // reset timer
+  MIXER_SCHEDULER_TIMER->CR1   = TIM_CR1_URS; // do not generate interrupt on soft update
+  MIXER_SCHEDULER_TIMER->PSC   = MIXER_SCHEDULER_TIMER_FREQ / 2000000 - 1; // 0.5uS (2Mhz)
+  MIXER_SCHEDULER_TIMER->CCER  = 0;
+  MIXER_SCHEDULER_TIMER->CCMR1 = 0;
+  MIXER_SCHEDULER_TIMER->ARR   = 2 * getMixerSchedulerPeriod() - 1;
+  MIXER_SCHEDULER_TIMER->EGR   = TIM_EGR_UG;   // reset timer
 
-    NVIC_EnableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
-    NVIC_SetPriority(MIXER_SCHEDULER_TIMER_IRQn, 8);
+  NVIC_EnableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
+  NVIC_SetPriority(MIXER_SCHEDULER_TIMER_IRQn, 8);
 
-    MIXER_SCHEDULER_TIMER->SR   &= TIM_SR_UIF;   // clear interrupt flag
-    MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
-    MIXER_SCHEDULER_TIMER->CR1  |= TIM_CR1_CEN;
+  MIXER_SCHEDULER_TIMER->SR   &= TIM_SR_UIF;   // clear interrupt flag
+  MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
+  MIXER_SCHEDULER_TIMER->CR1  |= TIM_CR1_CEN;
 }
 
 void mixerSchedulerStop()
 {
-    MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
-    NVIC_DisableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
+  MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
+  NVIC_DisableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
 }
 
 void mixerSchedulerEnableTrigger()
 {
-    MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
+  MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
 }
 
 void mixerSchedulerDisableTrigger()
 {
-    MIXER_SCHEDULER_TIMER->DIER &= ~TIM_DIER_UIE; // disable interrupt
+  MIXER_SCHEDULER_TIMER->DIER &= ~TIM_DIER_UIE; // disable interrupt
 }
 
 extern "C" void MIXER_SCHEDULER_TIMER_IRQHandler(void)
 {
-    MIXER_SCHEDULER_TIMER->SR &= ~TIM_SR_UIF; // clear flag
-    mixerSchedulerDisableTrigger();
+  MIXER_SCHEDULER_TIMER->SR &= ~TIM_SR_UIF; // clear flag
+  mixerSchedulerDisableTrigger();
 
-    // set next period
-    MIXER_SCHEDULER_TIMER->ARR = 2 * getMixerSchedulerPeriod() - 1;
+  // set next period
+  MIXER_SCHEDULER_TIMER->ARR = 2 * getMixerSchedulerPeriod() - 1;
 
-    // trigger mixer start
-    mixerSchedulerISRTrigger();
+  // trigger mixer start
+  mixerSchedulerISRTrigger();
 }
 
 #endif

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _MIXER_SCHEDULER_DRIVER_H_
+#define _MIXER_SCHEDULER_DRIVER_H_
+
+// Call once to initialize the mixer scheduler
+void mixerSchedulerInit();
+
+// Configure and start the scheduler timer
+void mixerSchedulerStart();
+
+// Stop the scheduler timer
+void mixerSchedulerStop();
+
+// Set the scheduling period for a given module
+void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs);
+
+// Wait for the scheduler timer to trigger
+void mixerSchedulerWaitForTrigger(uint8_t timeoutMs);
+
+// Enable the timer trigger
+void mixerSchedulerEnableTrigger();
+
+// Disable the timer trigger
+void mixerSchedulerDisableTrigger();
+
+#endif

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
@@ -34,7 +34,8 @@ void mixerSchedulerStop();
 void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs);
 
 // Wait for the scheduler timer to trigger
-void mixerSchedulerWaitForTrigger(uint8_t timeoutMs);
+// returns true if timeout, false otherwise
+bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs);
 
 // Enable the timer trigger
 void mixerSchedulerEnableTrigger();

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.h
@@ -21,6 +21,7 @@
 #ifndef _MIXER_SCHEDULER_DRIVER_H_
 #define _MIXER_SCHEDULER_DRIVER_H_
 
+#if !defined(SIMU)
 // Call once to initialize the mixer scheduler
 void mixerSchedulerInit();
 
@@ -42,5 +43,23 @@ void mixerSchedulerEnableTrigger();
 
 // Disable the timer trigger
 void mixerSchedulerDisableTrigger();
+
+#else
+
+#define mixerSchedulerInit()
+#define mixerSchedulerStart()
+#define mixerSchedulerStop()
+#define mixerSchedulerSetPeriod(m,p)
+
+static inline bool mixerSchedulerWaitForTrigger(uint8_t timeout)
+{
+  simuSleep(timeout);
+  return false;
+}
+
+#define mixerSchedulerEnableTrigger()
+#define mixerSchedulerDisableTrigger()
+
+#endif
 
 #endif

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -190,6 +190,7 @@ set(TARGET_SRC
   led_driver.cpp
   extmodule_driver.cpp
   trainer_driver.cpp
+  mixer_scheduler_driver.cpp
   ../common/arm/stm32/heartbeat_driver.cpp
   ../common/arm/stm32/timers_driver.cpp
   ../common/arm/stm32/intmodule_serial_driver.cpp

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -190,7 +190,7 @@ set(TARGET_SRC
   led_driver.cpp
   extmodule_driver.cpp
   trainer_driver.cpp
-  mixer_scheduler_driver.cpp
+  ../common/arm/stm32/mixer_scheduler_driver.cpp
   ../common/arm/stm32/heartbeat_driver.cpp
   ../common/arm/stm32/timers_driver.cpp
   ../common/arm/stm32/intmodule_serial_driver.cpp

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -106,6 +106,7 @@ void boardInit()
                          AUDIO_RCC_APB1Periph |
                          INTMODULE_RCC_APB1Periph |
                          EXTMODULE_RCC_APB1Periph |
+                         MIXER_SCHEDULER_TIMER_RCC_APB1Periph |
                          GPS_RCC_APB1Periph |
                          BACKLIGHT_RCC_APB1Periph,
                          ENABLE);

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -190,14 +190,6 @@ void stop_trainer_ppm();
 void init_trainer_capture();
 void stop_trainer_capture();
 
-// Mixer scheduler driver
-void mixerSchedulerInit();
-void mixerSchedulerStart(uint16_t periodUs);
-void mixerSchedulerStop();
-void mixerSchedulerWaitForTrigger(uint8_t timeoutMs);
-void mixerSchedulerEnableTrigger();
-void mixerSchedulerDisableTrigger();
-  
 // Keys driver
 enum EnumKeys
 {

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -174,9 +174,6 @@ void init_intmodule_heartbeat();
 void check_intmodule_heartbeat();
 
 void intmoduleSerialStart(uint32_t baudrate, uint8_t rxEnable, uint16_t parity, uint16_t stopBits, uint16_t wordLength);
-#if defined(INTERNAL_MODULE_MULTI)
-void intmoduleTimerStart(uint32_t periodMs);
-#endif
 void intmoduleSendByte(uint8_t byte);
 void intmoduleSendBuffer(const uint8_t * data, uint8_t size);
 void intmoduleSendNextFrame();
@@ -193,6 +190,14 @@ void stop_trainer_ppm();
 void init_trainer_capture();
 void stop_trainer_capture();
 
+// Mixer scheduler driver
+void mixerSchedulerInit();
+void mixerSchedulerStart(uint16_t periodUs);
+void mixerSchedulerStop();
+void mixerSchedulerWaitForTrigger(uint8_t timeoutMs);
+void mixerSchedulerEnableTrigger();
+void mixerSchedulerDisableTrigger();
+  
 // Keys driver
 enum EnumKeys
 {

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -178,7 +178,7 @@ void intmoduleSendByte(uint8_t byte);
 void intmoduleSendBuffer(const uint8_t * data, uint8_t size);
 void intmoduleSendNextFrame();
 
-void extmoduleSerialStart(uint32_t baudrate, uint32_t period_half_us, bool inverted);
+void extmoduleSerialStart();
 void extmoduleInvertedSerialStart(uint32_t baudrate);
 void extmoduleSendBuffer(const uint8_t * data, uint8_t size);
 void extmoduleSendNextFrame();

--- a/radio/src/targets/horus/extmodule_driver.cpp
+++ b/radio/src/targets/horus/extmodule_driver.cpp
@@ -402,14 +402,20 @@ extern "C" void EXTMODULE_TIMER_DMA_IRQHandler()
 
   DMA_ClearITPendingBit(EXTMODULE_TIMER_DMA_STREAM, EXTMODULE_TIMER_DMA_FLAG_TC);
 
-  EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
-  //EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
+  switch (moduleState[EXTERNAL_MODULE].protocol) {
+    case PROTOCOL_CHANNELS_PXX1_PULSES:
+    case PROTOCOL_CHANNELS_PPM:
+      EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
+      EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
+      break;
+  }
 }
 
 extern "C" void EXTMODULE_TIMER_IRQHandler()
 {
   EXTMODULE_TIMER->DIER &= ~TIM_DIER_CC2IE; // Stop this interrupt
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF;
-  // if (setupPulsesExternalModule())
-  //   extmoduleSendNextFrame();
+
+  if (setupPulsesExternalModule())
+    extmoduleSendNextFrame();
 }

--- a/radio/src/targets/horus/extmodule_driver.cpp
+++ b/radio/src/targets/horus/extmodule_driver.cpp
@@ -179,7 +179,7 @@ void extmoduleSerialStart(uint32_t /*baudrate*/, uint32_t period_half_us, bool i
   EXTMODULE_TIMER->ARR = period_half_us;
   EXTMODULE_TIMER->CCR2 = period_half_us - 4000;
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
-  EXTMODULE_TIMER->DIER |= TIM_DIER_UDE | TIM_DIER_CC2IE;
+  EXTMODULE_TIMER->DIER |= TIM_DIER_UDE;
   EXTMODULE_TIMER->CR1 |= TIM_CR1_CEN;
 
   NVIC_EnableIRQ(EXTMODULE_TIMER_DMA_STREAM_IRQn);
@@ -318,23 +318,36 @@ void extmoduleSendNextFrame()
 
 #if defined(DSM2)
     case PROTOCOL_CHANNELS_SBUS:
-#if defined(PCBX10) || PCBREV >= 13
-      EXTMODULE_TIMER->CCER = TIM_CCER_CC3E | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? TIM_CCER_CC3P : 0); // reverse polarity for Sbus if needed
-#else
-      EXTMODULE_TIMER->CCER = TIM_CCER_CC1E | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? TIM_CCER_CC1P : 0); // reverse polarity for Sbus if needed
-#endif
-      // no break
     case PROTOCOL_CHANNELS_DSM2_LP45:
     case PROTOCOL_CHANNELS_DSM2_DSM2:
     case PROTOCOL_CHANNELS_DSM2_DSMX:
     case PROTOCOL_CHANNELS_MULTIMODULE:
-      EXTMODULE_TIMER->CCR2 = *(extmodulePulsesData.dsm2.ptr - 1) - 4000; // 2mS in advance
+
+      if (EXTMODULE_TIMER_DMA_STREAM->CR & DMA_SxCR_EN)
+        return;
+
+      if (PROTOCOL_CHANNELS_SBUS == moduleState[EXTERNAL_MODULE].protocol) {
+#if defined(PCBX10) || PCBREV >= 13
+        EXTMODULE_TIMER->CCER = TIM_CCER_CC3E | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? TIM_CCER_CC3P : 0); // reverse polarity for Sbus if needed
+#else
+        EXTMODULE_TIMER->CCER = TIM_CCER_CC1E | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? TIM_CCER_CC1P : 0); // reverse polarity for Sbus if needed
+#endif
+      }
+
+      // disable timer
+      EXTMODULE_TIMER->CR1 &= ~TIM_CR1_CEN;
+
+      // send DMA request
       EXTMODULE_TIMER_DMA_STREAM->CR &= ~DMA_SxCR_EN; // Disable DMA
       EXTMODULE_TIMER_DMA_STREAM->CR |= EXTMODULE_TIMER_DMA_CHANNEL | DMA_SxCR_DIR_0 | DMA_SxCR_MINC | EXTMODULE_TIMER_DMA_SIZE | DMA_SxCR_PL_0 | DMA_SxCR_PL_1;
       EXTMODULE_TIMER_DMA_STREAM->PAR = CONVERT_PTR_UINT(&EXTMODULE_TIMER->ARR);
       EXTMODULE_TIMER_DMA_STREAM->M0AR = CONVERT_PTR_UINT(extmodulePulsesData.dsm2.pulses);
       EXTMODULE_TIMER_DMA_STREAM->NDTR = extmodulePulsesData.dsm2.ptr - extmodulePulsesData.dsm2.pulses;
       EXTMODULE_TIMER_DMA_STREAM->CR |= DMA_SxCR_EN | DMA_SxCR_TCIE; // Enable DMA
+
+      // re-init timer
+      EXTMODULE_TIMER->EGR = 1;
+      EXTMODULE_TIMER->CR1 |= TIM_CR1_CEN;
       break;
 #endif
 
@@ -390,13 +403,13 @@ extern "C" void EXTMODULE_TIMER_DMA_IRQHandler()
   DMA_ClearITPendingBit(EXTMODULE_TIMER_DMA_STREAM, EXTMODULE_TIMER_DMA_FLAG_TC);
 
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
-  EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
+  //EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
 }
 
 extern "C" void EXTMODULE_TIMER_IRQHandler()
 {
   EXTMODULE_TIMER->DIER &= ~TIM_DIER_CC2IE; // Stop this interrupt
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF;
-  if (setupPulsesExternalModule())
-    extmoduleSendNextFrame();
+  // if (setupPulsesExternalModule())
+  //   extmoduleSendNextFrame();
 }

--- a/radio/src/targets/horus/extmodule_driver.cpp
+++ b/radio/src/targets/horus/extmodule_driver.cpp
@@ -143,7 +143,7 @@ void extmodulePxx1PulsesStart()
 }
 #endif
 
-void extmoduleSerialStart(uint32_t /*baudrate*/, uint32_t period_half_us, bool inverted)
+void extmoduleSerialStart()
 {
   EXTERNAL_MODULE_ON();
 
@@ -176,8 +176,7 @@ void extmoduleSerialStart(uint32_t /*baudrate*/, uint32_t period_half_us, bool i
   EXTMODULE_TIMER->CCMR1 = TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0;
 #endif
 
-  EXTMODULE_TIMER->ARR = period_half_us;
-  EXTMODULE_TIMER->CCR2 = period_half_us - 4000;
+  EXTMODULE_TIMER->ARR = 40000; // dummy value until the DMA request kicks in
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
   EXTMODULE_TIMER->DIER |= TIM_DIER_UDE;
   EXTMODULE_TIMER->CR1 |= TIM_CR1_CEN;

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -365,7 +365,7 @@
 // Telemetry
 #define TELEMETRY_RCC_AHB1Periph        (RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_DMA1)
 #define TELEMETRY_RCC_APB1Periph        RCC_APB1Periph_USART2
-#define TELEMETRY_RCC_APB2Periph        RCC_APB2Periph_TIM10
+#define TELEMETRY_RCC_APB2Periph        RCC_APB2Periph_TIM11
 #define TELEMETRY_DIR_GPIO              GPIOD
 #define TELEMETRY_DIR_GPIO_PIN          GPIO_Pin_4  // PD.04
 #define TELEMETRY_GPIO                  GPIOD
@@ -750,6 +750,13 @@
 // 2MHz Timer
 #define TIMER_2MHz_RCC_APB1Periph       RCC_APB1Periph_TIM7
 #define TIMER_2MHz_TIMER                TIM7
+
+// Mixer scheduler timer
+#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB1Periph_TIM13
+#define MIXER_SCHEDULER_TIMER                TIM13
+#define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
+#define MIXER_SCHEDULER_TIMER_IRQn           TIM8_UP_TIM13_IRQn
+#define MIXER_SCHEDULER_TIMER_IRQHandler     TIM8_UP_TIM13_IRQHandler
 
 // Bluetooth
 #define STORAGE_BLUETOOTH

--- a/radio/src/targets/horus/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/horus/mixer_scheduler_driver.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "opentx.h"
+
+RTOS_FLAG_HANDLE mixerFlag;
+
+void mixerSchedulerInit()
+{
+    RTOS_CREATE_FLAG(mixerFlag);
+}
+
+void mixerSchedulerStart(uint16_t periodUs)
+{
+    MIXER_SCHEDULER_TIMER->CR1   = TIM_CR1_URS; // do not generate interrupt on soft update
+    MIXER_SCHEDULER_TIMER->PSC   = INTMODULE_TIMER_FREQ / 2000000 - 1; // 0.5uS (2Mhz)
+    MIXER_SCHEDULER_TIMER->CCER  = 0;
+    MIXER_SCHEDULER_TIMER->CCMR1 = 0;
+    MIXER_SCHEDULER_TIMER->ARR   = 2 * periodUs - 1;
+    MIXER_SCHEDULER_TIMER->EGR   = TIM_EGR_UG;   // reset timer
+
+    NVIC_EnableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
+    NVIC_SetPriority(MIXER_SCHEDULER_TIMER_IRQn, 8);
+
+    MIXER_SCHEDULER_TIMER->SR   &= TIM_SR_UIF;   // clear interrupt flag
+    MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
+    MIXER_SCHEDULER_TIMER->CR1  |= TIM_CR1_CEN;
+}
+
+void mixerSchedulerStop()
+{
+    MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
+    NVIC_DisableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
+}
+
+void mixerSchedulerEnableTrigger()
+{
+    MIXER_SCHEDULER_TIMER->DIER |= TIM_DIER_UIE; // enable interrupt
+}
+
+void mixerSchedulerDisableTrigger()
+{
+    MIXER_SCHEDULER_TIMER->DIER &= ~TIM_DIER_UIE; // disable interrupt
+}
+
+void mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
+{
+    RTOS_CLEAR_FLAG(mixerFlag);
+    RTOS_WAIT_FLAG(mixerFlag, timeoutMs);
+}
+
+extern "C" void MIXER_SCHEDULER_TIMER_IRQHandler(void)
+{
+    MIXER_SCHEDULER_TIMER->SR &= ~TIM_SR_UIF; // clear flag
+    mixerSchedulerDisableTrigger();
+
+    // trigger mixer start
+    CoEnterISR();
+    CoSchedLock();
+    isr_SetFlag(mixerFlag);
+    CoSchedUnlock();
+    CoExitISR();
+}

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -319,6 +319,7 @@ set(TARGET_SRC
   ../common/arm/stm32/audio_dac_driver.cpp
   ../common/arm/stm32/adc_driver.cpp
   ../common/arm/stm32/heartbeat_driver.cpp
+  ../common/arm/stm32/mixer_scheduler_driver.cpp
   )
 
 if(PCB STREQUAL XLITE OR PCB STREQUAL XLITES)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -102,6 +102,7 @@ void boardInit()
                          AUX_SERIAL_RCC_APB1Periph |
                          INTMODULE_RCC_APB1Periph |
                          TRAINER_MODULE_RCC_APB1Periph |
+                         MIXER_SCHEDULER_TIMER_RCC_APB1Periph |
                          BT_RCC_APB1Periph |
                          GYRO_RCC_APB1Periph,
                          ENABLE);

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -129,7 +129,7 @@ void intmoduleSendByte(uint8_t byte);
 void intmoduleSendBuffer(const uint8_t * data, uint8_t size);
 void intmoduleSendNextFrame();
 
-void extmoduleSerialStart(uint32_t baudrate, uint32_t period_half_us, bool inverted);
+void extmoduleSerialStart();
 void extmoduleInvertedSerialStart(uint32_t baudrate);
 void extmoduleSendBuffer(const uint8_t * data, uint8_t size);
 void extmoduleSendNextFrame();

--- a/radio/src/targets/taranis/extmodule_driver.cpp
+++ b/radio/src/targets/taranis/extmodule_driver.cpp
@@ -356,7 +356,7 @@ extern "C" void EXTMODULE_TIMER_CC_IRQHandler()
 {
   EXTMODULE_TIMER->DIER &= ~TIM_DIER_CC2IE; // Stop this interrupt
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF;
-  if (setupPulsesExternalModule()) {
-    extmoduleSendNextFrame();
-  }
 }
+  // if (setupPulsesExternalModule()) {
+  //   extmoduleSendNextFrame();
+  // }

--- a/radio/src/targets/taranis/extmodule_driver.cpp
+++ b/radio/src/targets/taranis/extmodule_driver.cpp
@@ -82,7 +82,7 @@ void extmodulePpmStart()
   NVIC_SetPriority(EXTMODULE_TIMER_CC_IRQn, 7);
 }
 
-void extmoduleSerialStart(uint32_t /*baudrate*/, uint32_t period_half_us, bool inverted)
+void extmoduleSerialStart()
 {
   EXTERNAL_MODULE_ON();
 
@@ -98,16 +98,17 @@ void extmoduleSerialStart(uint32_t /*baudrate*/, uint32_t period_half_us, bool i
 
   EXTMODULE_TIMER->CR1 &= ~TIM_CR1_CEN;
   EXTMODULE_TIMER->PSC = EXTMODULE_TIMER_FREQ / 2000000 - 1; // 0.5uS from 30MHz
-  EXTMODULE_TIMER->CCER = EXTMODULE_TIMER_OUTPUT_ENABLE | (inverted ? 0 : EXTMODULE_TIMER_OUTPUT_POLARITY);
+
+  EXTMODULE_TIMER->CCR3 = 0;
+  EXTMODULE_TIMER->CCER = EXTMODULE_TIMER_OUTPUT_ENABLE | EXTMODULE_TIMER_OUTPUT_POLARITY;
   EXTMODULE_TIMER->BDTR = TIM_BDTR_MOE; // Enable outputs
   EXTMODULE_TIMER->CCR1 = 0;
   EXTMODULE_TIMER->CCMR1 = TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0; // Force O/P high
   EXTMODULE_TIMER->EGR = 1; // Restart
   EXTMODULE_TIMER->CCMR1 = TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0;
-  EXTMODULE_TIMER->ARR = period_half_us;
-  EXTMODULE_TIMER->CCR2 = 40000; // The first frame will be sent in 20ms
+  EXTMODULE_TIMER->ARR = 40000; // dummy value until the DMA request kicks in
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
-  EXTMODULE_TIMER->DIER |= TIM_DIER_UDE | TIM_DIER_CC2IE;
+  EXTMODULE_TIMER->DIER |= TIM_DIER_UDE;
   EXTMODULE_TIMER->CR1 |= TIM_CR1_CEN;
 
   NVIC_EnableIRQ(EXTMODULE_TIMER_DMA_STREAM_IRQn);
@@ -281,19 +282,33 @@ void extmoduleSendNextFrame()
 
 #if defined(SBUS) || defined(DSM2) || defined(MULTIMODULE)
     case PROTOCOL_CHANNELS_SBUS:
-      EXTMODULE_TIMER->CCER = EXTMODULE_TIMER_OUTPUT_ENABLE | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? 0 : EXTMODULE_TIMER_OUTPUT_POLARITY); // reverse polarity for Sbus if needed
       // no break
     case PROTOCOL_CHANNELS_DSM2_LP45:
     case PROTOCOL_CHANNELS_DSM2_DSM2:
     case PROTOCOL_CHANNELS_DSM2_DSMX:
     case PROTOCOL_CHANNELS_MULTIMODULE:
-      EXTMODULE_TIMER->CCR2 = *(extmodulePulsesData.dsm2.ptr - 1) - 4000; // 2mS in advance
+
+      if (EXTMODULE_TIMER_DMA_STREAM->CR & DMA_SxCR_EN)
+        return;
+
+      if (PROTOCOL_CHANNELS_SBUS == moduleState[EXTERNAL_MODULE].protocol) {
+        EXTMODULE_TIMER->CCER = EXTMODULE_TIMER_OUTPUT_ENABLE | (GET_SBUS_POLARITY(EXTERNAL_MODULE) ? EXTMODULE_TIMER_OUTPUT_POLARITY : 0); // reverse polarity for Sbus if needed
+      }
+
+      // disable timer
+      EXTMODULE_TIMER->CR1 &= ~TIM_CR1_CEN;
+
+      // send DMA request
       EXTMODULE_TIMER_DMA_STREAM->CR &= ~DMA_SxCR_EN; // Disable DMA
       EXTMODULE_TIMER_DMA_STREAM->CR |= EXTMODULE_TIMER_DMA_CHANNEL | DMA_SxCR_DIR_0 | DMA_SxCR_MINC | DMA_SxCR_PSIZE_0 | DMA_SxCR_MSIZE_0 | DMA_SxCR_PL_0 | DMA_SxCR_PL_1;
       EXTMODULE_TIMER_DMA_STREAM->PAR = CONVERT_PTR_UINT(&EXTMODULE_TIMER->ARR);
       EXTMODULE_TIMER_DMA_STREAM->M0AR = CONVERT_PTR_UINT(extmodulePulsesData.dsm2.pulses);
       EXTMODULE_TIMER_DMA_STREAM->NDTR = extmodulePulsesData.dsm2.ptr - extmodulePulsesData.dsm2.pulses;
       EXTMODULE_TIMER_DMA_STREAM->CR |= DMA_SxCR_EN | DMA_SxCR_TCIE; // Enable DMA
+
+      // re-init timer
+      EXTMODULE_TIMER->EGR = 1;
+      EXTMODULE_TIMER->CR1 |= TIM_CR1_CEN;
       break;
 #endif
 
@@ -348,15 +363,21 @@ extern "C" void EXTMODULE_TIMER_DMA_STREAM_IRQHandler()
 
   DMA_ClearITPendingBit(EXTMODULE_TIMER_DMA_STREAM, EXTMODULE_TIMER_DMA_FLAG_TC);
 
-  EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
-  EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
+  switch (moduleState[EXTERNAL_MODULE].protocol) {
+    case PROTOCOL_CHANNELS_PXX1_PULSES:
+    case PROTOCOL_CHANNELS_PPM:
+      EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF; // Clear flag
+      EXTMODULE_TIMER->DIER |= TIM_DIER_CC2IE; // Enable this interrupt
+      break;
+  }
 }
 
 extern "C" void EXTMODULE_TIMER_CC_IRQHandler()
 {
   EXTMODULE_TIMER->DIER &= ~TIM_DIER_CC2IE; // Stop this interrupt
   EXTMODULE_TIMER->SR &= ~TIM_SR_CC2IF;
+
+  if (setupPulsesExternalModule()) {
+    extmoduleSendNextFrame();
+  }
 }
-  // if (setupPulsesExternalModule()) {
-  //   extmoduleSendNextFrame();
-  // }

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1880,4 +1880,11 @@
 #define TIMER_2MHz_RCC_APB1Periph       RCC_APB1Periph_TIM7
 #define TIMER_2MHz_TIMER                TIM7
 
+// Mixer scheduler timer
+#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB1Periph_TIM13
+#define MIXER_SCHEDULER_TIMER                TIM13
+#define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
+#define MIXER_SCHEDULER_TIMER_IRQn           TIM8_UP_TIM13_IRQn
+#define MIXER_SCHEDULER_TIMER_IRQHandler     TIM8_UP_TIM13_IRQHandler
+
 #endif // _HAL_H_

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -143,7 +143,7 @@ TASK_FUNCTION(mixerTask)
     // - add trigger based on heartbeat driver
     
     // run mixer at least every 10ms
-    mixerSchedulerWaitForTrigger(10);
+    bool timeout = mixerSchedulerWaitForTrigger(10);
 
 #if defined(DEBUG_MIXER_SCHEDULER)
     GPIO_SetBits(EXTMODULE_TX_GPIO, EXTMODULE_TX_GPIO_PIN);
@@ -200,6 +200,7 @@ TASK_FUNCTION(mixerTask)
       if (t0 > maxMixerDuration)
         maxMixerDuration = t0;
 
+      //if (!timeout)
       sendSynchronousPulses();
     }
   }

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -88,6 +88,12 @@ bool isModuleSynchronous(uint8_t module)
 #if defined(INTMODULE_USART) || defined(EXTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
 #endif
+#if defined(DSM2)
+    case PROTOCOL_CHANNELS_SBUS:
+    case PROTOCOL_CHANNELS_DSM2_LP45:
+    case PROTOCOL_CHANNELS_DSM2_DSM2:
+    case PROTOCOL_CHANNELS_DSM2_DSMX:
+#endif
       return true;
   }
   return false;
@@ -108,7 +114,7 @@ void sendSynchronousPulses()
   }
 }
 
-#define DEBUG_MIXER_SCHEDULER
+//#define DEBUG_MIXER_SCHEDULER
 
 uint32_t nextMixerTime[NUM_MODULES];
 
@@ -194,6 +200,7 @@ TASK_FUNCTION(mixerTask)
       if (t0 > maxMixerDuration)
         maxMixerDuration = t0;
 
+      serialPrint("cnt = %d", EXTMODULE_TIMER->CNT);
       sendSynchronousPulses();
     }
   }

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -139,19 +139,13 @@ TASK_FUNCTION(mixerTask)
     bluetooth.wakeup();
 #endif
 
-    // TODO:
-    // - add trigger based on heartbeat driver
-    
-    // run mixer at least every 10ms
-    bool timeout = mixerSchedulerWaitForTrigger(10);
+    // run mixer at least every 30ms
+    bool timeout = mixerSchedulerWaitForTrigger(30);
 
 #if defined(DEBUG_MIXER_SCHEDULER)
     GPIO_SetBits(EXTMODULE_TX_GPIO, EXTMODULE_TX_GPIO_PIN);
     GPIO_ResetBits(EXTMODULE_TX_GPIO, EXTMODULE_TX_GPIO_PIN);
 #endif
-
-    // TODO:
-    //  - compute next trigger
 
     // re-enable trigger
     mixerSchedulerEnableTrigger();
@@ -200,7 +194,12 @@ TASK_FUNCTION(mixerTask)
       if (t0 > maxMixerDuration)
         maxMixerDuration = t0;
 
-      //if (!timeout)
+      // TODO:
+      // - check the cause of timeouts when switching
+      //    between protocols with multi-proto RF
+      if (timeout)
+        serialPrint("mix sched timeout!");
+
       sendSynchronousPulses();
     }
   }

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -123,7 +123,7 @@ TASK_FUNCTION(mixerTask)
   s_pulses_paused = true;
 
   mixerSchedulerInit();
-  mixerSchedulerStart(6666); // 150 Hz
+  mixerSchedulerStart();
 
   while (true) {
 #if defined(PCBTARANIS) && defined(SBUS)
@@ -206,6 +206,8 @@ TASK_FUNCTION(mixerTask)
   }
 }
 
+
+//TODO: remove that one
 void scheduleNextMixerCalculation(uint8_t module, uint16_t period_ms)
 {
   // Schedule next mixer calculation time,

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -200,32 +200,11 @@ TASK_FUNCTION(mixerTask)
       if (t0 > maxMixerDuration)
         maxMixerDuration = t0;
 
-      serialPrint("cnt = %d", EXTMODULE_TIMER->CNT);
       sendSynchronousPulses();
     }
   }
 }
 
-
-//TODO: remove that one
-void scheduleNextMixerCalculation(uint8_t module, uint16_t period_ms)
-{
-  // Schedule next mixer calculation time,
-
-  if (isModuleSynchronous(module)) {
-    nextMixerTime[module] += period_ms / RTOS_MS_PER_TICK;
-    if (nextMixerTime[module] < RTOS_GET_TIME()) {
-      // we are late ... let's add some small delay
-      nextMixerTime[module] = (uint32_t) RTOS_GET_TIME() + (period_ms / RTOS_MS_PER_TICK);
-    }
-  }
-  else {
-    // for now assume mixer calculation takes 2 ms.
-    nextMixerTime[module] = (uint32_t) RTOS_GET_TIME() + (period_ms / RTOS_MS_PER_TICK);
-  }
-
-  DEBUG_TIMER_STOP(debugTimerMixerCalcToUsage);
-}
 
 #define MENU_TASK_PERIOD_TICKS         (50 / RTOS_MS_PER_TICK)    // 50ms
 

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "opentx.h"
+#include "mixer_scheduler.h"
 
 RTOS_TASK_HANDLE menusTaskId;
 RTOS_DEFINE_STACK(menusStack, MENUS_STACK_SIZE);

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -191,8 +191,8 @@ void processCrossfireTelemetryFrame()
           update_interval /= 10;
           offset /= 10;
 
-          serialPrint("[XF] Rate: %d, Lag: %d", update_interval, offset);
-          getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset);
+          TRACE("[XF] Rate: %d, Lag: %d", update_interval, offset);
+          getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset + SAFE_SYNC_LAG);
         }
       }
       break;

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -178,6 +178,17 @@ void processCrossfireTelemetryFrame()
       break;
     }
 
+    // case RADIO_ID:
+    // {
+    //   uint32_t update_interval, offset;
+    //   if (getCrossfireTelemetryValue<4>(2, update_interval) && getCrossfireTelemetryValue<4>(2, offset)) {
+    //     // values are in 10th of micro-seconds
+    //     update_interval /= 10;
+    //     offset /= 10;
+    //     getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset);
+    //   }
+    // }
+
 #if defined(LUA)
     default:
       if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(telemetryRxBufferCount-2) ) {

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -178,16 +178,25 @@ void processCrossfireTelemetryFrame()
       break;
     }
 
-    // case RADIO_ID:
-    // {
-    //   uint32_t update_interval, offset;
-    //   if (getCrossfireTelemetryValue<4>(2, update_interval) && getCrossfireTelemetryValue<4>(2, offset)) {
-    //     // values are in 10th of micro-seconds
-    //     update_interval /= 10;
-    //     offset /= 10;
-    //     getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset);
-    //   }
-    // }
+    case RADIO_ID:
+      if (telemetryRxBuffer[3] == 0xEA    // radio address
+          && telemetryRxBuffer[5] == 0x10 // timing correction frame
+          ) {
+
+        uint32_t update_interval;
+        int32_t  offset;
+        if (getCrossfireTelemetryValue<4>(6, (int32_t&)update_interval) && getCrossfireTelemetryValue<4>(10, offset)) {
+
+          // values are in 10th of micro-seconds
+          update_interval /= 10;
+          offset /= 10;
+
+          serialPrint("[XF] Rate: %d, Lag: %d", update_interval, offset);
+          getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset);
+        }
+      }
+      break;
+
 
 #if defined(LUA)
     default:

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -40,6 +40,7 @@
 #define PING_DEVICES_ID                0x28
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
+#define RADIO_ID                       0x3A
 
 
 struct CrossfireSensor {
@@ -87,14 +88,14 @@ const uint32_t CROSSFIRE_BAUDRATES[] = {
   115200,
 };
 const uint8_t CROSSFIRE_PERIODS[] = {
-  4,
+   4,
   16,
 };
 #define CROSSFIRE_BAUDRATE    CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate]
-#define CROSSFIRE_PERIOD      CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]
+#define CROSSFIRE_PERIOD      (CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]*1000)
 #else
 #define CROSSFIRE_BAUDRATE       400000
-#define CROSSFIRE_PERIOD         4 // 4ms
+#define CROSSFIRE_PERIOD         4000 /*us*/
 #endif
 
 #define CROSSFIRE_TELEM_MIRROR_BAUDRATE   115200

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -95,7 +95,7 @@ const uint8_t CROSSFIRE_PERIODS[] = {
 #define CROSSFIRE_PERIOD      (CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]*1000)
 #else
 #define CROSSFIRE_BAUDRATE       400000
-#define CROSSFIRE_PERIOD         4000 /*us*/
+#define CROSSFIRE_PERIOD         6666 /* us; 150 Hz */
 #endif
 
 #define CROSSFIRE_TELEM_MIRROR_BAUDRATE   115200

--- a/radio/src/telemetry/multi.cpp
+++ b/radio/src/telemetry/multi.cpp
@@ -62,7 +62,6 @@ enum MultiBufferState : uint8_t
 #if defined(INTERNAL_MODULE_MULTI)
 
 static MultiModuleStatus multiModuleStatus[NUM_MODULES] = {MultiModuleStatus(), MultiModuleStatus()};
-static MultiModuleSyncStatus multiSyncStatus[NUM_MODULES] = {MultiModuleSyncStatus(), MultiModuleSyncStatus()};
 static uint8_t multiBindStatus[NUM_MODULES] = {MULTI_NORMAL_OPERATION, MULTI_NORMAL_OPERATION};
 
 static MultiBufferState multiTelemetryBufferState[NUM_MODULES];
@@ -71,11 +70,6 @@ static uint16_t multiTelemetryLastRxTS[NUM_MODULES];
 MultiModuleStatus &getMultiModuleStatus(uint8_t module)
 {
   return multiModuleStatus[module];
-}
-
-MultiModuleSyncStatus &getMultiSyncStatus(uint8_t module)
-{
-  return multiSyncStatus[module];
 }
 
 uint8_t getMultiBindStatus(uint8_t module)
@@ -110,7 +104,6 @@ uint8_t intTelemetryRxBufferCount;
 #else // !INTERNAL_MODULE_MULTI
 
 static MultiModuleStatus multiModuleStatus;
-static MultiModuleSyncStatus multiSyncStatus;
 static uint8_t multiBindStatus = MULTI_NORMAL_OPERATION;
 
 static MultiBufferState multiTelemetryBufferState;
@@ -119,11 +112,6 @@ static uint16_t multiTelemetryLastRxTS;
 MultiModuleStatus& getMultiModuleStatus(uint8_t)
 {
   return multiModuleStatus;
-}
-
-MultiModuleSyncStatus& getMultiSyncStatus(uint8_t)
-{
-  return multiSyncStatus;
 }
 
 uint8_t getMultiBindStatus(uint8_t)
@@ -253,24 +241,41 @@ static void processMultiStatusPacket(const uint8_t * data, uint8_t module, uint8
 
 static void processMultiSyncPacket(const uint8_t * data, uint8_t module)
 {
-  MultiModuleSyncStatus &status = getMultiSyncStatus(module);
+  ModuleSyncStatus &status = getModuleSyncStatus(module);
 
-  status.lastUpdate = get_tmr10ms();
-  status.interval = data[4];
-  status.target = data[5];
-#if !defined(PPM_PIN_SERIAL)
-  auto oldlag = status.inputLag;
-  (void) oldlag;
-#endif
+//   status.lastUpdate = get_tmr10ms();
+//   status.interval = data[4];
+//   status.target = data[5];
+// #if !defined(PPM_PIN_SERIAL)
+//   auto oldlag = status.inputLag;
+//   (void) oldlag;
+// #endif
 
-  status.calcAdjustedRefreshRate(data[0] << 8 | data[1], data[2] << 8 | data[3]);
+//   uint16_t refreshRate = data[0] << 8 | data[1];
+//   status.calcAdjustedRefreshRate(refreshRate, data[2] << 8 | data[3]);
 
-#if !defined(PPM_PIN_SERIAL)
-  TRACE("MP ADJ: rest: %d, lag %04d, diff: %04d  target: %d, interval: %d, Refresh: %d, intAdjRefresh: %d, adjRefresh %d\r\n",
-        module == EXTERNAL_MODULE ? extmodulePulsesData.dsm2.rest : 0,
-        status.inputLag, oldlag - status.inputLag, status.target, status.interval, status.refreshRate, status.adjustedRefreshRate / 50,
-        status.getAdjustedRefreshRate());
-#endif
+//   serialPrint("MP ADJ: R %d, L %04d, T %03d, calc %04d",
+//               refreshRate,
+//               data[2] << 8 | data[3],
+//               status.target,
+//               status.getAdjustedRefreshRate()/2);
+  uint16_t refreshRate = data[0] << 8 | data[1];
+  int16_t  inputLag    = data[2] << 8 | data[3];
+
+  // if (inputLag > refreshRate/2)
+  //   inputLag -= refreshRate;
+
+  status.update(refreshRate, inputLag);
+
+  serialPrint("MP ADJ: R %d, L %04d",
+              refreshRate, inputLag);
+
+// #if !defined(PPM_PIN_SERIAL)
+//   TRACE("MP ADJ: rest: %d, lag %04d, diff: %04d  target: %d, interval: %d, Refresh: %d, intAdjRefresh: %d, adjRefresh %d\r\n",
+//         module == EXTERNAL_MODULE ? extmodulePulsesData.dsm2.rest : 0,
+//         status.inputLag, oldlag - status.inputLag, status.target, status.interval, status.refreshRate, status.adjustedRefreshRate / 50,
+//         status.getAdjustedRefreshRate());
+// #endif
 }
 
 #if defined(PCBTARANIS) || defined(PCBHORUS)
@@ -418,104 +423,6 @@ static void processMultiTelemetryPaket(const uint8_t * packet, uint8_t module)
       TRACE("[MP] Unkown multi packet type 0x%02X, len %d", type, len);
       break;
   }
-}
-
-#define MIN_REFRESH_RATE      5500
-
-void MultiModuleSyncStatus::calcAdjustedRefreshRate(uint16_t newRefreshRate, uint16_t newInputLag)
-{
-  // Check how far off we are from our target, positive means we are too slow, negative we are too fast
-  int lagDifference = newInputLag - inputLag;
-
-  // The refresh rate that we target
-  // Below is least common multiple of MIN_REFRESH_RATE and requested rate
-  uint16_t targetRefreshRate = (uint16_t) (newRefreshRate * ((MIN_REFRESH_RATE / (newRefreshRate - 1)) + 1));
-
-  // Overflow, reverse sample
-  if (lagDifference < -targetRefreshRate / 2)
-    lagDifference = -lagDifference;
-
-
-  // Reset adjusted refresh if rate has changed
-  if (newRefreshRate != refreshRate) {
-    refreshRate = newRefreshRate;
-    adjustedRefreshRate = targetRefreshRate;
-    if (adjustedRefreshRate >= 30000)
-      adjustedRefreshRate /= 2;
-
-    // Our refresh rate in ps
-    adjustedRefreshRate *= 1000;
-    return;
-  }
-
-  // Caluclate how many samples went into the reported input Lag (*10)
-  int numsamples = interval * 10000 / targetRefreshRate;
-
-  // Convert lagDifference to ps
-  lagDifference = lagDifference * 1000;
-
-  // Calculate the time we intentionally were late/early
-  if (inputLag > target * 10 + 30)
-    lagDifference += numsamples * 500;
-  else if (inputLag < target * 10 - 30)
-    lagDifference -= numsamples * 500;
-
-  // Caculate the time in ps each frame is to slow (positive), fast(negative)
-  int perframeps = lagDifference * 10 / numsamples;
-
-  if (perframeps > 20000)
-    perframeps = 20000;
-
-  if (perframeps < -20000)
-    perframeps = -20000;
-
-  adjustedRefreshRate = (adjustedRefreshRate + perframeps);
-
-  // Safeguards
-  if (adjustedRefreshRate < MIN_REFRESH_RATE * 1000)
-    adjustedRefreshRate = MIN_REFRESH_RATE * 1000;
-  if (adjustedRefreshRate > 30 * 1000 * 1000)
-    adjustedRefreshRate = 30 * 1000 * 1000;
-
-  inputLag = newInputLag;
-}
-
-static uint8_t counter;
-
-const uint16_t MultiModuleSyncStatus::getAdjustedRefreshRate()
-{
-  if (!isValid() || refreshRate == 0)
-    return 18000;
-
-  counter = (uint8_t) (counter + 1 % 10);
-  uint16_t rate = (uint16_t) ((adjustedRefreshRate + counter * 50) / 500);
-  // Check how far off we are from our target, positive means we are too slow, negative we are too fast
-  if (inputLag > target * 10 + 30)
-    return (uint16_t) (rate - 1);
-  else if (inputLag < target * 10 - 30)
-    return (uint16_t) (rate + 1);
-  else
-    return rate;
-}
-
-void MultiModuleSyncStatus::getRefreshString(char * statusText)
-{
-  if (!isValid()) {
-    return;
-  }
-
-  char * tmp = statusText;
-#if defined(DEBUG)
-  *tmp++ = 'L';
-  tmp = strAppendUnsigned(tmp, inputLag, 5);
-  tmp = strAppend(tmp, "us R ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (adjustedRefreshRate / 1000), 5);
-  tmp = strAppend(tmp, "us");
-#else
-  tmp = strAppend(tmp, "Sync at ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (adjustedRefreshRate / 1000000));
-  tmp = strAppend(tmp, " ms");
-#endif
 }
 
 void MultiModuleStatus::getStatusString(char * statusText) const

--- a/radio/src/telemetry/multi.h
+++ b/radio/src/telemetry/multi.h
@@ -94,28 +94,6 @@ void processMultiTelemetryData(uint8_t data, uint8_t module);
 
 #define MULTI_SCANNER_MAX_CHANNEL 249
 
-// This should be put into the Module definition if other modules gain this functionality
-struct MultiModuleSyncStatus {
-  uint32_t adjustedRefreshRate = 9000 * 1000;    // in ps
-  tmr10ms_t lastUpdate;
-  uint16_t refreshRate;
-  uint16_t inputLag;
-  uint8_t interval;
-  uint8_t target;
-
-  inline bool isValid() const
-  {
-    return (get_tmr10ms()  - lastUpdate < 100);
-  }
-  
-  void getRefreshString(char * refreshText);
-  const uint16_t getAdjustedRefreshRate();
-  void calcAdjustedRefreshRate(uint16_t newRefreshRate, uint16_t newInputLag);
-};
-
-MultiModuleSyncStatus& getMultiSyncStatus(uint8_t module);
-
-
 struct MultiModuleStatus {
 
   uint8_t major;

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -404,30 +404,6 @@ uint16_t ModuleSyncStatus::getAdjustedRefreshRate()
   return (uint16_t)newRefreshRate;
 }
 
-// sprintf does not work AVR ARM
-// use a small helper function
-static void appendInt(char * buf, uint32_t val)
-{
-  while (*buf)
-    buf++;
-
-  strAppendUnsigned(buf, val);
-}
-
-static void prependSpaces(char * buf, int val)
-{
-  while (*buf)
-    buf++;
-
-  int k = 10000;
-  while (val / k == 0 && k > 0) {
-    *buf = ' ';
-    buf++;
-    k /= 10;
-  }
-  *buf = '\0';
-}
-
 void ModuleSyncStatus::getRefreshString(char * statusText)
 {
   if (!isValid()) {
@@ -439,11 +415,11 @@ void ModuleSyncStatus::getRefreshString(char * statusText)
   *tmp++ = 'L';
   tmp = strAppendUnsigned(tmp, inputLag, 5);
   tmp = strAppend(tmp, "us R ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (adjustedRefreshRate / 1000), 5);
+  tmp = strAppendUnsigned(tmp, (uint32_t) (refreshRate / 1000), 5);
   tmp = strAppend(tmp, "us");
 #else
   tmp = strAppend(tmp, "Sync at ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (adjustedRefreshRate / 1000000));
+  tmp = strAppendUnsigned(tmp, (uint32_t) (refreshRate / 1000000));
   tmp = strAppend(tmp, " ms");
 #endif
 }

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -385,7 +385,11 @@ uint16_t ModuleSyncStatus::getAdjustedRefreshRate()
   int16_t lag = currentLag - SAFE_SYNC_LAG;
   int32_t newRefreshRate = refreshRate;
 
-  newRefreshRate += lag/2;
+  if (lag == 0) {
+    return refreshRate;
+  }
+  
+  newRefreshRate += lag;
   
   if (newRefreshRate < MIN_REFRESH_RATE) {
       newRefreshRate = MIN_REFRESH_RATE;
@@ -393,6 +397,8 @@ uint16_t ModuleSyncStatus::getAdjustedRefreshRate()
   else if (newRefreshRate > MAX_REFRESH_RATE) {
     newRefreshRate = MAX_REFRESH_RATE;
   }
+
+  TRACE("[SYNC] rate = %dus",newRefreshRate);
   
   currentLag -= newRefreshRate - refreshRate;
   return (uint16_t)newRefreshRate;

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -338,10 +338,6 @@ OutputTelemetryBuffer outputTelemetryBuffer __DMA;
 Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> * luaInputTelemetryFifo = NULL;
 #endif
 
-#define MIN_REFRESH_RATE      4000 /* us */
-#define MAX_REFRESH_RATE     25000 /* us */
-#define SAFE_SYNC_LAG          800 /* us */
-
 #if defined(HARDWARE_INTERNAL_MODULE)
 
 static ModuleSyncStatus moduleSyncStatus[NUM_MODULES];

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -20,6 +20,7 @@
 
 #include "opentx.h"
 #include "multi.h"
+#include "mixer_scheduler.h"
 
 uint8_t telemetryStreaming = 0;
 uint8_t telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];   // Receive buffer. 9 bytes (full packet), worst case 18 bytes with byte-stuffing (+1)

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -268,7 +268,8 @@ struct ModuleSyncStatus
   int16_t   currentLag;  // in us
   
   inline bool isValid() {
-    return (get_tmr10ms() - lastUpdate < 100);
+    // 2 seconds
+    return (get_tmr10ms() - lastUpdate < 200);
   }
 
   // Set feedback from RF module

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -258,9 +258,6 @@ extern Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> * luaInputTelemetryFifo;
 void processPXX2Frame(uint8_t module, const uint8_t *frame);
 
 // Module pulse synchronization
-
-#define MIN_REFRESH_RATE      4000 /* us */
-#define MAX_REFRESH_RATE     25000 /* us */
 #define SAFE_SYNC_LAG          800 /* us */
 
 struct ModuleSyncStatus

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -257,4 +257,32 @@ extern Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> * luaInputTelemetryFifo;
 
 void processPXX2Frame(uint8_t module, const uint8_t *frame);
 
+// Module pulse synchronization
+struct ModuleSyncStatus
+{
+  // feedback input: last received values
+  uint16_t  refreshRate; // in us
+  int16_t   inputLag;    // in us
+
+  tmr10ms_t lastUpdate;  // in 10ms
+  int16_t   currentLag;  // in us
+  
+  inline bool isValid() {
+    return (get_tmr10ms() - lastUpdate < 100);
+  }
+
+  // Set feedback from RF module
+  void update(uint16_t newRefreshRate, uint16_t newInputLag);
+
+  // Get computed settings for scheduler
+  uint16_t getAdjustedRefreshRate();
+
+  // Status string for the UI
+  void getRefreshString(char* refreshText);
+
+  ModuleSyncStatus();
+};
+
+ModuleSyncStatus& getModuleSyncStatus(uint8_t moduleIdx);
+
 #endif // _TELEMETRY_H_

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -258,6 +258,11 @@ extern Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> * luaInputTelemetryFifo;
 void processPXX2Frame(uint8_t module, const uint8_t *frame);
 
 // Module pulse synchronization
+
+#define MIN_REFRESH_RATE      4000 /* us */
+#define MAX_REFRESH_RATE     25000 /* us */
+#define SAFE_SYNC_LAG          800 /* us */
+
 struct ModuleSyncStatus
 {
   // feedback input: last received values


### PR DESCRIPTION
Re-work of the mixer scheduling. It uses a separate timer (TIM13) to trigger a CoOS flag, which is waited for in the mixer loop.

TODO:
- [x] fix/test on X9D(+)
- [ ] deal with `SKY9X`