### PR TITLE
Companion update model references from enhanced context menus

### DIFF
--- a/companion/src/firmwares/CMakeLists.txt
+++ b/companion/src/firmwares/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(firmwares_SRCS
+  adjustmentreference.cpp
   boards.cpp
   curvereference.cpp
   customfunctiondata.cpp

--- a/companion/src/firmwares/adjustmentreference.cpp
+++ b/companion/src/firmwares/adjustmentreference.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "adjustmentreference.h"
+#include "radiodata.h"                  // for ModelData
+
+AdjustmentReference::AdjustmentReference(int value)
+{
+  int val = value;
+  if (abs(val) > ADJUST_REF_GVAR_BASE && abs(val) <= ADJUST_REF_GVAR_BASE + CPN_MAX_GVARS) {
+    type = ADJUST_REF_GVAR;
+    val = val >= 0 ? val - ADJUST_REF_GVAR_BASE : val + ADJUST_REF_GVAR_BASE;
+  }
+  else
+    this->type = ADJUST_REF_VALUE;
+
+  this->value = val;
+}
+
+AdjustmentReference::AdjustmentReference(AdjustRefType type, int value)
+{
+  this->type = type;
+  if (isValid(value))
+    this->value = value;
+  else
+    clear();
+}
+
+bool AdjustmentReference::isValid(const int value) const
+{
+  switch(type) {
+    case ADJUST_REF_VALUE:
+      if (abs(value) < ADJUST_REF_GVAR_BASE)
+        return true;
+      break;
+    case ADJUST_REF_GVAR:
+      if (abs(value) > 0 && abs(value) <= CPN_MAX_GVARS);
+        return true;
+      break;
+  }
+  return false;
+}
+
+QString AdjustmentReference::toString(const ModelData * model, const bool sign) const
+{
+  QString ret;
+
+  switch(type) {
+    case ADJUST_REF_GVAR:
+      ret = RawSource(SOURCE_TYPE_GVAR, abs(value) - 1).toString(model);
+      if (value < 0)
+        ret.prepend("-");
+      else if (sign)
+        ret.prepend("+");
+      break;
+    default:
+      ret = "%1%";
+      if (sign && value > 0)
+        ret.prepend("+");
+      ret = ret.arg(value);
+      break;
+  }
+  return ret;
+}

--- a/companion/src/firmwares/adjustmentreference.h
+++ b/companion/src/firmwares/adjustmentreference.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef ADJUSTMENTREFERENCE_H
+#define ADJUSTMENTREFERENCE_H
+
+#include <QtCore>
+
+class ModelData;
+
+constexpr int ADJUST_REF_GVAR_BASE { 10000 };
+
+class AdjustmentReference {
+  Q_DECLARE_TR_FUNCTIONS(AdjustmentReference)
+
+  public:
+    enum AdjustRefType {
+      ADJUST_REF_VALUE,
+      ADJUST_REF_GVAR,
+    };
+
+    AdjustmentReference() { clear(); }
+    explicit AdjustmentReference(int value);
+    AdjustmentReference(const AdjustRefType type, const int value);
+
+    void clear() { memset(this, 0, sizeof(AdjustmentReference)); }
+
+    bool isSet() const { return type != ADJUST_REF_VALUE || value != 0; }
+    bool isValid(const int value) const;
+    QString toString(const ModelData * model = nullptr, const bool sign = false) const;
+
+    inline const int toValue() const
+    {
+      if (type == ADJUST_REF_GVAR)
+        return value >= 0 ? value + ADJUST_REF_GVAR_BASE : value - ADJUST_REF_GVAR_BASE;
+      else
+        return value;
+    }
+
+    bool operator== ( const AdjustmentReference & other) const {
+      return (this->type == other.type) && (this->value == other.value);
+    }
+
+    bool operator!= ( const AdjustmentReference & other) const {
+      return (this->type != other.type) || (this->value != other.value);
+    }
+
+    AdjustRefType type;
+    int value;
+};
+
+#endif // ADJUSTMENTREFERENCE_H

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -50,6 +50,7 @@ class CurveReference {
     int value;
 
     QString toString(const ModelData * model = NULL, bool verbose = true) const;
+    bool isSet() const { return type != CURVE_REF_DIFF || value != 0; }
 };
 
 #endif // CURVEREFERENCE_H

--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -100,6 +100,8 @@ enum Capability {
   GvarsName,
   NoTelemetryProtocol,
   TelemetryCustomScreens,
+  TelemetryCustomScreensBars,
+  TelemetryCustomScreensLines,
   TelemetryCustomScreensFieldsPerLine,
   TelemetryMaxMultiplier,
   HasVario,
@@ -149,7 +151,8 @@ enum Capability {
   DangerousFunctions,
   HasModelCategories,
   HasSwitchableJack,
-  PwrButtonPress
+  PwrButtonPress,
+  Sensors
 };
 
 class EEPROMInterface

--- a/companion/src/firmwares/gvardata.cpp
+++ b/companion/src/firmwares/gvardata.cpp
@@ -90,3 +90,8 @@ float GVarData::getMaxPrec() const
 {
   return getMax() * multiplierGet();
 }
+
+bool GVarData::isEmpty() const
+{
+  return (name[0] == '\0' && min == 0 && max == 0 && (!popup) && prec == 0 && unit == 0);
+}

--- a/companion/src/firmwares/gvardata.h
+++ b/companion/src/firmwares/gvardata.h
@@ -43,7 +43,7 @@ class GVarData {
       GVAR_PREC_MUL1
     };
 
-    char name[GVAR_NAME_LEN+1];
+    char name[GVAR_NAME_LEN + 1];
     int min;
     int max;
     bool popup;
@@ -62,6 +62,7 @@ class GVarData {
     int getMax() const;
     float getMinPrec() const;
     float getMaxPrec() const;
+    bool isEmpty() const;
 };
 
 

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -104,7 +104,7 @@ bool LimitData::isEmpty() const
 
 CurveData::CurveData()
 {
-  clear(5);
+  clear();
 }
 
 void CurveData::clear(int count)

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -35,6 +35,10 @@ void ExpoData::convert(RadioDataConversionState & cstate)
   swtch.convert(cstate);
 }
 
+bool ExpoData::isEmpty() const
+{
+  return (chn == 0 && mode == INPUT_MODE_NONE);
+}
 
 /*
  * MixData
@@ -48,6 +52,10 @@ void MixData::convert(RadioDataConversionState & cstate)
   swtch.convert(cstate);
 }
 
+bool MixData::isEmpty() const
+{
+  return (destCh == 0);
+}
 
 /*
  * LimitData
@@ -87,9 +95,8 @@ void LimitData::clear()
 
 bool LimitData::isEmpty() const
 {
-  return (min == -1000 && max == 1000 && !revert && !offset && !ppmCenter && !symetrical && name[0] == '\0');
+  return (min == -1000 && max == 1000 && !revert && !offset && !ppmCenter && !symetrical && name[0] == '\0' && !curve.isSet());
 }
-
 
 /*
  * CurveData
@@ -131,10 +138,10 @@ void FlightModeData::clear(const int phase)
   memset(reinterpret_cast<void *>(this), 0, sizeof(FlightModeData));
   if (phase != 0) {
     for (int idx=0; idx<CPN_MAX_GVARS; idx++) {
-      gvars[idx] = 1025;
+      gvars[idx] = GVAR_MAX_VALUE + 1;
     }
     for (int idx=0; idx<CPN_MAX_ENCODERS; idx++) {
-      rotaryEncoders[idx] = 1025;
+      rotaryEncoders[idx] = ENCODER_MAX_VALUE + 1;
     }
   }
 }

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -140,7 +140,7 @@ void FlightModeData::clear(const int phaseIdx)
     gvars[i] = linkedGVarFlightModeZero(phaseIdx);
   }
   for (int i = 0; i < CPN_MAX_ENCODERS; i++) {
-    rotaryEncoders[i] = linkedEncoderFlightModeZero(phaseIdx);
+    rotaryEncoders[i] = linkedREncFlightModeZero(phaseIdx);
   }
 }
 
@@ -165,26 +165,26 @@ bool FlightModeData::isEmpty(int phaseIdx) const
       return false;
   }
   for (int i = 0; i < CPN_MAX_GVARS; i++) {
-    if (!isGVEmpty(phaseIdx, i))
+    if (!isGVarEmpty(phaseIdx, i))
       return false;
   }
   for (int i = 0; i < CPN_MAX_ENCODERS; i++) {
-    if (!isREEmpty(phaseIdx, i))
+    if (!isREncEmpty(phaseIdx, i))
       return false;
   }
   return true;
 }
 
-bool FlightModeData::isGVEmpty(int phaseIdx, int gvIdx) const
+bool FlightModeData::isGVarEmpty(int phaseIdx, int gvIdx) const
 {
   if ((phaseIdx == 0 && gvars[gvIdx] == 0) || (phaseIdx != 0 && gvars[gvIdx] == linkedGVarFlightModeZero(phaseIdx)))
     return true;
   return false;
 }
 
-bool FlightModeData::isREEmpty(int phaseIdx, int reIdx) const
+bool FlightModeData::isREncEmpty(int phaseIdx, int reIdx) const
 {
-  if ((phaseIdx == 0 && rotaryEncoders[reIdx] == 0) || (phaseIdx != 0 && rotaryEncoders[reIdx] == linkedEncoderFlightModeZero(phaseIdx)))
+  if ((phaseIdx == 0 && rotaryEncoders[reIdx] == 0) || (phaseIdx != 0 && rotaryEncoders[reIdx] == linkedREncFlightModeZero(phaseIdx)))
     return true;
   return false;
 }
@@ -201,7 +201,7 @@ int FlightModeData::linkedGVarFlightModeZero(int phaseIdx) const
   return linkedFlightModeZero(phaseIdx, GVAR_MAX_VALUE);
 }
 
-int FlightModeData::linkedEncoderFlightModeZero(int phaseIdx) const
+int FlightModeData::linkedREncFlightModeZero(int phaseIdx) const
 {
-  return linkedFlightModeZero(phaseIdx, ENCODER_MAX_VALUE);
+  return linkedFlightModeZero(phaseIdx, RENC_MAX_VALUE);
 }

--- a/companion/src/firmwares/io_data.cpp
+++ b/companion/src/firmwares/io_data.cpp
@@ -137,10 +137,10 @@ void FlightModeData::clear(const int phaseIdx)
 {
   memset(reinterpret_cast<void *>(this), 0, sizeof(FlightModeData));
   for (int i = 0; i < CPN_MAX_GVARS; i++) {
-    gvars[i] = linkedFlightModeZero(phaseIdx, GVAR_MAX_VALUE);
+    gvars[i] = linkedGVarFlightModeZero(phaseIdx);
   }
   for (int i = 0; i < CPN_MAX_ENCODERS; i++) {
-    rotaryEncoders[i] = linkedFlightModeZero(phaseIdx, ENCODER_MAX_VALUE);
+    rotaryEncoders[i] = linkedEncoderFlightModeZero(phaseIdx);
   }
 }
 
@@ -177,14 +177,14 @@ bool FlightModeData::isEmpty(int phaseIdx) const
 
 bool FlightModeData::isGVEmpty(int phaseIdx, int gvIdx) const
 {
-  if ((phaseIdx == 0 && gvars[gvIdx] == 0) || (phaseIdx != 0 && gvars[gvIdx] == linkedFlightModeZero(phaseIdx, GVAR_MAX_VALUE)))
+  if ((phaseIdx == 0 && gvars[gvIdx] == 0) || (phaseIdx != 0 && gvars[gvIdx] == linkedGVarFlightModeZero(phaseIdx)))
     return true;
   return false;
 }
 
 bool FlightModeData::isREEmpty(int phaseIdx, int reIdx) const
 {
-  if ((phaseIdx == 0 && rotaryEncoders[reIdx] == 0) || (phaseIdx != 0 && rotaryEncoders[reIdx] == linkedFlightModeZero(phaseIdx, ENCODER_MAX_VALUE)))
+  if ((phaseIdx == 0 && rotaryEncoders[reIdx] == 0) || (phaseIdx != 0 && rotaryEncoders[reIdx] == linkedEncoderFlightModeZero(phaseIdx)))
     return true;
   return false;
 }

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -55,6 +55,7 @@ class ExpoData {
     char name[10+1];
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(ExpoData)); }
     void convert(RadioDataConversionState & cstate);
+    bool isEmpty() const;
 };
 
 enum MltpxValue {
@@ -90,6 +91,7 @@ class MixData {
     char   name[MIXDATA_NAME_LEN+1];
 
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(MixData)); }
+    bool isEmpty() const;
 };
 
 class LimitData {
@@ -142,6 +144,10 @@ class CurveData {
     char name[6+1];
 };
 
+#define FLIGHTMODE_NAME_LEN  10
+#define ENCODER_MAX_VALUE    1024
+#define ENCODER_MIN_VALUE    -ENCODER_MAX_VALUE
+
 class FlightModeData {
   Q_DECLARE_TR_FUNCTIONS(FlightModeData)
 
@@ -151,7 +157,7 @@ class FlightModeData {
     int trimRef[CPN_MAX_TRIMS];
     int trim[CPN_MAX_TRIMS];
     RawSwitch swtch;
-    char name[10+1];
+    char name[FLIGHTMODE_NAME_LEN+1];
     unsigned int fadeIn;
     unsigned int fadeOut;
     int rotaryEncoders[CPN_MAX_ENCODERS];

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -151,8 +151,8 @@ class CurveData {
 };
 
 #define FLIGHTMODE_NAME_LEN  10
-#define ENCODER_MAX_VALUE    1024
-#define ENCODER_MIN_VALUE    -ENCODER_MAX_VALUE
+#define RENC_MAX_VALUE       1024
+#define RENC_MIN_VALUE       -RENC_MAX_VALUE
 
 class FlightModeData {
   Q_DECLARE_TR_FUNCTIONS(FlightModeData)
@@ -172,11 +172,11 @@ class FlightModeData {
     QString nameToString(int phaseIdx) const;
     void convert(RadioDataConversionState & cstate);
     bool isEmpty(int phaseIdx) const;
-    bool isGVEmpty(int phaseIdx, int gvIdx) const;
-    bool isREEmpty(int phaseIdx, int reIdx) const;
+    bool isGVarEmpty(int phaseIdx, int gvIdx) const;
+    bool isREncEmpty(int phaseIdx, int reIdx) const;
     int linkedFlightModeZero(int phaseIdx, int maxOwnValue) const;
     int linkedGVarFlightModeZero(int phaseIdx) const;
-    int linkedEncoderFlightModeZero(int phaseIdx) const;
+    int linkedREncFlightModeZero(int phaseIdx) const;
 };
 
 class SwashRingData {

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -37,6 +37,8 @@ enum InputMode {
   INPUT_MODE_BOTH
 };
 
+#define EXPODATA_NAME_LEN  10
+
 class ExpoData {
   Q_DECLARE_TR_FUNCTIONS(ExpoData)
 
@@ -52,7 +54,7 @@ class ExpoData {
     int offset;
     CurveReference curve;
     int carryTrim;
-    char name[10+1];
+    char name[EXPODATA_NAME_LEN+1];
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(ExpoData)); }
     void convert(RadioDataConversionState & cstate);
     bool isEmpty() const;
@@ -94,6 +96,8 @@ class MixData {
     bool isEmpty() const;
 };
 
+#define LIMITDATA_NAME_LEN  6
+
 class LimitData {
   Q_DECLARE_TR_FUNCTIONS(LimitData)
 
@@ -105,7 +109,7 @@ class LimitData {
     int   offset;
     int   ppmCenter;
     bool  symetrical;
-    char  name[6+1];
+    char  name[LIMITDATA_NAME_LEN+1];
     CurveReference curve;
     QString minToString() const;
     QString maxToString() const;
@@ -121,6 +125,8 @@ class CurvePoint {
     int8_t x;
     int8_t y;
 };
+
+#define CURVEDATA_NAME_LEN  6
 
 class CurveData {
   Q_DECLARE_TR_FUNCTIONS(CurveData)
@@ -141,7 +147,7 @@ class CurveData {
     bool smooth;
     int  count;
     CurvePoint points[CPN_MAX_POINTS];
-    char name[6+1];
+    char name[CURVEDATA_NAME_LEN+1];
 };
 
 #define FLIGHTMODE_NAME_LEN  10

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -139,7 +139,7 @@ class CurveData {
     };
 
     CurveData();
-    void clear(int count);
+    void clear(int count = 5);
     bool isEmpty() const;
     QString nameToString(const int idx) const;
 

--- a/companion/src/firmwares/io_data.h
+++ b/companion/src/firmwares/io_data.h
@@ -162,9 +162,15 @@ class FlightModeData {
     unsigned int fadeOut;
     int rotaryEncoders[CPN_MAX_ENCODERS];
     int gvars[CPN_MAX_GVARS];
-    void clear(const int phase);
-    QString nameToString(int index) const;
+    void clear(const int phaseIdx);
+    QString nameToString(int phaseIdx) const;
     void convert(RadioDataConversionState & cstate);
+    bool isEmpty(int phaseIdx) const;
+    bool isGVEmpty(int phaseIdx, int gvIdx) const;
+    bool isREEmpty(int phaseIdx, int reIdx) const;
+    int linkedFlightModeZero(int phaseIdx, int maxOwnValue) const;
+    int linkedGVarFlightModeZero(int phaseIdx) const;
+    int linkedEncoderFlightModeZero(int phaseIdx) const;
 };
 
 class SwashRingData {

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -557,23 +557,32 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       switch(family) {
         case LS_FAMILY_VOFS:
           updateSourceIntRef(lsd->val1);
+          if (lsd->val1 == 0)
+            lsd->clear();
           break;
         case LS_FAMILY_STICKY:
         case LS_FAMILY_VBOOL:
           updateSwitchIntRef(lsd->val1);
           updateSwitchIntRef(lsd->val2);
+          if (lsd->val1 == 0 && lsd->val2 == 0)
+            lsd->clear();
           break;
         case LS_FAMILY_EDGE:
           updateSwitchIntRef(lsd->val1);
+          if (lsd->val1 == 0)
+            lsd->clear();
           break;
         case LS_FAMILY_VCOMP:
           updateSourceIntRef(lsd->val1);
           updateSourceIntRef(lsd->val2);
+          if (lsd->val1 == 0 && lsd->val2 == 0)
+            lsd->clear();
           break;
         default:
           break;
       }
-      updateSwitchIntRef(lsd->andsw);
+      if (!lsd->isEmpty())
+        updateSwitchIntRef(lsd->andsw);
     }
   }
   s1.report("Logical Switches");

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -478,12 +478,11 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       break;
     case REF_UPD_TYPE_TIMER:
       updRefInfo.srcType = SOURCE_TYPE_SPECIAL;
-      //updRefInfo.swtchType = SWITCH_TYPE_TIMER_MODE;
       updRefInfo.maxindex = fw->getCapability(Timers);
-      //  source index offset
-      updRefInfo.index1 = updRefInfo.index1 + 2;
-      updRefInfo.index2 = updRefInfo.index2 + 2;
-      updRefInfo.maxindex = updRefInfo.maxindex + 2;
+      //  rawsource index offset
+      updRefInfo.index1 += 2;
+      updRefInfo.index2 += 2;
+      updRefInfo.maxindex += 2;
       break;
     default:
       qDebug() << "Error - unhandled reference type:" << updRefInfo.type;

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1072,14 +1072,14 @@ void ModelData::updateModuleFailsafes(ModuleData * md)
         return;
 
       if (updRefInfo.shift > 0) {
-        for (int i = (updRefInfo.index1 + idxAdj); i < (CPN_MAX_CHNOUT - 1); i++) {
-          md->failsafeChannels[i] = md->failsafeChannels[i + 1];
+        for (int i = (CPN_MAX_CHNOUT - 1); i >(updRefInfo.index1 + idxAdj); i--) {
+          md->failsafeChannels[i] = md->failsafeChannels[i - 1];
         }
         md->failsafeChannels[updRefInfo.index1 + idxAdj] = 0;
       }
       else {
-        for (int i = (CPN_MAX_CHNOUT - 1); i > (updRefInfo.index1 + 1); i--) {
-          md->failsafeChannels[i] = md->failsafeChannels[i - 1];
+        for (int i = (updRefInfo.index1 + idxAdj + 1); i < (CPN_MAX_CHNOUT - 1); i++) {
+          md->failsafeChannels[i - 1] = md->failsafeChannels[i];
         }
         md->failsafeChannels[CPN_MAX_CHNOUT - 1] = 0;
       }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1061,24 +1061,23 @@ void ModelData::updateModuleFailsafes(ModuleData * md)
     return;
 
   bool updated = false;
-  const int idxAdj = 0;
 
   switch (updRefInfo.action)
   {
     case REF_UPD_ACT_CLEAR:
-      return;
+      break;
     case REF_UPD_ACT_SHIFT:
-      if (updRefInfo.shift == 0 || (updRefInfo.index1 + idxAdj) < 0 || (updRefInfo.index1 + idxAdj) >= CPN_MAX_CHNOUT)
+      if (updRefInfo.shift == 0 || updRefInfo.index1 < 0 || updRefInfo.index1 > CPN_MAX_CHNOUT - 1)
         return;
 
       if (updRefInfo.shift > 0) {
-        for (int i = (CPN_MAX_CHNOUT - 1); i >(updRefInfo.index1 + idxAdj); i--) {
+        for (int i = (CPN_MAX_CHNOUT - 1); i > updRefInfo.index1; i--) {
           md->failsafeChannels[i] = md->failsafeChannels[i - 1];
         }
-        md->failsafeChannels[updRefInfo.index1 + idxAdj] = 0;
+        md->failsafeChannels[updRefInfo.index1] = 0;
       }
       else {
-        for (int i = (updRefInfo.index1 + idxAdj + 1); i < (CPN_MAX_CHNOUT - 1); i++) {
+        for (int i = (updRefInfo.index1 + 1); i < (CPN_MAX_CHNOUT - 1); i++) {
           md->failsafeChannels[i - 1] = md->failsafeChannels[i];
         }
         md->failsafeChannels[CPN_MAX_CHNOUT - 1] = 0;
@@ -1087,19 +1086,19 @@ void ModelData::updateModuleFailsafes(ModuleData * md)
       break;
     case REF_UPD_ACT_SWAP:
       int tmp;
-      if ((updRefInfo.index1 + idxAdj) >= 0 && (updRefInfo.index1 + idxAdj) < CPN_MAX_CHNOUT) {
+      if (updRefInfo.index1 >= 0 && updRefInfo.index1 < CPN_MAX_CHNOUT) {
         updated = true;
-        tmp = md->failsafeChannels[updRefInfo.index1 + idxAdj];
-        if ((updRefInfo.index2 + idxAdj) >= 0 && (updRefInfo.index2 + idxAdj) < CPN_MAX_CHNOUT)
-          md->failsafeChannels[updRefInfo.index1 + idxAdj] = md->failsafeChannels[updRefInfo.index2 + idxAdj];
+        tmp = md->failsafeChannels[updRefInfo.index1];
+        if (updRefInfo.index2 >= 0 && updRefInfo.index2 < CPN_MAX_CHNOUT)
+          md->failsafeChannels[updRefInfo.index1] = md->failsafeChannels[updRefInfo.index2];
         else
-          md->failsafeChannels[updRefInfo.index1 + idxAdj] = 0;
+          md->failsafeChannels[updRefInfo.index1] = 0;
       }
       else
         tmp = 0;
-      if ((updRefInfo.index2 + idxAdj) >= 0 && (updRefInfo.index2 + idxAdj) < CPN_MAX_CHNOUT)
+      if (updRefInfo.index2 >= 0 && updRefInfo.index2 < CPN_MAX_CHNOUT)
         updated = true;
-        md->failsafeChannels[updRefInfo.index2 + idxAdj] = tmp;
+        md->failsafeChannels[updRefInfo.index2] = tmp;
       break;
     default:
       qDebug() << "Error - unhandled action:" << updRefInfo.action;

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -472,7 +472,7 @@ void ModelData::convert(RadioDataConversionState & cstate)
 void ModelData::appendUpdateReferenceParams(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2, const int shift)
 {
   if (updRefList) {
-    qDebug() << "Append parameters - type:" << type << " action:" << action << " index1:" << index1 << " index2:" << index2 << " shift:" << shift;
+    //qDebug() << "Append parameters - type:" << type << " action:" << action << " index1:" << index1 << " index2:" << index2 << " shift:" << shift;
     if (updRefList->size() <= MAX_REF_UPDATES)
       updRefList->append(UpdateReferenceParams(type, action, index1, index2, shift));
     else
@@ -482,8 +482,8 @@ void ModelData::appendUpdateReferenceParams(const ReferenceUpdateType type, cons
 
 int ModelData::updateAllReferences(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2, const int shift)
 {
-  Stopwatch s1("ModelData::updateAllReferences");
-  s1.report("Start");
+  //Stopwatch s1("ModelData::updateAllReferences");
+  //s1.report("Start");
 
   int loopcnt = 0;
   int updcnt = 0;
@@ -500,14 +500,14 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
           qDebug() << "Warning: Update iterations terminated early as the list exceeded " << MAX_REF_UPDATES;
           break;
         }
-        qDebug() << "Start of iteration:" << loopcnt;
+        //qDebug() << "Start of iteration:" << loopcnt;
         updcnt += updateReference();
         updRefList->removeFirst();
       }
   }
 
   qDebug() << "Iterations:" << loopcnt << " References updated:" << updcnt;
-  s1.report("Finish");
+  //s1.report("Finish");
 
   return updcnt;
 }
@@ -533,8 +533,8 @@ int ModelData::updateReference()
     return 0;
   }
 
-  Stopwatch s1("ModelData::updateReference");
-  s1.report("Start");
+  //Stopwatch s1("ModelData::updateReference");
+  //s1.report("Start");
 
   Firmware *fw = getCurrentFirmware();
 
@@ -588,17 +588,17 @@ int ModelData::updateReference()
 
   updRefInfo.maxindex--;  //  getCapabilities and constants are 1 based
 
-  qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
-  qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
+  //qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
+  //qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
 
-  s1.report("Initialise");
+  //s1.report("Initialise");
 
   for (int i = fw->getCapability(NumFirstUsableModule); i < fw->getCapability(NumModules); i++) {
     ModuleData *md = &moduleData[i];
     if (md->protocol != PULSES_OFF && md->failsafeMode == FAILSAFE_CUSTOM && md->hasFailsafes(fw))
       updateModuleFailsafes(md);
   }
-  s1.report("Modules");
+  //s1.report("Modules");
 
   for (int i = 0; i < CPN_MAX_TIMERS; i++) {
     TimerData *td = &timers[i];
@@ -608,7 +608,7 @@ int ModelData::updateReference()
         appendUpdateReferenceParams(REF_UPD_TYPE_TIMER, REF_UPD_ACT_CLEAR, i);
     }
   }
-  s1.report("Timers");
+  //s1.report("Timers");
 
   for (int i = 1; i < CPN_MAX_FLIGHT_MODES; i++) {  //  skip FM0 as switch not used
     FlightModeData *fmd = &flightModeData[i];
@@ -618,7 +618,7 @@ int ModelData::updateReference()
         appendUpdateReferenceParams(REF_UPD_TYPE_FLIGHT_MODE, REF_UPD_ACT_CLEAR, i);
     }
   }
-  s1.report("Flight Modes");
+  //s1.report("Flight Modes");
 
   for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     ExpoData *ed = &expoData[i];
@@ -640,7 +640,7 @@ int ModelData::updateReference()
       }
     }
   }
-  s1.report("Inputs");
+  //s1.report("Inputs");
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     MixData *md = &mixData[i];
@@ -662,7 +662,7 @@ int ModelData::updateReference()
       }
     }
   }
-  s1.report("Mixes");
+  //s1.report("Mixes");
 
   for (int i = 0; i < CPN_MAX_CHNOUT; i++) {
     LimitData *ld = &limitData[i];
@@ -673,7 +673,7 @@ int ModelData::updateReference()
       updateLimitCurveRef(ld->curve);
     }
   }
-  s1.report("Outputs");
+  //s1.report("Outputs");
 
   for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++) {
     LogicalSwitchData *lsd = &logicalSw[i];
@@ -716,7 +716,7 @@ int ModelData::updateReference()
       }
     }
   }
-  s1.report("Logical Switches");
+  //s1.report("Logical Switches");
 
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     CustomFunctionData *cfd = &customFn[i];
@@ -732,13 +732,13 @@ int ModelData::updateReference()
       }
     }
   }
-  s1.report("Special Functions");
+  //s1.report("Special Functions");
 
   if (fw->getCapability(Heli)) {
     updateSourceRef(swashRingData.aileronSource);
     updateSourceRef(swashRingData.collectiveSource);
     updateSourceRef(swashRingData.elevatorSource);
-    s1.report("Heli");
+    //s1.report("Heli");
   }
 
   if (fw->getCapability(Telemetry)) {
@@ -770,7 +770,7 @@ int ModelData::updateReference()
           break;
       }
     }
-    s1.report("Telemetry");
+    //s1.report("Telemetry");
   }
 
   //  TODO maybe less risk to leave it up to the user??
@@ -801,7 +801,7 @@ int ModelData::updateReference()
   //  TODO Horus CustomScreenData and TopBarData will need checking for updates but Companion does not current handle ie just data blobs refer modeldata.h
 
   qDebug() << "References updated this iteration:" << updRefInfo.updcnt;
-  s1.report("Finish");
+  //s1.report("Finish");
 
   return updRefInfo.updcnt;
 }
@@ -857,7 +857,7 @@ void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, c
 
   if (curRef.type != newRef.type || abs(curRef.index) != newRef.index) {
     newRef.index = curRef.index < 0 ? -newRef.index : newRef.index;
-    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    //qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
     curRef = newRef;
     updRefInfo.updcnt++;
   }
@@ -1218,7 +1218,7 @@ void ModelData::updateModuleFailsafes(ModuleData * md)
   }
 
   if (updated) {
-    qDebug() << "Updated module failsafes";
+    //qDebug() << "Updated module failsafes";
     updRefInfo.updcnt++;
   }
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -456,7 +456,6 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       break;
     case REF_UPD_TYPE_INPUT:
       updRefInfo.srcType = SOURCE_TYPE_VIRTUAL_INPUT;
-      updRefInfo.swtchType = SWITCH_TYPE_VIRTUAL;
       updRefInfo.maxindex = fw->getCapability(VirtualInputs);
       break;
     case REF_UPD_TYPE_LOGICAL_SWITCH:

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -38,6 +38,10 @@ void TimerData::convert(RadioDataConversionState & cstate)
   mode.convert(cstate);
 }
 
+bool TimerData::isEmpty()
+{
+  return (mode == RawSwitch(SWITCH_TYPE_TIMER_MODE, 0) && name[0] == '\0' && minuteBeep == 0 && countdownBeep == COUNTDOWN_SILENT && val == 0 && persistent == 0 /*&& pvalue == 0*/);
+}
 
 /*
  * ModelData

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -478,8 +478,12 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       break;
     case REF_UPD_TYPE_TIMER:
       updRefInfo.srcType = SOURCE_TYPE_SPECIAL;
-      updRefInfo.swtchType = SWITCH_TYPE_TIMER_MODE;
+      //updRefInfo.swtchType = SWITCH_TYPE_TIMER_MODE;
       updRefInfo.maxindex = fw->getCapability(Timers);
+      //  source index offset
+      updRefInfo.index1 = updRefInfo.index1 + 2;
+      updRefInfo.index2 = updRefInfo.index2 + 2;
+      updRefInfo.maxindex = updRefInfo.maxindex + 2;
       break;
     default:
       qDebug() << "Error - unhandled reference type:" << updRefInfo.type;
@@ -488,10 +492,10 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
 
   updRefInfo.maxindex--;  //  getCapabilities and constants are 1 based
 
-  //qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
-  //qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
+  qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
+  qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
 
-  //s1.report("Initialise");
+  s1.report("Initialise");
 
   for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     FlightModeData *fmd = &flightModeData[i];
@@ -499,13 +503,13 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateSwitchRef(fmd->swtch);
     }
   }
-  //s1.report("Flight Modes");
+  s1.report("Flight Modes");
 
   for (int i = 0; i < CPN_MAX_TIMERS; i++) {
     TimerData *td = &timers[i];
     updateTimerMode(td->mode);
   }
-  //s1.report("Timers");
+  s1.report("Timers");
 
   for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     ExpoData *ed = &expoData[i];
@@ -518,7 +522,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateFlightModeFlags(ed->flightModes);
     }
   }
-  //s1.report("Inputs");
+  s1.report("Inputs");
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     MixData *md = &mixData[i];
@@ -534,7 +538,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       }
     }
   }
-  //s1.report("Mixes");
+  s1.report("Mixes");
 
   for (int i = 0; i < CPN_MAX_CHNOUT; i++) {
     LimitData *ld = &limitData[i];
@@ -545,7 +549,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateLimitCurveRef(ld->curve);
     }
   }
-  //s1.report("Outputs");
+  s1.report("Outputs");
 
   for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++) {
     LogicalSwitchData *lsd = &logicalSw[i];
@@ -573,7 +577,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateSwitchIntRef(lsd->andsw);
     }
   }
-  //s1.report("Logical Switches");
+  s1.report("Logical Switches");
 
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     CustomFunctionData *cfd = &customFn[i];
@@ -586,13 +590,13 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       }
     }
   }
-  //s1.report("Special Functions");
+  s1.report("Special Functions");
 
   if (fw->getCapability(Heli)) {
     updateSourceRef(swashRingData.aileronSource);
     updateSourceRef(swashRingData.collectiveSource);
     updateSourceRef(swashRingData.elevatorSource);
-    //s1.report("Heli");
+    s1.report("Heli");
   }
 
   if (fw->getCapability(Telemetry)) {
@@ -624,7 +628,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
           break;
       }
     }
-    //s1.report("Telemetry");
+    s1.report("Telemetry");
   }
 
   //  TODO maybe less risk to leave it up to the user??
@@ -663,7 +667,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
 template <class R, typename T>
 void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, const bool defClear, const int defType, const int defIndex)
 {
-  //qDebug() << "Raw value: " << curRef.toValue() << " String:" << curRef.toString() << " Type: " << curRef.type << " Index:" << curRef.index << " idxAdj:" << idxAdj << " defClear:" << defClear << " defType:" << defType << " defIndex:" << defIndex;
+  qDebug() << "Raw value: " << curRef.toValue() << " String:" << curRef.toString() << " Type: " << curRef.type << " Index:" << curRef.index << " idxAdj:" << idxAdj << " defClear:" << defClear << " defType:" << defType << " defIndex:" << defIndex;
   if (!curRef.isSet() || curRef.type != type)
     return;
 
@@ -711,7 +715,7 @@ void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, c
 
   if (curRef.type != newRef.type || abs(curRef.index) != newRef.index) {
     newRef.index = curRef.index < 0 ? -newRef.index : newRef.index;
-    //qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
     curRef = newRef;
     updRefInfo.updcnt++;
   }
@@ -822,7 +826,7 @@ void ModelData::updateAssignFunc(CustomFunctionData * cfd)
     case REF_UPD_TYPE_TIMER:
       if (cfd->func < FuncSetTimer1 || cfd->func > FuncSetTimer3) //  TODO refactor to FuncSetTimerLast
         return;
-      idxAdj = FuncSetTimer1;
+      idxAdj = FuncSetTimer1 - 2;   //  reverse previous offset
       break;
     default:
       return;

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1077,3 +1077,31 @@ void ModelData::setEncoderFlightModeIndexToValue(const int phaseIdx, const int r
 {
   flightModeData[phaseIdx].rotaryEncoders[reIdx] = linkedFlightModeIndexToValue(phaseIdx, useFmIdx, ENCODER_MAX_VALUE);
 }
+
+bool ModelData::isExpoParent(const int index)
+{
+  const ExpoData &ed = expoData[index];
+  const QVector<const ExpoData *> chexpos = expos(ed.chn);
+  return chexpos.constFirst() == &ed;
+}
+
+bool ModelData::isExpoChild(const int index)
+{
+  const ExpoData &ed = expoData[index];
+  const QVector<const ExpoData *> chexpos = expos(ed.chn);
+  return chexpos.constFirst() != &ed;
+}
+
+bool ModelData::hasExpoChildren(const int index)
+{
+  const ExpoData &ed = expoData[index];
+  const QVector<const ExpoData *> chexpos = expos(ed.chn);
+  return chexpos.constFirst() == &ed && chexpos.constLast() != &ed;
+}
+
+bool ModelData::hasExpoSiblings(const int index)
+{
+  const ExpoData &ed = expoData[index];
+  const QVector<const ExpoData *> chexpos = expos(ed.chn);
+  return !isExpoParent(index) && chexpos.size() > 2;
+}

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -187,7 +187,7 @@ void ModelData::clear()
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++)
     customFn[i].clear();
   for (int i = 0; i < CPN_MAX_CURVES; i++)
-    curves[i].clear(5);
+    curves[i].clear();
   for (int i = 0; i < CPN_MAX_TIMERS; i++)
     timers[i].clear();
   swashRingData.clear();

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -25,6 +25,7 @@
 #include "macros.h"
 #include "radiodataconversionstate.h"
 #include "helpers.h"
+#include "adjustmentreference.h"
 
 /*
  * TimerData
@@ -60,16 +61,16 @@ ModelData & ModelData::operator = (const ModelData & src)
 
 ExpoData * ModelData::insertInput(const int idx)
 {
-  memmove(&expoData[idx+1], &expoData[idx], (CPN_MAX_EXPOS-(idx+1))*sizeof(ExpoData));
+  memmove(&expoData[idx + 1], &expoData[idx], (CPN_MAX_EXPOS - (idx + 1)) * sizeof(ExpoData));
   expoData[idx].clear();
   return &expoData[idx];
 }
 
 bool ModelData::isInputValid(const unsigned int idx) const
 {
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     const ExpoData * expo = &expoData[i];
-    if (expo->mode == 0) break;
+    if (expo->mode == INPUT_MODE_NONE) break;
     if (expo->chn == idx)
       return true;
   }
@@ -78,9 +79,9 @@ bool ModelData::isInputValid(const unsigned int idx) const
 
 bool ModelData::hasExpos(uint8_t inputIdx) const
 {
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     const ExpoData & expo = expoData[i];
-    if (expo.chn==inputIdx && expo.mode!=0) {
+    if (expo.chn == inputIdx && expo.mode != INPUT_MODE_NONE) {
       return true;
     }
   }
@@ -90,7 +91,7 @@ bool ModelData::hasExpos(uint8_t inputIdx) const
 bool ModelData::hasMixes(uint8_t channelIdx) const
 {
   channelIdx += 1;
-  for (int i=0; i<CPN_MAX_MIXERS; i++) {
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     if (mixData[i].destCh == channelIdx) {
       return true;
     }
@@ -101,9 +102,9 @@ bool ModelData::hasMixes(uint8_t channelIdx) const
 QVector<const ExpoData *> ModelData::expos(int input) const
 {
   QVector<const ExpoData *> result;
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     const ExpoData * ed = &expoData[i];
-    if ((int)ed->chn==input && ed->mode!=0) {
+    if ((int)ed->chn == input && ed->mode != INPUT_MODE_NONE) {
       result << ed;
     }
   }
@@ -113,9 +114,9 @@ QVector<const ExpoData *> ModelData::expos(int input) const
 QVector<const MixData *> ModelData::mixes(int channel) const
 {
   QVector<const MixData *> result;
-  for (int i=0; i<CPN_MAX_MIXERS; i++) {
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     const MixData * md = &mixData[i];
-    if ((int)md->destCh == channel+1) {
+    if ((int)md->destCh == channel + 1) {
       result << md;
     }
   }
@@ -126,8 +127,8 @@ void ModelData::removeInput(const int idx, bool clearName)
 {
   unsigned int chn = expoData[idx].chn;
 
-  memmove(&expoData[idx], &expoData[idx+1], (CPN_MAX_EXPOS-(idx+1))*sizeof(ExpoData));
-  expoData[CPN_MAX_EXPOS-1].clear();
+  memmove(&expoData[idx], &expoData[idx + 1], (CPN_MAX_EXPOS - (idx + 1)) * sizeof(ExpoData));
+  expoData[CPN_MAX_EXPOS - 1].clear();
 
   //also remove input name if removing last line for this input
   if (clearName && !expos(chn).size())
@@ -136,12 +137,12 @@ void ModelData::removeInput(const int idx, bool clearName)
 
 void ModelData::clearInputs()
 {
-  for (int i=0; i<CPN_MAX_EXPOS; i++)
+  for (int i = 0; i < CPN_MAX_EXPOS; i++)
     expoData[i].clear();
 
   //clear all input names
   if (getCurrentFirmware()->getCapability(VirtualInputs)) {
-    for (int i=0; i<CPN_MAX_INPUTS; i++) {
+    for (int i = 0; i < CPN_MAX_INPUTS; i++) {
       inputNames[i][0] = 0;
     }
   }
@@ -149,7 +150,7 @@ void ModelData::clearInputs()
 
 void ModelData::clearMixes()
 {
-  for (int i=0; i<CPN_MAX_MIXERS; i++)
+  for (int i = 0; i < CPN_MAX_MIXERS; i++)
     mixData[i].clear();
 }
 
@@ -165,30 +166,30 @@ void ModelData::clear()
   moduleData[0].ppm.delay = 300;
   moduleData[1].ppm.delay = 300;
   moduleData[2].ppm.delay = 300;  //Trainer PPM
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     flightModeData[i].clear(i);
   }
-  for (int i=0; i<CPN_MAX_GVARS; i++) {
+  for (int i = 0; i < CPN_MAX_GVARS; i++) {
     gvarData[i].clear();
   }
   clearInputs();
   clearMixes();
-  for (int i=0; i<CPN_MAX_CHNOUT; i++)
+  for (int i = 0; i < CPN_MAX_CHNOUT; i++)
     limitData[i].clear();
-  for (int i=0; i<CPN_MAX_STICKS; i++)
+  for (int i = 0; i < CPN_MAX_STICKS; i++)
     expoData[i].clear();
-  for (int i=0; i<CPN_MAX_LOGICAL_SWITCHES; i++)
+  for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++)
     logicalSw[i].clear();
-  for (int i=0; i<CPN_MAX_SPECIAL_FUNCTIONS; i++)
+  for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++)
     customFn[i].clear();
-  for (int i=0; i<CPN_MAX_CURVES; i++)
+  for (int i = 0; i < CPN_MAX_CURVES; i++)
     curves[i].clear(5);
-  for (int i=0; i<CPN_MAX_TIMERS; i++)
+  for (int i = 0; i < CPN_MAX_TIMERS; i++)
     timers[i].clear();
   swashRingData.clear();
   frsky.clear();
   rssiAlarms.clear();
-  for (unsigned i=0; i<CPN_MAX_SENSORS; i++)
+  for (unsigned i = 0; i < CPN_MAX_SENSORS; i++)
     sensorData[i].clear();
 
   static const uint8_t blob[] = { 0x4c, 0x61, 0x79, 0x6f, 0x75, 0x74, 0x32, 0x50, 0x31, 0x00, 0x4d, 0x6f, 0x64, 0x65, 0x6c, 0x42, 0x6d, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
@@ -204,13 +205,13 @@ void ModelData::setDefaultInputs(const GeneralSettings & settings)
 {
   Board::Type board = getCurrentBoard();
   if (IS_ARM(board)) {
-    for (int i=0; i<CPN_MAX_STICKS; i++) {
+    for (int i = 0; i < CPN_MAX_STICKS; i++) {
       ExpoData * expo = &expoData[i];
       expo->chn = i;
       expo->mode = INPUT_MODE_BOTH;
       expo->srcRaw = settings.getDefaultSource(i);
       expo->weight = 100;
-      strncpy(inputNames[i], Helpers::removeAccents(expo->srcRaw.toString(this)).toLatin1().constData(), sizeof(inputNames[i])-1);
+      strncpy(inputNames[i], Helpers::removeAccents(expo->srcRaw.toString(this)).toLatin1().constData(), sizeof(inputNames[i]) - 1);
     }
   }
 }
@@ -222,9 +223,9 @@ void ModelData::setDefaultMixes(const GeneralSettings & settings)
     setDefaultInputs(settings);
   }
 
-  for (int i=0; i<CPN_MAX_STICKS; i++) {
+  for (int i = 0; i < CPN_MAX_STICKS; i++) {
     MixData * mix = &mixData[i];
-    mix->destCh = i+1;
+    mix->destCh = i + 1;
     mix->weight = 100;
     if (IS_ARM(board)) {
       mix->srcRaw = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, i);
@@ -240,8 +241,8 @@ void ModelData::setDefaultValues(unsigned int id, const GeneralSettings & settin
   clear();
   used = true;
   sprintf(name, "MODEL%02d", id+1);
-  for (int i=0; i<CPN_MAX_MODULES; i++) {
-    moduleData[i].modelId = id+1;
+  for (int i = 0; i < CPN_MAX_MODULES; i++) {
+    moduleData[i].modelId = id + 1;
   }
   setDefaultMixes(settings);
 }
@@ -249,7 +250,7 @@ void ModelData::setDefaultValues(unsigned int id, const GeneralSettings & settin
 int ModelData::getTrimValue(int phaseIdx, int trimIdx)
 {
   int result = 0;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     FlightModeData & phase = flightModeData[phaseIdx];
     if (phase.trimMode[trimIdx] < 0) {
       return result;
@@ -270,16 +271,14 @@ int ModelData::getTrimValue(int phaseIdx, int trimIdx)
 
 bool ModelData::isGVarLinked(int phaseIdx, int gvarIdx)
 {
-  return flightModeData[phaseIdx].gvars[gvarIdx] > 1024;
+  return flightModeData[phaseIdx].gvars[gvarIdx] > GVAR_MAX_VALUE;
 }
 
 int ModelData::getGVarFieldValue(int phaseIdx, int gvarIdx)
 {
   int idx = flightModeData[phaseIdx].gvars[gvarIdx];
-  for (int i=0; idx>GVAR_MAX_VALUE && i<CPN_MAX_FLIGHT_MODES; i++) {
-    int nextPhase = idx - GVAR_MAX_VALUE - 1;
-    if (nextPhase >= phaseIdx) nextPhase += 1;
-    phaseIdx = nextPhase;
+  for (int i = 0; idx > GVAR_MAX_VALUE && i < CPN_MAX_FLIGHT_MODES; i++) {
+    phaseIdx = linkedFlightModeValueToIndex(phaseIdx, idx, GVAR_MAX_VALUE);
     idx = flightModeData[phaseIdx].gvars[gvarIdx];
   }
   return idx;
@@ -287,7 +286,7 @@ int ModelData::getGVarFieldValue(int phaseIdx, int gvarIdx)
 
 void ModelData::setTrimValue(int phaseIdx, int trimIdx, int value)
 {
-  for (uint8_t i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (uint8_t i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     FlightModeData & phase = flightModeData[phaseIdx];
     int mode = phase.trimMode[trimIdx];
     int p = phase.trimRef[trimIdx];
@@ -315,22 +314,22 @@ void ModelData::setTrimValue(int phaseIdx, int trimIdx, int value)
 void ModelData::removeGlobalVar(int & var)
 {
   if (var >= 126 && var <= 130)
-    var = flightModeData[0].gvars[var-126];
+    var = flightModeData[0].gvars[var - 126];
   else if (var <= -126 && var >= -130)
-    var = - flightModeData[0].gvars[-126-var];
+    var = - flightModeData[0].gvars[-126 - var];
 }
 
 ModelData ModelData::removeGlobalVars()
 {
   ModelData result = *this;
 
-  for (int i=0; i<CPN_MAX_MIXERS; i++) {
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     removeGlobalVar(mixData[i].weight);
     removeGlobalVar(mixData[i].curve.value);
     removeGlobalVar(mixData[i].sOffset);
   }
 
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
+  for (int i  =0; i < CPN_MAX_EXPOS; i++) {
     removeGlobalVar(expoData[i].weight);
     removeGlobalVar(expoData[i].curve.value);
   }
@@ -384,31 +383,800 @@ void ModelData::convert(RadioDataConversionState & cstate)
     thrTraceSrc = RawSource(SOURCE_TYPE_STICK, (int)thrTraceSrc + 3).convert(cstate).index - 3;
   }
 
-  for (int i=0; i<CPN_MAX_TIMERS; i++) {
+  for (int i = 0; i < CPN_MAX_TIMERS; i++) {
     timers[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_MIXERS; i++) {
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     mixData[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_EXPOS; i++) {
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     expoData[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_LOGICAL_SWITCHES; i++) {
+  for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++) {
     logicalSw[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_SPECIAL_FUNCTIONS; i++) {
+  for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     customFn[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     flightModeData[i].convert(cstate.withComponentIndex(i));
   }
 
-  for (int i=0; i<CPN_MAX_MODULES; i++) {
+  for (int i = 0; i < CPN_MAX_MODULES; i++) {
     moduleData[i].convert(cstate.withComponentIndex(i));
+  }
+}
+
+int ModelData::updateAllReferences(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2, const int shift)
+{
+  if (action < REF_UPD_ACT_CLEAR || action > REF_UPD_ACT_SWAP || type < REF_UPD_TYPE_CHANNEL || type > REF_UPD_TYPE_TIMER) {
+    qDebug() << "Error - invalid parameters" << " > type:" << type << " action:" << action << " index1:" << index1 << " index2:" << index2 << " shift:" << shift;
+    return 0;
+  }
+
+  Stopwatch s1("ModelData::updateAllReferences");
+  s1.report("Start");
+
+  Firmware *fw = getCurrentFirmware();
+
+  memset(&updRefInfo, 0, sizeof(updRefInfo));
+  updRefInfo.type = type;
+  updRefInfo.action = action;
+  updRefInfo.index1 = abs(index1);
+  updRefInfo.index2 = abs(index2);
+  updRefInfo.shift = shift;
+
+  if ((action == REF_UPD_ACT_SWAP && updRefInfo.index1 == updRefInfo.index2) || (action == REF_UPD_ACT_SHIFT && shift == 0)) {
+    qDebug() << "Warning - nothing to do" << " > type:" << type << " action:" << action << " index1:" << index1 << " index2:" << index2 << " shift:" << shift;
+    return 0;
+  }
+
+  switch (updRefInfo.type)
+  {
+    case REF_UPD_TYPE_CHANNEL:
+      updRefInfo.srcType = SOURCE_TYPE_CH;
+      updRefInfo.maxindex = fw->getCapability(Outputs);
+      break;
+    case REF_UPD_TYPE_CURVE:
+      updRefInfo.maxindex = fw->getCapability(NumCurves);
+      break;
+    case REF_UPD_TYPE_FLIGHT_MODE:
+      updRefInfo.swtchType = SWITCH_TYPE_FLIGHT_MODE;
+      updRefInfo.maxindex = fw->getCapability(FlightModes);
+      break;
+    case REF_UPD_TYPE_GLOBAL_VARIABLE:
+      updRefInfo.srcType = SOURCE_TYPE_GVAR;
+      updRefInfo.maxindex = fw->getCapability(Gvars);
+      break;
+    case REF_UPD_TYPE_INPUT:
+      updRefInfo.srcType = SOURCE_TYPE_VIRTUAL_INPUT;
+      updRefInfo.swtchType = SWITCH_TYPE_VIRTUAL;
+      updRefInfo.maxindex = fw->getCapability(VirtualInputs);
+      break;
+    case REF_UPD_TYPE_LOGICAL_SWITCH:
+      updRefInfo.srcType = SOURCE_TYPE_CUSTOM_SWITCH;
+      updRefInfo.swtchType = SWITCH_TYPE_VIRTUAL;
+      updRefInfo.maxindex = fw->getCapability(LogicalSwitches);
+      break;
+    case REF_UPD_TYPE_SCRIPT:
+      updRefInfo.srcType = SOURCE_TYPE_LUA_OUTPUT;
+      updRefInfo.maxindex = fw->getCapability(LuaScripts);
+      break;
+    case REF_UPD_TYPE_SENSOR:
+      updRefInfo.srcType = SOURCE_TYPE_TELEMETRY;
+      updRefInfo.swtchType = SWITCH_TYPE_SENSOR;
+      updRefInfo.maxindex = fw->getCapability(Sensors);
+      break;
+    case REF_UPD_TYPE_TIMER:
+      updRefInfo.srcType = SOURCE_TYPE_SPECIAL;
+      updRefInfo.swtchType = SWITCH_TYPE_TIMER_MODE;
+      updRefInfo.maxindex = fw->getCapability(Timers);
+      break;
+    default:
+      qDebug() << "Error - unhandled reference type:" << updRefInfo.type;
+      return 0;
+  }
+
+  updRefInfo.maxindex--;  //  getCapabilities and constants are 1 based
+
+  //qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
+  //qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
+
+  s1.report("Initialise");
+
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
+    FlightModeData *fmd = &flightModeData[i];
+    if (fmd->swtch.isSet()) {
+      for (int j = 0; j < CPN_MAX_TRIMS; j++) {
+        if (fmd->trimMode[j] > -1)
+          updateFlightModeTrimRef(fmd->trimRef[j], fmd->trimMode[j], fmd->trim[j]);
+      }
+      updateSwitchRef(fmd->swtch);
+      for (int j = 0; j < CPN_MAX_GVARS; j++) {
+        updateFlightModeGVRERef(fmd->gvars[j], i, GVAR_MAX_VALUE);
+      }
+      for (int j = 0; j < CPN_MAX_ENCODERS; j++) {
+        updateFlightModeGVRERef(fmd->rotaryEncoders[j], i, ENCODER_MAX_VALUE);
+      }
+    }
+  }
+  s1.report("Flight Modes");
+
+  for (int i = 0; i < CPN_MAX_TIMERS; i++) {
+    TimerData *td = &timers[i];
+    updateTimerMode(td->mode);
+  }
+  s1.report("Timers");
+
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
+    ExpoData *ed = &expoData[i];
+    if (!ed->isEmpty()) {
+      updateSourceRef(ed->srcRaw);
+      updateSwitchRef(ed->swtch);
+      updateCurveRef(ed->curve);
+      updateAdjustRef(ed->weight);
+      updateAdjustRef(ed->offset);
+      updateFlightModeFlags(ed->flightModes);
+    }
+  }
+  s1.report("Inputs");
+
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
+    MixData *md = &mixData[i];
+    if (!md->isEmpty()) {
+      updateDestCh(md);
+      if (!md->isEmpty()) {
+        updateSourceRef(md->srcRaw);
+        updateSwitchRef(md->swtch);
+        updateCurveRef(md->curve);
+        updateAdjustRef(md->weight);
+        updateAdjustRef(md->sOffset);
+        updateFlightModeFlags(md->flightModes);
+      }
+    }
+  }
+  s1.report("Mixes");
+
+  for (int i = 0; i < CPN_MAX_CHNOUT; i++) {
+    LimitData *ld = &limitData[i];
+    if (!ld->isEmpty()) {
+      updateAdjustRef(ld->min);
+      updateAdjustRef(ld->max);
+      updateAdjustRef(ld->offset);
+      updateLimitCurveRef(ld->curve);
+    }
+  }
+  s1.report("Outputs");
+
+  for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++) {
+    LogicalSwitchData *lsd = &logicalSw[i];
+    if (!lsd->isEmpty()) {
+      CSFunctionFamily family = lsd->getFunctionFamily();
+      switch(family) {
+        case LS_FAMILY_VOFS:
+          updateSourceIntRef(lsd->val1);
+          break;
+        case LS_FAMILY_STICKY:
+        case LS_FAMILY_VBOOL:
+          updateSwitchIntRef(lsd->val1);
+          updateSwitchIntRef(lsd->val2);
+          break;
+        case LS_FAMILY_EDGE:
+          updateSwitchIntRef(lsd->val1);
+          break;
+        case LS_FAMILY_VCOMP:
+          updateSourceIntRef(lsd->val1);
+          updateSourceIntRef(lsd->val2);
+          break;
+        default:
+          break;
+      }
+      updateSwitchIntRef(lsd->andsw);
+    }
+  }
+  s1.report("Logical Switches");
+
+  for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
+    CustomFunctionData *cfd = &customFn[i];
+    if (!cfd->isEmpty()) {
+      updateAssignFunc(cfd);
+      if (!cfd->isEmpty()) {
+        updateSwitchRef(cfd->swtch);
+        if (cfd->func == FuncVolume || cfd->func == FuncPlayValue || (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE)))
+          updateSourceIntRef(cfd->param);
+      }
+    }
+  }
+  s1.report("Special Functions");
+
+  if (fw->getCapability(Heli)) {
+    updateSourceRef(swashRingData.aileronSource);
+    updateSourceRef(swashRingData.collectiveSource);
+    updateSourceRef(swashRingData.elevatorSource);
+    s1.report("Heli");
+  }
+
+  if (fw->getCapability(Telemetry)) {
+    updateTelemetryRef(frsky.voltsSource);
+    updateTelemetryRef(frsky.altitudeSource);
+    updateTelemetryRef(frsky.currentSource);
+    updateTelemetryRef(frsky.varioSource);
+    for (int i = 0; i < fw->getCapability(TelemetryCustomScreens); i++) {
+      switch(frsky.screens[i].type) {
+        case TELEMETRY_SCREEN_BARS:
+          for (int j = 0; j < fw->getCapability(TelemetryCustomScreensBars); j++) {
+            FrSkyBarData *fbd = &frsky.screens[i].body.bars[j];
+            updateSourceRef(fbd->source);
+            if (!fbd->source.isSet()) {
+              fbd->barMin = 0;
+              fbd->barMax = 0;
+            }
+          }
+          break;
+        case TELEMETRY_SCREEN_NUMBERS:
+          for (int j = 0; j < fw->getCapability(TelemetryCustomScreensLines); j++) {
+            FrSkyLineData *fld = &frsky.screens[i].body.lines[j];
+            for (int k = 0; k < fw->getCapability(TelemetryCustomScreensFieldsPerLine); k++) {
+              updateSourceRef(fld->source[k]);
+            }
+          }
+          break;
+        default:
+          break;
+      }
+    }
+    s1.report("Telemetry");
+  }
+
+  //  TODO maybe less risk to leave it up to the user??
+  /*
+  for (int i = 0; i < CPN_MAX_SENSORS; i++) {
+    SensorData *sd = &sensorData[i];
+    if (sd->isAvailable() && sd->type == SensorData::TELEM_TYPE_CALCULATED) {
+    }
+  }
+  s1.report("Telemetry Sensors");
+  */
+
+  //  TODO needs lua incorporated into Companion as script needs to be parsed to determine if input field is source or value
+  /*
+  for (int i=0; i < CPN_MAX_SCRIPTS; i++) {
+    ScriptData *sd = &scriptData[i];
+    if (sd->filename[0] != '\0') {
+      for (int j = 0; j < CPN_MAX_SCRIPT_INPUTS; j++) {
+        //  get input parameters and for each one where type is SOURCE
+        if(inputtype = "SOURCE")
+          updateSourceIntRef(sd->inputs[j]);
+      }
+    }
+  }
+  s1.report("Custom Scripts");
+  */
+
+  //  TODO Horus CustomScreenData and TopBarData will need checking for updates but Companion does not current handle ie just data blobs refer modeldata.h
+
+  qDebug() << updRefInfo.updcnt << " references updated";
+  s1.report("Finish");
+
+  return updRefInfo.updcnt;
+}
+
+template <class R, typename T>
+void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, const bool defClear, const int defType, const int defIndex)
+{
+  //qDebug() << "Raw value: " << curRef.toValue() << " String:" << curRef.toString() << " Type: " << curRef.type << " Index:" << curRef.index << " idxAdj:" << idxAdj << " defClear:" << defClear << " defType:" << defType << " defIndex:" << defIndex;
+  if (!curRef.isSet() || curRef.type != type)
+    return;
+
+  R newRef;
+  newRef.type = curRef.type;
+  newRef.index = abs(curRef.index);
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef.index != (updRefInfo.index1 + idxAdj))
+        return;
+      if (defClear)
+        newRef.clear();
+      else {
+        newRef.type = (T)defType;
+        newRef.index = defIndex;
+      }
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef.index < (updRefInfo.index1 + idxAdj))
+        return;
+
+      newRef.index += updRefInfo.shift;
+
+      if (newRef.index < (updRefInfo.index1 + idxAdj) || newRef.index > (updRefInfo.maxindex + idxAdj)) {
+        if (defClear)
+          newRef.clear();
+        else {
+          newRef.type = (T)defType;
+          newRef.index = defIndex;
+        }
+      }
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef.index == updRefInfo.index1 + idxAdj)
+        newRef.index = updRefInfo.index2 + idxAdj;
+      else if (newRef.index == updRefInfo.index2 + idxAdj)
+        newRef.index = updRefInfo.index1 + idxAdj;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (curRef.type != newRef.type || abs(curRef.index) != newRef.index) {
+    newRef.index = curRef.index < 0 ? -newRef.index : newRef.index;
+    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    curRef = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+template <class R, typename T>
+void ModelData::updateTypeValueRef(R & curRef, const T type, const int idxAdj, const bool defClear, const int defType, const int defValue)
+{
+  //qDebug() << " String:" << curRef.toString() << " Type: " << curRef.type << " Value:" << curRef.value;
+  if (!curRef.isSet() || curRef.type != type)
+    return;
+
+  R newRef;
+  newRef.type = curRef.type;
+  newRef.value = abs(curRef.value);
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef.value != (updRefInfo.index1 + idxAdj))
+        return;
+      if (defClear)
+        newRef.clear();
+      else {
+        newRef.type = (T)defType;
+        newRef.value = defValue;
+      }
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef.value < (updRefInfo.index1 + idxAdj))
+        return;
+
+      newRef.value += updRefInfo.shift;
+
+      if (newRef.value < (updRefInfo.index1 + idxAdj) || newRef.value > (updRefInfo.maxindex + idxAdj)) {
+        if (defClear)
+          newRef.clear();
+        else {
+          newRef.type = (T)defType;
+          newRef.value = defValue;
+        }
+      }
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef.value == updRefInfo.index1 + idxAdj)
+        newRef.value = updRefInfo.index2 + idxAdj;
+      else if (newRef.value == updRefInfo.index2 + idxAdj)
+        newRef.value = updRefInfo.index1 + idxAdj;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (curRef.type != newRef.type || abs(curRef.value) != newRef.value) {
+    newRef.value = curRef.value < 0 ? -newRef.value : newRef.value;
+    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    curRef = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+void ModelData::updateCurveRef(CurveReference & crv)
+{
+  if (updRefInfo.type == REF_UPD_TYPE_GLOBAL_VARIABLE && (crv.type == CurveReference::CURVE_REF_DIFF || crv.type == CurveReference::CURVE_REF_EXPO))
+    updateAdjustRef(crv.value);
+  else if (updRefInfo.type == REF_UPD_TYPE_CURVE && crv.type == CurveReference::CURVE_REF_CUSTOM)
+    updateTypeValueRef<CurveReference, CurveReference::CurveRefType>(crv, CurveReference::CURVE_REF_CUSTOM, 1);
+}
+
+void ModelData::updateLimitCurveRef(CurveReference & crv)
+{
+  CurveReference src = CurveReference(CurveReference::CURVE_REF_CUSTOM, crv.value);
+  updateCurveRef(src);
+  if (crv.value != src.value)
+    crv.value = src.value;
+}
+
+void ModelData::updateAdjustRef(int & value)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_GLOBAL_VARIABLE)
+    return;
+
+  AdjustmentReference adj = AdjustmentReference(value);
+  updateTypeValueRef<AdjustmentReference, AdjustmentReference::AdjustRefType>(adj, AdjustmentReference::ADJUST_REF_GVAR, 1);
+  if (value != adj.toValue())
+    value = adj.toValue();
+}
+
+void ModelData::updateAssignFunc(CustomFunctionData * cfd)
+{
+  const int invalidateRef = -1;
+  int newRef = (int)cfd->func;
+  int idxAdj;
+
+  switch (updRefInfo.type)
+  {
+    case REF_UPD_TYPE_CHANNEL:
+      if(cfd->func < FuncOverrideCH1 || cfd->func > FuncOverrideCH32) //  TODO refactor to FuncOverrideCHLast
+        return;
+      idxAdj = FuncOverrideCH1;
+      break;
+    case REF_UPD_TYPE_GLOBAL_VARIABLE:
+      if (cfd->func < FuncAdjustGV1 || cfd->func > FuncAdjustGVLast)
+        return;
+      idxAdj = FuncAdjustGV1;
+      break;
+    case REF_UPD_TYPE_TIMER:
+      if (cfd->func < FuncSetTimer1 || cfd->func > FuncSetTimer3) //  TODO refactor to FuncSetTimerLast
+        return;
+      idxAdj = FuncSetTimer1;
+      break;
+    default:
+      return;
+  }
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef != (updRefInfo.index1 + idxAdj))
+        return;
+      newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef < (updRefInfo.index1 + idxAdj))
+        return;
+
+      newRef += updRefInfo.shift;
+
+      if (newRef < (updRefInfo.index1 + idxAdj) || newRef > (updRefInfo.maxindex + idxAdj))
+        newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef == updRefInfo.index1 + idxAdj)
+        newRef = updRefInfo.index2 + idxAdj;
+      else if (newRef == updRefInfo.index2 + idxAdj)
+        newRef = updRefInfo.index1 + idxAdj;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (newRef == invalidateRef) {
+    cfd->clear();
+    qDebug() << "Function cleared";
+    updRefInfo.updcnt++;
+  }
+  else if (cfd->func != (AssignFunc)newRef) {
+    qDebug() << "Updated reference:" << cfd->func << " -> " << newRef;
+    cfd->func = (AssignFunc)newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+void ModelData::updateDestCh(MixData * md)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_CHANNEL)
+    return;
+
+  const int invalidateRef = -1;
+  const int idxAdj = 1;
+  int newRef = md->destCh;
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef != (updRefInfo.index1 + idxAdj))
+        return;
+      newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef < (updRefInfo.index1 + idxAdj))
+        return;
+
+      newRef += updRefInfo.shift;
+
+      if (newRef < (updRefInfo.index1 + idxAdj) || newRef > (updRefInfo.maxindex + idxAdj))
+        newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef == updRefInfo.index1 + idxAdj)
+        newRef = updRefInfo.index2 + idxAdj;
+      else if (newRef == updRefInfo.index2 + idxAdj)
+        newRef = updRefInfo.index1 + idxAdj;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (newRef == invalidateRef) {
+    md->clear();
+    qDebug() << "Mix cleared";
+    updRefInfo.updcnt++;
+  }
+  else if (md->destCh != static_cast<unsigned int>(newRef)) {
+    qDebug() << "Updated reference:" << md->destCh << " -> " << newRef;
+    md->destCh = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+void ModelData::updateFlightModeFlags(unsigned int & curRef)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_FLIGHT_MODE || curRef == 0 /*all selected*/ || curRef == 511 /*all deselected*/)
+   return;
+
+  if (updRefInfo.index1 > CPN_MAX_FLIGHT_MODES || updRefInfo.index2 > CPN_MAX_FLIGHT_MODES)
+    return;
+
+  unsigned int newRef = curRef;
+  bool flag[CPN_MAX_FLIGHT_MODES];
+  bool f;
+
+  int mask = 1;
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
+    flag[i] = curRef & mask;
+    mask <<= 1;
+  }
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      flag[updRefInfo.index1] = false;
+      break;
+    case REF_UPD_ACT_SHIFT:
+        if(updRefInfo.shift < 0) {
+          for (int i = updRefInfo.index1; i < CPN_MAX_FLIGHT_MODES; i++) {
+            if (i - updRefInfo.shift <= updRefInfo.maxindex)
+              flag[i] = flag[i - updRefInfo.shift];
+            else
+              flag[i] = false;
+          }
+        }
+        else {
+          for (int i = CPN_MAX_FLIGHT_MODES - 1; i >= updRefInfo.index1; i--) {
+            if (i - updRefInfo.shift >= updRefInfo.index1)
+              flag[i] = flag[i - updRefInfo.shift];
+            else
+              flag[i] = false;
+          }
+        }
+      break;
+    case REF_UPD_ACT_SWAP:
+      f = flag[updRefInfo.index1];
+      flag[updRefInfo.index1] = flag[updRefInfo.index2];
+      flag[updRefInfo.index2] = f;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  newRef = 0;
+  for (int i = CPN_MAX_FLIGHT_MODES - 1; i >= 0 ; i--) {
+    if (flag[i])
+      newRef++;
+    newRef <<= 1;
+  }
+  newRef >>= 1;
+
+  if (curRef != newRef) {
+    qDebug() << "Updated reference:" << curRef << " -> " << newRef;
+    curRef = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+void ModelData::updateFlightModeTrimRef(int & trimRef, int & trimMode, int & trim)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_FLIGHT_MODE)
+    return;
+
+  const int invalidateRef = -1;
+  int newRef = trimRef;
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef != updRefInfo.index1)
+        return;
+      newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef < updRefInfo.index1)
+        return;
+
+      newRef += updRefInfo.shift;
+
+      if (newRef < updRefInfo.index1 || newRef > updRefInfo.maxindex)
+        newRef = invalidateRef;
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef == updRefInfo.index1)
+        newRef = updRefInfo.index2;
+      else if (newRef == updRefInfo.index2)
+        newRef = updRefInfo.index1;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (newRef == invalidateRef) {
+    trimRef = 0;
+    trimMode = 0;
+    trim = 0;
+    qDebug() << "Trim cleared";
+    updRefInfo.updcnt++;
+  }
+  else if (trimRef != newRef) {
+    qDebug() << "Updated reference:" << trimRef << " -> " << newRef;
+    trimRef = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+void ModelData::updateFlightModeGVRERef(int & curRef, const int phaseIdx, const int maxOwnValue)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_FLIGHT_MODE)
+    return;
+
+  int fmIdx = linkedFlightModeValueToIndex(phaseIdx, curRef, maxOwnValue);
+  if (fmIdx < 0)
+    return;
+
+  int newRef = curRef;
+
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (fmIdx != updRefInfo.index1)
+        return;
+      newRef = linkedFlightModeZero(maxOwnValue);
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (fmIdx < updRefInfo.index1)
+        return;
+
+      fmIdx += updRefInfo.shift;
+
+      if (fmIdx < updRefInfo.index1 || fmIdx > updRefInfo.maxindex)
+        newRef = linkedFlightModeZero(maxOwnValue);
+      else
+        newRef = linkedFlightModeIndexToValue(phaseIdx, fmIdx, maxOwnValue);
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (fmIdx == updRefInfo.index1) {
+        if (updRefInfo.index2 == phaseIdx)
+          newRef = linkedFlightModeIndexToValue(phaseIdx, updRefInfo.index2, maxOwnValue);
+      }
+      else if (fmIdx == updRefInfo.index2) {
+        if (updRefInfo.index1 == phaseIdx)
+          newRef = linkedFlightModeIndexToValue(phaseIdx, updRefInfo.index1, maxOwnValue);
+      }
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (curRef != newRef) {
+    qDebug() << "Updated reference:" << curRef << " -> " << newRef;
+    curRef = newRef;
+    updRefInfo.updcnt++;
+  }
+}
+
+int ModelData::linkedFlightModeIndexToValue(const int phaseIdx, const int useFmIdx, const int maxOwnValue)
+{
+  int val;
+
+  if (phaseIdx == useFmIdx || phaseIdx < 0 || phaseIdx > (CPN_MAX_FLIGHT_MODES - 1) || useFmIdx < 0 || useFmIdx > (CPN_MAX_FLIGHT_MODES - 1))
+    val = linkedFlightModeZero(maxOwnValue);
+  else
+    val = maxOwnValue + useFmIdx + (useFmIdx >= phaseIdx ? 0 : 1);
+
+  return val;
+}
+
+int ModelData::linkedFlightModeValueToIndex(const int phaseIdx, const int val, const int maxOwnValue)
+{
+  int idx = val - maxOwnValue - 1;
+  if (idx == phaseIdx)
+    idx += 1;
+  return idx;
+}
+
+int ModelData::getGVarFlightModeIndex(const int phaseIdx, const int gvarIdx)
+{
+  if (!isGVarLinked(phaseIdx, gvarIdx))
+    return -1;
+  return (linkedFlightModeValueToIndex(phaseIdx, flightModeData[phaseIdx].gvars[gvarIdx], GVAR_MAX_VALUE));
+}
+
+void ModelData::setGVarFlightModeValue(const int phaseIdx, const int gvarIdx, const int useFmIdx)
+{
+  flightModeData[phaseIdx].gvars[gvarIdx] = linkedFlightModeIndexToValue(phaseIdx, useFmIdx, GVAR_MAX_VALUE);
+}
+
+bool ModelData::isEncoderLinked(const int phaseIdx, const int reIdx)
+{
+  return flightModeData[phaseIdx].rotaryEncoders[reIdx] > ENCODER_MAX_VALUE;
+}
+
+int ModelData::getEncoderFlightModeIndex(const int phaseIdx, const int reIdx)
+{
+  if (!isEncoderLinked(phaseIdx, reIdx))
+    return -1;
+  return (linkedFlightModeValueToIndex(phaseIdx, flightModeData[phaseIdx].rotaryEncoders[reIdx], ENCODER_MAX_VALUE));
+}
+
+void ModelData::setEncoderFlightModeValue(const int phaseIdx, const int reIdx, const int useFmIdx)
+{
+  flightModeData[phaseIdx].rotaryEncoders[reIdx] = linkedFlightModeIndexToValue(phaseIdx, useFmIdx, ENCODER_MAX_VALUE);
+}
+
+int ModelData::linkedFlightModeZero(const int maxOwnValue)
+{
+  return maxOwnValue + 1;
+}
+
+void ModelData::updateTelemetryRef(unsigned int & curRef)
+{
+  if (updRefInfo.type != REF_UPD_TYPE_SENSOR)
+    return;
+
+  const int idxAdj = 1;
+  int newRef = curRef;
+  switch (updRefInfo.action)
+  {
+    case REF_UPD_ACT_CLEAR:
+      if (newRef != (updRefInfo.index1 + idxAdj))
+        return;
+      newRef = 0;
+      break;
+    case REF_UPD_ACT_SHIFT:
+      if (newRef < (updRefInfo.index1 + idxAdj))
+        return;
+
+      newRef += updRefInfo.shift;
+
+      if (newRef < (updRefInfo.index1 + idxAdj) || newRef > (updRefInfo.maxindex + idxAdj))
+        newRef = 0;
+      break;
+    case REF_UPD_ACT_SWAP:
+      if (newRef == updRefInfo.index1 + idxAdj)
+        newRef = updRefInfo.index2 + idxAdj;
+      else if (newRef == updRefInfo.index2 + idxAdj)
+        newRef = updRefInfo.index1 + idxAdj;
+      break;
+    default:
+      qDebug() << "Error - unhandled action:" << updRefInfo.action;
+      return;
+  }
+
+  if (curRef != static_cast<unsigned int>(newRef)) {
+    qDebug() << "Updated reference:" << curRef << " -> " << newRef;
+    curRef = newRef;
+    updRefInfo.updcnt++;
   }
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -488,7 +488,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
   //qDebug() << "updRefInfo - type:" << updRefInfo.type << " action:" << updRefInfo.action << " index1:" << updRefInfo.index1 << " index2:" << updRefInfo.index2 << " shift:" << updRefInfo.shift;
   //qDebug() << "maxindex:" << updRefInfo.maxindex << "updRefInfo - srcType:" << updRefInfo.srcType << " swtchType:" << updRefInfo.swtchType;
 
-  s1.report("Initialise");
+  //s1.report("Initialise");
 
   for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     FlightModeData *fmd = &flightModeData[i];
@@ -496,13 +496,13 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateSwitchRef(fmd->swtch);
     }
   }
