### PR TITLE
Add output name on bottom status bar even when no mix line is active

### DIFF
--- a/radio/src/gui/480x272/model_mixes.cpp
+++ b/radio/src/gui/480x272/model_mixes.cpp
@@ -607,6 +607,8 @@ bool menuModelMixAll(event_t event)
         if (!s_copyMode) {
           attr = INVERS;
         }
+        if (g_model.limitData[ch-1].name[0] != '\0')
+          lcdDrawSizedText(MENUS_MARGIN_LEFT, MENU_FOOTER_TOP, g_model.limitData[ch-1].name, sizeof(g_model.limitData[ch-1].name), MENU_TITLE_COLOR | LEFT | ZCHAR);
       }
       if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
         putsChn(MENUS_MARGIN_LEFT, y, ch, attr); // show CHx


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5167938/79850939-e65e7480-83c4-11ea-913c-bd8e7f6acebd.png)
