### PR TITLE
[USB] Power up immediately when booting with USB connected

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -356,6 +356,7 @@ set(SRC
   stamp.cpp
   timers.cpp
   trainer.cpp
+  pwr.cpp
   )
 
 if(GUI)

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1840,10 +1840,7 @@ void opentxInit()
   BACKLIGHT_ENABLE(); // we start the backlight during the startup animation
 
 #if defined(STARTUP_ANIMATION)
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
-  else {
+  if (!pwrOnIfImmediate()) {
     runStartupAnimation();
   }
 #else // defined(PWR_BUTTON_PRESS)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -439,6 +439,8 @@ bool cmpStrWithZchar(const char * charString, const char * zcharString, int size
 #include "keys.h"
 #include "pwr.h"
 
+uint32_t pwrCheck();
+
 #if defined(PCBTARANIS) || defined(PCBHORUS)
 div_t switchInfo(int switchPosition);
 extern uint8_t potsPos[NUM_XPOTS];

--- a/radio/src/pwr.cpp
+++ b/radio/src/pwr.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) OpenTX
  *
  * Based on code named
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -18,24 +18,25 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _PWR_H_
-#define _PWR_H_
+#include "board.h"
 
-enum PowerState {
-  e_power_on,
-  e_power_trainer,
-  e_power_usb,
-  e_power_off,
-  e_power_press,
-};
+bool pwrOnShouldBeImmediate()
+{
+#if defined(WAS_RESET_BY_WATCHDOG_OR_SOFTWARE)
+  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
+    return true;
+  }
+#endif
+  // We need to power on immediately when USB is plugged, so
+  // we can get out of ST's bootloader without user intervention.
+  return usbPlugged();
+}
 
-/// Check if power should be turned on immediately.
-/// @see pwrOnIfImmediate()
-bool pwrOnShouldBeImmediate();
-/// If power should be turned on immediately, call pwrOn()
-/// and return true. Return false otherwise.
-/// @see pwrOnShouldBeImmediate()
-/// @see pwrOn()
-bool pwrOnIfImmediate();
-
-#endif // _PWR_H_
+bool pwrOnIfImmediate()
+{
+  if (pwrOnShouldBeImmediate()) {
+    pwrOn();
+    return true;
+  }
+  return false;
+}

--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -56,6 +56,7 @@ set(BOOTLOADER_SRC
   ../../../../../gui/${GUI_DIR}/lcd.cpp
   ../../../../../gui/${GUI_DIR}/fonts.cpp
   ../../../../../keys.cpp
+  ../../../../../pwr.cpp
   ../../../../../strhelpers.cpp
   ../../../../../stamp.cpp
   ../../../../../${STM32USB_DIR}/STM32_USB_OTG_Driver/src/usb_core.c

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -21,6 +21,7 @@
 #include "opentx.h"
 #include "boot.h"
 #include "bin_files.h"
+#include "pwr.h"
 
 #if defined(PCBXLITE)
   #define BOOTLOADER_KEYS                 0x0F
@@ -211,7 +212,7 @@ int main()
   keysInit();
 
   // wait a bit for the inputs to stabilize...
-  if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
+  if (!pwrOnShouldBeImmediate()) {
     for (uint32_t i = 0; i < 150000; i++) {
       __ASM volatile ("nop");
     }

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -191,9 +191,9 @@ set(TARGET_SRC
   extmodule_driver.cpp
   trainer_driver.cpp
   ../common/arm/stm32/heartbeat_driver.cpp
-  ../common/arm/stm32/timers_driver.cpp
   ../common/arm/stm32/intmodule_serial_driver.cpp
   ../common/arm/stm32/rotary_encoder_driver.cpp
+  ../common/arm/stm32/timers_driver.cpp
   )
 
 if(BLUETOOTH)

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -483,7 +483,6 @@ extern "C" {
 // Power driver
 #define SOFT_PWR_CTRL
 void pwrInit();
-uint32_t pwrCheck();
 void pwrOn();
 void pwrOff();
 void pwrResetHandler();

--- a/radio/src/targets/horus/pwr_driver.cpp
+++ b/radio/src/targets/horus/pwr_driver.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "board.h"
+#include "pwr.h"
 #include "storage/rtc_backup.h"
 
 void pwrInit()
@@ -103,7 +104,5 @@ void pwrResetHandler()
   __ASM volatile ("nop");
   __ASM volatile ("nop");
 
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
+  pwrOnIfImmediate();
 }

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -361,10 +361,10 @@ set(TARGET_SRC
   backlight_driver.cpp
   extmodule_driver.cpp
   trainer_driver.cpp
-  ../common/arm/stm32/timers_driver.cpp
   ../common/arm/stm32/audio_dac_driver.cpp
   ../common/arm/stm32/adc_driver.cpp
   ../common/arm/stm32/heartbeat_driver.cpp
+  ../common/arm/stm32/timers_driver.cpp
   )
 
 if(PCB STREQUAL XLITE OR PCB STREQUAL XLITES)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "opentx.h"
+#include "pwr.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -175,9 +176,7 @@ void boardInit()
 #endif
 
 #if defined(PWR_BUTTON_PRESS)
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
+  pwrOnIfImmediate();
 #endif
 
 #if defined(TOPLCD_GPIO)

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -629,7 +629,6 @@ extern "C" {
 // Power driver
 #define SOFT_PWR_CTRL
 void pwrInit();
-uint32_t pwrCheck();
 void pwrOn();
 void pwrOff();
 bool pwrPressed();

--- a/radio/src/targets/taranis/pwr_driver.cpp
+++ b/radio/src/targets/taranis/pwr_driver.cpp
@@ -20,6 +20,8 @@
 
 #include "opentx.h"
 
+#include "pwr.h"
+
 void pwrInit()
 {
   GPIO_InitTypeDef GPIO_InitStructure;
@@ -107,7 +109,5 @@ void pwrResetHandler()
   __ASM volatile ("nop");
   __ASM volatile ("nop");
 
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
+  pwrOnIfImmediate();
 }


### PR DESCRIPTION
This allows jumping out of ST's bootloader without manual user
intervention when the radio is connected to the USB host while
it's powered off.

Note that the radio doesn't power on as soon as it's connected, since
the hardware is wired to boot the MCU into bootloader mode. However,
the host can detect the USB connection and issue a DFU_DNLOAD to
turn on the radio.