### PR TITLE
Using the right precision for unknown (custom) sensors

### DIFF
--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -130,7 +130,7 @@ uint16_t rboxState;
 void sportProcessTelemetryPacket(uint16_t id, uint8_t subId, uint8_t instance, uint32_t data, TelemetryUnit unit=UNIT_RAW)
 {
   const FrSkySportSensor * sensor = getFrSkySportSensor(id, subId);
-  uint8_t precision = 0;
+  uint8_t precision = 255;
   if (sensor) {
     if (unit == UNIT_RAW)
       unit = sensor->unit;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -82,6 +82,10 @@ void TelemetryItem::setValue(const TelemetrySensor & sensor, int32_t val, uint32
 {
   int32_t newVal = val;
 
+  if(prec == 255) {
+    prec = sensor.prec;
+  }
+
   if (unit == UNIT_CELLS) {
     uint32_t data = uint32_t(newVal);
     uint8_t cellsCount = (data >> 24);


### PR DESCRIPTION
Precision is set to out of range value 255 unless there is a known sensor found. If out of bound spec is found when setting the value then the configured spec is used.