### PR TITLE
Bars inverse - Closes #2495

### DIFF
--- a/radio/src/gui/128x64/model_display.cpp
+++ b/radio/src/gui/128x64/model_display.cpp
@@ -242,10 +242,10 @@ void menuModelDisplay(event_t event)
                 }
                 break;
               case 1:
-                bar.barMin = checkIncDec(event, bar.barMin, barMin, bar.barMax, EE_MODEL|NO_INCDEC_MARKS);
+                bar.barMin = checkIncDec(event, bar.barMin, barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
                 break;
               case 2:
-                bar.barMax = checkIncDec(event, bar.barMax, bar.barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
+                bar.barMax = checkIncDec(event, bar.barMax, barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
                 break;
             }
           }

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -67,6 +67,8 @@ bool displayGaugesTelemetryScreen(TelemetryScreenData & screen)
     if (source <= MIXSRC_LAST_CH) {
       barMin = calc100toRESX(barMin);
       barMax = calc100toRESX(barMax);
+    }
+    if (source) {
       uint8_t y = barHeight+6+i*(barHeight+6);
       drawSource(0, y+barHeight/2-3, source, SMLSIZE);
       lcdDrawRect(BAR_LEFT, y, BAR_WIDTH+1, barHeight+2);

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -67,28 +67,19 @@ bool displayGaugesTelemetryScreen(TelemetryScreenData & screen)
     if (source <= MIXSRC_LAST_CH) {
       barMin = calc100toRESX(barMin);
       barMax = calc100toRESX(barMax);
-    }
-    if (source && barMax > barMin) {
       uint8_t y = barHeight+6+i*(barHeight+6);
       drawSource(0, y+barHeight/2-3, source, SMLSIZE);
       lcdDrawRect(BAR_LEFT, y, BAR_WIDTH+1, barHeight+2);
       getvalue_t value = getValue(source);
-
       uint8_t thresholdX = 0;
-
-
-      uint8_t width = barCoord(value, barMin, barMax);
-
+      uint8_t width = (barMin < barMax) ? barCoord(value, barMin, barMax) : 99 - barCoord(value, barMax, barMin);
       uint8_t barShade = SOLID;
-
       lcdDrawFilledRect(BAR_LEFT+1, y+1, width, barHeight, barShade);
-
       for (uint8_t j=24; j<99; j+=25) {
         if (j>thresholdX || j>width) {
           lcdDrawSolidVerticalLine(j*BAR_WIDTH/100+BAR_LEFT+1, y+1, barHeight);
         }
       }
-
       if (thresholdX) {
         lcdDrawVerticalLine(BAR_LEFT+1+thresholdX, y-2, barHeight+3, DOTTED);
         lcdDrawSolidHorizontalLine(BAR_LEFT+thresholdX, y-2, 3);

--- a/radio/src/gui/212x64/model_display.cpp
+++ b/radio/src/gui/212x64/model_display.cpp
@@ -245,10 +245,10 @@ void menuModelDisplay(event_t event)
                 }
                 break;
               case 1:
-                bar.barMin = checkIncDec(event, bar.barMin, barMin, bar.barMax, EE_MODEL|NO_INCDEC_MARKS);
+                bar.barMin = checkIncDec(event, bar.barMin, barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
                 break;
               case 2:
-                bar.barMax = checkIncDec(event, bar.barMax, bar.barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
+                bar.barMax = checkIncDec(event, bar.barMax, barMin, barMax, EE_MODEL|NO_INCDEC_MARKS);
                 break;
             }
           }

--- a/radio/src/gui/212x64/view_telemetry.cpp
+++ b/radio/src/gui/212x64/view_telemetry.cpp
@@ -65,15 +65,13 @@ void displayGaugesTelemetryScreen(TelemetryScreenData & screen)
     if (source <= MIXSRC_LAST_CH) {
       barMin = calc100toRESX(barMin);
       barMax = calc100toRESX(barMax);
-    }
-    if (source && barMax > barMin) {
       int y = barHeight+6+i*(barHeight+6);
       drawSource(0, y+barHeight-5, source, 0);
       lcdDrawRect(BAR_LEFT, y, BAR_WIDTH+1, barHeight+2);
       getvalue_t value = getValue(source);
       drawSourceValue(BAR_LEFT+2+BAR_WIDTH, y+barHeight-5, source, LEFT);
       uint8_t thresholdX = 0;
-      int width = barCoord(value, barMin, barMax);
+      uint8_t width = (barMin < barMax) ? barCoord(value, barMin, barMax) : limit(0, 151 - barCoord(value, barMax, barMin), 151);
       uint8_t barShade = SOLID;
       lcdDrawFilledRect(BAR_LEFT+1, y+1, width, barHeight, barShade);
       for (uint8_t j=24; j<99; j+=25) {

--- a/radio/src/gui/212x64/view_telemetry.cpp
+++ b/radio/src/gui/212x64/view_telemetry.cpp
@@ -65,6 +65,8 @@ void displayGaugesTelemetryScreen(TelemetryScreenData & screen)
     if (source <= MIXSRC_LAST_CH) {
       barMin = calc100toRESX(barMin);
       barMax = calc100toRESX(barMax);
+    }
+    if (source) {
       int y = barHeight+6+i*(barHeight+6);
       drawSource(0, y+barHeight-5, source, 0);
       lcdDrawRect(BAR_LEFT, y, BAR_WIDTH+1, barHeight+2);

--- a/radio/src/gui/480x272/widgets/gauge.cpp
+++ b/radio/src/gui/480x272/widgets/gauge.cpp
@@ -49,14 +49,16 @@ void GaugeWidget::refresh()
   uint16_t color = persistentData->options[3].unsignedValue;
 
   int32_t value = getValue(index);
-  int32_t value_in_range = value;
-  if (value < min)
-    value_in_range = min;
-  else if (value > max)
-    value_in_range = max;
 
-  int w = divRoundClosest(zone.w * (value_in_range - min), (max - min));
-  int percent = divRoundClosest(100 * (value_in_range - min), (max - min));
+  if (min > max) {
+    SWAP(min, max);
+    value = value - min - max;
+  }
+
+  value = limit(min, value, max);
+
+  int w = divRoundClosest(zone.w * (value - min), (max - min));
+  int percent = divRoundClosest(100 * (value - min), (max - min));
 
   // Gauge label
   drawSource(zone.x, zone.y, index, SMLSIZE | TEXT_INVERTED_COLOR);


### PR DESCRIPTION
Closes #2495

When the min is set bigger than the max, the bar progress shown is the complementary. This allows to discount values from a maximum. Eg. to measure the remaining of a 5000mAh battery, set min to 5000 and max to 0