### PR TITLE
Fix ar9x compile/boot

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -186,7 +186,7 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
     const uint8_t negative = (timerState.val<0 ? BLINK | INVERS : 0);
     LcdFlags att = RIGHT | DBLSIZE;
     if (timerState.val < 60 * 60) { // display MM:SS
-      div_t qr = div(abs(timerState.val), 60);
+      div_t qr = div((int)abs(timerState.val), 60);
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0 | negative, 2);
       lcdDrawText(lcdLastLeftPos, y, ":", att|BLINK | negative);
       lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att | negative);
@@ -194,7 +194,7 @@ void drawTimerWithMode(coord_t x, coord_t y, uint8_t index)
         lcdDrawText(lcdLastLeftPos, y, "-", att | negative);
     }
     else if (timerState.val < (99 * 60 * 60) + (59 * 60)) { // display HHhMM
-      div_t qr = div(abs(timerState.val) / 60, 60);
+      div_t qr = div((int)(abs(timerState.val) / 60), 60);
       lcdDrawNumber(x - 5, y, qr.rem, att | LEADING0, 2);
       lcdDrawText(lcdLastLeftPos, y, "h", att);
       lcdDrawNumber(lcdLastLeftPos, y, qr.quot, att);

--- a/radio/src/targets/sky9x/board.cpp
+++ b/radio/src/targets/sky9x/board.cpp
@@ -330,6 +330,7 @@ void i2cInit()
   TWI0->TWI_MMR = 0x002F0000 ;          // Device 5E (>>1) and master is writing
   NVIC_EnableIRQ(TWI0_IRQn) ;
 }
+#endif
 
 void boardInit()
 {
@@ -388,12 +389,11 @@ void boardInit()
   lcdInit();
 
   init_SDcard();
-}
-#else
-void boardInit()
-{
-}
+
+#if defined(PCBAR9X)
+  rtcInit();
 #endif
+}
 
 uint8_t temperature = 0;          // Raw temp reading
 uint8_t maxTemperature = 0 ;       // Raw temp reading


### PR DESCRIPTION
When removing REVA in 0ec34fd72c5d1ab356c9129aac52985466005654 boardInit() for AR9X got lost completely due to some #if/#endif mixup.
I've also readded rtcInit() to boardInit() for AR9X so the (optional) rtc is working again.

Additionally there's a small compile fix in view_main.cpp for datatype issues when compling for ATSAM