### PR TITLE
Fix 7641

### DIFF
--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -259,7 +259,7 @@ void menuModelLogicalSwitches(event_t event)
     LogicalSwitchData * cs = lswAddress(sub);
     if (cs->func)
       s_currIdx = sub;
-    POPUP_MENU_ADD_ITEM(STR_EDIT);
+    if (sub >=0) POPUP_MENU_ADD_ITEM(STR_EDIT);
     if (cs->func || cs->v1 || cs->v2 || cs->delay || cs->duration || cs->andsw)
       POPUP_MENU_ADD_ITEM(STR_COPY);
     if (clipboard.type == CLIPBOARD_TYPE_CUSTOM_SWITCH)


### PR DESCRIPTION
Fixes 7641. Do not open logical switch edit menu from the logical switches page index (with logical switch index -1)