### PR TITLE
Improve popupConfirmation

### DIFF
--- a/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
+++ b/radio/sdcard/horus/SCRIPTS/TOOLS/CROSSFIRE/device.lua
@@ -489,7 +489,7 @@ end
 local function runPopupPage(event)
   local result
   if fieldPopup.status == 3 then
-    result = popupConfirmation(fieldPopup.info, event)
+    result = popupConfirmation("Confirmation", fieldPopup.info, event)
   else
     result = popupWarning(fieldPopup.info, event)
   end

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1229,7 +1229,8 @@ static int luaPopupConfirmation(lua_State * L)
   warningType = WARNING_TYPE_CONFIRM;
   event_t event;
 
-  if (lua_isnone(L, 3)) {   // only tow args: deprecated mode
+  if (lua_isnone(L, 3)) {
+    // only two args: deprecated mode
     warningText = luaL_checkstring(L, 1);
     event = luaL_checkinteger(L, 2);
   }

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1206,11 +1206,14 @@ static int luaPopupWarning(lua_State * L)
 }
 
 /*luadoc
-@function popupConfirmation(title, event)
+@function popupConfirmation(title, event) deprecated, please replace by
+@function popupConfirmation(title, message, event)
 
 Raises a pop-up on screen that asks for confirmation
 
-@param title (string) text to display
+@param title (string) title to display
+
+@param message (string) text to display
 
 @param event (number) the event variable that is passed in from the
 Run function (key pressed)
@@ -1219,13 +1222,23 @@ Run function (key pressed)
 
 @notice Use only from stand-alone and telemetry scripts.
 
-@status current Introduced in 2.2.0
+@status current Introduced in 2.2.0, changed to (title, message, event) in 2.3.8
 */
 static int luaPopupConfirmation(lua_State * L)
 {
-  event_t event = luaL_checkinteger(L, 2);
-  warningText = luaL_checkstring(L, 1);
   warningType = WARNING_TYPE_CONFIRM;
+  event_t event;
+
+  if (lua_isnone(L, 3)) {   // only tow args: deprecated mode
+    warningText = luaL_checkstring(L, 1);
+    event = luaL_checkinteger(L, 2);
+  }
+  else {
+    warningText = luaL_checkstring(L, 1);
+    warningInfoText = luaL_checkstring(L, 2);
+    event = luaL_optinteger(L, 3, 0);
+  }
+
   runPopupWarning(event);
   if (!warningText) {
     lua_pushstring(L, warningResult ? "OK" : "CANCEL");


### PR DESCRIPTION
Improve lua popupConfirmation() by allowing to set both title and message.

This fixes #7480 