### PR TITLE
Stop sensor discovery when table is already full

### DIFF
--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -214,6 +214,7 @@ void menuModelTelemetry(event_t event)
             pushMenu(menuModelSensor);
           }
           else {
+            allowNewSensors = 0;
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
         }

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -205,6 +205,7 @@ void menuModelTelemetry(event_t event)
             pushMenu(menuModelSensor);
           }
           else {
+            allowNewSensors = 0;
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
         }

--- a/radio/src/gui/480x272/model_telemetry.cpp
+++ b/radio/src/gui/480x272/model_telemetry.cpp
@@ -195,6 +195,7 @@ bool menuModelTelemetry(event_t event)
             pushMenu(menuModelSensor);
           }
           else {
+            allowNewSensors = 0;
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
         }


### PR DESCRIPTION
This fixes #7060