### PR TITLE
telemetry tim11 rcc

### DIFF
--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -369,7 +369,7 @@
 // Telemetry
 #define TELEMETRY_RCC_AHB1Periph        (RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_DMA1)
 #define TELEMETRY_RCC_APB1Periph        RCC_APB1Periph_USART2
-#define TELEMETRY_RCC_APB2Periph        RCC_APB2Periph_TIM10
+#define TELEMETRY_RCC_APB2Periph        RCC_APB2Periph_TIM11
 #define TELEMETRY_DIR_GPIO              GPIOD
 #define TELEMETRY_DIR_GPIO_PIN          GPIO_Pin_4  // PD.04
 #define TELEMETRY_GPIO                  GPIOD


### PR DESCRIPTION
this looks to me like it is incorrect

from https://github.com/opentx/opentx/blob/2.3/radio/src/targets/horus/hal.h#L388-L390 and https://github.com/opentx/opentx/blob/2.3/radio/src/targets/horus/telemetry_driver.cpp#L159 it appears TIM11 is used for TELEMETRY, and a RCC_APB2Periph_TIM11 doesn't appear to be set anywhere else, while TIM10 doesn't appear to be used else.

I could not note any difference on my JumperT16, but I don't use telemetry so no good test.

as a note: It's maybe not so nice that RCC_APB2ENR_TIM11EN is explicitly used in targets/horus/telemetry_driver.cpp, which somewhat defeats the purpose of a HAL.