### PR TITLE
Adds the version into the Windows registry (and "Programs and Features")

### DIFF
--- a/companion/targets/windows/companion.nsi.in
+++ b/companion/targets/windows/companion.nsi.in
@@ -117,6 +117,7 @@ Section "OpenTX Companion @VERSION_FAMILY@" SecDummy
 
   ;Registry information for add/remove programs
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenTX Companion @VERSION_FAMILY@" "DisplayName" "OpenTX Companion @VERSION_FAMILY@"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenTX Companion @VERSION_FAMILY@" "DisplayVersion" "@VERSION@"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenTX Companion @VERSION_FAMILY@" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenTX Companion @VERSION_FAMILY@" "DisplayIcon" "$\"$INSTDIR\companion.exe$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenTX Companion @VERSION_FAMILY@" "Publisher" "OpenTX"


### PR DESCRIPTION
Displays the installed version in the Windows "Programs and Feature" application.

It always displays the full version.

Currently without version information:

![without-version](https://user-images.githubusercontent.com/5703553/78281474-05cb5580-751b-11ea-97d5-b9607d5c4f4e.png)

After applying this PR with version number:

![with-version](https://user-images.githubusercontent.com/5703553/78281494-0c59cd00-751b-11ea-99d4-4c5a8984f19d.png)

Note: The version is "2.x" and "2.x.7" because I am using modified values for the CMake variables "VERSION" and "VERSION_FAMILY". The final build will contain correct values, of course, like "2.3" and "2.3.8".