### PR TITLE
[build] Fix building with semihosting enabled

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -134,6 +134,7 @@ endif()
 remove_definitions(-DDISK_CACHE)
 remove_definitions(-DLUA)
 remove_definitions(-DCLI)
+remove_definitions(-DSEMIHOSTING)
 remove_definitions(-DUSB_SERIAL)
 remove_definitions(-DWATCHDOG)
 


### PR DESCRIPTION
Remove -DSEMIHOSTING from the bootloader CFLAGS unconditionally.

-DSEMIHOSTING is passed to the bootloader by the parent project when
SEMIHOSTING=ON, however the bootloader wouldn't fit on flash with
semihosting enabled.

If we leave the -DSEMIHOSTING flag, we would get a compilation error
on non-horus radios (since -DDEBUG is removed) and a link time error
on horus (since the bootloader won't fit in its allocated flash
region).