### PR TITLE
Fix  6853

### DIFF
--- a/radio/src/gui/128x64/model_curve_edit.cpp
+++ b/radio/src/gui/128x64/model_curve_edit.cpp
@@ -125,6 +125,9 @@ void menuModelCurveOne(event_t event)
   lcdDrawNumber(INDENT_WIDTH, 6*FH+1, 5+crv.points, LEFT|attr);
   lcdDrawText(lcdLastRightPos, 6*FH+1, STR_PTS, attr);
   if (attr) {
+#if defined(ROTARY_ENCODER_NAVIGATION)
+    rotencSpeed = ROTENC_LOWSPEED;
+#endif
     int8_t count = checkIncDecModel(event, crv.points, -3, 12); // 2pts - 17pts
     if (checkIncDec_Ret) {
       int8_t newPoints[MAX_POINTS_PER_CURVE];

--- a/radio/src/gui/212x64/model_curve_edit.cpp
+++ b/radio/src/gui/212x64/model_curve_edit.cpp
@@ -131,6 +131,9 @@ void menuModelCurveOne(event_t event)
   lcdDrawNumber(INDENT_WIDTH, 6*FH+1, 5+crv.points, LEFT|attr);
   lcdDrawText(lcdLastRightPos, 6*FH+1, STR_PTS, attr);
   if (attr) {
+#if defined(ROTARY_ENCODER_NAVIGATION)
+    rotencSpeed = ROTENC_LOWSPEED;
+#endif
     int8_t count = checkIncDecModel(event, crv.points, -3, 12); // 2pts - 17pts
     if (checkIncDec_Ret) {
       int8_t newPoints[MAX_POINTS_PER_CURVE];

--- a/radio/src/gui/480x272/model_curves.cpp
+++ b/radio/src/gui/480x272/model_curves.cpp
@@ -155,6 +155,9 @@ bool menuModelCurveOne(event_t event)
   lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP + FH, STR_COUNT);
   lcdDrawNumber(MODEL_CURVE_ONE_2ND_COLUMN, MENU_CONTENT_TOP + FH, 5+crv.points, LEFT|attr, 0, NULL, STR_PTS);
   if (attr) {
+#if defined(ROTARY_ENCODER_NAVIGATION)
+    rotencSpeed = ROTENC_LOWSPEED;
+#endif
     int count = checkIncDecModel(event, crv.points, -3, 12); // 2pts - 17pts
     if (checkIncDec_Ret) {
       int newPoints[MAX_POINTS_PER_CURVE];


### PR DESCRIPTION
Fix #6853. This issue is affecting radios with rotary encoders

When increasing the number of points of the curve, it has to be done in increments of one. If the rotary goes faster then the new points are also copied to adjacent curves. So lets force low rotary speed when changing the number points of the curves