-  s1.report("Flight Modes");
+  //s1.report("Flight Modes");
 
   for (int i = 0; i < CPN_MAX_TIMERS; i++) {
     TimerData *td = &timers[i];
     updateTimerMode(td->mode);
   }
-  s1.report("Timers");
+  //s1.report("Timers");
 
   for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     ExpoData *ed = &expoData[i];
@@ -515,7 +515,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateFlightModeFlags(ed->flightModes);
     }
   }
-  s1.report("Inputs");
+  //s1.report("Inputs");
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     MixData *md = &mixData[i];
@@ -531,7 +531,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       }
     }
   }
-  s1.report("Mixes");
+  //s1.report("Mixes");
 
   for (int i = 0; i < CPN_MAX_CHNOUT; i++) {
     LimitData *ld = &limitData[i];
@@ -542,7 +542,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateLimitCurveRef(ld->curve);
     }
   }
-  s1.report("Outputs");
+  //s1.report("Outputs");
 
   for (int i = 0; i < CPN_MAX_LOGICAL_SWITCHES; i++) {
     LogicalSwitchData *lsd = &logicalSw[i];
@@ -570,7 +570,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateSwitchIntRef(lsd->andsw);
     }
   }
-  s1.report("Logical Switches");
+  //s1.report("Logical Switches");
 
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     CustomFunctionData *cfd = &customFn[i];
@@ -583,13 +583,13 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       }
     }
   }
