### PR TITLE
Option to prompt for radio profile on companion start

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -250,6 +250,7 @@ set(companion_SRCS
   wizarddialog.cpp
   styleeditdialog.cpp
   dialogs/filesyncdialog.cpp         # TODO move to own lib with other dialogs
+  profilechooser.cpp
   )
 
 set(companion_MOC_HDRS
@@ -284,6 +285,7 @@ set(companion_MOC_HDRS
   styleeditdialog.h
   helpers_html.h
   dialogs/filesyncdialog.h
+  profilechooser.h
   )
 
 set(companion_UIS
@@ -305,6 +307,7 @@ set(companion_UIS
   flasheepromdialog.ui
   radionotfound.ui
   styleeditdialog.ui
+  profilechooser.ui
   )
 
 if(WIN32)

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -73,6 +73,7 @@ void AppPreferencesDialog::accept()
   g.OpenTxBranch(AppData::DownloadBranchType(ui->OpenTxBranch->currentIndex()));
   g.autoCheckFw(ui->autoCheckFirmware->isChecked());
   g.showSplash(ui->showSplash->isChecked());
+  g.promptProfile(ui->chkPromptProfile->isChecked());
   g.simuSW(ui->simuSW->isChecked());
   g.removeModelSlots(ui->opt_removeBlankSlots->isChecked());
   g.newModelAction(ui->opt_newMdl_useWizard->isChecked() ? AppData::MODEL_ACT_WIZARD : ui->opt_newMdl_useEditor->isChecked() ? AppData::MODEL_ACT_EDITOR : AppData::MODEL_ACT_NONE);
@@ -185,6 +186,7 @@ void AppPreferencesDialog::initSettings()
   ui->autoCheckCompanion->setChecked(g.autoCheckApp());
   ui->autoCheckFirmware->setChecked(g.autoCheckFw());
   ui->showSplash->setChecked(g.showSplash());
+  ui->chkPromptProfile->setChecked(g.promptProfile());
   ui->historySize->setValue(g.historySize());
   ui->backLightColor->setCurrentIndex(g.backLight());
   ui->volumeGain->setValue(profile.volumeGain() / 10.0);

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>741</width>
+    <width>864</width>
     <height>668</height>
    </rect>
   </property>
@@ -722,32 +722,21 @@ Mode 4:
          <property name="spacing">
           <number>6</number>
          </property>
-         <item row="7" column="1">
-          <layout class="QVBoxLayout" name="updatesLayout">
-           <item>
-            <widget class="QCheckBox" name="autoCheckFirmware">
-             <property name="text">
-              <string>Automatic check for OpenTX firmware updates</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="autoCheckCompanion">
-             <property name="text">
-              <string>Automatic check for Companion updates</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+         <item row="15" column="1">
+          <widget class="QCheckBox" name="backupEnable">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Enable automatic backup before writing firmware</string>
+           </property>
+          </widget>
          </item>
-         <item row="6" column="0" rowspan="2">
-          <widget class="QLabel" name="label_16">
+         <item row="22" column="0">
+          <widget class="QLabel" name="ge_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -755,7 +744,66 @@ Mode 4:
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Startup Settings</string>
+            <string>Google Earth Executable</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QComboBox" name="OpenTxBranch">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>Releases (stable)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Release candidates (testing)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Nightly builds (unstable)</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="18" column="1">
+          <widget class="QComboBox" name="splashincludeCB">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <item>
+            <property name="text">
+             <string>Only show user splash images</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Show user and companion splash images</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="12" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="16" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line_5">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -795,76 +843,27 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="13" column="0">
-          <widget class="QLabel" name="label_17">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Automatic Backup Folder</string>
-           </property>
-          </widget>
-         </item>
-         <item row="21" column="0">
-          <widget class="QLabel" name="ge_label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Google Earth Executable</string>
-           </property>
-          </widget>
-         </item>
          <item row="6" column="1">
           <widget class="QCheckBox" name="showSplash">
            <property name="text">
-            <string>Show splash screen when Companion starts</string>
+            <string>Show splash screen</string>
            </property>
            <property name="checked">
             <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="11" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Remember</string>
-           </property>
-          </widget>
-         </item>
-         <item row="18" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <item row="22" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_9">
            <item>
-            <widget class="QLineEdit" name="libraryPath">
-             <property name="enabled">
+            <widget class="QLineEdit" name="ge_lineedit">
+             <property name="readOnly">
               <bool>true</bool>
              </property>
-             <property name="readOnly">
-              <bool>false</bool>
-             </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="libraryPathButton">
+            <widget class="QPushButton" name="ge_pathButton">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -872,127 +871,13 @@ Mode 4:
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Select Folder</string>
+              <string>Select Executable</string>
              </property>
             </widget>
            </item>
           </layout>
-         </item>
-         <item row="13" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_8">
-           <item>
-            <widget class="QLineEdit" name="backupPath">
-             <property name="readOnly">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="backupPathButton">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Select Folder</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="19" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line_7">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="23" column="0">
-          <widget class="QLabel" name="label_12">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Debug Output Logging</string>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="1">
-          <widget class="QCheckBox" name="backupEnable">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Enable automatic backup before writing firmware</string>
-           </property>
-          </widget>
          </item>
          <item row="10" column="1">
-          <widget class="QCheckBox" name="opt_removeBlankSlots">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Remove empty model slots when deleting models (only applies for radios w/out categories)</string>
-           </property>
-          </widget>
-         </item>
-         <item row="24" column="0">
-          <widget class="QLabel" name="lbl_appLogsDir">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Output Logs Folder</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="17" column="1">
-          <widget class="QComboBox" name="splashincludeCB">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <item>
-            <property name="text">
-             <string>Only show user splash images</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Show user and companion splash images</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="15" column="0" rowspan="2" colspan="2">
-          <widget class="Line" name="line_5">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QRadioButton" name="opt_newMdl_useWizard">
@@ -1026,38 +911,17 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="24" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item row="14" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
            <item>
-            <widget class="QLineEdit" name="appLogsDir">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
+            <widget class="QLineEdit" name="backupPath">
              <property name="readOnly">
               <bool>false</bool>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="btn_appLogsDir">
-             <property name="text">
-              <string>Select Folder</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="21" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
-           <item>
-            <widget class="QLineEdit" name="ge_lineedit">
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="ge_pathButton">
+            <widget class="QPushButton" name="backupPathButton">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -1065,13 +929,62 @@ Mode 4:
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Select Executable</string>
+              <string>Select Folder</string>
              </property>
             </widget>
            </item>
           </layout>
          </item>
-         <item row="18" column="0">
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Remember</string>
+           </property>
+          </widget>
+         </item>
+         <item row="25" column="0">
+          <widget class="QLabel" name="lbl_appLogsDir">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Output Logs Folder</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0" rowspan="3">
+          <widget class="QLabel" name="label_16">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Startup Settings</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="1">
+          <widget class="QCheckBox" name="opt_removeBlankSlots">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Remove empty model slots when deleting models (only applies for radios w/out categories)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="0">
           <widget class="QLabel" name="label_9">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1084,47 +997,7 @@ Mode 4:
            </property>
           </widget>
          </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="label_18">
-           <property name="text">
-            <string>Release channel</string>
-           </property>
-          </widget>
-         </item>
-         <item row="17" column="0">
-          <widget class="QLabel" name="label_10">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Splash Screen Library</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="label_8">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Action on New Model</string>
-           </property>
-          </widget>
-         </item>
-         <item row="22" column="0" colspan="2">
-          <widget class="Line" name="line_4">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="23" column="1">
+         <item row="24" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QCheckBox" name="opt_appDebugLog">
@@ -1148,29 +1021,163 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="8" column="1">
-          <widget class="QComboBox" name="OpenTxBranch">
+         <item row="25" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QLineEdit" name="appLogsDir">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="readOnly">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btn_appLogsDir">
+             <property name="text">
+              <string>Select Folder</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="label_8">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="text">
+            <string>Action on New Model</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
            <item>
-            <property name="text">
-             <string>Releases (stable)</string>
-            </property>
+            <widget class="QLineEdit" name="libraryPath">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="readOnly">
+              <bool>false</bool>
+             </property>
+            </widget>
            </item>
            <item>
-            <property name="text">
-             <string>Release candidates (testing)</string>
-            </property>
+            <widget class="QPushButton" name="libraryPathButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Select Folder</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="18" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Splash Screen Library</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="label_18">
+           <property name="text">
+            <string>Release channel</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="24" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Debug Output Logging</string>
+           </property>
+          </widget>
+         </item>
+         <item row="23" column="0" colspan="2">
+          <widget class="Line" name="line_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="0">
+          <widget class="QLabel" name="label_17">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Automatic Backup Folder</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <layout class="QVBoxLayout" name="updatesLayout">
+           <item>
+            <widget class="QCheckBox" name="autoCheckFirmware">
+             <property name="text">
+              <string>Automatic check for OpenTX firmware updates</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
            <item>
-            <property name="text">
-             <string>Nightly builds (unstable)</string>
-            </property>
+            <widget class="QCheckBox" name="autoCheckCompanion">
+             <property name="text">
+              <string>Automatic check for Companion updates</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
+          </layout>
+         </item>
+         <item row="20" column="0" rowspan="2" colspan="2">
+          <widget class="Line" name="line_7">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="chkPromptProfile">
+           <property name="text">
+            <string>Prompt for radio profile</string>
+           </property>
           </widget>
          </item>
         </layout>

--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -128,6 +128,7 @@ class MainWindow : public QMainWindow
     void exportSettings();
     void importSettings();
     void autoClose();
+    void chooseProfile();
 
     void openUpdatesWaitDialog();
     void closeUpdatesWaitDialog();

--- a/companion/src/profilechooser.cpp
+++ b/companion/src/profilechooser.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "profilechooser.h"
+#include "ui_profilechooser.h"
+#include "appdata.h"
+
+ProfileChooserDialog::ProfileChooserDialog(QWidget * parent):
+  QDialog(parent),
+  ui(new Ui::ProfileChooserDialog)
+{
+  ui->setupUi(this);
+  setWindowIcon(QIcon(":/icon.png"));
+  QComboBox *prof = ui->cboProfiles;
+  prof->clear();
+  for (int i = 0; i < MAX_PROFILES; i++) {
+    if (g.profile[i].existsOnDisk()) {
+      if (g.profile[i].name() != "") {
+        QString text = g.profile[i].name();
+        prof->addItem(text, i);
+      }
+    }
+  }
+  prof->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  prof->setCurrentIndex(prof->findData(g.id()));
+  connect(prof, SIGNAL(currentIndexChanged(int)), this, SLOT(on_cboProfilesCurrentIndexChanged(int)));
+}
+
+ProfileChooserDialog::~ProfileChooserDialog()
+{
+  delete ui;
+}
+
+void ProfileChooserDialog::on_cboProfilesCurrentIndexChanged(int index)
+{
+  QComboBox *prof = ui->cboProfiles;
+
+  if ((prof->currentIndex() > -1)) {
+    int oldid = g.id();
+    int newid = prof->currentData().toInt();
+    if (oldid != newid)
+      emit profileChanged(newid);
+  }
+}

--- a/companion/src/profilechooser.cpp
+++ b/companion/src/profilechooser.cpp
@@ -30,14 +30,15 @@ ProfileChooserDialog::ProfileChooserDialog(QWidget * parent):
   setWindowIcon(QIcon(":/icon.png"));
   QComboBox *prof = ui->cboProfiles;
   prof->clear();
-  for (int i = 0; i < MAX_PROFILES; i++) {
-    if (g.profile[i].existsOnDisk()) {
-      if (g.profile[i].name() != "") {
-        QString text = g.profile[i].name();
-        prof->addItem(text, i);
-      }
-    }
+
+  QMap<int, QString> active;
+  active = g.getActiveProfiles();
+  QMapIterator<int, QString> i(active);
+  while (i.hasNext()) {
+      i.next();
+      prof->addItem(i.value(), i.key());
   }
+
   prof->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   prof->setCurrentIndex(prof->findData(g.id()));
   connect(prof, SIGNAL(currentIndexChanged(int)), this, SLOT(on_cboProfilesCurrentIndexChanged(int)));

--- a/companion/src/profilechooser.h
+++ b/companion/src/profilechooser.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _PROFILECHOOSER_H_
+#define _PROFILECHOOSER_H_
+
+#include <QtWidgets>
+
+namespace Ui {
+  class ProfileChooserDialog;
+}
+
+class ProfileChooserDialog : public QDialog
+{
+  Q_OBJECT
+
+  public:
+    ProfileChooserDialog(QWidget * parent = 0);
+    ~ProfileChooserDialog();
+signals:
+  void profileChanged(int newid);
+
+  private slots:
+    void on_cboProfilesCurrentIndexChanged(int index);
+
+  private:
+    Ui::ProfileChooserDialog *ui;
+};
+
+#endif // _PROFILECHOOSER_H_

--- a/companion/src/profilechooser.ui
+++ b/companion/src/profilechooser.ui
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ProfileChooserDialog</class>
+ <widget class="QDialog" name="ProfileChooserDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>352</width>
+    <height>102</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Profile Chooser</string>
+  </property>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>311</width>
+     <height>66</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Use profile</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cboProfiles">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Ok</set>
+      </property>
+      <property name="centerButtons">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ProfileChooserDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ProfileChooserDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/companion/src/profilechooser.ui
+++ b/companion/src/profilechooser.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Profile Chooser</string>
+   <string>Select Profile</string>
   </property>
   <widget class="QWidget" name="layoutWidget">
    <property name="geometry">
@@ -40,7 +40,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Use profile</string>
+         <string>Profile</string>
         </property>
        </widget>
       </item>

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -575,6 +575,7 @@ class AppData: public CompStoreObj
     PROPERTY4(bool, snapToClpbrd,    "snapshot_to_clipboard",   false)
     PROPERTY4(bool, autoCheckApp,    "startup_check_companion", true)
     PROPERTY4(bool, autoCheckFw,     "startup_check_fw",        true)
+    PROPERTY4(bool, promptProfile,   "startup_prompt_profile",  false)
 
     PROPERTY(bool, enableBackup,               false)
     PROPERTY(bool, backupOnFlash,              true)


### PR DESCRIPTION
Fixes #7514
The default setting is 'off' to maintain current functionality.
If the setting is 'on' and more than 1 profile is defined, the user will prompted to select a profile.
The default profile is the one used in the previous session.

![Application Settings](https://user-images.githubusercontent.com/15316949/80781926-8bdcc980-8bb7-11ea-9aa0-99c956cdd91f.png)

![Startup Profile Chooser](https://user-images.githubusercontent.com/15316949/80781923-8aab9c80-8bb7-11ea-86fb-cc274cc61ea4.png)
