### PR TITLE
fix: reverse t12 pot direction. up -> high, down -> low

### DIFF
--- a/radio/src/targets/common/arm/stm32/adc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/adc_driver.cpp
@@ -26,6 +26,8 @@
   const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,1,  -1,1,  -1,1};
 #elif defined(RADIO_TX16S)
   const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,1,  -1,1,  -1,1};
+#elif defined(RADIO_T12)
+  const int8_t adcDirection[NUM_ANALOGS] = {-1,1,-1,1,  -1,-1,  1,1};
 #elif defined(PCBX10)
   const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  -1,1,-1,   1,1,    1, -1};
 #elif defined(PCBX9E)


### PR DESCRIPTION
did this for the t12 pro, which i don't know why its setup like that because it feels completely unnatural. i don't know if this affects the original t12.