-  s1.report("Special Functions");
+  //s1.report("Special Functions");
 
   if (fw->getCapability(Heli)) {
     updateSourceRef(swashRingData.aileronSource);
     updateSourceRef(swashRingData.collectiveSource);
     updateSourceRef(swashRingData.elevatorSource);
-    s1.report("Heli");
+    //s1.report("Heli");
   }
 
   if (fw->getCapability(Telemetry)) {
@@ -621,7 +621,7 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
           break;
       }
     }
-    s1.report("Telemetry");
+    //s1.report("Telemetry");
   }
 
   //  TODO maybe less risk to leave it up to the user??
@@ -708,7 +708,7 @@ void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, c
 
   if (curRef.type != newRef.type || abs(curRef.index) != newRef.index) {
     newRef.index = curRef.index < 0 ? -newRef.index : newRef.index;
-    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    //qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
     curRef = newRef;
     updRefInfo.updcnt++;
   }
@@ -765,7 +765,7 @@ void ModelData::updateTypeValueRef(R & curRef, const T type, const int idxAdj, c
 
   if (curRef.type != newRef.type || abs(curRef.value) != newRef.value) {
     newRef.value = curRef.value < 0 ? -newRef.value : newRef.value;
-    qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
+    //qDebug() << "Updated reference: " << curRef.toString() << " -> " << newRef.toString();
     curRef = newRef;
     updRefInfo.updcnt++;
   }
@@ -854,11 +854,11 @@ void ModelData::updateAssignFunc(CustomFunctionData * cfd)
 
   if (newRef == invalidateRef) {
     cfd->clear();
-    qDebug() << "Function cleared";
+    //qDebug() << "Function cleared";
     updRefInfo.updcnt++;
   }
   else if (cfd->func != (AssignFunc)newRef) {
-    qDebug() << "Updated reference:" << cfd->func << " -> " << newRef;
+    //qDebug() << "Updated reference:" << cfd->func << " -> " << newRef;
     cfd->func = (AssignFunc)newRef;
     updRefInfo.updcnt++;
   }
@@ -901,11 +901,11 @@ void ModelData::updateDestCh(MixData * md)
 
   if (newRef == invalidateRef) {
     md->clear();
-    qDebug() << "Mix cleared";
+    //qDebug() << "Mix cleared";
     updRefInfo.updcnt++;
   }
   else if (md->destCh != static_cast<unsigned int>(newRef)) {
-    qDebug() << "Updated reference:" << md->destCh << " -> " << newRef;
+    //qDebug() << "Updated reference:" << md->destCh << " -> " << newRef;
     md->destCh = newRef;
     updRefInfo.updcnt++;
   }
@@ -971,7 +971,7 @@ void ModelData::updateFlightModeFlags(unsigned int & curRef)
   newRef >>= 1;
 
   if (curRef != newRef) {
-    qDebug() << "Updated reference:" << curRef << " -> " << newRef;
+    //qDebug() << "Updated reference:" << curRef << " -> " << newRef;
     curRef = newRef;
     updRefInfo.updcnt++;
   }
@@ -1012,7 +1012,7 @@ void ModelData::updateTelemetryRef(unsigned int & curRef)
   }
 
   if (curRef != static_cast<unsigned int>(newRef)) {
-    qDebug() << "Updated reference:" << curRef << " -> " << newRef;
+    //qDebug() << "Updated reference:" << curRef << " -> " << newRef;
     curRef = newRef;
     updRefInfo.updcnt++;
   }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -514,11 +514,17 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
     ExpoData *ed = &expoData[i];
     if (!ed->isEmpty()) {
       updateSourceRef(ed->srcRaw);
-      updateSwitchRef(ed->swtch);
-      updateCurveRef(ed->curve);
-      updateAdjustRef(ed->weight);
-      updateAdjustRef(ed->offset);
-      updateFlightModeFlags(ed->flightModes);
+      if (ed->srcRaw.isSet()) {
+        updateSwitchRef(ed->swtch);
+        updateCurveRef(ed->curve);
+        updateAdjustRef(ed->weight);
+        updateAdjustRef(ed->offset);
+        updateFlightModeFlags(ed->flightModes);
+      }
+      else {
+        removeInput(i);
+        i--;
+      }
     }
   }
   s1.report("Inputs");
@@ -529,11 +535,17 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateDestCh(md);
       if (!md->isEmpty()) {
         updateSourceRef(md->srcRaw);
-        updateSwitchRef(md->swtch);
-        updateCurveRef(md->curve);
-        updateAdjustRef(md->weight);
-        updateAdjustRef(md->sOffset);
-        updateFlightModeFlags(md->flightModes);
+        if (md->srcRaw.isSet()) {
+          updateSwitchRef(md->swtch);
+          updateCurveRef(md->curve);
+          updateAdjustRef(md->weight);
+          updateAdjustRef(md->sOffset);
+          updateFlightModeFlags(md->flightModes);
+        }
+        else {
+          removeMix(i);
+          i--;
+        }
       }
     }
   }
@@ -1122,4 +1134,10 @@ bool ModelData::hasExpoSiblings(const int index)
   const ExpoData &ed = expoData[index];
   const QVector<const ExpoData *> chexpos = expos(ed.chn);
   return !isExpoParent(index) && chexpos.size() > 2;
+}
+
+void ModelData::removeMix(const int idx)
+{
+  memmove(&mixData[idx], &mixData[idx + 1], (CPN_MAX_MIXERS - (idx + 1)) * sizeof(MixData));
+  mixData[CPN_MAX_MIXERS - 1].clear();
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -584,8 +584,11 @@ int ModelData::updateAllReferences(const ReferenceUpdateType type, const Referen
       updateAssignFunc(cfd);
       if (!cfd->isEmpty()) {
         updateSwitchRef(cfd->swtch);
-        if (cfd->func == FuncVolume || cfd->func == FuncPlayValue || (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE)))
+        if (cfd->func == FuncVolume || cfd->func == FuncPlayValue || (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE))) {
           updateSourceIntRef(cfd->param);
+          if (cfd->param == 0)
+            cfd->clear();
+        }
       }
     }
   }

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -77,6 +77,7 @@ class TimerData {
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(TimerData)); mode = RawSwitch(SWITCH_TYPE_TIMER_MODE, 0); }
     void convert(RadioDataConversionState & cstate);
     bool isEmpty();
+    bool isModeOff() { return mode == RawSwitch(SWITCH_TYPE_TIMER_MODE, 0); }
 };
 
 #define CPN_MAX_SCRIPTS       9

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -76,6 +76,7 @@ class TimerData {
     int          pvalue;
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(TimerData)); mode = RawSwitch(SWITCH_TYPE_TIMER_MODE, 0); }
     void convert(RadioDataConversionState & cstate);
