### PR TITLE
Increase lua telemetry push output buffer

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -456,6 +456,10 @@ static int luaSportTelemetryPush(lua_State * L)
     lua_pushboolean(L, outputTelemetryBuffer.isAvailable());
     return 1;
   }
+  else if (lua_gettop(L) > sizeof(SportTelemetryPacket) ) {
+    lua_pushboolean(L, false);
+    return 1;
+  }
 
   uint16_t dataId = luaL_checkunsigned(L, 3);
 
@@ -652,6 +656,10 @@ static int luaCrossfireTelemetryPush(lua_State * L)
 
   if (lua_gettop(L) == 0) {
     lua_pushboolean(L, outputTelemetryBuffer.isAvailable());
+  }
+  else if (lua_gettop(L) > TELEMETRY_OUTPUT_BUFFER_SIZE ) {
+    lua_pushboolean(L, false);
+    return 1;
   }
   else if (outputTelemetryBuffer.isAvailable()) {
     uint8_t command = luaL_checkunsigned(L, 1);

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -171,6 +171,7 @@ void logTelemetryWriteByte(uint8_t data);
 #define LOG_TELEMETRY_WRITE_START()
 #define LOG_TELEMETRY_WRITE_BYTE(data)
 #endif
+#define TELEMETRY_OUTPUT_BUFFER_SIZE  64
 
 class OutputTelemetryBuffer {
   public:
@@ -212,7 +213,8 @@ class OutputTelemetryBuffer {
 
     void pushByte(uint8_t byte)
     {
-      data[size++] = byte;
+      if (size < TELEMETRY_OUTPUT_BUFFER_SIZE)
+        data[size++] = byte;
     }
 
     void pushByteWithBytestuffing(uint8_t byte)
@@ -244,7 +246,7 @@ class OutputTelemetryBuffer {
   public:
     union {
       SportTelemetryPacket sport;
-      uint8_t data[16];
+      uint8_t data[TELEMETRY_OUTPUT_BUFFER_SIZE];
     };
     uint8_t size;
     uint8_t timeout;


### PR DESCRIPTION
- Increase size to 64 bytes as per Crossfire specs. 
- Protect against overflow

This fixes #7310