### PR TITLE
Crossfire LUA add missing support for PREC3 values

### DIFF
--- a/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -72,7 +72,7 @@ local function incrField(step)
     end
   else
     local min, max = 0, 0
-    if field.type <= 5 then
+    if ((field.type <= 5) or (field.type == 8)) then
       min = field.min
       max = field.max
       step = field.step * step
@@ -239,25 +239,21 @@ local function fieldFloatLoad(field, data, offset)
   field.default = fieldGetValue(data, offset+12, 4)
   fieldUnsignedToSigned(field, 4)
   field.prec = data[offset+16]
-  if field.prec > 2 then
-    field.prec = 2
+  if field.prec > 3 then
+    field.prec = 3
   end
   field.step = fieldGetValue(data, offset+17, 4)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
+local function round(num, decimals)
+  local mult = 10^(decimals or 0)
+  local val = num / mult
+  return string.format("%." .. decimals .. "f", val)
+end
+
 local function fieldFloatDisplay(field, y, attr)
-  local attrnum
-  if field.prec == 1 then
-    attrnum = LEFT + attr + PREC1
-  elseif field.prec == 2 then
-    attrnum = LEFT + attr + PREC2
-  else
-    attrnum = LEFT + attr
-  end
-  -- lcd.drawNumber(140, y, field.value, attrnum)			-- NOTE: original code getLastPos not available in Horus
-  -- lcd.drawText(lcd.getLastPos(), y, field.unit, attr)    -- NOTE: original code getLastPos not available in Horus
-  lcd.drawText(140, y, field.value .. field.unit, attr) 	-- NOTE: Concenated fields instead of get lastPos
+  lcd.drawText(140, y, round(field.value, field.prec) .. field.unit, attr)
 end
 
 local function fieldFloatSave(field)

--- a/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -246,14 +246,14 @@ local function fieldFloatLoad(field, data, offset)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
-local function round(num, decimals)
+local function formatFloat(num, decimals)
   local mult = 10^(decimals or 0)
   local val = num / mult
   return string.format("%." .. decimals .. "f", val)
 end
 
 local function fieldFloatDisplay(field, y, attr)
-  lcd.drawText(140, y, round(field.value, field.prec) .. field.unit, attr)
+  lcd.drawText(140, y, formatFloat(field.value, field.prec) .. field.unit, attr)
 end
 
 local function fieldFloatSave(field)

--- a/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -245,14 +245,14 @@ local function fieldFloatLoad(field, data, offset)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
-local function round(num, decimals)
+local function formatFloat(num, decimals)
   local mult = 10^(decimals or 0)
   local val = num / mult
   return string.format("%." .. decimals .. "f", val)
 end
 
 local function fieldFloatDisplay(field, y, attr)
-  lcd.drawText(89, y, round(field.value, field.prec), LEFT + attr)
+  lcd.drawText(89, y, formatFloat(field.value, field.prec), LEFT + attr)
   lcd.drawText(lcd.getLastPos(), y, field.unit, attr)
 end
 

--- a/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -72,7 +72,7 @@ local function incrField(step)
     end
   else
     local min, max = 0, 0
-    if field.type <= 5 then
+    if ((field.type <= 5) or (field.type == 8)) then
       min = field.min
       max = field.max
       step = field.step * step
@@ -238,23 +238,21 @@ local function fieldFloatLoad(field, data, offset)
   field.default = fieldGetValue(data, offset+12, 4)
   fieldUnsignedToSigned(field, 4)
   field.prec = data[offset+16]
-  if field.prec > 2 then
-    field.prec = 2
+  if field.prec > 3 then
+    field.prec = 3
   end
   field.step = fieldGetValue(data, offset+17, 4)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
+local function round(num, decimals)
+  local mult = 10^(decimals or 0)
+  local val = num / mult
+  return string.format("%." .. decimals .. "f", val)
+end
+
 local function fieldFloatDisplay(field, y, attr)
-  local attrnum
-  if field.prec == 1 then
-    attrnum = LEFT + attr + PREC1
-  elseif field.prec == 2 then
-    attrnum = LEFT + attr + PREC2
-  else
-    attrnum = LEFT + attr
-  end
-  lcd.drawNumber(89, y, field.value, attrnum)
+  lcd.drawText(89, y, round(field.value, field.prec), LEFT + attr)
   lcd.drawText(lcd.getLastPos(), y, field.unit, attr)
 end
 

--- a/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -72,7 +72,7 @@ local function incrField(step)
     end
   else
     local min, max = 0, 0
-    if field.type <= 5 then
+    if ((field.type <= 5) or (field.type == 8)) then
       min = field.min
       max = field.max
       step = field.step * step
@@ -238,23 +238,21 @@ local function fieldFloatLoad(field, data, offset)
   field.default = fieldGetValue(data, offset+12, 4)
   fieldUnsignedToSigned(field, 4)
   field.prec = data[offset+16]
-  if field.prec > 2 then
-    field.prec = 2
+  if field.prec > 3 then
+    field.prec = 3
   end
   field.step = fieldGetValue(data, offset+17, 4)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
+local function round(num, decimals)
+  local mult = 10^(decimals or 0)
+  local val = num / mult
+  return string.format("%." .. decimals .. "f", val)
+end
+
 local function fieldFloatDisplay(field, y, attr)
-  local attrnum
-  if field.prec == 1 then
-    attrnum = LEFT + attr + PREC1
-  elseif field.prec == 2 then
-    attrnum = LEFT + attr + PREC2
-  else
-    attrnum = LEFT + attr
-  end
-  lcd.drawNumber(140, y, field.value, attrnum)
+  lcd.drawText(140, y, round(field.value, field.prec), LEFT + attr)
   lcd.drawText(lcd.getLastPos(), y, field.unit, attr)
 end
 

--- a/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -245,14 +245,14 @@ local function fieldFloatLoad(field, data, offset)
   field.unit, offset = fieldGetString(data, offset+21)
 end
 
-local function round(num, decimals)
+local function formatFloat(num, decimals)
   local mult = 10^(decimals or 0)
   local val = num / mult
   return string.format("%." .. decimals .. "f", val)
 end
 
 local function fieldFloatDisplay(field, y, attr)
-  lcd.drawText(140, y, round(field.value, field.prec), LEFT + attr)
+  lcd.drawText(140, y, formatFloat(field.value, field.prec), LEFT + attr)
   lcd.drawText(lcd.getLastPos(), y, field.unit, attr)
 end
 


### PR DESCRIPTION
This is the PR for the crossfire device.lua to support 3 digit precission (eg. used on KISSFC) Credits to @fedorcomander