### PR TITLE
Call parent class load method when loading the dark blue theme

### DIFF
--- a/radio/src/gui/480x272/themes/darkblue.cpp
+++ b/radio/src/gui/480x272/themes/darkblue.cpp
@@ -224,6 +224,7 @@ class DarkblueTheme: public Theme
 
     virtual void load() const
     {
+      Theme::load();
       loadColors();
       loadMenusIcons();
       loadThemeBitmaps();


### PR DESCRIPTION
Fixes the warning (asterisk), busy, and question bitmaps not showing on T16/X10, etc. when the dark blue theme is in use.