### PR TITLE
Check model is off before changing model - Fixes #7715

### DIFF
--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -36,6 +36,20 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
+    if (TELEMETRY_STREAMING()) {
+      RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
+      while (TELEMETRY_STREAMING()) {
+        RTOS_WAIT_MS(20);
+        if (readKeys() == (1 << KEY_ENTER)) {
+          killEvents(KEY_ENTER);
+          break;
+        }
+        else if (readKeys() == (1 << KEY_EXIT)) {
+          killEvents(KEY_EXIT);
+          return;
+        }
+      }
+    }
     selectModel(sub);
   }
   else if (result == STR_COPY_MODEL) {

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -36,19 +36,8 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
-    if (TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm) {
-      RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
-      while (TELEMETRY_STREAMING()) {
-        RTOS_WAIT_MS(20);
-        if (readKeys() == (1 << KEY_ENTER)) {
-          killEvents(KEY_ENTER);
-          break;
-        }
-        else if (readKeys() == (1 << KEY_EXIT)) {
-          killEvents(KEY_EXIT);
-          return;
-        }
-      }
+    if (!g_eeGeneral.disableRssiPoweroffAlarm) {
+      if (!confirmModelChange()) return;
     }
     selectModel(sub);
   }

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -37,7 +37,8 @@ void onModelSelectMenu(const char * result)
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
     if (!g_eeGeneral.disableRssiPoweroffAlarm) {
-      if (!confirmModelChange()) return;
+      if (!confirmModelChange())
+        return;
     }
     selectModel(sub);
   }

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -36,7 +36,7 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
-    if (TELEMETRY_STREAMING()) {
+    if (TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm) {
       RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
       while (TELEMETRY_STREAMING()) {
         RTOS_WAIT_MS(20);

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -29,7 +29,8 @@ void onModelSelectMenu(const char * result)
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
     if (!g_eeGeneral.disableRssiPoweroffAlarm) {
-      if (!confirmModelChange()) return;
+      if (!confirmModelChange())
+        return;
     }
     selectModel(sub);
   }

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -28,6 +28,20 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
+    if (TELEMETRY_STREAMING()) {
+      RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
+      while (TELEMETRY_STREAMING()) {
+        RTOS_WAIT_MS(20);
+        if (readKeys() == (1 << KEY_ENTER)) {
+          killEvents(KEY_ENTER);
+          break;
+        }
+        else if (readKeys() == (1 << KEY_EXIT)) {
+          killEvents(KEY_EXIT);
+          return;
+        }
+      }
+    }
     selectModel(sub);
   }
   else if (result == STR_COPY_MODEL) {

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -28,19 +28,8 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
-    if (TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm) {
-      RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
-      while (TELEMETRY_STREAMING()) {
-        RTOS_WAIT_MS(20);
-        if (readKeys() == (1 << KEY_ENTER)) {
-          killEvents(KEY_ENTER);
-          break;
-        }
-        else if (readKeys() == (1 << KEY_EXIT)) {
-          killEvents(KEY_EXIT);
-          return;
-        }
-      }
+    if (!g_eeGeneral.disableRssiPoweroffAlarm) {
+      if (!confirmModelChange()) return;
     }
     selectModel(sub);
   }

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -28,7 +28,7 @@ void onModelSelectMenu(const char * result)
   int8_t sub = menuVerticalPosition;
 
   if (result == STR_SELECT_MODEL || result == STR_CREATE_MODEL) {
-    if (TELEMETRY_STREAMING()) {
+    if (TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm) {
       RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
       while (TELEMETRY_STREAMING()) {
         RTOS_WAIT_MS(20);

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -260,7 +260,7 @@ bool isModelOff() {
 void onModelSelectMenu(const char * result)
 {
   if (result == STR_SELECT_MODEL) {
-    if (isModelOff()) {
+    if (isModelOff() && !g_eeGeneral.disableRssiPoweroffAlarm) {
       // we store the latest changes if any
       storageFlushCurrentModel();
       storageCheck(true);
@@ -279,7 +279,7 @@ void onModelSelectMenu(const char * result)
     deleteMode = MODE_DELETE_MODEL;
   }
   else if (result == STR_CREATE_MODEL) {
-    if (isModelOff()) {
+    if (isModelOff() && !g_eeGeneral.disableRssiPoweroffAlarm) {
       storageCheck(true);
       modelslist.addModel(currentCategory, createModel());
       selectMode = MODE_SELECT_MODEL;

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -239,24 +239,6 @@ void onDeleteModelConfirm(const char * result)
   }
 }
 
-bool confirmModelChange() {
-  if (TELEMETRY_STREAMING()) {
-    RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
-    while (TELEMETRY_STREAMING()) {
-      RTOS_WAIT_MS(20);
-      if (readKeys() == (1 << KEY_ENTER)) {
-        killEvents(KEY_ENTER);
-        return true;
-      }
-      else if (readKeys() == (1 << KEY_EXIT)) {
-        killEvents(KEY_EXIT);
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 void onModelSelectMenu(const char * result)
 {
   if (result == STR_SELECT_MODEL) {

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -239,7 +239,7 @@ void onDeleteModelConfirm(const char * result)
   }
 }
 
-bool isModelOff() {
+bool confirmModelChange() {
   if (TELEMETRY_STREAMING()) {
     RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
     while (TELEMETRY_STREAMING()) {
@@ -260,18 +260,19 @@ bool isModelOff() {
 void onModelSelectMenu(const char * result)
 {
   if (result == STR_SELECT_MODEL) {
-    if (isModelOff() && !g_eeGeneral.disableRssiPoweroffAlarm) {
-      // we store the latest changes if any
-      storageFlushCurrentModel();
-      storageCheck(true);
-      memcpy(g_eeGeneral.currModelFilename, currentModel->modelFilename, LEN_MODEL_FILENAME);
-      modelslist.setCurrentModel(currentModel);
-      modelslist.setCurrentCategory(currentCategory);
-      loadModel(g_eeGeneral.currModelFilename, true);
-      storageDirty(EE_GENERAL);
-      storageCheck(true);
-      chainMenu(menuMainView);
+    if (!g_eeGeneral.disableRssiPoweroffAlarm) {
+      if (!confirmModelChange()) return;
     }
+    // we store the latest changes if any
+    storageFlushCurrentModel();
+    storageCheck(true);
+    memcpy(g_eeGeneral.currModelFilename, currentModel->modelFilename, LEN_MODEL_FILENAME);
+    modelslist.setCurrentModel(currentModel);
+    modelslist.setCurrentCategory(currentCategory);
+    loadModel(g_eeGeneral.currModelFilename, true);
+    storageDirty(EE_GENERAL);
+    storageCheck(true);
+    chainMenu(menuMainView);
   }
   else if (result == STR_DELETE_MODEL) {
     POPUP_CONFIRMATION(STR_DELETEMODEL, onDeleteModelConfirm);
@@ -279,18 +280,19 @@ void onModelSelectMenu(const char * result)
     deleteMode = MODE_DELETE_MODEL;
   }
   else if (result == STR_CREATE_MODEL) {
-    if (isModelOff() && !g_eeGeneral.disableRssiPoweroffAlarm) {
-      storageCheck(true);
-      modelslist.addModel(currentCategory, createModel());
-      selectMode = MODE_SELECT_MODEL;
-      setCurrentModel(currentCategory->size() - 1);
-      modelslist.setCurrentModel(currentModel);
-      modelslist.setCurrentCategory(currentCategory);
-      modelslist.onNewModelCreated(currentModel, &g_model);
-#if defined(LUA)
-      chainMenu(menuModelWizard);
-#endif
+    if (!g_eeGeneral.disableRssiPoweroffAlarm) {
+      if (!confirmModelChange()) return;
     }
+    storageCheck(true);
+    modelslist.addModel(currentCategory, createModel());
+    selectMode = MODE_SELECT_MODEL;
+    setCurrentModel(currentCategory->size() - 1);
+    modelslist.setCurrentModel(currentModel);
+    modelslist.setCurrentCategory(currentCategory);
+    modelslist.onNewModelCreated(currentModel, &g_model);
+#if defined(LUA)
+    chainMenu(menuModelWizard);
+#endif
   }
   else if (result == STR_DUPLICATE_MODEL) {
     char duplicatedFilename[LEN_MODEL_FILENAME+1];

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -239,6 +239,24 @@ void onDeleteModelConfirm(const char * result)
   }
 }
 
+bool isModelOff() {
+  if (TELEMETRY_STREAMING()) {
+    RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
+    while (TELEMETRY_STREAMING()) {
+      RTOS_WAIT_MS(20);
+      if (readKeys() == (1 << KEY_ENTER)) {
+        killEvents(KEY_ENTER);
+        return true;
+      }
+      else if (readKeys() == (1 << KEY_EXIT)) {
+        killEvents(KEY_EXIT);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 void onModelSelectMenu(const char * result)
 {
   if (result == STR_SELECT_MODEL) {
@@ -520,23 +538,5 @@ bool menuModelSelect(event_t event)
   lcd->drawBitmap(70, LCD_H-FH-20, modelselModelQtyBitmap);
   lcdDrawNumber(92, LCD_H-FH-21, modelslist.getModelsCount(),SMLSIZE);
 
-  return true;
-}
-
-bool isModelOff() {
-  if (TELEMETRY_STREAMING()) {
-    RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
-    while (TELEMETRY_STREAMING()) {
-      RTOS_WAIT_MS(20);
-      if (readKeys() == (1 << KEY_ENTER)) {
-        killEvents(KEY_ENTER);
-        return true;
-      }
-      else if (readKeys() == (1 << KEY_EXIT)) {
-        killEvents(KEY_EXIT);
-        return false;
-      }
-    }
-  }
   return true;
 }

--- a/radio/src/gui/480x272/model_select.cpp
+++ b/radio/src/gui/480x272/model_select.cpp
@@ -243,7 +243,8 @@ void onModelSelectMenu(const char * result)
 {
   if (result == STR_SELECT_MODEL) {
     if (!g_eeGeneral.disableRssiPoweroffAlarm) {
-      if (!confirmModelChange()) return;
+      if (!confirmModelChange())
+        return;
     }
     // we store the latest changes if any
     storageFlushCurrentModel();
@@ -263,7 +264,8 @@ void onModelSelectMenu(const char * result)
   }
   else if (result == STR_CREATE_MODEL) {
     if (!g_eeGeneral.disableRssiPoweroffAlarm) {
-      if (!confirmModelChange()) return;
+      if (!confirmModelChange())
+        return;
     }
     storageCheck(true);
     modelslist.addModel(currentCategory, createModel());

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -775,6 +775,25 @@ bool modelHasNotes()
   return false;
 }
 
+bool confirmModelChange()
+{
+  if (TELEMETRY_STREAMING()) {
+    RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
+    while (TELEMETRY_STREAMING()) {
+      RTOS_WAIT_MS(20);
+      if (readKeys() == (1 << KEY_ENTER)) {
+        killEvents(KEY_ENTER);
+        return true;
+      }
+      else if (readKeys() == (1 << KEY_EXIT)) {
+        killEvents(KEY_EXIT);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 int getFirstAvailable(int min, int max, IsValueAvailable isValueAvailable)
 {
   int retval = 0;

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -97,6 +97,8 @@ bool isRssiSensorAvailable(int sensor);
 
 bool modelHasNotes();
 
+bool confirmModelChange();
+
 #if defined(COLORLCD)
 bool isSwitch2POSWarningStateAvailable(int state);
 #endif


### PR DESCRIPTION
Fixes #7715. Check there is no telemetry when changing/creating model

May be linked to the option _disableRssiPoweroffAlarm_ and update var name and translations accordingly? 