+    bool isEmpty();
 };
 
 #define CPN_MAX_SCRIPTS       9

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -298,6 +298,7 @@ class ModelData {
     void updateLimitCurveRef(CurveReference & crv);
     void updateFlightModeFlags(unsigned int & flags);
     void updateTelemetryRef(unsigned int & idx);
+    void updateModuleFailsafes(ModuleData * md);
     inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType); }
     inline void updateSwitchRef(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1); }
     inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, 0); }

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -267,6 +267,7 @@ class ModelData {
     bool isExpoChild(const int index);
     bool hasExpoChildren(const int index);
     bool hasExpoSiblings(const int index);
+    void removeMix(const int idx);
 
   protected:
     void removeGlobalVar(int & var);

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -223,20 +223,22 @@ class ModelData {
     void setTrimValue(int phaseIdx, int trimIdx, int value);
 
     bool isGVarLinked(int phaseIdx, int gvarIdx);
-    int getGVarFieldValue(int phaseIdx, int gvarIdx);
-    float getGVarFieldValuePrec(int phaseIdx, int gvarIdx);
+    bool isGVarLinkedCircular(int phaseIdx, int gvarIdx);
+    int getGVarValue(int phaseIdx, int gvarIdx);
+    float getGVarValuePrec(int phaseIdx, int gvarIdx);
     int getGVarFlightModeIndex(const int phaseIdx, const int gvarIdx);
     void setGVarFlightModeIndexToValue(const int phaseIdx, const int gvarIdx, const int useFmIdx);
+
+    bool isREncLinked(int phaseIdx, int reIdx);
+    bool isREncLinkedCircular(int phaseIdx, int reIdx);
+    int getREncValue(int phaseIdx, int reIdx);
+    int getREncFlightModeIndex(const int phaseIdx, const int reIdx);
+    void setREncFlightModeIndexToValue(const int phaseIdx, const int reIdx, const int useFmIdx);
 
     ModelData removeGlobalVars();
 
     int linkedFlightModeIndexToValue(const int phaseIdx, const int useFmIdx, const int maxOwnValue);
     int linkedFlightModeValueToIndex(const int phaseIdx, const int val, const int maxOwnValue);
-
-    bool isEncoderLinked(const int phaseIdx, const int reIdx);
-    int getEncoderFieldValue(int phaseIdx, int reIdx);
-    int getEncoderFlightModeIndex(const int phaseIdx, const int reIdx);
-    void setEncoderFlightModeIndexToValue(const int phaseIdx, const int reIdx, const int useFmIdx);
 
     void clearMixes();
     void clearInputs();

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -222,17 +222,17 @@ class ModelData {
     int getGVarFieldValue(int phaseIdx, int gvarIdx);
     float getGVarFieldValuePrec(int phaseIdx, int gvarIdx);
     int getGVarFlightModeIndex(const int phaseIdx, const int gvarIdx);
-    void setGVarFlightModeValue(const int phaseIdx, const int gvarIdx, const int useFmIdx);
+    void setGVarFlightModeIndexToValue(const int phaseIdx, const int gvarIdx, const int useFmIdx);
 
     ModelData removeGlobalVars();
 
     int linkedFlightModeIndexToValue(const int phaseIdx, const int useFmIdx, const int maxOwnValue);
     int linkedFlightModeValueToIndex(const int phaseIdx, const int val, const int maxOwnValue);
-    int linkedFlightModeZero(const int maxOwnValue);
 
     bool isEncoderLinked(const int phaseIdx, const int reIdx);
+    int getEncoderFieldValue(int phaseIdx, int reIdx);
     int getEncoderFlightModeIndex(const int phaseIdx, const int reIdx);
-    void setEncoderFlightModeValue(const int phaseIdx, const int reIdx, const int useFmIdx);
+    void setEncoderFlightModeIndexToValue(const int phaseIdx, const int reIdx, const int useFmIdx);
 
     void clearMixes();
     void clearInputs();
@@ -289,8 +289,6 @@ class ModelData {
     void updateDestCh(MixData * md);
     void updateLimitCurveRef(CurveReference & crv);
     void updateFlightModeFlags(unsigned int & flags);
-    void updateFlightModeTrimRef(int & trimRef, int & trimMode, int & trim);
-    void updateFlightModeGVRERef(int & gvre, const int phaseIdx, const int maxOwnValue);
     void updateTelemetryRef(unsigned int & idx);
     inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType); }
     inline void updateSwitchRef(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1); }

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -262,6 +262,19 @@ class ModelData {
       REF_UPD_TYPE_TIMER,
     };
 
+    struct UpdateReferenceParams
+    {
+      ReferenceUpdateType type;
+      ReferenceUpdateAction action;
+      int index1;
+      int index2;
+      int shift;
+
+      UpdateReferenceParams() {}
+      UpdateReferenceParams(ReferenceUpdateType t, ReferenceUpdateAction a, int i1, int i2 = 0, int s = 0) :
+        type(t), action(a), index1(i1), index2(i2), shift(s) {}
+    };
+
     int updateAllReferences(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2 = 0, const int shift = 0);
     bool isExpoParent(const int index);
     bool isExpoChild(const int index);
@@ -273,6 +286,8 @@ class ModelData {
     void removeGlobalVar(int & var);
 
   private:
+    QVector<UpdateReferenceParams> *updRefList = nullptr;
+
     struct UpdateReferenceInfo
     {
       ReferenceUpdateType type;
@@ -287,6 +302,8 @@ class ModelData {
     };
     UpdateReferenceInfo updRefInfo;
 
+    int updateReference();
+    void appendUpdateReferenceParams(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2 = 0, const int shift = 0);
     template <class R, typename T>
     void updateTypeIndexRef(R & curref, const T type, const int idxAdj = 0, const bool defClear = true, const int defType = 0, const int defIndex = 0);
     template <class R, typename T>

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -128,6 +128,8 @@ enum TrainerMode {
   TRAINER_MODE_MULTI
 };
 
+#define INPUT_NAME_LEN 4
+
 class ModelData {
   Q_DECLARE_TR_FUNCTIONS(ModelData)
 
@@ -170,7 +172,7 @@ class ModelData {
     MixData   mixData[CPN_MAX_MIXERS];
     LimitData limitData[CPN_MAX_CHNOUT];
 
-    char      inputNames[CPN_MAX_INPUTS][4+1];
+    char      inputNames[CPN_MAX_INPUTS][INPUT_NAME_LEN+1];
     ExpoData  expoData[CPN_MAX_EXPOS];
 
     CurveData curves[CPN_MAX_CURVES];
@@ -260,6 +262,10 @@ class ModelData {
     };
 
     int updateAllReferences(const ReferenceUpdateType type, const ReferenceUpdateAction action, const int index1, const int index2 = 0, const int shift = 0);
+    bool isExpoParent(const int index);
+    bool isExpoChild(const int index);
+    bool hasExpoChildren(const int index);
+    bool hasExpoSiblings(const int index);
 
   protected:
     void removeGlobalVar(int & var);

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -181,3 +181,18 @@ QStringList ModuleData::powerValueStrings(int subType, Firmware * fw)
     strIdx += 2;
   return strings[strIdx];
 }
+
+bool ModuleData::hasFailsafes(Firmware * fw) const
+{
+  return fw->getCapability(HasFailsafe) && (
+    protocol == PULSES_ACCESS_ISRM ||
+    protocol == PULSES_ACCST_ISRM_D16 ||
+    protocol == PULSES_PXX_XJT_X16 ||
+    protocol == PULSES_PXX_R9M ||
+    protocol == PULSES_ACCESS_R9M ||
+    protocol == PULSES_ACCESS_R9M_LITE ||
+    protocol == PULSES_ACCESS_R9M_LITE_PRO ||
+    protocol == PULSES_XJT_LITE_X16 ||
+    protocol == PULSES_MULTIMODULE
+    );
+}

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -196,3 +196,44 @@ bool ModuleData::hasFailsafes(Firmware * fw) const
     protocol == PULSES_MULTIMODULE
     );
 }
+
+int ModuleData::getMaxChannelCount()
+{
+  switch (protocol) {
+    case PULSES_ACCESS_ISRM:
+      return 24;
+    case PULSES_PXX_R9M:
+    case PULSES_ACCESS_R9M:
+    case PULSES_ACCESS_R9M_LITE:
+    case PULSES_ACCESS_R9M_LITE_PRO:
+    case PULSES_ACCST_ISRM_D16:
+    case PULSES_XJT_LITE_X16:
+    case PULSES_PXX_XJT_X16:
+    case PULSES_CROSSFIRE:
+    case PULSES_SBUS:
+    case PULSES_PPM:
+      return 16;
+    case PULSES_XJT_LITE_LR12:
+    case PULSES_PXX_XJT_LR12:
+      return 12;
+    case PULSES_PXX_DJT:
+    case PULSES_XJT_LITE_D8:
+    case PULSES_PXX_XJT_D8:
+      return 8;
+    case PULSES_LP45:
+    case PULSES_DSM2:
+    case PULSES_DSMX:
+      return 6;
+    case PULSES_MULTIMODULE:
+      if (multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2)
+        return 12;
+      else
+        return 16;
+      break;
+    case PULSES_OFF:
+      break;
+    default:
+      break;
+  }
+  return 8;
+}

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -149,7 +149,7 @@ class ModuleData {
     unsigned int modelId;
     unsigned int protocol;   // type in datastructs.h
     int          rfProtocol; // rfProtocol in datastructs.h
-  
+
     unsigned int subType;
     bool         invertedSerial;
     unsigned int channelsStart;
@@ -197,6 +197,7 @@ class ModuleData {
     static QString indexToString(int index, Firmware * fw);
     static QString protocolToString(unsigned protocol);
     static QStringList powerValueStrings(int subType, Firmware * fw);
+    bool hasFailsafes(Firmware * fw) const;
 };
 
 #endif // MODULEDATA_H

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -198,6 +198,7 @@ class ModuleData {
     static QString protocolToString(unsigned protocol);
     static QStringList powerValueStrings(int subType, Firmware * fw);
     bool hasFailsafes(Firmware * fw) const;
+    int getMaxChannelCount();
 };
 
 #endif // MODULEDATA_H

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -616,6 +616,10 @@ int OpenTxFirmware::getCapability(::Capability capability)
         return 0;
       else
         return IS_ARM(board) ? 4 : 2;
+    case TelemetryCustomScreensBars:
+      return (getCapability(TelemetryCustomScreens) ? 4 : 0);
+    case TelemetryCustomScreensLines:
+      return (getCapability(TelemetryCustomScreens) ? 4 : 0);
     case TelemetryCustomScreensFieldsPerLine:
       return HAS_LARGE_LCD(board) ? 3 : 2;
     case NoTelemetryProtocol:
@@ -754,6 +758,11 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return IS_TARANIS_XLITES(board);
     case PwrButtonPress:
       return IS_HORUS_OR_TARANIS(board) && (board!=Board::BOARD_TARANIS_X9D) && (board!=Board::BOARD_TARANIS_X9DP);
+    case Sensors:
+      if (IS_HORUS(board) || IS_TARANIS_X9(board))
+        return 60;
+      else
+        return 40;
     default:
       return 0;
   }

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -759,7 +759,7 @@ int OpenTxFirmware::getCapability(::Capability capability)
     case PwrButtonPress:
       return IS_HORUS_OR_TARANIS(board) && (board!=Board::BOARD_TARANIS_X9D) && (board!=Board::BOARD_TARANIS_X9DP);
     case Sensors:
-      if (IS_HORUS(board) || IS_TARANIS_X9(board))
+      if (IS_FAMILY_HORUS_OR_T16(board) || IS_TARANIS_X9(board))
         return 60;
       else
         return 40;

--- a/companion/src/firmwares/rawsource.h
+++ b/companion/src/firmwares/rawsource.h
@@ -227,11 +227,7 @@ class RawSource {
       AllSourceGroups   = InputSourceGroups | GVarsGroup | TelemGroup | ScriptsGroup
     };
 
-    RawSource():
-      type(SOURCE_TYPE_NONE),
-      index(0)
-    {
-    }
+    RawSource() { clear(); }
 
     explicit RawSource(int value):
       type(RawSourceType(abs(value)/65536)),
@@ -258,6 +254,8 @@ class RawSource {
     bool isSlider(int * sliderIndex = NULL, Board::Type board = Board::BOARD_UNKNOWN) const;
     bool isTimeBased(Board::Type board = Board::BOARD_UNKNOWN) const;
     bool isAvailable(const ModelData * const model = NULL, const GeneralSettings * const gs = NULL, Board::Type board = Board::BOARD_UNKNOWN) const;
+    bool isSet() const { return type != SOURCE_TYPE_NONE || index != 0; }
+    void clear() { type = SOURCE_TYPE_NONE; index = 0; }
 
     bool operator == ( const RawSource & other) const {
       return (this->type == other.type) && (this->index == other.index);

--- a/companion/src/firmwares/rawswitch.h
+++ b/companion/src/firmwares/rawswitch.h
@@ -65,11 +65,7 @@ class RawSwitch {
       AllSwitchContexts       = AllModelContexts | GlobalFunctionsContext
     };
 
-    RawSwitch():
-      type(SWITCH_TYPE_NONE),
-      index(0)
-    {
-    }
+    RawSwitch() { clear(); }
 
     explicit RawSwitch(int value):
       type(RawSwitchType(abs(value)/256)),
@@ -91,6 +87,8 @@ class RawSwitch {
     RawSwitch convert(RadioDataConversionState & cstate);
     QString toString(Board::Type board = Board::BOARD_UNKNOWN, const GeneralSettings * const generalSettings = NULL, const ModelData * const modelData = NULL) const;
     bool isAvailable(const ModelData * const model = NULL, const GeneralSettings * const gs = NULL, Board::Type board = Board::BOARD_UNKNOWN) const;
+    bool isSet() const { return type != SWITCH_TYPE_NONE || index != 0; }
+    void clear() { type = SWITCH_TYPE_NONE; index = 0; }
 
     bool operator== ( const RawSwitch& other) const {
       return (this->type == other.type) && (this->index == other.index);
@@ -99,7 +97,6 @@ class RawSwitch {
     bool operator!= ( const RawSwitch& other) const {
       return (this->type != other.type) || (this->index != other.index);
     }
-
 
     RawSwitchType type;
     int index;

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -392,12 +392,12 @@ void Channels::chn_customContextMenuRequested(QPoint pos)
 
 void Channels::chnMoveUp()
 {
-  swapChnData(selectedChannel, selectedChannel - 1);
+  swapData(selectedChannel, selectedChannel - 1);
 }
 
 void Channels::chnMoveDown()
 {
-  swapChnData(selectedChannel, selectedChannel + 1);
+  swapData(selectedChannel, selectedChannel + 1);
 }
 
 void Channels::chnClear()
@@ -437,7 +437,7 @@ void Channels::chnInsert()
   emit modified();
 }
 
-void Channels::swapChnData(int idx1, int idx2)
+void Channels::swapData(int idx1, int idx2)
 {
   if ((idx1 != idx2) && (!model->limitData[idx1].isEmpty() || !model->limitData[idx2].isEmpty())) {
     LimitData chntmp = model->limitData[idx2];

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -131,7 +131,7 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
     label->setContextMenuPolicy(Qt::CustomContextMenu);
     label->setToolTip(tr("Popup menu available"));
     label->setMouseTracking(true);
-    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(chn_customContextMenuRequested(QPoint)));
+    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)));
     tableLayout->addWidget(i, col++, label);
 
     // Channel name
@@ -312,26 +312,23 @@ void Channels::updateLine(int i)
   lock = false;
 }
 
-void Channels::chnPaste()
+void Channels::cmPaste()
 {
-  const QClipboard *clipboard = QApplication::clipboard();
-  const QMimeData *mimeData = clipboard->mimeData();
-  if (mimeData->hasFormat(MIMETYPE_CHN)) {
-    QByteArray chnData = mimeData->data(MIMETYPE_CHN);
-    LimitData *chn = &model->limitData[selectedChannel];
-    memcpy(chn, chnData.constData(), sizeof(LimitData));
-    updateLine(selectedChannel);
+  QByteArray data;
+  if (hasClipboardData(&data)) {
+    memcpy(&model->limitData[selectedIndex], data.constData(), sizeof(LimitData));
+    updateLine(selectedIndex);
     emit modified();
   }
 }
 
-void Channels::chnDelete()
+void Channels::cmDelete()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
 
   int maxidx = chnCapability - 1;
-  for (int i=selectedChannel; i<maxidx; i++) {
+  for (int i=selectedIndex; i<maxidx; i++) {
     if (!model->limitData[i].isEmpty() || !model->limitData[i+1].isEmpty()) {
       LimitData *chn1 = &model->limitData[i];
       LimitData *chn2 = &model->limitData[i+1];
@@ -340,78 +337,97 @@ void Channels::chnDelete()
     }
   }
   model->limitData[maxidx].clear();
-  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedChannel, 0, -1);
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   updateLine(maxidx);
   emit modified();
 }
 
-void Channels::chnCopy()
+void Channels::cmCopy()
 {
-  QByteArray chnData;
-  chnData.append((char*)&model->limitData[selectedChannel],sizeof(LimitData));
+  QByteArray data;
+  data.append((char*)&model->limitData[selectedIndex],sizeof(LimitData));
   QMimeData *mimeData = new QMimeData;
-  mimeData->setData(MIMETYPE_CHN, chnData);
+  mimeData->setData(MIMETYPE_CHANNEL, data);
   QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
 }
 
-void Channels::chnCut()
+void Channels::cmCut()
 {
-  chnCopy();
-  chnClear();
+  cmCopy();
+  cmClear();
 }
 
-void Channels::chn_customContextMenuRequested(QPoint pos)
+void Channels::onCustomContextMenuRequested(QPoint pos)
 {
   QLabel *label = (QLabel *)sender();
-  selectedChannel = label->property("index").toInt();
-
+  selectedIndex = label->property("index").toInt();
   QPoint globalPos = label->mapToGlobal(pos);
 
-  const QClipboard *clipboard = QApplication::clipboard();
-  const QMimeData *mimeData = clipboard->mimeData();
-  bool hasData = mimeData->hasFormat(MIMETYPE_CHN);
-  bool moveUpAllowed = (selectedChannel > 0);
-  bool moveDownAllowed = (selectedChannel < (chnCapability - 1));
-  bool insertAllowed = (selectedChannel < (chnCapability - 1)) && (model->limitData[chnCapability - 1].isEmpty());
-
   QMenu contextMenu;
-  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"),this,SLOT(chnCopy()));
-  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"),this,SLOT(chnCut()));
-  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"),this,SLOT(chnPaste()))->setEnabled(hasData);
-  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"),this,SLOT(chnClear()));
+  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"),this,SLOT(cmCopy()));
+  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"),this,SLOT(cmCut()));
+  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"),this,SLOT(cmPaste()))->setEnabled(hasClipboardData());
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"),this,SLOT(cmClear()));
   contextMenu.addSeparator();
-  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"),this,SLOT(chnInsert()))->setEnabled(insertAllowed);
-  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"),this,SLOT(chnDelete()));
-  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"),this,SLOT(chnMoveUp()))->setEnabled(moveUpAllowed);
-  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"),this,SLOT(chnMoveDown()))->setEnabled(moveDownAllowed);
+  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"),this,SLOT(cmInsert()))->setEnabled(insertAllowed());
+  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"),this,SLOT(cmDelete()));
+  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"),this,SLOT(cmMoveUp()))->setEnabled(moveUpAllowed());
+  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"),this,SLOT(cmMoveDown()))->setEnabled(moveDownAllowed());
   contextMenu.addSeparator();
-  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"),this,SLOT(chnClearAll()));
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"),this,SLOT(cmClearAll()));
 
   contextMenu.exec(globalPos);
 }
 
-void Channels::chnMoveUp()
+bool Channels::hasClipboardData(QByteArray * data) const
 {
-  swapData(selectedChannel, selectedChannel - 1);
+  const QClipboard * clipboard = QApplication::clipboard();
+  const QMimeData * mimeData = clipboard->mimeData();
+  if (mimeData->hasFormat(MIMETYPE_CHANNEL)) {
+    if (data)
+      data->append(mimeData->data(MIMETYPE_CHANNEL));
+    return true;
+  }
+  return false;
 }
 
-void Channels::chnMoveDown()
+bool Channels::insertAllowed() const
 {
-  swapData(selectedChannel, selectedChannel + 1);
+  return ((selectedIndex < chnCapability - 1) && (model->limitData[chnCapability - 1].isEmpty()));
 }
 
-void Channels::chnClear()
+bool Channels::moveDownAllowed() const
+{
+  return selectedIndex < chnCapability - 1;
+}
+
+bool Channels::moveUpAllowed() const
+{
+  return selectedIndex > 0;
+}
+
+void Channels::cmMoveUp()
+{
+  swapData(selectedIndex, selectedIndex - 1);
+}
+
+void Channels::cmMoveDown()
+{
+  swapData(selectedIndex, selectedIndex + 1);
+}
+
+void Channels::cmClear()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
 
-  model->limitData[selectedChannel].clear();
-  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, selectedChannel);
-  updateLine(selectedChannel);
+  model->limitData[selectedIndex].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
+  updateLine(selectedIndex);
   emit modified();
 }
 
-void Channels::chnClearAll()
+void Channels::cmClearAll()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Channels. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -424,15 +440,15 @@ void Channels::chnClearAll()
   emit modified();
 }
 
-void Channels::chnInsert()
+void Channels::cmInsert()
 {
-  for (int i=(chnCapability - 1); i>selectedChannel; i--) {
+  for (int i=(chnCapability - 1); i>selectedIndex; i--) {
     if (!model->limitData[i].isEmpty() || !model->limitData[i-1].isEmpty()) {
       memcpy(&model->limitData[i], &model->limitData[i-1], sizeof(LimitData));
     }
   }
-  model->limitData[selectedChannel].clear();
-  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedChannel, 0, 1);
+  model->limitData[selectedIndex].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
   emit modified();
 }

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -327,6 +327,9 @@ void Channels::chnPaste()
 
 void Channels::chnDelete()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   int maxidx = chnCapability - 1;
   for (int i=selectedChannel; i<maxidx; i++) {
     if (!model->limitData[i].isEmpty() || !model->limitData[i+1].isEmpty()) {
@@ -337,6 +340,7 @@ void Channels::chnDelete()
     }
   }
   model->limitData[maxidx].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedChannel, 0, -1);
   updateLine(maxidx);
   emit modified();
 }
@@ -398,15 +402,23 @@ void Channels::chnMoveDown()
 
 void Channels::chnClear()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   model->limitData[selectedChannel].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, selectedChannel);
   updateLine(selectedChannel);
   emit modified();
 }
 
 void Channels::chnClearAll()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Channels. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   for (int i=0; i<chnCapability; i++) {
     model->limitData[i].clear();
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, i);
     updateLine(i);
   }
   emit modified();
@@ -417,10 +429,12 @@ void Channels::chnInsert()
   for (int i=(chnCapability - 1); i>selectedChannel; i--) {
     if (!model->limitData[i].isEmpty() || !model->limitData[i-1].isEmpty()) {
       memcpy(&model->limitData[i], &model->limitData[i-1], sizeof(LimitData));
-      updateLine(i);
     }
   }
-  chnClear();
+  model->limitData[selectedChannel].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedChannel, 0, 1);
+  update();
+  emit modified();
 }
 
 void Channels::swapChnData(int idx1, int idx2)
@@ -431,6 +445,7 @@ void Channels::swapChnData(int idx1, int idx2)
     LimitData *chn2 = &model->limitData[idx2];
     memcpy(chn2, chn1, sizeof(LimitData));
     memcpy(chn1, &chntmp, sizeof(LimitData));
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     updateLine(idx1);
     updateLine(idx2);
     emit modified();

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -80,7 +80,7 @@ class Channels : public ModelPanel
     void chn_customContextMenuRequested(QPoint pos);
 
   private:
-    void swapChnData(int idx1, int idx2);
+    void swapData(int idx1, int idx2);
     QLineEdit *name[CPN_MAX_CHNOUT];
     LimitsGroup *chnOffset[CPN_MAX_CHNOUT];
     LimitsGroup *chnMin[CPN_MAX_CHNOUT];

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -26,7 +26,7 @@
 
 #include <QtCore>
 
-constexpr char MIMETYPE_CHN[] = "application/x-companion-chn";
+constexpr char MIMETYPE_CHANNEL[] = "application/x-companion-channel";
 
 class GVarGroup;
 
@@ -68,18 +68,22 @@ class Channels : public ModelPanel
     void ppmcenterEdited();
     void update();
     void updateLine(int index);
-    void chnDelete();
-    void chnCopy();
-    void chnPaste();
-    void chnCut();
-    void chnMoveUp();
-    void chnMoveDown();
-    void chnInsert();
-    void chnClear();
-    void chnClearAll();
-    void chn_customContextMenuRequested(QPoint pos);
+    void cmDelete();
+    void cmCopy();
+    void cmPaste();
+    void cmCut();
+    void cmMoveUp();
+    void cmMoveDown();
+    void cmInsert();
+    void cmClear();
+    void cmClearAll();
+    void onCustomContextMenuRequested(QPoint pos);
 
   private:
+    bool hasClipboardData(QByteArray * data = nullptr) const;
+    bool insertAllowed() const;
+    bool moveDownAllowed() const;
+    bool moveUpAllowed() const;
     void swapData(int idx1, int idx2);
     QLineEdit *name[CPN_MAX_CHNOUT];
     LimitsGroup *chnOffset[CPN_MAX_CHNOUT];
@@ -89,7 +93,7 @@ class Channels : public ModelPanel
     QComboBox *curveCB[CPN_MAX_CHNOUT];
     QSpinBox *centerSB[CPN_MAX_CHNOUT];
     QCheckBox *symlimitsChk[CPN_MAX_CHNOUT];
-    int selectedChannel;
+    int selectedIndex;
     int chnCapability;
 };
 

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -686,7 +686,7 @@ bool Curves::hasClipboardData(QByteArray * data) const
 
 bool Curves::insertAllowed() const
 {
-  return model->curves[maxCurves - 1].isEmpty();
+  return ((selectedIndex < maxCurves - 1) && (model->curves[maxCurves - 1].isEmpty()));
 }
 
 bool Curves::moveDownAllowed() const

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -704,7 +704,7 @@ void Curves::cmClear()
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
 
-  model->curves[selectedIndex].clear(5);
+  model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   update();
   emit modified();
@@ -716,7 +716,7 @@ void Curves::cmClearAll()
     return;
 
   for (int i = 0; i < maxCurves; i++) {
-    model->curves[i].clear(5);
+    model->curves[i].clear();
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, i);
   }
   update();
@@ -744,7 +744,7 @@ void Curves::cmDelete()
     return;
 
   memmove(&model->curves[selectedIndex], &model->curves[selectedIndex + 1], (CPN_MAX_CURVES - (selectedIndex + 1)) * sizeof(CurveData));
-  model->curves[maxCurves - 1].clear(5);
+  model->curves[maxCurves - 1].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
   emit modified();
