### PR TITLE
Change Act duration

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1458,6 +1458,7 @@ void doMixerCalculations()
     if ((s_cnt_100ms += tick10ms) >= 10) { // 0.1sec
       s_cnt_100ms -= 10;
       s_cnt_1s += 1;
+      inactivity.counter++;
 
       logicalSwitchesTimerTick();
       checkTrainerSignalWarning();
@@ -1465,8 +1466,8 @@ void doMixerCalculations()
       if (s_cnt_1s >= 10) { // 1sec
         s_cnt_1s -= 10;
         sessionTimer += 1;
-        inactivity.counter++;
-        if ((((uint8_t)inactivity.counter) & 0x07) == 0x01 && g_eeGeneral.inactivityTimer && inactivity.counter > ((uint16_t)g_eeGeneral.inactivityTimer * 60))
+
+        if ((((uint8_t)inactivity.counter / 10) & 0x07) == 0x01 && g_eeGeneral.inactivityTimer && inactivity.counter > ((uint16_t)g_eeGeneral.inactivityTimer * 600))
           AUDIO_INACTIVITY();
 
 #if defined(AUDIO)


### PR DESCRIPTION
Initial implementation of Act was set at 3 secs, why might be perfect for some, but too short or long for others. This moves to a rapid Act "true" state.

User can then set a logical switch to their desired duration. The following LS mirror the previous 3 secs behavior
![image](https://user-images.githubusercontent.com/5167938/82751073-0d89d680-9db5-11ea-9e54-94e1a1e04e75.png)

While allowing user to work out their LS duration themselves, this change also allows a nice improvement of trainer usability. Using the following LS, trainer can give control to the student via a short SH impulsion, and will regain control with any actions on the radio, sticks included

![image](https://user-images.githubusercontent.com/5167938/82751113-60638e00-9db5-11ea-8e2c-455b918fdfeb.png)

