### PR TITLE
Add optional alternative button layout for Xlite

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -55,6 +55,7 @@ option(MODULE_PROTOCOL_D8 "Add support for D8 modules" ON)
 option(FRSKY_RELEASE "Used to build FrSky released firmware" OFF)
 option(TBS_RELEASE "Used to build TBS released firmware" OFF)
 option(ALLOW_TRAINER_MULTI "Allow multi trainer" OFF)
+option(XLITEALT "Enable alternative Xlite button layout" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -342,6 +343,10 @@ endif()
 
 if(TBS_RELEASE)
   add_definitions(-DTBS_RELEASE)
+endif()
+
+if(XLITEALT)
+  add_definitions(-DXLITE_ALT)
 endif()
 
 if(FRSKY_RELEASE)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -32,20 +32,37 @@
   #define KEYS_GPIO_REG_ENTER           GPIOF->IDR
   #define KEYS_GPIO_PIN_ENTER           GPIO_Pin_0  // PF.00
 #elif defined(PCBXLITE)
-  #define KEYS_GPIO_REG_SHIFT           GPIOE->IDR
-  #define KEYS_GPIO_PIN_SHIFT           GPIO_Pin_8  // PE.08
-  #define KEYS_GPIO_REG_EXIT            GPIOE->IDR
-  #define KEYS_GPIO_PIN_EXIT            GPIO_Pin_7  // PE.07
-  #define KEYS_GPIO_REG_ENTER           GPIOE->IDR
-  #define KEYS_GPIO_PIN_ENTER           GPIO_Pin_11 // PE.11
-  #define KEYS_GPIO_REG_UP              GPIOE->IDR
-  #define KEYS_GPIO_PIN_UP              GPIO_Pin_10 // PE.10
-  #define KEYS_GPIO_REG_DOWN            GPIOE->IDR
-  #define KEYS_GPIO_PIN_DOWN            GPIO_Pin_14 // PE.14
-  #define KEYS_GPIO_REG_LEFT            GPIOE->IDR
-  #define KEYS_GPIO_PIN_LEFT            GPIO_Pin_12 // PE.12
-  #define KEYS_GPIO_REG_RIGHT           GPIOE->IDR
-  #define KEYS_GPIO_PIN_RIGHT           GPIO_Pin_13 // PE.13
+  #if defined(XLITEALT)
+    #define KEYS_GPIO_REG_SHIFT           GPIOE->IDR
+    #define KEYS_GPIO_PIN_SHIFT           GPIO_Pin_11 // PE.11
+    #define KEYS_GPIO_REG_EXIT            GPIOE->IDR
+    #define KEYS_GPIO_PIN_EXIT            GPIO_Pin_7  // PE.07
+    #define KEYS_GPIO_REG_ENTER           GPIOE->IDR
+    #define KEYS_GPIO_PIN_ENTER           GPIO_Pin_8  // PE.08
+    #define KEYS_GPIO_REG_UP              GPIOB->IDR
+    #define KEYS_GPIO_PIN_UP              GPIO_Pin_0  // PB.00
+    #define KEYS_GPIO_REG_DOWN            GPIOB->IDR
+    #define KEYS_GPIO_PIN_DOWN            GPIO_Pin_1  // PB.01
+    #define KEYS_GPIO_REG_LEFT            GPIOC->IDR
+    #define KEYS_GPIO_PIN_LEFT            GPIO_Pin_4  // PC.04
+    #define KEYS_GPIO_REG_RIGHT           GPIOC->IDR
+    #define KEYS_GPIO_PIN_RIGHT           GPIO_Pin_5  // PC.05
+  #else
+    #define KEYS_GPIO_REG_SHIFT           GPIOE->IDR
+    #define KEYS_GPIO_PIN_SHIFT           GPIO_Pin_8  // PE.08
+    #define KEYS_GPIO_REG_EXIT            GPIOE->IDR
+    #define KEYS_GPIO_PIN_EXIT            GPIO_Pin_7  // PE.07
+    #define KEYS_GPIO_REG_ENTER           GPIOE->IDR
+    #define KEYS_GPIO_PIN_ENTER           GPIO_Pin_11 // PE.11
+    #define KEYS_GPIO_REG_UP              GPIOE->IDR
+    #define KEYS_GPIO_PIN_UP              GPIO_Pin_10 // PE.10
+    #define KEYS_GPIO_REG_DOWN            GPIOE->IDR
+    #define KEYS_GPIO_PIN_DOWN            GPIO_Pin_14 // PE.14
+    #define KEYS_GPIO_REG_LEFT            GPIOE->IDR
+    #define KEYS_GPIO_PIN_LEFT            GPIO_Pin_12 // PE.12
+    #define KEYS_GPIO_REG_RIGHT           GPIOE->IDR
+    #define KEYS_GPIO_PIN_RIGHT           GPIO_Pin_13 // PE.13
+  #endif
 #elif defined(RADIO_T12)
   #define KEYS_GPIO_REG_EXIT            GPIOD->IDR
   #define KEYS_GPIO_PIN_EXIT            GPIO_Pin_2  // PD.02
@@ -185,14 +202,25 @@
   #define TRIMS_GPIO_REG_RHR            GPIOC->IDR
   #define TRIMS_GPIO_PIN_RHR            GPIO_Pin_13 // PC.13
 #elif defined(PCBXLITE)
-  #define TRIMS_GPIO_REG_LHL            GPIOC->IDR
-  #define TRIMS_GPIO_PIN_LHL            GPIO_Pin_4  // PC.04
-  #define TRIMS_GPIO_REG_LHR            GPIOC->IDR
-  #define TRIMS_GPIO_PIN_LHR            GPIO_Pin_5  // PC.05
-  #define TRIMS_GPIO_REG_LVU            GPIOB->IDR
-  #define TRIMS_GPIO_PIN_LVU            GPIO_Pin_0  // PB.00
-  #define TRIMS_GPIO_REG_LVD            GPIOB->IDR
-  #define TRIMS_GPIO_PIN_LVD            GPIO_Pin_1  // PB.01
+  #if defined(XLITEALT)
+    #define TRIMS_GPIO_REG_LHL            GPIOE->IDR
+    #define TRIMS_GPIO_PIN_LHL            GPIO_Pin_12 // PE.12
+    #define TRIMS_GPIO_REG_LHR            GPIOE->IDR
+    #define TRIMS_GPIO_PIN_LHR            GPIO_Pin_13 // PE.13
+    #define TRIMS_GPIO_REG_LVU            GPIOE->IDR
+    #define TRIMS_GPIO_PIN_LVU            GPIO_Pin_10 // PE.10
+    #define TRIMS_GPIO_REG_LVD            GPIOE->IDR
+    #define TRIMS_GPIO_PIN_LVD            GPIO_Pin_14 // PE.14
+  #else
+    #define TRIMS_GPIO_REG_LHL            GPIOC->IDR
+    #define TRIMS_GPIO_PIN_LHL            GPIO_Pin_4 // PC.04
+    #define TRIMS_GPIO_REG_LHR            GPIOC->IDR
+    #define TRIMS_GPIO_PIN_LHR            GPIO_Pin_5 // PC.05
+    #define TRIMS_GPIO_REG_LVU            GPIOB->IDR
+    #define TRIMS_GPIO_PIN_LVU            GPIO_Pin_0 // PB.00
+    #define TRIMS_GPIO_REG_LVD            GPIOB->IDR
+    #define TRIMS_GPIO_PIN_LVD            GPIO_Pin_1 // PB.01
+  #endif
 #elif defined(RADIO_X7ACCESS)
   #define TRIMS_GPIO_REG_LHR            GPIOD->IDR
   #define TRIMS_GPIO_PIN_LHR            GPIO_Pin_15 // PD.15

--- a/radio/util/fwoptions.py
+++ b/radio/util/fwoptions.py
@@ -124,6 +124,7 @@ options_taranis_xlite = {
     "nooverridech": ("OVERRIDE_CHANNEL_FUNCTION", "NO", "YES"),
     "shutdownconfirm": ("SHUTDOWN_CONFIRMATION", "YES", "NO"),
     "eu": ("MODULE_PROTOCOL_D8", "NO", "YES"),
+    "xlitealt": ("XLITEALT", "YES", None),
     "flexr9m": ("MODULE_PROTOCOL_FLEX", "YES", None)
 }
 


### PR DESCRIPTION
This adds an optional compile-time flag that changes the button layout of the Xlite transmitter.
New layout looks like this: https://downloads.simonernst.com/xlite/after.jpg

There is a long story behind this layout, that I will spare you 😝
I have been maintaining a fork with these modifications for about a year. My hope is that this is useful enough to be in the main codebase, so I can stop maintaining that fork 😉