@@ -753,7 +753,7 @@ void Curves::cmDelete()
 void Curves::cmInsert()
 {
   memmove(&model->curves[selectedIndex + 1], &model->curves[selectedIndex], (CPN_MAX_CURVES - (selectedIndex + 1)) * sizeof(CurveData));
-  model->curves[selectedIndex].clear(5);
+  model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
   emit modified();

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -117,7 +117,12 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
 
   lock = true;
 
-  if (!firmware->getCapability(HasCvNames)) {
+  maxCurves = firmware->getCapability(NumCurves);
+  hasNames = firmware->getCapability(HasCvNames);
+  hasEnhanced = firmware->getCapability(EnhancedCurves);
+  maxPoints = firmware->getCapability(NumCurvePoints);
+
+  if (!hasNames) {
     ui->curveName->hide();
     ui->curveNameLabel->hide();
   }
@@ -127,14 +132,14 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
   connect(scene, SIGNAL(newPoint(int, int)), this, SLOT(onSceneNewPoint(int, int)));
 
   ui->curvePreview->setScene(scene);
-  int numcurves=firmware->getCapability(NumCurves);
+
   int limit;
-  if (numcurves>16) {
-      limit=numcurves/2;
+  if (maxCurves > 16) {
+      limit = maxCurves / 2;
   } else {
-      limit=numcurves;
+      limit = maxCurves;
   }
-  for (int i=0; i<numcurves; i++) {
+  for (int i = 0; i < maxCurves; i++) {
     visibleCurves[i] = false;
 
     // The edit curve button
@@ -151,15 +156,15 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
     edit->setStyleSheet(QString("background-color: %1; color: white; padding: 2px 3px; border-style: outset; border-width: 1px; border-radius: 2px; border-color: inherit;").arg(colors[i].name()));
 #endif
     edit->setPalette(palette);
-    edit->setText(tr("Curve %1").arg(i+1));
+    edit->setText(tr("Curve %1").arg(i + 1));
     edit->setContextMenuPolicy(Qt::CustomContextMenu);
     edit->setToolTip(tr("Popup menu available"));
-    connect(edit, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(ShowContextMenu(const QPoint&)));
+    connect(edit, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(onCustomContextMenuRequested(const QPoint&)));
     connect(edit, SIGNAL(clicked()), this, SLOT(editCurve()));
-    if (i<limit) {
+    if (i < limit) {
       ui->curvesLayout->addWidget(edit, i, 1, 1, 1);
     } else {
-      ui->curvesLayout2->addWidget(edit, i-limit, 2, 1, 1);
+      ui->curvesLayout2->addWidget(edit, i - limit, 2, 1, 1);
     }
 
     // The curve plot checkbox
@@ -167,7 +172,7 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
     plot->setProperty("index", i);
     plot->setPalette(palette);
     connect(plot, SIGNAL(toggled(bool)), this, SLOT(plotCurve(bool)));
-    if (i<limit) {
+    if (i < limit) {
       ui->curvesLayout->addWidget(plot, i, 2, 1, 1);
     } else {
       ui->curvesLayout2->addWidget(plot, i-limit, 1, 1, 1);
@@ -175,13 +180,13 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
   }
   QSpacerItem * item = new QSpacerItem(1,1, QSizePolicy::Fixed, QSizePolicy::Expanding);
 
-  ui->curvesLayout->addItem(item,limit+1,1,1,1,0);
-  if (limit!=numcurves) {
+  ui->curvesLayout->addItem(item,limit + 1, 1, 1, 1, 0);
+  if (limit != maxCurves) {
     QSpacerItem * item2 = new QSpacerItem(1,1, QSizePolicy::Fixed, QSizePolicy::Expanding);
-    ui->curvesLayout2->addItem(item2,limit+1,1,1,1,0);
+    ui->curvesLayout2->addItem(item2,limit + 1, 1, 1, 1, 0);
   }
 
-  for (int i=0; i<CPN_MAX_POINTS; i++) {
+  for (int i = 0; i < CPN_MAX_POINTS; i++) {
     spnx[i] = new QSpinBox(this);
     spnx[i]->setProperty("index", i);
     spnx[i]->setAlignment(Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter);
@@ -199,14 +204,14 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
     ui->pointsLayout->addWidget(spny[i], i, 1, 1, 1);
 
     bool insert;
-    if (firmware->getCapability(EnhancedCurves)) {
+    if (hasEnhanced) {
       insert = (i >= 1);
     }
     else {
-      insert = (i==2 || i==4 || i==8 || i==16);
+      insert = (i == 2 || i == 4 || i ==8 || i == 16);
     }
     if (insert) {
-      ui->curvePoints->addItem(tr("%1 points").arg(i+1), i+1);
+      ui->curvePoints->addItem(tr("%1 points").arg(i + 1), i + 1);
     }
   }
 
@@ -250,7 +255,7 @@ void Curves::update()
 {
   lock = true;
 
-  if (firmware->getCapability(HasCvNames)) {
+  if (hasNames) {
     ui->curveName->setText(model->curves[currentCurve].name);
   }
 
@@ -272,7 +277,7 @@ void Curves::updateCurveType()
 
   int index = 0;
 
-  if (firmware->getCapability(EnhancedCurves)) {
+  if (hasEnhanced) {
     index = model->curves[currentCurve].count - 2;
   }
   else {
@@ -305,35 +310,34 @@ void Curves::updateCurve()
   qreal width  = scene->sceneRect().width();
   qreal height = scene->sceneRect().height();
 
-  qreal centerX = scene->sceneRect().left() + width/2;
-  qreal centerY = scene->sceneRect().top() + height/2;
+  qreal centerX = scene->sceneRect().left() + width / 2;
+  qreal centerY = scene->sceneRect().top() + height / 2;
 
-  QGraphicsSimpleTextItem *ti = scene->addSimpleText(tr("Editing curve %1").arg(currentCurve+1));
+  QGraphicsSimpleTextItem *ti = scene->addSimpleText(tr("Editing curve %1").arg(currentCurve + 1));
   ti->setPos(3, 3);
 
-  scene->addLine(centerX, GFX_MARGIN, centerX, height+GFX_MARGIN);
-  scene->addLine(GFX_MARGIN, centerY, width+GFX_MARGIN, centerY);
+  scene->addLine(centerX, GFX_MARGIN, centerX, height + GFX_MARGIN);
+  scene->addLine(GFX_MARGIN, centerY, width + GFX_MARGIN, centerY);
 
   QPen pen;
   pen.setWidth(1);
   pen.setStyle(Qt::SolidLine);
 
-  int numcurves = firmware->getCapability(NumCurves);
-  for (int k=0; k<numcurves; k++) {
+  for (int k = 0; k < maxCurves; k++) {
     pen.setColor(colors[k]);
-    if (currentCurve!=k && visibleCurves[k]) {
+    if (currentCurve != k && visibleCurves[k]) {
       int numpoints = model->curves[k].count;
-      for (int i=0; i<numpoints-1; i++) {
+      for (int i = 0; i < numpoints - 1; i++) {
         if (model->curves[k].type == CurveData::CURVE_TYPE_CUSTOM)
-          scene->addLine(centerX + (qreal)model->curves[k].points[i].x*width/200,centerY - (qreal)model->curves[k].points[i].y*height/200,centerX + (qreal)model->curves[k].points[i+1].x*width/200,centerY - (qreal)model->curves[k].points[i+1].y*height/200, pen);
+          scene->addLine(centerX + (qreal)model->curves[k].points[i].x*width/200, centerY - (qreal)model->curves[k].points[i].y*height/200,centerX + (qreal)model->curves[k].points[i+1].x*width/200,centerY - (qreal)model->curves[k].points[i+1].y*height/200, pen);
         else
-          scene->addLine(GFX_MARGIN + i*width/(numpoints-1),centerY - (qreal)model->curves[k].points[i].y*height/200,GFX_MARGIN + (i+1)*width/(numpoints-1),centerY - (qreal)model->curves[k].points[i+1].y*height/200, pen);
+          scene->addLine(GFX_MARGIN + i*width/(numpoints-1), centerY - (qreal)model->curves[k].points[i].y*height/200,GFX_MARGIN + (i+1)*width/(numpoints-1),centerY - (qreal)model->curves[k].points[i+1].y*height/200, pen);
       }
     }
   }
 
   int numpoints = model->curves[currentCurve].count;
-  for (int i=0; i<numpoints; i++) {
+  for (int i = 0; i < numpoints; i++) {
     nodel = nodex;
     nodex = new Node();
     nodex->setProperty("index", i);
@@ -341,26 +345,27 @@ void Curves::updateCurve()
     nodex->setBallSize(ui->pointSize->value());
     nodex->setBallHeight(0);
     if (model->curves[currentCurve].type == CurveData::CURVE_TYPE_CUSTOM) {
-      if (i>0 && i<numpoints-1) {
+      if (i > 0 && i < numpoints - 1) {
         nodex->setFixedX(false);
-        nodex->setMinX(model->curves[currentCurve].points[i-1].x);
-        nodex->setMaxX(model->curves[currentCurve].points[i+1].x);
+        nodex->setMinX(model->curves[currentCurve].points[i - 1].x);
+        nodex->setMaxX(model->curves[currentCurve].points[i + 1].x);
       }
       else {
         nodex->setFixedX(true);
       }
-      nodex->setPos(centerX + (qreal)model->curves[currentCurve].points[i].x*width/200,centerY - (qreal)model->curves[currentCurve].points[i].y*height/200);
+      nodex->setPos(centerX + (qreal)model->curves[currentCurve].points[i].x * width / 200, centerY - (qreal)model->curves[currentCurve].points[i].y * height / 200);
     }
     else {
       nodex->setFixedX(true);
-      nodex->setPos(GFX_MARGIN + i*width/(numpoints-1), centerY - (qreal)model->curves[currentCurve].points[i].y*height/200);
+      nodex->setPos(GFX_MARGIN + i * width / (numpoints - 1), centerY - (qreal)model->curves[currentCurve].points[i].y * height / 200);
     }
     connect(nodex, SIGNAL(moved(int, int)), this, SLOT(onNodeMoved(int, int)));
     connect(nodex, SIGNAL(focus()), this, SLOT(onNodeFocus()));
     connect(nodex, SIGNAL(unfocus()), this, SLOT(onNodeUnfocus()));
     connect(nodex, SIGNAL(deleteMe()), this, SLOT(onNodeDelete()));
     scene->addItem(nodex);
-    if (i>0) scene->addItem(new Edge(nodel, nodex));
+    if (i > 0)
+      scene->addItem(new Edge(nodel, nodex));
   }
 
   lock = false;
@@ -371,20 +376,20 @@ void Curves::updateCurvePoints()
   lock = true;
 
   int count = model->curves[currentCurve].count;
-  for (int i=0; i<count; i++) {
+  for (int i = 0; i < count; i++) {
     spny[i]->show();
     spny[i]->setValue(model->curves[currentCurve].points[i].y);
     if (model->curves[currentCurve].type == CurveData::CURVE_TYPE_CUSTOM) {
       spnx[i]->show();
-      if (i==0 || i==model->curves[currentCurve].count-1) {
+      if (i == 0 || i == model->curves[currentCurve].count - 1) {
         spnx[i]->setDisabled(true);
         spnx[i]->setMaximum(+100);
         spnx[i]->setMinimum(-100);
       }
       else {
         spnx[i]->setDisabled(false);
-        spnx[i]->setMaximum(model->curves[currentCurve].points[i+1].x);
-        spnx[i]->setMinimum(model->curves[currentCurve].points[i-1].x);
+        spnx[i]->setMaximum(model->curves[currentCurve].points[i + 1].x);
+        spnx[i]->setMinimum(model->curves[currentCurve].points[i - 1].x);
       }
       spnx[i]->setValue(model->curves[currentCurve].points[i].x);
     }
@@ -392,7 +397,7 @@ void Curves::updateCurvePoints()
       spnx[i]->hide();
     }
   }
-  for (int i=count; i<CPN_MAX_POINTS; i++) {
+  for (int i = count; i < CPN_MAX_POINTS; i++) {
     spny[i]->hide();
     spnx[i]->hide();
   }
@@ -421,9 +426,9 @@ void Curves::onNodeMoved(int x, int y)
     spnx[index]->setValue(x);
     spny[index]->setValue(y);
     if (index > 0)
-      spnx[index-1]->setMaximum(x);
-    if (index < model->curves[currentCurve].count-1)
-      spnx[index+1]->setMinimum(x);
+      spnx[index - 1]->setMaximum(x);
+    if (index < model->curves[currentCurve].count - 1)
+      spnx[index + 1]->setMinimum(x);
     emit modified();
     lock = false;
   }
@@ -444,17 +449,14 @@ void Curves::onNodeUnfocus()
 
 bool Curves::allowCurveType(int points, CurveData::CurveType type)
 {
-  int numcurves = firmware->getCapability(NumCurves);
-
   int totalpoints = 0;
-  for (int i=0; i<numcurves; i++) {
-    int cvPoints = (i==currentCurve ? points : model->curves[i].count);
-    CurveData::CurveType cvType = (i==currentCurve ? type : model->curves[i].type);
-    totalpoints += cvPoints + (cvType==CurveData::CURVE_TYPE_CUSTOM ? cvPoints-2 : 0);
+  for (int i = 0; i < maxCurves; i++) {
+    int cvPoints = (i == currentCurve ? points : model->curves[i].count);
+    CurveData::CurveType cvType = (i == currentCurve ? type : model->curves[i].type);
+    totalpoints += cvPoints + (cvType == CurveData::CURVE_TYPE_CUSTOM ? cvPoints - 2 : 0);
   }
 
-  int fwpoints = firmware->getCapability(NumCurvePoints);
-  if (totalpoints > fwpoints) {
+  if (totalpoints > maxPoints) {
     QMessageBox::warning(this, "companion", tr("Not enough free points in EEPROM to store the curve."));
     return false;
   }
@@ -472,8 +474,8 @@ void Curves::on_curvePoints_currentIndexChanged(int index)
       model->curves[currentCurve].count = numpoints;
 
       // TODO something better + reuse!
-      for (int i=0; i<CPN_MAX_POINTS; i++) {
-        model->curves[currentCurve].points[i].x = (i >= numpoints-1 ? +100 : -100 + (200*i)/(numpoints-1));
+      for (int i = 0; i < CPN_MAX_POINTS; i++) {
+        model->curves[currentCurve].points[i].x = (i >= numpoints - 1 ? +100 : -100 + (200 * i) / (numpoints - 1));
         model->curves[currentCurve].points[i].y = 0;
       }
 
@@ -491,12 +493,13 @@ void Curves::on_curveCustom_currentIndexChanged(int index)
   if (!lock) {
     CurveData::CurveType type = (CurveData::CurveType)index;
     int numpoints = ui->curvePoints->itemData(ui->curvePoints->currentIndex()).toInt();
+
     if (allowCurveType(model->curves[currentCurve].count, type)) {
       model->curves[currentCurve].type = type;
 
       // TODO something better + reuse!
-      for (int i=0; i<CPN_MAX_POINTS; i++) {
-        model->curves[currentCurve].points[i].x = (i >= numpoints-1 ? +100 : -100 + (200*i)/(numpoints-1));
+      for (int i = 0; i < CPN_MAX_POINTS; i++) {
+        model->curves[currentCurve].points[i].x = (i >= numpoints - 1 ? +100 : -100 + (200 * i) / (numpoints - 1));
         model->curves[currentCurve].points[i].y = 0;
       }
 
@@ -525,7 +528,7 @@ void Curves::on_curveName_editingFinished()
 void Curves::resizeEvent(QResizeEvent *event)
 {
   QRect qr = ui->curvePreview->contentsRect();
-  ui->curvePreview->scene()->setSceneRect(GFX_MARGIN, GFX_MARGIN, qr.width()-GFX_MARGIN*2, qr.height()-GFX_MARGIN*2);
+  ui->curvePreview->scene()->setSceneRect(GFX_MARGIN, GFX_MARGIN, qr.width() - GFX_MARGIN * 2, qr.height() - GFX_MARGIN * 2);
   updateCurve();
   ModelPanel::resizeEvent(event);
 }
@@ -559,12 +562,12 @@ void Curves::on_curveApply_clicked()
   int index = ui->curveType->currentIndex();
   int numpoints = model->curves[currentCurve].count;
 
-  for (int i=0; i<numpoints; i++) {
+  for (int i = 0; i < numpoints; i++) {
     float x;
     if (model->curves[currentCurve].type == CurveData::CURVE_TYPE_CUSTOM)
       x = model->curves[currentCurve].points[i].x;
     else
-      x = -100.0 + (200.0/(numpoints-1))*i;
+      x = -100.0 + (200.0 / (numpoints - 1)) * i;
 
     bool apply = false;
     switch (ui->curveSide->currentIndex()) {
@@ -572,11 +575,11 @@ void Curves::on_curveApply_clicked()
         apply = true;
         break;
       case 1:
-        if (x>=0)
+        if (x >= 0)
           apply = true;
         break;
       case 2:
-        if (x<0)
+        if (x < 0)
           apply = true;
         break;
     }
@@ -589,68 +592,6 @@ void Curves::on_curveApply_clicked()
   updateCurve();
   updateCurvePoints();
   emit modified();
-}
-
-void Curves::ShowContextMenu(const QPoint& pos) // this is a slot
-{
-  QPushButton *button = (QPushButton *)sender();
-  int index = button->property("index").toInt();
-  const QClipboard *clipboard = QApplication::clipboard();
-  const QMimeData *mimeData = clipboard->mimeData();
-  QPoint globalPos = button->mapToGlobal(pos);
-  QMenu myMenu;
-  QAction *action;
-  action = myMenu.addAction(CompanionIcon("copy.png"),tr("Copy"));
-  action->setProperty("index", CURVE_COPY);
-
-  action = myMenu.addAction(CompanionIcon("paste.png"),tr("Paste"));
-  if (!mimeData->hasFormat("application/x-companion-curve-item")) {
-    action->setEnabled(false);
-  }
-  action->setProperty("index", CURVE_PASTE);
-
-  action = myMenu.addAction(CompanionIcon("clear.png"),tr("Clear"));
-  action->setProperty("index", CURVE_RESET);
-  action = myMenu.addAction(CompanionIcon("clear.png"),tr("Clear all curves"));
-  action->setProperty("index", CURVE_RESETALL);
-
-  QAction* selectedItem = myMenu.exec(globalPos);
-  if (selectedItem) {
-    int action=selectedItem->property("index").toInt();
-    if (action==CURVE_COPY) {
-      QByteArray curveData;
-      QMimeData *mimeData2 = new QMimeData;
-      curveData.append((char*)&model->curves[index], sizeof(CurveData));
-      mimeData2->setData("application/x-companion-curve-item", curveData);
-      QApplication::clipboard()->setMimeData(mimeData2, QClipboard::Clipboard);
-    }
-    else if (action==CURVE_PASTE) {
-      QByteArray curveData = mimeData->data("application/x-companion-curve-item");
-      CurveData *curve = &model->curves[index];
-      memcpy(curve, curveData.constData(), sizeof(CurveData));
-      update();
-      emit modified();
-    }
-    else if (action==CURVE_RESET) {
-      int res = QMessageBox::question(this, "companion", tr("Are you sure you want to reset curve %1?").arg(index+1), QMessageBox::Yes | QMessageBox::No);
-      if (res == QMessageBox::Yes) {
-        model->curves[index].clear(5);
-        update();
-        emit modified();
-      }
-    }
-    else if (action==CURVE_RESETALL) {
-      int res = QMessageBox::question(this, "companion", tr("Are you sure you want to reset all curves?"), QMessageBox::Yes | QMessageBox::No);
-      if (res == QMessageBox::Yes) {
-        int numcurves = firmware->getCapability(NumCurves);
-        for (int i=0; i<numcurves; i++) {
-          model->curves[i].clear(5);
-        }
-        update();
-        emit modified();
-      }
-    }
-  }
 }
 
 void Curves::onPointSizeEdited()
@@ -690,7 +631,7 @@ void Curves::onSceneNewPoint(int x, int y)
       newidx = numpoints;
     }
     else {
-      for (int i=0; i<numpoints; i++) {
+      for (int i = 0; i < numpoints; i++) {
         if (x < model->curves[currentCurve].points[i].x) {
           newidx = i;
           break;
@@ -699,11 +640,164 @@ void Curves::onSceneNewPoint(int x, int y)
     }
     numpoints++;
     model->curves[currentCurve].count = numpoints;
-    for (int idx=(numpoints-1); idx>(newidx); idx--) {
-      model->curves[currentCurve].points[idx] = model->curves[currentCurve].points[idx-1];
+    for (int idx = (numpoints - 1); idx > newidx; idx--) {
+      model->curves[currentCurve].points[idx] = model->curves[currentCurve].points[idx - 1];
     }
     model->curves[currentCurve].points[newidx].x = x;
     model->curves[currentCurve].points[newidx].y = y;
+    update();
+    emit modified();
+  }
+}
+
+void Curves::onCustomContextMenuRequested(QPoint pos)
+{
+  QPushButton *button = (QPushButton *)sender();
+  selectedIndex = button->property("index").toInt();
+  QPoint globalPos = button->mapToGlobal(pos);
+
+  QMenu contextMenu;
+  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"), this, SLOT(cmCopy()));
+  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"), this, SLOT(cmCut()));
+  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"), this, SLOT(cmPaste()))->setEnabled(hasClipboardData());
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"), this, SLOT(cmClear()));
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"), this, SLOT(cmInsert()))->setEnabled(insertAllowed());
+  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"), this, SLOT(cmDelete()));
+  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"), this, SLOT(cmMoveUp()))->setEnabled(moveUpAllowed());
+  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"), this, SLOT(cmMoveDown()))->setEnabled(moveDownAllowed());
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"), this, SLOT(cmClearAll()));
+
+  contextMenu.exec(globalPos);
+}
+
+bool Curves::hasClipboardData(QByteArray * data) const
+{
+  const QClipboard * clipboard = QApplication::clipboard();
+  const QMimeData * mimeData = clipboard->mimeData();
+  if (mimeData->hasFormat(MIMETYPE_CURVE)) {
+    if (data)
+      data->append(mimeData->data(MIMETYPE_CURVE));
+    return true;
+  }
+  return false;
+}
+
+bool Curves::insertAllowed() const
+{
+  return model->curves[maxCurves - 1].isEmpty();
+}
+
+bool Curves::moveDownAllowed() const
+{
+  return selectedIndex < maxCurves - 1;
+}
+
+bool Curves::moveUpAllowed() const
+{
+  return selectedIndex > 0;
+}
+
+void Curves::cmClear()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  model->curves[selectedIndex].clear(5);
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
+  update();
+  emit modified();
+}
+
+void Curves::cmClearAll()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Curves. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  for (int i = 0; i < maxCurves; i++) {
+    model->curves[i].clear(5);
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, i);
+  }
+  update();
+  emit modified();
+}
+
+void Curves::cmCopy()
+{
+  QByteArray data;
+  data.append((char*)&model->curves[selectedIndex], sizeof(CurveData));
+  QMimeData *mimeData = new QMimeData;
+  mimeData->setData(MIMETYPE_CURVE, data);
+  QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
+}
+
+void Curves::cmCut()
+{
+  cmCopy();
+  cmClear();
+}
+
+void Curves::cmDelete()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  int maxidx = maxCurves - 1;
+  for (int i = selectedIndex; i < maxidx; i++) {
+    if (!model->curves[i].isEmpty() || !model->curves[i + 1].isEmpty()) {
+      memcpy(&model->curves[i], &model->curves[i+1], sizeof(CurveData));
+    }
+  }
+  model->curves[maxidx].clear(5);
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
+  update();
+  emit modified();
+}
+
+void Curves::cmInsert()
+{
+  for (int i = (maxCurves - 1); i > selectedIndex; i--) {
+    if (!model->curves[i].isEmpty() || !model->curves[i-1].isEmpty()) {
+      memcpy(&model->curves[i], &model->curves[i-1], sizeof(CurveData));
+    }
+  }
+  model->curves[selectedIndex].clear(5);
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
+  update();
+  emit modified();
+}
+
+void Curves::cmMoveDown()
+{
+  swapData(selectedIndex, selectedIndex + 1);
+}
+
+void Curves::cmMoveUp()
+{
+  swapData(selectedIndex, selectedIndex - 1);
+}
+
+void Curves::cmPaste()
+{
+  QByteArray data;
+  if (hasClipboardData(&data)) {
+    CurveData *cd = &model->curves[selectedIndex];
+    memcpy(cd, data.constData(), sizeof(CurveData));
+    update();
+    emit modified();
+  }
+}
+
+void Curves::swapData(int idx1, int idx2)
+{
+  if ((idx1 != idx2) && (!model->curves[idx1].isEmpty() || !model->curves[idx2].isEmpty())) {
+    CurveData cdtmp = model->curves[idx2];
+    CurveData *cd1 = &model->curves[idx1];
+    CurveData *cd2 = &model->curves[idx2];
+    memcpy(cd2, cd1, sizeof(CurveData));
+    memcpy(cd1, &cdtmp, sizeof(CurveData));
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     update();
     emit modified();
   }

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -743,13 +743,8 @@ void Curves::cmDelete()
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
 
-  int maxidx = maxCurves - 1;
-  for (int i = selectedIndex; i < maxidx; i++) {
-    if (!model->curves[i].isEmpty() || !model->curves[i + 1].isEmpty()) {
-      memcpy(&model->curves[i], &model->curves[i+1], sizeof(CurveData));
-    }
-  }
-  model->curves[maxidx].clear(5);
+  memmove(&model->curves[selectedIndex], &model->curves[selectedIndex + 1], (CPN_MAX_CURVES - (selectedIndex + 1)) * sizeof(CurveData));
+  model->curves[maxCurves - 1].clear(5);
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
   emit modified();
@@ -757,11 +752,7 @@ void Curves::cmDelete()
 
 void Curves::cmInsert()
 {
-  for (int i = (maxCurves - 1); i > selectedIndex; i--) {
-    if (!model->curves[i].isEmpty() || !model->curves[i-1].isEmpty()) {
-      memcpy(&model->curves[i], &model->curves[i-1], sizeof(CurveData));
-    }
-  }
+  memmove(&model->curves[selectedIndex + 1], &model->curves[selectedIndex], (CPN_MAX_CURVES - (selectedIndex + 1)) * sizeof(CurveData));
   model->curves[selectedIndex].clear(5);
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();

--- a/companion/src/modeledit/curves.h
+++ b/companion/src/modeledit/curves.h
@@ -26,12 +26,7 @@
 #include <QGraphicsScene>
 #include <QGraphicsView>
 
-enum CopyAction {
-  CURVE_COPY,
-  CURVE_PASTE,
-  CURVE_RESET,
-  CURVE_RESETALL
-};
+constexpr char MIMETYPE_CURVE[] = "application/x-companion-curve";
 
 namespace Ui {
   class Curves;
@@ -71,7 +66,6 @@ class Curves : public ModelPanel
 
   private slots:
     void editCurve();
-    void ShowContextMenu(const QPoint& pos);
     void plotCurve(bool checked);
     void on_curveName_editingFinished();
     void on_curvePoints_currentIndexChanged(int index);
@@ -86,6 +80,16 @@ class Curves : public ModelPanel
     void onSceneNewPoint(int x, int y);
     void onPointSizeEdited();
     void onNodeDelete();
+    void onCustomContextMenuRequested(QPoint pos);
+    void cmClear();
+    void cmClearAll();
+    void cmCopy();
+    void cmCut();
+    void cmDelete();
+    void cmInsert();
+    void cmPaste();
+    void cmMoveDown();
+    void cmMoveUp();
 
   protected:
     virtual void resizeEvent(QResizeEvent *event);
@@ -105,6 +109,16 @@ class Curves : public ModelPanel
     bool allowCurveType(int points, CurveData::CurveType type);
     void setPointY(int i, int x, int y);
     CustomScene * scene;
+    int maxCurves;
+    int hasNames;
+    int hasEnhanced;
+    int maxPoints;
+    int selectedIndex;
+    bool hasClipboardData(QByteArray * data = nullptr) const;
+    bool insertAllowed() const;
+    bool moveDownAllowed() const;
+    bool moveUpAllowed() const;
+    void swapData(int idx1, int idx2);
 };
 
 #endif // _CURVES_H_

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -127,7 +127,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     else
       label->setText(tr("GF%1").arg(i+1));
     label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
-    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(fsw_customContextMenuRequested(QPoint)));
+    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)));
     tableLayout->addWidget(i, 0, label);
     // s1.report("label");
 
@@ -608,23 +608,20 @@ void CustomFunctionsPanel::update()
   lock = false;
 }
 
-void CustomFunctionsPanel::fswPaste()
+void CustomFunctionsPanel::cmPaste()
 {
-  const QClipboard *clipboard = QApplication::clipboard();
-  const QMimeData *mimeData = clipboard->mimeData();
-  if (mimeData->hasFormat(MIMETYPE_FSW)) {
-    QByteArray fswData = mimeData->data(MIMETYPE_FSW);
-    CustomFunctionData *fsw = &functions[selectedFunction];
-    memcpy(fsw, fswData.constData(), sizeof(CustomFunctionData));
-    resetCBsAndRefresh(selectedFunction);
+  QByteArray data;
+  if (hasClipboardData(&data)) {
+    memcpy(&functions[selectedIndex], data.constData(), sizeof(CustomFunctionData));
+    resetCBsAndRefresh(selectedIndex);
     emit modified();
   }
 }
 
-void CustomFunctionsPanel::fswDelete()
+void CustomFunctionsPanel::cmDelete()
 {
   int maxidx = fswCapability - 1;
-  for (int i=selectedFunction; i<maxidx; i++) {
+  for (int i=selectedIndex; i<maxidx; i++) {
     if (!functions[i].isEmpty() || !functions[i+1].isEmpty()) {
       CustomFunctionData *fsw1 = &functions[i];
       CustomFunctionData *fsw2 = &functions[i+1];
@@ -637,47 +634,39 @@ void CustomFunctionsPanel::fswDelete()
   emit modified();
 }
 
-void CustomFunctionsPanel::fswCopy()
+void CustomFunctionsPanel::cmCopy()
 {
-  QByteArray fswData;
-  fswData.append((char*)&functions[selectedFunction], sizeof(CustomFunctionData));
+  QByteArray data;
+  data.append((char*)&functions[selectedIndex], sizeof(CustomFunctionData));
   QMimeData *mimeData = new QMimeData;
-  mimeData->setData(MIMETYPE_FSW, fswData);
+  mimeData->setData(MIMETYPE_CUSTOM_FUNCTION, data);
   QApplication::clipboard()->setMimeData(mimeData, QClipboard::Clipboard);
 }
 
-void CustomFunctionsPanel::fswCut()
+void CustomFunctionsPanel::cmCut()
 {
-  fswCopy();
-  fswClear();
+  cmCopy();
+  cmClear();
 }
 
-void CustomFunctionsPanel::fsw_customContextMenuRequested(QPoint pos)
+void CustomFunctionsPanel::onCustomContextMenuRequested(QPoint pos)
 {
   QLabel *label = (QLabel *)sender();
-  selectedFunction = label->property("index").toInt();
-
+  selectedIndex = label->property("index").toInt();
   QPoint globalPos = label->mapToGlobal(pos);
 
-  const QClipboard *clipboard = QApplication::clipboard();
-  const QMimeData *mimeData = clipboard->mimeData();
-  bool hasData = mimeData->hasFormat(MIMETYPE_FSW);
-  bool moveUpAllowed = (selectedFunction > 0);
-  bool moveDownAllowed = (selectedFunction < (fswCapability - 1));
-  bool insertAllowed = (selectedFunction < (fswCapability - 1)) && (functions[fswCapability - 1].isEmpty());
-
   QMenu contextMenu;
-  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"),this,SLOT(fswCopy()));
-  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"),this,SLOT(fswCut()));
-  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"),this,SLOT(fswPaste()))->setEnabled(hasData);
-  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"),this,SLOT(fswClear()));
+  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"),this,SLOT(cmCopy()));
+  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"),this,SLOT(cmCut()));
+  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"),this,SLOT(cmPaste()))->setEnabled(hasClipboardData());
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"),this,SLOT(cmClear()));
   contextMenu.addSeparator();
-  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"),this,SLOT(fswInsert()))->setEnabled(insertAllowed);
-  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"),this,SLOT(fswDelete()));
-  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"),this,SLOT(fswMoveUp()))->setEnabled(moveUpAllowed);
-  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"),this,SLOT(fswMoveDown()))->setEnabled(moveDownAllowed);
+  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"),this,SLOT(cmInsert()))->setEnabled(insertAllowed());
+  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"),this,SLOT(cmDelete()));
+  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"),this,SLOT(cmMoveUp()))->setEnabled(moveUpAllowed());
+  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"),this,SLOT(cmMoveDown()))->setEnabled(moveDownAllowed());
   contextMenu.addSeparator();
-  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"),this,SLOT(fswClearAll()));
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"),this,SLOT(cmClearAll()));
 
   contextMenu.exec(globalPos);
 }
@@ -762,25 +751,28 @@ void CustomFunctionsPanel::populateFuncParamCB(QComboBox *b, uint function, unsi
   }
 }
 
-void CustomFunctionsPanel::fswMoveUp()
+void CustomFunctionsPanel::cmMoveUp()
 {
-  swapFuncData(selectedFunction, selectedFunction - 1);
+  swapData(selectedIndex, selectedIndex - 1);
 }
 
-void CustomFunctionsPanel::fswMoveDown()
+void CustomFunctionsPanel::cmMoveDown()
 {
-  swapFuncData(selectedFunction, selectedFunction + 1);
+  swapData(selectedIndex, selectedIndex + 1);
 }
 
-void CustomFunctionsPanel::fswClear()
+void CustomFunctionsPanel::cmClear()
 {
-  functions[selectedFunction].clear();
-  resetCBsAndRefresh(selectedFunction);
+  functions[selectedIndex].clear();
+  resetCBsAndRefresh(selectedIndex);
   emit modified();
 }
 
-void CustomFunctionsPanel::fswClearAll()
+void CustomFunctionsPanel::cmClearAll()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Special Functions. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   for (int i=0; i<fswCapability; i++) {
     functions[i].clear();
     resetCBsAndRefresh(i);
@@ -788,18 +780,18 @@ void CustomFunctionsPanel::fswClearAll()
   emit modified();
 }
 
-void CustomFunctionsPanel::fswInsert()
+void CustomFunctionsPanel::cmInsert()
 {
-  for (int i=(fswCapability - 1); i>selectedFunction; i--) {
+  for (int i=(fswCapability - 1); i>selectedIndex; i--) {
     if (!functions[i].isEmpty() || !functions[i-1].isEmpty()) {
       memcpy(&functions[i], &functions[i-1], sizeof(CustomFunctionData));
       resetCBsAndRefresh(i);
     }
   }
-  fswClear();
+  cmClear();
 }
 
-void CustomFunctionsPanel::swapFuncData(int idx1, int idx2)
+void CustomFunctionsPanel::swapData(int idx1, int idx2)
 {
   if ((idx1 != idx2) && (!functions[idx1].isEmpty() || !functions[idx2].isEmpty())) {
     CustomFunctionData fswtmp = functions[idx2];
@@ -822,4 +814,31 @@ void CustomFunctionsPanel::resetCBsAndRefresh(int idx)
   populateFuncParamCB(fswtchParamT[idx], functions[idx].func, functions[idx].param, functions[idx].adjustMode);
   refreshCustomFunction(idx);
   lock = false;
+}
+
+bool CustomFunctionsPanel::hasClipboardData(QByteArray * data) const
+{
+  const QClipboard * clipboard = QApplication::clipboard();
+  const QMimeData * mimeData = clipboard->mimeData();
+  if (mimeData->hasFormat(MIMETYPE_CUSTOM_FUNCTION)) {
+    if (data)
+      data->append(mimeData->data(MIMETYPE_CUSTOM_FUNCTION));
+    return true;
+  }
+  return false;
+}
+
+bool CustomFunctionsPanel::insertAllowed() const
+{
+  return ((selectedIndex < fswCapability - 1) && (model->curves[fswCapability - 1].isEmpty()));
+}
+
+bool CustomFunctionsPanel::moveDownAllowed() const
+{
+  return selectedIndex < fswCapability - 1;
+}
+
+bool CustomFunctionsPanel::moveUpAllowed() const
+{
+  return selectedIndex > 0;
 }

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -620,6 +620,9 @@ void CustomFunctionsPanel::cmPaste()
 
 void CustomFunctionsPanel::cmDelete()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Special Function. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   int maxidx = fswCapability - 1;
   for (int i=selectedIndex; i<maxidx; i++) {
     if (!functions[i].isEmpty() || !functions[i+1].isEmpty()) {
@@ -763,6 +766,9 @@ void CustomFunctionsPanel::cmMoveDown()
 
 void CustomFunctionsPanel::cmClear()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Special Function. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   functions[selectedIndex].clear();
   resetCBsAndRefresh(selectedIndex);
   emit modified();

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -623,17 +623,12 @@ void CustomFunctionsPanel::cmDelete()
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Special Function. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
 
-  int maxidx = fswCapability - 1;
-  for (int i=selectedIndex; i<maxidx; i++) {
-    if (!functions[i].isEmpty() || !functions[i+1].isEmpty()) {
-      CustomFunctionData *fsw1 = &functions[i];
-      CustomFunctionData *fsw2 = &functions[i+1];
-      memcpy(fsw1, fsw2, sizeof(CustomFunctionData));
-      resetCBsAndRefresh(i);
-    }
+  memmove(&functions[selectedIndex], &functions[selectedIndex + 1], (CPN_MAX_SPECIAL_FUNCTIONS - (selectedIndex + 1)) * sizeof(CustomFunctionData));
+  functions[fswCapability - 1].clear();
+
+  for (int i = selectedIndex; i < (fswCapability - 1); i++) {
+    resetCBsAndRefresh(i);
   }
-  functions[maxidx].clear();
-  resetCBsAndRefresh(maxidx);
   emit modified();
 }
 
@@ -788,13 +783,12 @@ void CustomFunctionsPanel::cmClearAll()
 
 void CustomFunctionsPanel::cmInsert()
 {
-  for (int i=(fswCapability - 1); i>selectedIndex; i--) {
-    if (!functions[i].isEmpty() || !functions[i-1].isEmpty()) {
-      memcpy(&functions[i], &functions[i-1], sizeof(CustomFunctionData));
-      resetCBsAndRefresh(i);
-    }
+  memmove(&functions[selectedIndex + 1], &functions[selectedIndex], (CPN_MAX_SPECIAL_FUNCTIONS - (selectedIndex + 1)) * sizeof(CustomFunctionData));
+  functions[selectedIndex].clear();
+
+  for (int i = selectedIndex; i < (fswCapability - 1); i++) {
+    resetCBsAndRefresh(i);
   }
-  cmClear();
 }
 
 void CustomFunctionsPanel::swapData(int idx1, int idx2)

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -30,7 +30,7 @@ class RawSourceFilterItemModel;
 class RawSwitchFilterItemModel;
 class TimerEdit;
 
-constexpr char MIMETYPE_FSW[] = "application/x-companion-fsw";
+constexpr char MIMETYPE_CUSTOM_FUNCTION[] = "application/x-companion-custom-function";
 
 class RepeatComboBox: public QComboBox
 {
@@ -67,7 +67,7 @@ class CustomFunctionsPanel : public GenericPanel
     void updateDataModels();
     void customFunctionEdited();
     void functionEdited();
-    void fsw_customContextMenuRequested(QPoint pos);
+    void onCustomContextMenuRequested(QPoint pos);
     void refreshCustomFunction(int index, bool modified=false);
     void onChildModified();
     bool playSound(int index);
@@ -75,21 +75,25 @@ class CustomFunctionsPanel : public GenericPanel
     void toggleSound(bool play);
     void onMediaPlayerStateChanged(QMediaPlayer::State state);
     void onMediaPlayerError(QMediaPlayer::Error error);
-    void fswDelete();
-    void fswCopy();
-    void fswPaste();
-    void fswCut();
-    void fswMoveUp();
-    void fswMoveDown();
-    void fswInsert();
-    void fswClear();
-    void fswClearAll();
+    void cmDelete();
+    void cmCopy();
+    void cmPaste();
+    void cmCut();
+    void cmMoveUp();
+    void cmMoveDown();
+    void cmInsert();
+    void cmClear();
+    void cmClearAll();
 
   private:
     void populateFuncCB(QComboBox *b, unsigned int value);
     void populateGVmodeCB(QComboBox *b, unsigned int value);
     void populateFuncParamCB(QComboBox *b, uint function, unsigned int value, unsigned int adjustmode=0);
-    void swapFuncData(int idx1, int idx2);
+    bool hasClipboardData(QByteArray * data = nullptr) const;
+    bool insertAllowed() const;
+    bool moveDownAllowed() const;
+    bool moveUpAllowed() const;
+    void swapData(int idx1, int idx2);
     void resetCBsAndRefresh(int idx);
     RawSwitchFilterItemModel * rawSwitchItemModel;
     RawSourceFilterItemModel * rawSrcAllItemModel;
@@ -113,7 +117,7 @@ class CustomFunctionsPanel : public GenericPanel
     QSlider * fswtchBLcolor[CPN_MAX_SPECIAL_FUNCTIONS];
     QMediaPlayer * mediaPlayer;
 
-    int selectedFunction;
+    int selectedIndex;
     int fswCapability;
 
 };

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -219,6 +219,7 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
       label->setText(tr("GVAR%1").arg(i + 1));
       label->setProperty("index", i);
       label->setContextMenuPolicy(Qt::CustomContextMenu);
+      label->setToolTip(tr("Popup menu available"));
       connect(label, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(gvOnCustomContextMenuRequested(const QPoint &)));
       gvLayout->addWidget(label, i + 1, col++, 1, 1);
       // GVar name

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -455,6 +455,7 @@ void FlightModePanel::phaseGVValue_editingFinished()
     QDoubleSpinBox *spinBox = qobject_cast<QDoubleSpinBox*>(sender());
     int gvar = spinBox->property("index").toInt();
     phase.gvars[gvar] = spinBox->value() * model->gvarData[gvar].multiplierSet();
+    emit datachanged();
     emit modified();
   }
 }
@@ -466,6 +467,7 @@ void FlightModePanel::GVName_editingFinished()
     int gvar = lineedit->property("index").toInt();
     memset(&model->gvarData[gvar].name, 0, sizeof(model->gvarData[gvar].name));
     strcpy(model->gvarData[gvar].name, lineedit->text().toLatin1());
+    emit datachanged();
     emit modified();
   }
 }
@@ -482,9 +484,9 @@ void FlightModePanel::phaseGVUse_currentIndexChanged(int index)
     else {
       phase.gvars[gvar] = GVAR_MAX_VALUE + index;
     }
-    updateGVar(gvar);
     if (model->isGVarLinkedCircular(phaseIdx, gvar))
       QMessageBox::warning(this, "Companion", tr("Warning: Global variable links back to itself. Flight Mode 0 value used."));
+    emit datachanged();
     emit modified();
     lock = false;
   }
@@ -496,7 +498,7 @@ void FlightModePanel::phaseGVUnit_currentIndexChanged(int index)
     QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
     int gvar = comboBox->property("index").toInt();
     model->gvarData[gvar].unit = index;
-    updateGVar(gvar);
+    emit datachanged();
     emit modified();
   }
 }
@@ -507,7 +509,7 @@ void FlightModePanel::phaseGVPrec_currentIndexChanged(int index)
     QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
     int gvar = comboBox->property("index").toInt();
     model->gvarData[gvar].prec = index;
-    updateGVar(gvar);
+    emit datachanged();
     emit modified();
   }
 }
@@ -530,7 +532,7 @@ void FlightModePanel::phaseGVMin_editingFinished()
         }
       }
     }
-    updateGVar(gvar);
+    emit datachanged();
     emit modified();
   }
 }
@@ -553,7 +555,7 @@ void FlightModePanel::phaseGVMax_editingFinished()
         }
       }
     }
-    updateGVar(gvar);
+    emit datachanged();
     emit modified();
   }
 }

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -686,7 +686,7 @@ bool FlightModePanel::hasClipboardData(QByteArray * data) const
 
 bool FlightModePanel::insertAllowed() const
 {
-  return model->flightModeData[fmCount - 1].isEmpty(fmCount - 1);
+  return ((phaseIdx < fmCount - 1) && (model->flightModeData[fmCount - 1].isEmpty(fmCount - 1)));
 }
 
 bool FlightModePanel::moveDownAllowed() const

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -316,6 +316,8 @@ void FlightModePanel::update()
   for (int i = 0; i < reCount; i++) {
     updateRotaryEncoder(i);
   }
+
+  emit nameModified();
 }
 
 void FlightModePanel::updateGVar(int index)
@@ -737,9 +739,8 @@ void FlightModePanel::cmClear()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_CLEAR, phaseIdx);
 
-  update();
+  emit datachanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::cmClearAll()
@@ -766,7 +767,6 @@ void FlightModePanel::cmClearAll()
 
   emit datachanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::cmCopy()
@@ -844,7 +844,6 @@ void FlightModePanel::cmDelete()
 
   emit datachanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::cmInsert()
@@ -896,7 +895,6 @@ void FlightModePanel::cmInsert()
 
   emit datachanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::cmMoveDown()
@@ -944,9 +942,8 @@ void FlightModePanel::cmPaste()
       }
     }
 
-    update();
+    emit datachanged();
     emit modified();
-    emit nameModified();
   }
 }
 
@@ -1036,7 +1033,6 @@ void FlightModePanel::swapData(int idx1, int idx2)
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
   emit datachanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::gvOnCustomContextMenuRequested(QPoint pos)

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -26,6 +26,10 @@
 
 class RawSwitchFilterItemModel;
 
+constexpr char MIMETYPE_FLIGHTMODE[] = "application/x-companion-flightmode";
+constexpr char MIMETYPE_GVAR_PARAMS[]  = "application/x-companion-gvar-params";
+constexpr char MIMETYPE_GVAR_VALUE[] = "application/x-companion-gvar-value";
+
 namespace Ui {
   class FlightMode;
 }
@@ -42,6 +46,7 @@ class FlightModePanel : public ModelPanel
 
   signals:
     void nameModified();
+    void datachanged();
 
   private slots:
     void phaseName_editingFinished();
@@ -61,18 +66,36 @@ class FlightModePanel : public ModelPanel
     void phaseGVMax_editingFinished();
     void phaseREValue_editingFinished();
     void phaseREUse_currentIndexChanged(int index);
-    void name_customContextMenuRequested(const QPoint & pos);
-    void fmClear();
-    void gvLabel_customContextMenuRequested(const QPoint & pos);
-    void gvClear();
+    void onCustomContextMenuRequested(QPoint pos);
+    void cmClear();
+    void cmClearAll();
+    void cmCopy();
+    void cmCut();
+    void cmDelete();
+    void cmInsert();
+    void cmPaste();
+    void cmMoveDown();
+    void cmMoveUp();
+    void gvOnCustomContextMenuRequested(QPoint pos);
+    void gvCmClear();
+    void gvCmClearAll();
+    void gvCmCopy();
+    void gvCmCut();
+    void gvCmDelete();
+    void gvCmInsert();
+    void gvCmPaste();
+    void gvCmMoveDown();
+    void gvCmMoveUp();
 
   private:
     Ui::FlightMode *ui;
     int phaseIdx;
     FlightModeData & phase;
+    int fmCount;
     int reCount;
     int gvCount;
     int gvIdx;
+    int trimCount;
     QVector<QLabel *> trimsLabel;
     QLineEdit * gvNames[CPN_MAX_GVARS];
     QDoubleSpinBox * gvValues[CPN_MAX_GVARS];
@@ -88,12 +111,27 @@ class FlightModePanel : public ModelPanel
     QVector<QSpinBox *> trimsValue;
     QVector<QSlider *> trimsSlider;
     RawSwitchFilterItemModel * rawSwitchItemModel;
+    Board::Type board;
 
     void trimUpdate(unsigned int trim);
     void updateGVar(int index);
+    void updateRotaryEncoder(int index);
     void setGVSB(QDoubleSpinBox * spinBox, int min, int max, int val);
     void populateGvarUnitCB(QComboBox * cb);
     void populateGvarPrecCB(QComboBox * cb);
+    bool hasClipboardData(QByteArray * data = nullptr) const;
+    bool insertAllowed() const;
+    bool moveDownAllowed() const;
+    bool moveUpAllowed() const;
+    void swapData(int idx1, int idx2);
+    bool gvHasClipboardData() const;
+    bool gvHasDefnClipboardData(QByteArray * data = nullptr) const;
+    bool gvHasValueClipboardData(QByteArray * data = nullptr) const;
+    bool gvDeleteAllowed() const;
+    bool gvInsertAllowed() const;
+    bool gvMoveDownAllowed() const;
+    bool gvMoveUpAllowed() const;
+    void gvSwapData(int idx1, int idx2);
 };
 
 class FlightModesPanel : public ModelPanel

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -25,6 +25,8 @@
 #include "mixerslistwidget.h"
 #include "modelprinter.h"
 
+constexpr char MIMETYPE_EXPO[] = "application/x-companion-expo";
+
 class InputsPanel : public ModelPanel
 {
     Q_OBJECT
@@ -52,12 +54,19 @@ class InputsPanel : public ModelPanel
     void expoOpen(QListWidgetItem *item = NULL);
     void expoAdd();
     void maybeCopyInputName(int srcChan, int destChan);
+    void cmInputClear();
+    void cmInputDelete();
+    void cmInputInsert();
+    void cmInputMoveDown();
+    void cmInputMoveUp();
 
   private:
     bool expoInserted;
     MixersListWidget *ExposlistWidget;
     int inputsCount;
     ModelPrinter modelPrinter;
+    int selectedIdx;
+    int inputIdx;
 
     int getExpoIndex(unsigned int dch);
     bool gm_insertExpo(int idx);
@@ -70,7 +79,14 @@ class InputsPanel : public ModelPanel
     void pasteExpoMimeData(const QMimeData * mimeData, int destIdx);
     void AddInputLine(int dest);
     QString getInputText(int dest, bool newChan);
-
+    bool cmInputInsertAllowed() const;
+    bool cmInputMoveDownAllowed() const;
+    bool cmInputMoveUpAllowed() const;
+    void cmInputSwapData(int idx1, int idx2);
+    bool isInputIndex(const int index);
+    bool isExpoIndex(const int index);
+    int getIndexFromSelected();
+    int getInputIndexFromSelected();
 };
 
 #endif // _INPUTS_H_

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -35,19 +35,22 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   const int srcGroups = firmware->getCapability(GvarsInCS) ? 0 : (RawSource::AllSourceGroups & ~RawSource::GVarsGroup);
   rawSourceItemModel = new RawSourceFilterItemModel(&generalSettings, &model, srcGroups, this);
 
+  lsCapability = firmware->getCapability(LogicalSwitches);
+  lsCapabilityExt = firmware->getCapability(LogicalSwitchesExt);
+
   QStringList headerLabels;
   headerLabels << "#" << tr("Function") << tr("V1") << tr("V2") << tr("AND Switch");
-  if (firmware->getCapability(LogicalSwitchesExt)) {
+  if (lsCapabilityExt) {
     headerLabels << tr("Duration") << tr("Delay");
   }
-  TableLayout * tableLayout = new TableLayout(this, firmware->getCapability(LogicalSwitches), headerLabels);
+  TableLayout * tableLayout = new TableLayout(this, lsCapability, headerLabels);
 
   s1.report("header");
 
   const int channelsMax = model.getChannelsMax(true);
 
   lock = true;
-  for (int i=0; i<firmware->getCapability(LogicalSwitches); i++) {
+  for (int i=0; i<lsCapability; i++) {
     // The label
     QLabel * label = new QLabel(this);
     label->setProperty("index", i);
@@ -56,96 +59,96 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
     label->setToolTip(tr("Popup menu available"));
     label->setMouseTracking(true);
     label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
-    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(csw_customContextMenuRequested(QPoint)));
+    connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)));
     tableLayout->addWidget(i, 0, label);
 
     // The function
-    csw[i] = new QComboBox(this);
-    csw[i]->setProperty("index", i);
-    populateCSWCB(csw[i]);
-    connect(csw[i], SIGNAL(currentIndexChanged(int)), this, SLOT(functionChanged()));
-    tableLayout->addWidget(i, 1, csw[i]);
+    cbFunction[i] = new QComboBox(this);
+    cbFunction[i]->setProperty("index", i);
+    populateFunctionCB(cbFunction[i]);
+    connect(cbFunction[i], SIGNAL(currentIndexChanged(int)), this, SLOT(onFunctionChanged()));
+    tableLayout->addWidget(i, 1, cbFunction[i]);
 
     // V1
     QHBoxLayout *v1Layout = new QHBoxLayout();
-    cswitchSource1[i] = new QComboBox(this);
-    cswitchSource1[i]->setProperty("index",i);
-    connect(cswitchSource1[i], SIGNAL(currentIndexChanged(int)), this, SLOT(v1Edited(int)));
-    v1Layout->addWidget(cswitchSource1[i]);
-    cswitchSource1[i]->setVisible(false);
-    cswitchValue[i] = new QDoubleSpinBox(this);
-    cswitchValue[i]->setMaximum(channelsMax);
-    cswitchValue[i]->setMinimum(-channelsMax);
-    cswitchValue[i]->setAccelerated(true);
-    cswitchValue[i]->setDecimals(0);
-    cswitchValue[i]->setProperty("index", i);
-    connect(cswitchValue[i], SIGNAL(editingFinished()), this, SLOT(offsetEdited()));
-    v1Layout->addWidget(cswitchValue[i]);
-    cswitchValue[i]->setVisible(false);
+    cbSource1[i] = new QComboBox(this);
+    cbSource1[i]->setProperty("index",i);
+    connect(cbSource1[i], SIGNAL(currentIndexChanged(int)), this, SLOT(onV1Changed(int)));
+    v1Layout->addWidget(cbSource1[i]);
+    cbSource1[i]->setVisible(false);
+    dsbValue[i] = new QDoubleSpinBox(this);
+    dsbValue[i]->setMaximum(channelsMax);
+    dsbValue[i]->setMinimum(-channelsMax);
+    dsbValue[i]->setAccelerated(true);
+    dsbValue[i]->setDecimals(0);
+    dsbValue[i]->setProperty("index", i);
+    connect(dsbValue[i], SIGNAL(editingFinished()), this, SLOT(onOffsetChanged()));
+    v1Layout->addWidget(dsbValue[i]);
+    dsbValue[i]->setVisible(false);
     tableLayout->addLayout(i, 2, v1Layout);
 
     // V2
     QHBoxLayout *v2Layout = new QHBoxLayout();
-    cswitchSource2[i] = new QComboBox(this);
-    cswitchSource2[i]->setProperty("index", i);
-    connect(cswitchSource2[i], SIGNAL(currentIndexChanged(int)), this, SLOT(v2Edited(int)));
-    v2Layout->addWidget(cswitchSource2[i]);
-    cswitchSource2[i]->setVisible(false);
-    cswitchOffset[i] = new QDoubleSpinBox(this);
-    cswitchOffset[i]->setProperty("index",i);
-    cswitchOffset[i]->setMaximum(channelsMax);
-    cswitchOffset[i]->setMinimum(-channelsMax);
-    cswitchOffset[i]->setAccelerated(true);
-    cswitchOffset[i]->setDecimals(0);
-    connect(cswitchOffset[i], SIGNAL(editingFinished()), this, SLOT(offsetEdited()));
-    cswitchOffset[i]->setVisible(false);
-    v2Layout->addWidget(cswitchOffset[i]);
-    cswitchOffset2[i] = new QDoubleSpinBox(this);
-    cswitchOffset2[i]->setProperty("index",i);
-    cswitchOffset2[i]->setMaximum(channelsMax);
-    cswitchOffset2[i]->setMinimum(-channelsMax);
-    cswitchOffset2[i]->setAccelerated(true);
-    cswitchOffset2[i]->setDecimals(0);
-    cswitchOffset2[i]->setSpecialValueText(" " + tr("(instant)"));
-    connect(cswitchOffset2[i], SIGNAL(editingFinished()), this, SLOT(offsetEdited()));
-    cswitchOffset2[i]->setVisible(false);
-    v2Layout->addWidget(cswitchOffset2[i]);
-    cswitchTOffset[i] = new TimerEdit(this);
-    cswitchTOffset[i]->setProperty("index",i);
-    connect(cswitchTOffset[i],SIGNAL(editingFinished()),this,SLOT(offsetEdited()));
-    v2Layout->addWidget(cswitchTOffset[i]);
-    cswitchTOffset[i]->setVisible(false);
+    cbSource2[i] = new QComboBox(this);
+    cbSource2[i]->setProperty("index", i);
+    connect(cbSource2[i], SIGNAL(currentIndexChanged(int)), this, SLOT(onV2Changed(int)));
+    v2Layout->addWidget(cbSource2[i]);
+    cbSource2[i]->setVisible(false);
+    dsbOffset[i] = new QDoubleSpinBox(this);
+    dsbOffset[i]->setProperty("index",i);
+    dsbOffset[i]->setMaximum(channelsMax);
+    dsbOffset[i]->setMinimum(-channelsMax);
+    dsbOffset[i]->setAccelerated(true);
+    dsbOffset[i]->setDecimals(0);
+    connect(dsbOffset[i], SIGNAL(editingFinished()), this, SLOT(onOffsetChanged()));
+    dsbOffset[i]->setVisible(false);
+    v2Layout->addWidget(dsbOffset[i]);
+    dsbOffset2[i] = new QDoubleSpinBox(this);
+    dsbOffset2[i]->setProperty("index",i);
+    dsbOffset2[i]->setMaximum(channelsMax);
+    dsbOffset2[i]->setMinimum(-channelsMax);
+    dsbOffset2[i]->setAccelerated(true);
+    dsbOffset2[i]->setDecimals(0);
+    dsbOffset2[i]->setSpecialValueText(" " + tr("(instant)"));
+    connect(dsbOffset2[i], SIGNAL(editingFinished()), this, SLOT(onOffsetChanged()));
+    dsbOffset2[i]->setVisible(false);
+    v2Layout->addWidget(dsbOffset2[i]);
+    teOffset[i] = new TimerEdit(this);
+    teOffset[i]->setProperty("index",i);
+    connect(teOffset[i],SIGNAL(editingFinished()),this,SLOT(onOffsetChanged()));
+    v2Layout->addWidget(teOffset[i]);
+    teOffset[i]->setVisible(false);
     tableLayout->addLayout(i, 3, v2Layout);
 
     // AND
-    cswitchAnd[i] = new QComboBox(this);
-    cswitchAnd[i]->setProperty("index", i);
-    populateAndSwitchCB(cswitchAnd[i]);
-    connect(cswitchAnd[i], SIGNAL(currentIndexChanged(int)), this, SLOT(andEdited(int)));
-    tableLayout->addWidget(i, 4, cswitchAnd[i]);
+    cbAndSwitch[i] = new QComboBox(this);
+    cbAndSwitch[i]->setProperty("index", i);
+    populateAndSwitchCB(cbAndSwitch[i]);
+    connect(cbAndSwitch[i], SIGNAL(currentIndexChanged(int)), this, SLOT(onAndSwitchChanged(int)));
+    tableLayout->addWidget(i, 4, cbAndSwitch[i]);
 
-    if (firmware->getCapability(LogicalSwitchesExt)) {
+    if (lsCapabilityExt) {
       // Duration
-      cswitchDuration[i] = new QDoubleSpinBox(this);
-      cswitchDuration[i]->setProperty("index", i);
-      cswitchDuration[i]->setSingleStep(0.1);
-      cswitchDuration[i]->setMaximum(25);
-      cswitchDuration[i]->setMinimum(0);
-      cswitchDuration[i]->setAccelerated(true);
-      cswitchDuration[i]->setDecimals(1);
-      connect(cswitchDuration[i], SIGNAL(valueChanged(double)), this, SLOT(durationEdited(double)));
-      tableLayout->addWidget(i, 5, cswitchDuration[i]);
+      dsbDuration[i] = new QDoubleSpinBox(this);
+      dsbDuration[i]->setProperty("index", i);
+      dsbDuration[i]->setSingleStep(0.1);
+      dsbDuration[i]->setMaximum(25);
+      dsbDuration[i]->setMinimum(0);
+      dsbDuration[i]->setAccelerated(true);
+      dsbDuration[i]->setDecimals(1);
+      connect(dsbDuration[i], SIGNAL(valueChanged(double)), this, SLOT(onDurationChanged(double)));
+      tableLayout->addWidget(i, 5, dsbDuration[i]);
 
       // Delay
-      cswitchDelay[i] = new QDoubleSpinBox(this);
-      cswitchDelay[i]->setProperty("index", i);
-      cswitchDelay[i]->setSingleStep(0.1);
-      cswitchDelay[i]->setMaximum(25);
-      cswitchDelay[i]->setMinimum(0);
-      cswitchDelay[i]->setAccelerated(true);
-      cswitchDelay[i]->setDecimals(1);
-      connect(cswitchDelay[i], SIGNAL(valueChanged(double)), this, SLOT(delayEdited(double)));
-      tableLayout->addWidget(i, 6, cswitchDelay[i]);
+      dsbDelay[i] = new QDoubleSpinBox(this);
+      dsbDelay[i]->setProperty("index", i);
+      dsbDelay[i]->setSingleStep(0.1);
+      dsbDelay[i]->setMaximum(25);
+      dsbDelay[i]->setMinimum(0);
+      dsbDelay[i]->setAccelerated(true);
+      dsbDelay[i]->setDecimals(1);
+      connect(dsbDelay[i], SIGNAL(valueChanged(double)), this, SLOT(onDelayChanged(double)));
+      tableLayout->addWidget(i, 6, dsbDelay[i]);
     }
   }
 
@@ -155,7 +158,7 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   lock = false;
   update();
   tableLayout->resizeColumnsToContents();
-  tableLayout->pushRowsUp(firmware->getCapability(LogicalSwitches)+1);
+  tableLayout->pushRowsUp(lsCapability+1);
   s1.report("end");
 }
 
@@ -172,10 +175,10 @@ void LogicalSwitchesPanel::updateDataModels()
   lock = oldLock;
 }
 
-void LogicalSwitchesPanel::functionChanged()
+void LogicalSwitchesPanel::onFunctionChanged()
 {
   int i = sender()->property("index").toInt();
-  unsigned newFunc = csw[i]->currentData().toUInt();
+  unsigned newFunc = cbFunction[i]->currentData().toUInt();
 
   if (model->logicalSw[i].func == newFunc)
     return;
@@ -204,13 +207,13 @@ void LogicalSwitchesPanel::functionChanged()
   emit modified();
 }
 
-void LogicalSwitchesPanel::v1Edited(int value)
+void LogicalSwitchesPanel::onV1Changed(int value)
 {
   if (!lock) {
     int i = sender()->property("index").toInt();
-    model->logicalSw[i].val1 = cswitchSource1[i]->itemData(value).toInt();
+    model->logicalSw[i].val1 = cbSource1[i]->itemData(value).toInt();
     if (model->logicalSw[i].getFunctionFamily() == LS_FAMILY_VOFS) {
-      if (!offsetEditedAt(i))
+      if (!offsetChangedAt(i))
         updateLine(i);
     }
     else {
@@ -219,25 +222,25 @@ void LogicalSwitchesPanel::v1Edited(int value)
   }
 }
 
-void LogicalSwitchesPanel::v2Edited(int value)
+void LogicalSwitchesPanel::onV2Changed(int value)
 {
   if (!lock) {
     int i = sender()->property("index").toInt();
-    model->logicalSw[i].val2 = cswitchSource2[i]->itemData(value).toInt();
+    model->logicalSw[i].val2 = cbSource2[i]->itemData(value).toInt();
     emit modified();
   }
 }
 
-void LogicalSwitchesPanel::andEdited(int value)
+void LogicalSwitchesPanel::onAndSwitchChanged(int value)
 {
   if (!lock) {
     int index = sender()->property("index").toInt();
-    model->logicalSw[index].andsw = cswitchAnd[index]->itemData(value).toInt();
+    model->logicalSw[index].andsw = cbAndSwitch[index]->itemData(value).toInt();
     emit modified();
   }
 }
 
-void LogicalSwitchesPanel::durationEdited(double duration)
+void LogicalSwitchesPanel::onDurationChanged(double duration)
 {
   if (!lock) {
     int index = sender()->property("index").toInt();
@@ -246,7 +249,7 @@ void LogicalSwitchesPanel::durationEdited(double duration)
   }
 }
 
-void LogicalSwitchesPanel::delayEdited(double delay)
+void LogicalSwitchesPanel::onDelayChanged(double delay)
 {
   if (!lock) {
     int index = sender()->property("index").toInt();
@@ -255,12 +258,12 @@ void LogicalSwitchesPanel::delayEdited(double delay)
   }
 }
 
-void LogicalSwitchesPanel::offsetEdited()
+void LogicalSwitchesPanel::onOffsetChanged()
 {
-  offsetEditedAt(sender()->property("index").toInt());
+  offsetChangedAt(sender()->property("index").toInt());
 }
 
-bool LogicalSwitchesPanel::offsetEditedAt(int index)
+bool LogicalSwitchesPanel::offsetChangedAt(int index)
 {
   if (lock)
     return false;
@@ -275,7 +278,7 @@ bool LogicalSwitchesPanel::offsetEditedAt(int index)
     {
       RawSource source = RawSource(model->logicalSw[index].val1);
       RawSourceRange range = source.getRange(model, generalSettings, model->logicalSw[index].getRangeFlags());
-      double currVal = source.isTimeBased() ? cswitchTOffset[index]->timeInSeconds() : cswitchOffset[index]->value();
+      double currVal = source.isTimeBased() ? teOffset[index]->timeInSeconds() : dsbOffset[index]->value();
       value = round((currVal - range.offset) / range.step);
       mod = (mod || value != model->logicalSw[index].val2);
       model->logicalSw[index].val2 = value;
@@ -283,22 +286,22 @@ bool LogicalSwitchesPanel::offsetEditedAt(int index)
     }
 
     case LS_FAMILY_TIMER:
-      value = TimToVal(cswitchValue[index]->value());
+      value = TimToVal(dsbValue[index]->value());
       mod = (mod || value != model->logicalSw[index].val1);
       model->logicalSw[index].val1 = value;
-      value = TimToVal(cswitchOffset[index]->value());
+      value = TimToVal(dsbOffset[index]->value());
       mod = (mod || value != model->logicalSw[index].val2);
       model->logicalSw[index].val2 = value;
       break;
 
     case LS_FAMILY_EDGE:
-      if (sender() == cswitchOffset[index]) {
-        value = TimToVal(cswitchOffset[index]->value());
+      if (sender() == dsbOffset[index]) {
+        value = TimToVal(dsbOffset[index]->value());
         mod = (mod || value != model->logicalSw[index].val2);
         model->logicalSw[index].val2 = value;
       }
       else {
-        value = TimToVal(cswitchOffset2[index]->value()) - model->logicalSw[index].val2;
+        value = TimToVal(dsbOffset2[index]->value()) - model->logicalSw[index].val2;
         mod = (mod || value != model->logicalSw[index].val3);
         model->logicalSw[index].val3 = value;
       }
@@ -347,8 +350,8 @@ void LogicalSwitchesPanel::updateLine(int i)
   lock = true;
   unsigned int mask;
 
-  csw[i]->setCurrentIndex(csw[i]->findData(model->logicalSw[i].func));
-  cswitchAnd[i]->setCurrentIndex(cswitchAnd[i]->findData(RawSwitch(model->logicalSw[i].andsw).toValue()));
+  cbFunction[i]->setCurrentIndex(cbFunction[i]->findData(model->logicalSw[i].func));
+  cbAndSwitch[i]->setCurrentIndex(cbAndSwitch[i]->findData(RawSwitch(model->logicalSw[i].andsw).toValue()));
 
   if (!model->logicalSw[i].func) {
     mask = 0;
@@ -364,27 +367,27 @@ void LogicalSwitchesPanel::updateLine(int i)
         RawSource source = RawSource(model->logicalSw[i].val1);
         RawSourceRange range = source.getRange(model, generalSettings, model->logicalSw[i].getRangeFlags());
         double value = range.step * model->logicalSw[i].val2 + range.offset;  /* TODO+source.getRawOffset(model)*/
-        cswitchSource1[i]->setModel(rawSourceItemModel);
-        cswitchSource1[i]->setCurrentIndex(cswitchSource1[i]->findData(source.toValue()));
+        cbSource1[i]->setModel(rawSourceItemModel);
+        cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(source.toValue()));
         if (source.isTimeBased()) {
           mask |= VALUE_TO_VISIBLE;
-          cswitchTOffset[i]->setTimeRange(range.min, range.max);
-          cswitchTOffset[i]->setSingleStep(range.step);
-          cswitchTOffset[i]->setPageStep(range.step * 60);
-          cswitchTOffset[i]->setShowSeconds(range.step != 60);
-          cswitchTOffset[i]->setTime((int)value);
+          teOffset[i]->setTimeRange(range.min, range.max);
+          teOffset[i]->setSingleStep(range.step);
+          teOffset[i]->setPageStep(range.step * 60);
+          teOffset[i]->setShowSeconds(range.step != 60);
+          teOffset[i]->setTime((int)value);
         }
         else {
           mask |= VALUE2_VISIBLE;
           if (range.unit.isEmpty())
-            cswitchOffset[i]->setSuffix("");
+            dsbOffset[i]->setSuffix("");
           else
-            cswitchOffset[i]->setSuffix(" " + range.unit);
-          cswitchOffset[i]->setDecimals(range.decimals);
-          cswitchOffset[i]->setMinimum(range.min);
-          cswitchOffset[i]->setMaximum(range.max);
-          cswitchOffset[i]->setSingleStep(range.step);
-          cswitchOffset[i]->setValue(value);
+            dsbOffset[i]->setSuffix(" " + range.unit);
+          dsbOffset[i]->setDecimals(range.decimals);
+          dsbOffset[i]->setMinimum(range.min);
+          dsbOffset[i]->setMaximum(range.max);
+          dsbOffset[i]->setSingleStep(range.step);
+          dsbOffset[i]->setValue(value);
         }
 
         break;
@@ -393,58 +396,58 @@ void LogicalSwitchesPanel::updateLine(int i)
       case LS_FAMILY_STICKY:  // no break
       case LS_FAMILY_VBOOL:
         mask |= SOURCE1_VISIBLE | SOURCE2_VISIBLE;
-        cswitchSource1[i]->setModel(rawSwitchItemModel);
-        cswitchSource1[i]->setCurrentIndex(cswitchSource1[i]->findData(model->logicalSw[i].val1));
-        cswitchSource2[i]->setModel(rawSwitchItemModel);
-        cswitchSource2[i]->setCurrentIndex(cswitchSource2[i]->findData(model->logicalSw[i].val2));
+        cbSource1[i]->setModel(rawSwitchItemModel);
+        cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(model->logicalSw[i].val1));
+        cbSource2[i]->setModel(rawSwitchItemModel);
+        cbSource2[i]->setCurrentIndex(cbSource2[i]->findData(model->logicalSw[i].val2));
         break;
 
       case LS_FAMILY_EDGE:
         mask |= SOURCE1_VISIBLE | VALUE2_VISIBLE | VALUE3_VISIBLE;
         mask &= ~DELAY_ENABLED;
-        cswitchSource1[i]->setModel(rawSwitchItemModel);
-        cswitchSource1[i]->setCurrentIndex(cswitchSource1[i]->findData(model->logicalSw[i].val1));
-        updateTimerParam(cswitchOffset[i], model->logicalSw[i].val2, 0.0);
-        updateTimerParam(cswitchOffset2[i], model->logicalSw[i].val2+model->logicalSw[i].val3, ValToTim(TimToVal(cswitchOffset[i]->value())-1));
-        cswitchOffset2[i]->setSuffix((model->logicalSw[i].val3) ? "" : tr(" (infinite)"));
+        cbSource1[i]->setModel(rawSwitchItemModel);
+        cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(model->logicalSw[i].val1));
+        updateTimerParam(dsbOffset[i], model->logicalSw[i].val2, 0.0);
+        updateTimerParam(dsbOffset2[i], model->logicalSw[i].val2+model->logicalSw[i].val3, ValToTim(TimToVal(dsbOffset[i]->value())-1));
+        dsbOffset2[i]->setSuffix((model->logicalSw[i].val3) ? "" : tr(" (infinite)"));
         break;
 
       case LS_FAMILY_VCOMP:
         mask |= SOURCE1_VISIBLE | SOURCE2_VISIBLE;
-        cswitchSource1[i]->setModel(rawSourceItemModel);
-        cswitchSource1[i]->setCurrentIndex(cswitchSource1[i]->findData(model->logicalSw[i].val1));
-        cswitchSource2[i]->setModel(rawSourceItemModel);
-        cswitchSource2[i]->setCurrentIndex(cswitchSource2[i]->findData(model->logicalSw[i].val2));
+        cbSource1[i]->setModel(rawSourceItemModel);
+        cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(model->logicalSw[i].val1));
+        cbSource2[i]->setModel(rawSourceItemModel);
+        cbSource2[i]->setCurrentIndex(cbSource2[i]->findData(model->logicalSw[i].val2));
         break;
 
       case LS_FAMILY_TIMER:
         mask |= VALUE1_VISIBLE | VALUE2_VISIBLE;
-        updateTimerParam(cswitchValue[i], model->logicalSw[i].val1, 0.1);
-        updateTimerParam(cswitchOffset[i], model->logicalSw[i].val2, 0.1);
+        updateTimerParam(dsbValue[i], model->logicalSw[i].val1, 0.1);
+        updateTimerParam(dsbOffset[i], model->logicalSw[i].val2, 0.1);
         break;
     }
   }
 
