### PR TITLE
[MSC] Add a file in the virtual Taranis drive with radio information

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -77,13 +77,14 @@ set(BOOTLOADER_SRC
   ../../../../../targets/${TARGET_DIR}/board.cpp
   ../../../../../targets/${TARGET_DIR}/pwr_driver.cpp
   ../../../../../targets/${TARGET_DIR}/bootloader/boot_menu.cpp
-  ../usbd_usr.cpp
-  ../usbd_storage_msd.cpp
+  ../cpu_id.cpp
   ../delays.cpp
-  ../usbd_desc.c
+  ../flash_driver.cpp
   ../usb_bsp.c
   ../usb_driver.cpp
-  ../flash_driver.cpp
+  ../usbd_desc.c
+  ../usbd_storage_msd.cpp
+  ../usbd_usr.cpp
   init.c
   boot.cpp
   bin_files.cpp

--- a/radio/src/targets/common/arm/stm32/cpu_id.cpp
+++ b/radio/src/targets/common/arm/stm32/cpu_id.cpp
@@ -34,3 +34,26 @@ void getCPUUniqueID(char * s)
   *tmp = ' ';
   strAppendUnsigned(tmp+1, cpu_uid[2], 8, 16);
 }
+
+void getCPUDFUSerial(char * s)
+{
+	uint8_t *id = (uint8_t *)cpu_uid;
+
+	uint8_t serial[6];
+	serial[0] = id[11];
+	serial[1] = id[10] + id[2];
+	serial[2] = id[9];
+	serial[3] = id[8] + id[0];
+	serial[4] = id[7];
+	serial[5] = id[6];
+
+	uint8_t *ser = &serial[0];
+	uint8_t *end = &serial[6];
+	const char hex_digit[] = "0123456789ABCDEF";
+
+	for (; ser < end; ser++) {
+		*s++ = hex_digit[(*ser >> 4) & 0x0f];
+		*s++ = hex_digit[(*ser >> 0) & 0x0f];
+	}
+	*s = '\0';
+}

--- a/radio/src/targets/common/arm/stm32/cpu_id.h
+++ b/radio/src/targets/common/arm/stm32/cpu_id.h
@@ -20,9 +20,27 @@
 
 #include <inttypes.h>
 
+/// Format the 96-bit MCU unique ID into the given buffer
+/// as a null terminated hexadecimal decimal string.
+/// Each 32 bit segment is separated by a space
+/// (e.g. 00510046 3136510C 35393532).
+///
+/// @param s Buffer to write the string to. Must be at least
+/// LEN_CPU_UID + 1 bytes long.
 void getCPUUniqueID(char * s);
+/// Generate a serial number from the MCU unique ID following
+/// ST's algorithm used by the DFU bootloader. The resulting
+/// string uses only uppercase hexadecimal characters and is
+/// null terminated.
+///
+/// @param s Buffer to write the string to. Must be at least
+/// LEN_CPU_DFU_SERIAL + 1 bytes long.
+void getCPUDFUSerial(char * s);
 
+/// Length of the CPU UUID string without the null terminator
 #define LEN_CPU_UID                    (3*8+2)
+/// Length of the CPU DFU serial string without the null terminator
+#define LEN_CPU_DFU_SERIAL             (12)
 
 #if defined(SIMU)
 extern const uint32_t cpu_uid[3];


### PR DESCRIPTION
Add a new readonly file called RADIO.TXT to the root directory.
This file contains the unique ID of the CPU as well as a DFU
serial using the same algorithm as ST's DFU bootloader.

This way we can keep track of an specific radio when it's connected
in MSC mode.