### PR TITLE
Make TX voltage for simu more flexible

### DIFF
--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -697,7 +697,7 @@ void serialPutc(char c) { }
 
 uint16_t getBatteryVoltage()
 {
-  return (BATTERY_MAX + BATTERY_WARN) * 5;
+  return (g_eeGeneral.vBatWarn * 10) + 50; // 0.5 volt above alerm (value is PREC1)
 }
 
 void boardOff()


### PR DESCRIPTION
Set simu (and libsimu) TX voltage 0.5 above warn value,  allowing non standard battery setup

This fixes #7019 