### PR TITLE
fix rfprotocol corruption of write models and settings to radio dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cmake-build-*/
 /*.vscode
 radio/src/tests/googletest*
 radio/src/tests/gtest*.tar.gz
+/.vs

--- a/companion/src/firmwares/eepromimportexport.h
+++ b/companion/src/firmwares/eepromimportexport.h
@@ -544,6 +544,7 @@ class TransformedField: public DataField {
     {
       beforeExport();
       field.ExportBits(output);
+      afterImport(); // always needed after beforeExport()
     }
 
     void ImportBits(const QBitArray & input) override


### PR DESCRIPTION
The "Write Models and Settings to Radio" corrupts "Multi Radio Protocol" of external Radio Module "DIY Multiprotocol Module"

Testcase:

Companion 2.3.7 on Windows 10 Build 1909 english
Open Companion
Create New Document (File|New)
Add Model (Wizard): Next, Next... Agree, Finish
Edit Model
Change "external Radio Module" to: "DIY Multiprotocol Module"
Change "Multi Radio Protocol" to "HoTT" (value is important, internal ID has to be > 16)
Close edit dialog
Open "Write Models and Settings to Radio" dialog
Close "Write Models and Settings to Radio" dialog
Edit Model
"Multi Radio Protocol" is corrupted: Changed from "HoTT" to "Devo"

Fix:
eepromimportexport.h implements TransformedField:ExportBits()
This function calls: beforeExport()

opentxeeprom.cpp implements Multifield:beforeExport()

module.multi.rfProtocol is split here in 4 bit rfProtocol and 3 bit rfProtExtra
After that rfProtoCol contains only the lower 4 bits

This has to be reverted by calling
Multifield:AfterImport()