### PR TITLE
Disable interrupts before jump to application in horus bootloader

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -105,6 +105,11 @@ void init10msTimer()
   NVIC_EnableIRQ(INTERRUPT_xMS_IRQn);
 }
 
+void deinit10msTimer()
+{
+  NVIC_DisableIRQ(INTERRUPT_xMS_IRQn);
+}
+
 extern "C" void INTERRUPT_xMS_IRQHandler()
 {
   INTERRUPT_xMS_TIMER->SR &= ~TIM_SR_UIF;
@@ -509,6 +514,11 @@ int main()
 #if !defined(EEPROM)
       // Use jump on radios with emergency mode
       // to avoid triggering it with a soft reset
+
+      // disable interrupts before jump to application
+      usbStop();
+      rotaryEncoderStop();
+      deinit10msTimer();
 
       // Jump to proper application address
       jumpTo(APP_START_ADDRESS);

--- a/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
@@ -69,6 +69,15 @@ void rotaryEncoderInit()
   NVIC_SetPriority(ROTARY_ENCODER_TIMER_IRQn, 7);
 }
 
+void rotaryEncoderStop()
+{
+  NVIC_DisableIRQ(ROTARY_ENCODER_TIMER_IRQn);
+  NVIC_DisableIRQ(ROTARY_ENCODER_EXTI_IRQn1);
+#if defined(ROTARY_ENCODER_EXTI_IRQn2)
+  NVIC_DisableIRQ(ROTARY_ENCODER_EXTI_IRQn2);
+#endif
+}
+
 void rotaryEncoderCheck()
 {
 #if defined(RADIO_T16)

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -303,6 +303,7 @@ uint32_t readTrims();
 #define ROTARY_ENCODER_NAVIGATION
 void rotaryEncoderInit();
 void rotaryEncoderCheck();
+void rotaryEncoderStop();
 
 // WDT driver
 #define WDTO_500MS                              500


### PR DESCRIPTION
As far as I could see, it seems SysTicks interrupt is not enabled at this point. Did I forget anything else?