-  cswitchSource1[i]->setVisible(mask & SOURCE1_VISIBLE);
-  cswitchSource2[i]->setVisible(mask & SOURCE2_VISIBLE);
-  cswitchValue[i]->setVisible(mask & VALUE1_VISIBLE);
-  cswitchOffset[i]->setVisible(mask & VALUE2_VISIBLE);
-  cswitchOffset2[i]->setVisible(mask & VALUE3_VISIBLE);
-  cswitchTOffset[i]->setVisible(mask & VALUE_TO_VISIBLE);
-  cswitchAnd[i]->setVisible(mask & LINE_ENABLED);
-  if (firmware->getCapability(LogicalSwitchesExt)) {
-    cswitchDuration[i]->setVisible(mask & DURATION_ENABLED);
-    cswitchDelay[i]->setVisible(mask & DELAY_ENABLED);
+  cbSource1[i]->setVisible(mask & SOURCE1_VISIBLE);
+  cbSource2[i]->setVisible(mask & SOURCE2_VISIBLE);
+  dsbValue[i]->setVisible(mask & VALUE1_VISIBLE);
+  dsbOffset[i]->setVisible(mask & VALUE2_VISIBLE);
+  dsbOffset2[i]->setVisible(mask & VALUE3_VISIBLE);
+  teOffset[i]->setVisible(mask & VALUE_TO_VISIBLE);
+  cbAndSwitch[i]->setVisible(mask & LINE_ENABLED);
+  if (lsCapabilityExt) {
+    dsbDuration[i]->setVisible(mask & DURATION_ENABLED);
+    dsbDelay[i]->setVisible(mask & DELAY_ENABLED);
     if (mask & DURATION_ENABLED)
-      cswitchDuration[i]->setValue(model->logicalSw[i].duration/10.0);
+      dsbDuration[i]->setValue(model->logicalSw[i].duration/10.0);
     if (mask & DELAY_ENABLED)
-      cswitchDelay[i]->setValue(model->logicalSw[i].delay/10.0);
+      dsbDelay[i]->setValue(model->logicalSw[i].delay/10.0);
   }
 
   lock = false;
 }
 
