### PR TITLE
LUA sport/crossfireTelemetryPush protocol detection

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -440,13 +440,15 @@ When called without parameters, it will only return the status of the output buf
 
 @retval boolean  data queued in output buffer or not.
 
-@status current Introduced in 2.2.0
+@retval nil      incorrect telemetry protocol.
+
+@status current Introduced in 2.2.0, retval nil added in 2.3.4
 */
 
 static int luaSportTelemetryPush(lua_State * L)
 {
   if (!IS_FRSKY_SPORT_PROTOCOL()) {
-    lua_pushboolean(L, false);
+    lua_pushnil(L);
     return 1;
   }
 
@@ -637,12 +639,14 @@ When called without parameters, it will only return the status of the output buf
 
 @retval boolean  data queued in output buffer or not.
 
-@status current Introduced in 2.2.0
+@retval nil      incorrect telemetry protocol.
+
+@status current Introduced in 2.2.0, retval nil added in 2.3.4
 */
 static int luaCrossfireTelemetryPush(lua_State * L)
 {
   if (telemetryProtocol != PROTOCOL_TELEMETRY_CROSSFIRE) {
-    lua_pushboolean(L, false);
+    lua_pushnil(L);
     return 1;
   }
 


### PR DESCRIPTION
Make sportTelemetryPush/crossfireTelemetryPush return nil if they detect the wrong telemetry protocol.
This allows us to differentiate between wrong protocol and telemetry buffer not available. For lua scripts supporting both crossfire and smartport this will let us reliably detect the telemetry protocol using these functions.