### PR TITLE
Add color option to luaLcdDrawPoint()

### DIFF
--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -71,6 +71,8 @@ Draw a single pixel at (x,y) position
 
 @param y (positive number) y position
 
+@param flags (unsigned number) drawing flags
+
 @notice Taranis has an LCD display width of 212 pixels and height of 64 pixels.
 Position (0,0) is at top left. Y axis is negative, top line is 0,
 bottom line is 63. Drawing on an existing black pixel produces white pixel (TODO check this!)

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -82,7 +82,8 @@ static int luaLcdDrawPoint(lua_State *L)
   if (!luaLcdAllowed) return 0;
   int x = luaL_checkinteger(L, 1);
   int y = luaL_checkinteger(L, 2);
-  lcdDrawPoint(x, y);
+  LcdFlags att = luaL_optunsigned(L, 3, 0);
+  lcdDrawPoint(x, y, att);
   return 0;
 }
 


### PR DESCRIPTION
in lua scripts only black points can be drawn currently with lcd.drawPoint() even on color displays. This PR corrects this, by adding an optional flag.

works for me on a Jumper T16