-void LogicalSwitchesPanel::populateCSWCB(QComboBox *b)
+void LogicalSwitchesPanel::populateFunctionCB(QComboBox *b)
 {
   int order[] = {
     LS_FN_OFF,
@@ -514,63 +517,131 @@ void LogicalSwitchesPanel::populateAndSwitchCB(QComboBox *b)
 void LogicalSwitchesPanel::update()
 {
   updateDataModels();
-  for (int i=0; i<firmware->getCapability(LogicalSwitches); i++) {
+  for (int i=0; i<lsCapability; i++) {
     updateLine(i);
   }
 }
 
-void LogicalSwitchesPanel::cswPaste()
+void LogicalSwitchesPanel::cmPaste()
 {
   const QClipboard *clipboard = QApplication::clipboard();
   const QMimeData *mimeData = clipboard->mimeData();
-  if (mimeData->hasFormat("application/x-companion-csw")) {
-    QByteArray cswData = mimeData->data("application/x-companion-csw");
-    LogicalSwitchData *csw = &model->logicalSw[selectedSwitch];
-    memcpy(csw, cswData.constData(), sizeof(LogicalSwitchData));
+  if (mimeData->hasFormat(MIMETYPE_LS)) {
+    QByteArray lsData = mimeData->data(MIMETYPE_LS);
+    LogicalSwitchData *ls = &model->logicalSw[selectedSwitch];
+    memcpy(ls, lsData.constData(), sizeof(LogicalSwitchData));
     update();
     emit modified();
   }
 }
 
-void LogicalSwitchesPanel::cswDelete()
+void LogicalSwitchesPanel::cmDelete()
+{
+  int maxidx = lsCapability - 1;
+  for (int i=selectedSwitch; i<maxidx; i++) {
+    if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i+1].isEmpty()) {
+      memcpy(&model->logicalSw[i], &model->logicalSw[i+1], sizeof(LogicalSwitchData));
+      updateLine(i);
+    }
+  }
+  model->logicalSw[maxidx].clear();
+  updateLine(maxidx);
+  emit modified();
+}
+
+void LogicalSwitchesPanel::cmCopy()
+{
+  QByteArray lsData;
+  lsData.append((char*)&model->logicalSw[selectedSwitch], sizeof(LogicalSwitchData));
+  QMimeData *mimeData = new QMimeData;
+  mimeData->setData(MIMETYPE_LS, lsData);
+  QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
+}
+
+void LogicalSwitchesPanel::cmCut()
+{
+  cmCopy();
+  cmClear();
+}
+
+// TODO make something generic here!
+void LogicalSwitchesPanel::onCustomContextMenuRequested(QPoint pos)
+{
+  QLabel *label = (QLabel *)sender();
+  selectedSwitch = label->property("index").toInt();
+
+  QPoint globalPos = label->mapToGlobal(pos);
+
+  const QClipboard * clipboard = QApplication::clipboard();
+  const QMimeData * mimeData = clipboard->mimeData();
+  bool hasData = mimeData->hasFormat(MIMETYPE_LS);
+  bool moveUpAllowed = (selectedSwitch > 0);
+  bool moveDownAllowed = (selectedSwitch < (lsCapability - 1));
+  bool insertAllowed = model->logicalSw[lsCapability - 1].isEmpty();
+
+  QMenu contextMenu;
+  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"),this,SLOT(cmCopy()));
+  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"),this,SLOT(cmCut()));
+  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"),this,SLOT(cmPaste()))->setEnabled(hasData);
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"),this,SLOT(cmClear()));
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"),this,SLOT(cmInsert()))->setEnabled(insertAllowed);
+  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"),this,SLOT(cmDelete()));
+  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"),this,SLOT(cmMoveUp()))->setEnabled(moveUpAllowed);
+  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"),this,SLOT(cmMoveDown()))->setEnabled(moveDownAllowed);
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"),this,SLOT(cmClearAll()));
+
+  contextMenu.exec(globalPos);
+}
+
+void LogicalSwitchesPanel::cmMoveUp()
+{
+  swapLSData(selectedSwitch, selectedSwitch - 1);
+}
+
+void LogicalSwitchesPanel::cmMoveDown()
+{
+  swapLSData(selectedSwitch, selectedSwitch + 1);
+}
+
+void LogicalSwitchesPanel::cmClear()
 {
   model->logicalSw[selectedSwitch].clear();
   emit modified();
   updateLine(selectedSwitch);
 }
 
-void LogicalSwitchesPanel::cswCopy()
+void LogicalSwitchesPanel::cmClearAll()
 {
-  QByteArray cswData;
-  cswData.append((char*)&model->logicalSw[selectedSwitch],sizeof(LogicalSwitchData));
-  QMimeData *mimeData = new QMimeData;
-  mimeData->setData("application/x-companion-csw", cswData);
-  QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
+  for (int i=0; i<lsCapability; i++) {
+    model->logicalSw[i].clear();
+    updateLine(i);
+  }
+  emit modified();
 }
 
-void LogicalSwitchesPanel::cswCut()
+void LogicalSwitchesPanel::cmInsert()
 {
-  cswCopy();
-  cswDelete();
+  for (int i=(lsCapability - 1); i>selectedSwitch; i--) {
+    if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i-1].isEmpty()) {
+      memcpy(&model->logicalSw[i], &model->logicalSw[i-1], sizeof(LogicalSwitchData));
+      updateLine(i);
+    }
+  }
+  cmClear();
 }
 
-// TODO make something generic here!
-void LogicalSwitchesPanel::csw_customContextMenuRequested(QPoint pos)
+void LogicalSwitchesPanel::swapLSData(int idx1, int idx2)
 {
-    QLabel *label = (QLabel *)sender();
-    selectedSwitch = label->property("index").toInt();
-
-    QPoint globalPos = label->mapToGlobal(pos);
-
-    const QClipboard * clipboard = QApplication::clipboard();
-    const QMimeData * mimeData = clipboard->mimeData();
-    bool hasData = mimeData->hasFormat("application/x-companion-csw");
-
-    QMenu contextMenu;
-    contextMenu.addAction(CompanionIcon("copy.png"), tr("&Copy"),this,SLOT(cswCopy()));
-    contextMenu.addAction(CompanionIcon("cut.png"), tr("&Cut"),this,SLOT(cswCut()));
-    contextMenu.addAction(CompanionIcon("paste.png"), tr("&Paste"),this,SLOT(cswPaste()))->setEnabled(hasData);
-    contextMenu.addAction(CompanionIcon("clear.png"), tr("&Delete"),this,SLOT(cswDelete()));
-
-    contextMenu.exec(globalPos);
+  if ((idx1 != idx2) && (!model->logicalSw[idx1].isEmpty() || !model->logicalSw[idx2].isEmpty())) {
+    LogicalSwitchData lstmp = model->logicalSw[idx2];
+    LogicalSwitchData *lsw1 = &model->logicalSw[idx1];
+    LogicalSwitchData *lsw2 = &model->logicalSw[idx2];
+    memcpy(lsw2, lsw1, sizeof(LogicalSwitchData));
+    memcpy(lsw1, &lstmp, sizeof(LogicalSwitchData));
+    updateLine(idx1);
+    updateLine(idx2);
+    emit modified();
+  }
 }

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -598,12 +598,12 @@ void LogicalSwitchesPanel::onCustomContextMenuRequested(QPoint pos)
 
 void LogicalSwitchesPanel::cmMoveUp()
 {
-  swapLSData(selectedSwitch, selectedSwitch - 1);
+  swapData(selectedSwitch, selectedSwitch - 1);
 }
 
 void LogicalSwitchesPanel::cmMoveDown()
 {
-  swapLSData(selectedSwitch, selectedSwitch + 1);
+  swapData(selectedSwitch, selectedSwitch + 1);
 }
 
 void LogicalSwitchesPanel::cmClear()
@@ -637,7 +637,7 @@ void LogicalSwitchesPanel::cmInsert()
   emit modified();
 }
 
-void LogicalSwitchesPanel::swapLSData(int idx1, int idx2)
+void LogicalSwitchesPanel::swapData(int idx1, int idx2)
 {
   if ((idx1 != idx2) && (!model->logicalSw[idx1].isEmpty() || !model->logicalSw[idx2].isEmpty())) {
     LogicalSwitchData lstmp = model->logicalSw[idx2];

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -530,7 +530,8 @@ void LogicalSwitchesPanel::cmPaste()
     QByteArray lsData = mimeData->data(MIMETYPE_LS);
     LogicalSwitchData *ls = &model->logicalSw[selectedSwitch];
     memcpy(ls, lsData.constData(), sizeof(LogicalSwitchData));
-    update();
+    updateDataModels();
+    updateLine(selectedSwitch);
     emit modified();
   }
 }
@@ -541,11 +542,11 @@ void LogicalSwitchesPanel::cmDelete()
   for (int i=selectedSwitch; i<maxidx; i++) {
     if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i+1].isEmpty()) {
       memcpy(&model->logicalSw[i], &model->logicalSw[i+1], sizeof(LogicalSwitchData));
-      updateLine(i);
     }
   }
   model->logicalSw[maxidx].clear();
-  updateLine(maxidx);
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedSwitch, 0, -1);
+  update();
   emit modified();
 }
 
@@ -608,16 +609,18 @@ void LogicalSwitchesPanel::cmMoveDown()
 void LogicalSwitchesPanel::cmClear()
 {
   model->logicalSw[selectedSwitch].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_CLEAR, selectedSwitch);
