### PR TITLE
Introduce ALLOW_TRAINER_MULTI 

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -53,6 +53,7 @@ option(MODULE_PROTOCOL_LBT "Add support for EU/LBT modules" ON)
 option(MODULE_PROTOCOL_FLEX "Add support for non certified FLEX modules" OFF)
 option(MODULE_PROTOCOL_D8 "Add support for D8 modules" ON)
 option(FRSKY_RELEASE "Used to build FrSky released firmware" OFF)
+option(ALLOW_TRAINER_MULTI "Allow multi trainer" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -341,6 +342,10 @@ endif()
 if(FRSKY_RELEASE)
   add_definitions(-DFRSKY_RELEASE)
   set(POPUP_LEVEL 3)
+endif()
+
+if(ALLOW_TRAINER_MULTI)
+  add_definitions(-DALLOW_TRAINER_MULTI)
 endif()
 
 add_definitions(-DPOPUP_LEVEL=${POPUP_LEVEL})

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -205,7 +205,7 @@ enum TrainerMode {
   };
 #endif
 
-#if defined(RADIO_T16)
+#if defined(RADIO_T16) || defined(ALLOW_TRAINER_MULTI)
   #define TRAINER_MODE_MAX()             TRAINER_MODE_MULTI
 #elif defined(BLUETOOTH)
   #define TRAINER_MODE_MAX()             TRAINER_MODE_SLAVE_BLUETOOTH


### PR DESCRIPTION
Provide a manual compilation option to force TRAINER multi  for Horus with hacked hardware

This closes #7181 