### PR TITLE
[SEMIHOSTING] Enable semihosting for any targets that support it

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1991,12 +1991,19 @@ void opentxInit()
   WDG_ENABLE(WDG_DURATION);
 }
 
+#if defined(SEMIHOSTING)
+extern "C" void initialise_monitor_handles();
+#endif
+
 #if defined(SIMU)
 void simuMain()
 #else
 int main()
 #endif
 {
+#if defined(SEMIHOSTING)
+  initialise_monitor_handles();
+#endif
 #if defined(STM32)
   TRACE("reusableBuffer: modelSel=%d, moduleSetup=%d, calib=%d, sdManager=%d, hardwareAndSettings=%d, spectrumAnalyser=%d, usb=%d",
         sizeof(reusableBuffer.modelsel),

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -481,7 +481,7 @@ extern uint8_t flightModeTransitionLast;
 
 #if defined(SIMU)
   inline int availableMemory() { return 1000; }
-#elif !defined(SIMU)
+#else
   extern unsigned char *heap;
   extern int _end;
   extern int _heap_end;

--- a/radio/src/syscalls.c
+++ b/radio/src/syscalls.c
@@ -97,6 +97,12 @@ extern int _write(int file, char *ptr, int len)
   return 0;
 }
 
+extern int _getpid()
+{
+    return -1 ;
+}
+#endif
+
 extern void _exit(int status)
 {
   TRACE("_exit(%d)", status);
@@ -107,10 +113,4 @@ extern void _kill(int pid, int sig)
 {
   return ;
 }
-
-extern int _getpid()
-{
-    return -1 ;
-}
-#endif
 

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -41,10 +41,6 @@ void watchdogInit(unsigned int duration)
   IWDG->KR = 0xCCCC;      // start
 }
 
-#if defined(SEMIHOSTING)
-extern "C" void initialise_monitor_handles();
-#endif
-
 #if defined(PCBX10) && !defined(RADIO_T16)
 void sportUpdateInit()
 {
@@ -70,10 +66,6 @@ void sportUpdatePowerOff()
 
 void boardInit()
 {
-#if defined(SEMIHOSTING)
-  initialise_monitor_handles();
-#endif
-
   RCC_AHB1PeriphClockCmd(PWR_RCC_AHB1Periph |
                          PCBREV_RCC_AHB1Periph |
                          LED_RCC_AHB1Periph |


### PR DESCRIPTION
- Move semihosting initialization to main()
- Provide _exit and _kill even when semihosting is enabled. librdimon
doesn't include them.