+  update();
   emit modified();
-  updateLine(selectedSwitch);
 }
 
 void LogicalSwitchesPanel::cmClearAll()
 {
   for (int i=0; i<lsCapability; i++) {
     model->logicalSw[i].clear();
-    updateLine(i);
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_CLEAR, i);
   }
+  update();
   emit modified();
 }
 
@@ -626,10 +629,12 @@ void LogicalSwitchesPanel::cmInsert()
   for (int i=(lsCapability - 1); i>selectedSwitch; i--) {
     if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i-1].isEmpty()) {
       memcpy(&model->logicalSw[i], &model->logicalSw[i-1], sizeof(LogicalSwitchData));
-      updateLine(i);
     }
   }
-  cmClear();
+  model->logicalSw[selectedSwitch].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedSwitch, 0, 1);
+  update();
+  emit modified();
 }
 
 void LogicalSwitchesPanel::swapLSData(int idx1, int idx2)
@@ -640,8 +645,8 @@ void LogicalSwitchesPanel::swapLSData(int idx1, int idx2)
     LogicalSwitchData *lsw2 = &model->logicalSw[idx2];
     memcpy(lsw2, lsw1, sizeof(LogicalSwitchData));
     memcpy(lsw1, &lstmp, sizeof(LogicalSwitchData));
-    updateLine(idx1);
-    updateLine(idx2);
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
+    update();
     emit modified();
   }
 }

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -535,13 +535,12 @@ void LogicalSwitchesPanel::cmPaste()
 
 void LogicalSwitchesPanel::cmDelete()
 {
-  int maxidx = lsCapability - 1;
-  for (int i=selectedIndex; i<maxidx; i++) {
-    if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i+1].isEmpty()) {
-      memcpy(&model->logicalSw[i], &model->logicalSw[i+1], sizeof(LogicalSwitchData));
-    }
-  }
-  model->logicalSw[maxidx].clear();
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Logical Switch. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  memmove(&model->logicalSw[selectedIndex], &model->logicalSw[selectedIndex + 1], (CPN_MAX_LOGICAL_SWITCHES - (selectedIndex + 1)) * sizeof(LogicalSwitchData));
+  model->logicalSw[lsCapability - 1].clear();
+
   model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
   emit modified();
@@ -632,6 +631,9 @@ void LogicalSwitchesPanel::cmClear()
 
 void LogicalSwitchesPanel::cmClearAll()
 {
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Logical Switches. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
   for (int i=0; i<lsCapability; i++) {
     model->logicalSw[i].clear();
     model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_CLEAR, i);
@@ -642,11 +644,7 @@ void LogicalSwitchesPanel::cmClearAll()
 
 void LogicalSwitchesPanel::cmInsert()
 {
-  for (int i=(lsCapability - 1); i>selectedIndex; i--) {
-    if (!model->logicalSw[i].isEmpty() || !model->logicalSw[i-1].isEmpty()) {
-      memcpy(&model->logicalSw[i], &model->logicalSw[i-1], sizeof(LogicalSwitchData));
-    }
-  }
+  memmove(&model->logicalSw[selectedIndex + 1], &model->logicalSw[selectedIndex], (CPN_MAX_LOGICAL_SWITCHES - (selectedIndex + 1)) * sizeof(LogicalSwitchData));
   model->logicalSw[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -28,6 +28,8 @@ class RawSwitchFilterItemModel;
 class RawSourceFilterItemModel;
 class TimerEdit;
 
+constexpr char MIMETYPE_LS[] = "application/x-companion-ls";
+
 class LogicalSwitchesPanel : public ModelPanel
 {
     Q_OBJECT
@@ -40,39 +42,46 @@ class LogicalSwitchesPanel : public ModelPanel
 
   private slots:
     void updateDataModels();
-    void functionChanged();
-    void v1Edited(int value);
-    void v2Edited(int value);
-    void andEdited(int value);
-    void durationEdited(double duration);
-    void delayEdited(double delay);
-    void offsetEdited();
-    bool offsetEditedAt(int index);
+    void onFunctionChanged();
+    void onV1Changed(int value);
+    void onV2Changed(int value);
+    void onAndSwitchChanged(int value);
+    void onDurationChanged(double duration);
+    void onDelayChanged(double delay);
+    void onOffsetChanged();
+    bool offsetChangedAt(int index);
     void updateLine(int index);
-    void csw_customContextMenuRequested(QPoint pos);
-    void cswDelete();
-    void cswCopy();
-    void cswPaste();
-    void cswCut();
+    void onCustomContextMenuRequested(QPoint pos);
+    void cmDelete();
+    void cmCopy();
+    void cmPaste();
+    void cmCut();
+    void cmMoveUp();
+    void cmMoveDown();
+    void cmInsert();
+    void cmClear();
+    void cmClearAll();
+    void swapLSData(int idx1, int idx2);
 
   private:
-    QComboBox * csw[CPN_MAX_LOGICAL_SWITCHES];
-    QDoubleSpinBox  * cswitchValue[CPN_MAX_LOGICAL_SWITCHES];
-    QDoubleSpinBox  * cswitchOffset[CPN_MAX_LOGICAL_SWITCHES];
-    QDoubleSpinBox  * cswitchOffset2[CPN_MAX_LOGICAL_SWITCHES];
-    TimerEdit * cswitchTOffset[CPN_MAX_LOGICAL_SWITCHES];
-    QComboBox * cswitchAnd[CPN_MAX_LOGICAL_SWITCHES];
-    QDoubleSpinBox  * cswitchDuration[CPN_MAX_LOGICAL_SWITCHES];
-    QDoubleSpinBox  * cswitchDelay[CPN_MAX_LOGICAL_SWITCHES];
-    QComboBox * cswitchSource1[CPN_MAX_LOGICAL_SWITCHES];
-    QComboBox * cswitchSource2[CPN_MAX_LOGICAL_SWITCHES];
+    QComboBox * cbFunction[CPN_MAX_LOGICAL_SWITCHES];
+    QDoubleSpinBox * dsbValue[CPN_MAX_LOGICAL_SWITCHES];
+    QDoubleSpinBox * dsbOffset[CPN_MAX_LOGICAL_SWITCHES];
+    QDoubleSpinBox * dsbOffset2[CPN_MAX_LOGICAL_SWITCHES];
+    TimerEdit * teOffset[CPN_MAX_LOGICAL_SWITCHES];
+    QComboBox * cbAndSwitch[CPN_MAX_LOGICAL_SWITCHES];
+    QDoubleSpinBox * dsbDuration[CPN_MAX_LOGICAL_SWITCHES];
+    QDoubleSpinBox * dsbDelay[CPN_MAX_LOGICAL_SWITCHES];
+    QComboBox * cbSource1[CPN_MAX_LOGICAL_SWITCHES];
+    QComboBox * cbSource2[CPN_MAX_LOGICAL_SWITCHES];
     RawSwitchFilterItemModel * rawSwitchItemModel;
     RawSourceFilterItemModel * rawSourceItemModel;
     int selectedSwitch;
-
-    void populateCSWCB(QComboBox *b);
+    void populateFunctionCB(QComboBox *b);
     void populateAndSwitchCB(QComboBox *b);
     void updateTimerParam(QDoubleSpinBox *sb, int timer, double minimum=0);
+    int lsCapability;
+    int lsCapabilityExt;
 
 };
 

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -28,7 +28,7 @@ class RawSwitchFilterItemModel;
 class RawSourceFilterItemModel;
 class TimerEdit;
 
-constexpr char MIMETYPE_LS[] = "application/x-companion-ls";
+constexpr char MIMETYPE_LOGICAL_SWITCH[] = "application/x-companion-logical-switch";
 
 class LogicalSwitchesPanel : public ModelPanel
 {
@@ -75,13 +75,17 @@ class LogicalSwitchesPanel : public ModelPanel
     QComboBox * cbSource2[CPN_MAX_LOGICAL_SWITCHES];
     RawSwitchFilterItemModel * rawSwitchItemModel;
     RawSourceFilterItemModel * rawSourceItemModel;
-    int selectedSwitch;
+    int selectedIndex;
     void populateFunctionCB(QComboBox *b);
     void populateAndSwitchCB(QComboBox *b);
     void updateTimerParam(QDoubleSpinBox *sb, int timer, double minimum=0);
     int lsCapability;
     int lsCapabilityExt;
     void swapData(int idx1, int idx2);
+    bool hasClipboardData(QByteArray * data = nullptr) const;
+    bool insertAllowed() const;
+    bool moveDownAllowed() const;
+    bool moveUpAllowed() const;
 };
 
 #endif // _LOGICALSWITCHES_H_

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -61,7 +61,6 @@ class LogicalSwitchesPanel : public ModelPanel
     void cmInsert();
     void cmClear();
     void cmClearAll();
-    void swapLSData(int idx1, int idx2);
 
   private:
     QComboBox * cbFunction[CPN_MAX_LOGICAL_SWITCHES];
@@ -82,7 +81,7 @@ class LogicalSwitchesPanel : public ModelPanel
     void updateTimerParam(QDoubleSpinBox *sb, int timer, double minimum=0);
     int lsCapability;
     int lsCapabilityExt;
-
+    void swapData(int idx1, int idx2);
 };
 
 #endif // _LOGICALSWITCHES_H_

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -285,27 +285,12 @@ ModulePanel::~ModulePanel()
   delete ui;
 }
 
-bool ModulePanel::moduleHasFailsafes()
-{
-  return firmware->getCapability(HasFailsafe) && (
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_ACCESS_ISRM ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_ACCST_ISRM_D16 ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_PXX_XJT_X16 ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_PXX_R9M ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_ACCESS_R9M ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_ACCESS_R9M_LITE ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_ACCESS_R9M_LITE_PRO ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_XJT_LITE_X16 ||
-    (PulsesProtocol)module.protocol == PulsesProtocol::PULSES_MULTIMODULE
-    );
-}
-
 void ModulePanel::setupFailsafes()
 {
   ChannelFailsafeWidgetsGroup grp;
   const int start = module.channelsStart;
   const int end = start + module.channelsCount;
-  const bool hasFailsafe = moduleHasFailsafes();
+  const bool hasFailsafe = module.hasFailsafes(firmware);
 
   lock = true;
 
@@ -522,7 +507,7 @@ void ModulePanel::update()
     mask |= MASK_PPM_FIELDS | MASK_CHANNELS_RANGE | MASK_CHANNELS_COUNT;
   }
 
-  if (moduleHasFailsafes()) {
+  if (module.hasFailsafes(firmware)) {
     mask |= MASK_FAILSAFES;
   }
 

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -379,48 +379,6 @@ void ModulePanel::setupFailsafes()
   lock = false;
 }
 
-int ModulePanel::getMaxChannelCount()
-{
-  const PulsesProtocol protocol = (PulsesProtocol)module.protocol;
-  switch (protocol) {
-    case PULSES_ACCESS_ISRM:
-      return 24;
-    case PULSES_PXX_R9M:
-    case PULSES_ACCESS_R9M:
-    case PULSES_ACCESS_R9M_LITE:
-    case PULSES_ACCESS_R9M_LITE_PRO:
-    case PULSES_ACCST_ISRM_D16:
-    case PULSES_XJT_LITE_X16:
-    case PULSES_PXX_XJT_X16:
-    case PULSES_CROSSFIRE:
-    case PULSES_SBUS:
-    case PULSES_PPM:
-      return 16;
-    case PULSES_XJT_LITE_LR12:
-    case PULSES_PXX_XJT_LR12:
-      return 12;
-    case PULSES_PXX_DJT:
-    case PULSES_XJT_LITE_D8:
-    case PULSES_PXX_XJT_D8:
-      return 8;
-    case PULSES_LP45:
-    case PULSES_DSM2:
-    case PULSES_DSMX:
-      return 6;
-    case PULSES_MULTIMODULE:
-      if (module.multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2)
-        return 12;
-      else
-        return 16;
-      break;
-    case PULSES_OFF:
-      break;
-    default:
-      break;
-  }
-  return 8;
-}
-
 void ModulePanel::update()
 {
   const PulsesProtocol protocol = (PulsesProtocol)module.protocol;
@@ -524,7 +482,7 @@ void ModulePanel::update()
   ui->label_channelsCount->setVisible(mask & MASK_CHANNELS_RANGE);
   ui->channelsCount->setVisible(mask & MASK_CHANNELS_RANGE);
   ui->channelsCount->setEnabled(mask & MASK_CHANNELS_COUNT);
-  ui->channelsCount->setMaximum(getMaxChannelCount());
+  ui->channelsCount->setMaximum(module.getMaxChannelCount());
   ui->channelsCount->setValue(module.channelsCount);
   ui->channelsCount->setSingleStep(firmware->getCapability(HasPPMStart) ? 1 : 2);
 
@@ -692,7 +650,7 @@ void ModulePanel::onProtocolChanged(int index)
 {
   if (!lock && module.protocol != ui->protocol->itemData(index).toUInt()) {
     module.protocol = ui->protocol->itemData(index).toInt();
-    module.channelsCount = getMaxChannelCount();
+    module.channelsCount = module.getMaxChannelCount();
     update();
     emit modified();
   }
@@ -787,7 +745,7 @@ void ModulePanel::onMultiProtocolChanged(int index)
     if (rfProtocol > MODULE_SUBTYPE_MULTI_LAST)
       maxSubTypes=8;
     module.subType = std::min(module.subType, maxSubTypes -1);
-    module.channelsCount = getMaxChannelCount();
+    module.channelsCount = module.getMaxChannelCount();
     update();
     emit modified();
     lock = false;

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -49,7 +49,7 @@ TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, Ge
   }
   else {
     ui->name->setMaxLength(length);
-    ui->name->setText(timer.name);
+    //ui->name->setText(timer.name);
   }
 
   // Mode
@@ -85,6 +85,7 @@ TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, Ge
   QWidget::setTabOrder(ui->countdownBeep, ui->minuteBeep);
   QWidget::setTabOrder(ui->minuteBeep, ui->persistent);
 
+  update();
   lock = false;
 }
 
@@ -95,6 +96,9 @@ TimerPanel::~TimerPanel()
 
 void TimerPanel::update()
 {
+  lock = true;
+  ui->name->setText(timer.name);
+
   int hour = timer.val / 3600;
   int min = (timer.val - (hour * 3600)) / 60;
   int sec = (timer.val - (hour * 3600)) % 60;
@@ -116,7 +120,10 @@ void TimerPanel::update()
     ui->persistentValue->setText(QString(" %1(%2:%3:%4)").arg(sign<0 ? "-" :" ").arg(hours, 2, 10, QLatin1Char('0')).arg(minutes, 2, 10, QLatin1Char('0')).arg(seconds, 2, 10, QLatin1Char('0')));
   }
 
+  ui->countdownBeep->updateValue();
   ui->minuteBeep->setChecked(timer.minuteBeep);
+  ui->persistent->updateValue();
+  lock = false;
 }
 
 QWidget * TimerPanel::getLastFocus()
@@ -126,38 +133,43 @@ QWidget * TimerPanel::getLastFocus()
 
 void TimerPanel::on_value_editingFinished()
 {
-  unsigned val = ui->value->time().hour()*3600 + ui->value->time().minute()*60 + ui->value->time().second();
-  if (timer.val != val) {
-    timer.val = val;
-    emit modified();
+  if (!lock) {
+    unsigned val = ui->value->time().hour()*3600 + ui->value->time().minute()*60 + ui->value->time().second();
+    if (timer.val != val) {
+      timer.val = val;
+      emit modified();
+    }
   }
 }
 
 void TimerPanel::onModeChanged(int index)
 {
-  if (lock)
-    return;
-
-  bool ok;
-  const RawSwitch rs(ui->mode->itemData(index).toInt(&ok));
-  if (ok && timer.mode.toValue() != rs.toValue()) {
-    timer.mode = rs;
-    emit modified();
+  if (!lock) {
+    bool ok;
+    const RawSwitch rs(ui->mode->itemData(index).toInt(&ok));
+    if (ok && timer.mode.toValue() != rs.toValue()) {
+      timer.mode = rs;
+      emit modified();
+    }
   }
 }
 
 void TimerPanel::on_minuteBeep_toggled(bool checked)
 {
-  timer.minuteBeep = checked;
-  emit modified();
+  if (!lock) {
+    timer.minuteBeep = checked;
+    emit modified();
+  }
 }
 
 void TimerPanel::on_name_editingFinished()
 {
-  if (QString(timer.name) != ui->name->text()) {
-    int length = ui->name->maxLength();
-    strncpy(timer.name, ui->name->text().toLatin1(), length);
-    emit modified();
+  if (!lock) {
+    if (QString(timer.name) != ui->name->text()) {
+      int length = ui->name->maxLength();
+      strncpy(timer.name, ui->name->text().toLatin1(), length);
+      emit modified();
+    }
   }
 }
 
@@ -1064,16 +1076,28 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   RawSwitchFilterItemModel * swModel = new RawSwitchFilterItemModel(&generalSettings, &model, RawSwitch::TimersContext, this);
   connect(this, &SetupPanel::updated, swModel, &RawSwitchFilterItemModel::update);
 
-  for (int i=0; i<CPN_MAX_TIMERS; i++) {
-    if (i<firmware->getCapability(Timers)) {
+  timersCount = firmware->getCapability(Timers);
+
+  for (int i = 0; i < CPN_MAX_TIMERS; i++) {
+    if (i < timersCount) {
       timers[i] = new TimerPanel(this, model, model.timers[i], generalSettings, firmware, prevFocus, swModel);
       ui->gridLayout->addWidget(timers[i], 1+i, 1);
       connect(timers[i], &TimerPanel::modified, this, &SetupPanel::modified);
       connect(this, &SetupPanel::updated, timers[i], &TimerPanel::update);
+      connect(this, &SetupPanel::timerUpdated, timers[i], &TimerPanel::update);
       prevFocus = timers[i]->getLastFocus();
+      //  TODO more reliable method required
+      QLabel *label = findChild<QLabel *>(QString("label_timer%1").arg(i + 1));
+      if (label) {  //  to stop crashing if not found
+        label->setProperty("index", i);
+        label->setContextMenuPolicy(Qt::CustomContextMenu);
+        label->setToolTip(tr("Popup menu available"));
+        label->setMouseTracking(true);
+        connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onTimerCustomContextMenuRequested(QPoint)));
+      }
     }
     else {
-      foreach(QLabel *label, findChildren<QLabel *>(QRegularExpression(QString("label_timer%1").arg(i+1)))) {
+      foreach(QLabel *label, findChildren<QLabel *>(QRegularExpression(QString("label_timer%1").arg(i + 1 )))) { //TODO more reliable method required
         label->hide();
       }
     }
@@ -1081,9 +1105,9 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
 
   if (firmware->getCapability(HasTopLcd)) {
     ui->toplcdTimer->setField(model.toplcdTimer, this);
-    for (int i=0; i<CPN_MAX_TIMERS; i++) {
-      if (i<firmware->getCapability(Timers)) {
-        ui->toplcdTimer->addItem(tr("Timer %1").arg(i+1), i);
+    for (int i = 0; i < CPN_MAX_TIMERS; i++) {
+      if (i<timersCount) {
+        ui->toplcdTimer->addItem(tr("Timer %1").arg(i + 1), i);
       }
     }
   }
@@ -1528,3 +1552,155 @@ void SetupPanel::on_editText_clicked()
   }
 }
 
+void SetupPanel::onTimerCustomContextMenuRequested(QPoint pos)
+{
+  QLabel *label = (QLabel *)sender();
+  selectedTimerIndex = label->property("index").toInt();
+  QPoint globalPos = label->mapToGlobal(pos);
+
+  QMenu contextMenu;
+  contextMenu.addAction(CompanionIcon("copy.png"), tr("Copy"), this, SLOT(cmTimerCopy()));
+  contextMenu.addAction(CompanionIcon("cut.png"), tr("Cut"), this, SLOT(cmTimerCut()));
+  contextMenu.addAction(CompanionIcon("paste.png"), tr("Paste"), this, SLOT(cmTimerPaste()))->setEnabled(hasTimerClipboardData());
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear"), this, SLOT(cmTimerClear()));
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("arrow-right.png"), tr("Insert"), this, SLOT(cmTimerInsert()))->setEnabled(insertTimerAllowed());
+  contextMenu.addAction(CompanionIcon("arrow-left.png"), tr("Delete"), this, SLOT(cmTimerDelete()));
+  contextMenu.addAction(CompanionIcon("moveup.png"), tr("Move Up"), this, SLOT(cmTimerMoveUp()))->setEnabled(moveTimerUpAllowed());
+  contextMenu.addAction(CompanionIcon("movedown.png"), tr("Move Down"), this, SLOT(cmTimerMoveDown()))->setEnabled(moveTimerDownAllowed());
+  contextMenu.addSeparator();
+  contextMenu.addAction(CompanionIcon("clear.png"), tr("Clear All"), this, SLOT(cmTimerClearAll()));
+
+  contextMenu.exec(globalPos);
+}
+
+bool SetupPanel::hasTimerClipboardData(QByteArray * data) const
+{
+  const QClipboard * clipboard = QApplication::clipboard();
+  const QMimeData * mimeData = clipboard->mimeData();
+  if (mimeData->hasFormat(MIMETYPE_TIMER)) {
+    if (data)
+      data->append(mimeData->data(MIMETYPE_TIMER));
+    return true;
+  }
+  return false;
+}
+
+bool SetupPanel::insertTimerAllowed() const
+{
+  return ((selectedTimerIndex < timersCount - 1) && (model->timers[timersCount - 1].isEmpty()));
+}
+
+bool SetupPanel::moveTimerDownAllowed() const
+{
+  return selectedTimerIndex < timersCount - 1;
+}
+
+bool SetupPanel::moveTimerUpAllowed() const
+{
+  return selectedTimerIndex > 0;
+}
+
+void SetupPanel::cmTimerClear()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Timer. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  model->timers[selectedTimerIndex].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_CLEAR, selectedTimerIndex);
+  emit timerUpdated();
+  emit modified();
+}
+
+void SetupPanel::cmTimerClearAll()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Timers. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  for (int i = 0; i < timersCount; i++) {
+    model->timers[i].clear();
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_CLEAR, i);
+  }
+  emit timerUpdated();
+  emit modified();
+}
+
+void SetupPanel::cmTimerCopy()
+{
+  QByteArray data;
+  data.append((char*)&model->timers[selectedTimerIndex], sizeof(TimerData));
+  QMimeData *mimeData = new QMimeData;
+  mimeData->setData(MIMETYPE_TIMER, data);
+  QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
+}
+
+void SetupPanel::cmTimerCut()
+{
+  cmTimerCopy();
+  cmTimerClear();
+}
+
+void SetupPanel::cmTimerDelete()
+{
+  if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Timer. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+    return;
+
+  int maxidx = timersCount - 1;
+  for (int i = selectedTimerIndex; i < maxidx; i++) {
+    if (!model->timers[i].isEmpty() || !model->timers[i + 1].isEmpty()) {
+      memcpy(&model->timers[i], &model->timers[i+1], sizeof(TimerData));
+    }
+  }
+  model->timers[maxidx].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SHIFT, selectedTimerIndex, 0, -1);
+  emit timerUpdated();
+  emit modified();
+}
+
+void SetupPanel::cmTimerInsert()
+{
+  for (int i = (timersCount - 1); i > selectedTimerIndex; i--) {
+    if (!model->timers[i].isEmpty() || !model->timers[i-1].isEmpty()) {
+      memcpy(&model->timers[i], &model->timers[i-1], sizeof(TimerData));
+    }
+  }
+  model->timers[selectedTimerIndex].clear();
+  model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SHIFT, selectedTimerIndex, 0, 1);
+  emit timerUpdated();
+  emit modified();
+}
+
+void SetupPanel::cmTimerMoveDown()
+{
+  swapTimerData(selectedTimerIndex, selectedTimerIndex + 1);
+}
+
+void SetupPanel::cmTimerMoveUp()
+{
+  swapTimerData(selectedTimerIndex, selectedTimerIndex - 1);
+}
+
+void SetupPanel::cmTimerPaste()
+{
+  QByteArray data;
+  if (hasTimerClipboardData(&data)) {
+    TimerData *td = &model->timers[selectedTimerIndex];
+    memcpy(td, data.constData(), sizeof(TimerData));
+    emit timerUpdated();
+    emit modified();
+  }
+}
+
+void SetupPanel::swapTimerData(int idx1, int idx2)
+{
+  if ((idx1 != idx2) && (!model->timers[idx1].isEmpty() || !model->timers[idx2].isEmpty())) {
+    TimerData tdtmp = model->timers[idx2];
+    TimerData *td1 = &model->timers[idx1];
+    TimerData *td2 = &model->timers[idx2];
+    memcpy(td2, td1, sizeof(TimerData));
+    memcpy(td1, &tdtmp, sizeof(TimerData));
+    model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
+    emit timerUpdated();
+    emit modified();
+  }
+}

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -72,7 +72,6 @@ class ModulePanel : public ModelPanel
     void channelsRangeChanged();
 
   private slots:
-    int getMaxChannelCount();
     void setupFailsafes();
     void on_trainerMode_currentIndexChanged(int index);
     void onProtocolChanged(int index);

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -24,6 +24,8 @@
 #include "modeledit.h"
 #include "eeprominterface.h"
 
+constexpr char MIMETYPE_TIMER[] = "application/x-companion-timer";
+
 class RawSwitchFilterItemModel;
 
 namespace Ui {
@@ -129,6 +131,7 @@ class SetupPanel : public ModelPanel
   signals:
     void extendedLimitsToggled();
     void updated();
+    void timerUpdated();
 
   private slots:
     void on_name_editingFinished();
@@ -148,6 +151,16 @@ class SetupPanel : public ModelPanel
     void potWarningToggled(bool checked);
     void on_potWarningMode_currentIndexChanged(int index);
     void on_editText_clicked();
+    void onTimerCustomContextMenuRequested(QPoint pos);
+    void cmTimerClear();
+    void cmTimerClearAll();
+    void cmTimerCopy();
+    void cmTimerCut();
+    void cmTimerDelete();
+    void cmTimerInsert();
+    void cmTimerPaste();
+    void cmTimerMoveDown();
+    void cmTimerMoveUp();
 
   private:
     Ui::Setup *ui;
@@ -161,6 +174,13 @@ class SetupPanel : public ModelPanel
     void updatePotWarnings();
     void updateBeepCenter();
     void populateThrottleSourceCB();
+    int timersCount;
+    int selectedTimerIndex;
+    bool hasTimerClipboardData(QByteArray * data = nullptr) const;
+    bool insertTimerAllowed() const;
+    bool moveTimerDownAllowed() const;
+    bool moveTimerUpAllowed() const;
+    void swapTimerData(int idx1, int idx2);
 };
 
 #endif // _SETUP_H_

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -64,7 +64,6 @@ class ModulePanel : public ModelPanel
     ModulePanel(QWidget *parent, ModelData & model, ModuleData & module, GeneralSettings & generalSettings, Firmware * firmware, int moduleIdx);
     virtual ~ModulePanel();
     virtual void update();
-    bool moduleHasFailsafes();
 
   public slots:
     void onExtendedLimitsToggled();

--- a/companion/src/modeledit/setup.ui
+++ b/companion/src/modeledit/setup.ui
@@ -590,7 +590,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_timer3_2">
+      <widget class="QLabel" name="label_timer3">
        <property name="font">
         <font>
          <weight>50</weight>


### PR DESCRIPTION
Based on feedback on #7025

In summary:
- new function to search and replace object references across the current model;
- new class for adjustment references;
- new and amended functions to support this change and for future refactoring across Companion;
~~- initially trigger from enhanced logical switches context menu (others if this PR accepted);~~
- housekeeping.

Notes:
- tested across all object types though still testing all use cases;
- some more debug and timing code needs to be removed;
- surprisingly the update executes fast, screen fresh is the slow part;
- tried to future proof eg shift action for values other than +/- 1;
- without lua plumbed into Companion placeholders for updates in scripts;
- once again highlights the need to centralise refreshing combo box lists (maybe my next challenge).