### PR TITLE
Add 6-position S3 to Taranis x9d+ 2019 SE

### DIFF
--- a/radio/src/targets/common/arm/stm32/adc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/adc_driver.cpp
@@ -91,6 +91,11 @@ void adcInit()
   GPIO_Init(GPIOC, &GPIO_InitStructure);
 #endif
 
+#if defined(ADC_GPIOD_PINS)
+  GPIO_InitStructure.GPIO_Pin = ADC_GPIOD_PINS;
+  GPIO_Init(GPIOD, &GPIO_InitStructure);
+#endif
+
 #if defined(ADC_GPIOF_PINS)
   GPIO_InitStructure.GPIO_Pin = ADC_GPIOF_PINS;
   GPIO_Init(GPIOF, &GPIO_InitStructure);

--- a/radio/src/targets/common/arm/stm32/adc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/adc_driver.cpp
@@ -39,7 +39,7 @@
                                             12 /*SLIDER1*/, 13 /*SLIDER2*/, 7 /*SLIDER3*/, 8 /*SLIDER4*/,
                                             9 /*TX_VOLTAGE*/, 10 /*TX_VBAT*/ };
 #elif defined(PCBX9DP)
-  const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,-1,  1,1,  1,  1};
+  const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,1,  1,1,  1,  1};
 #elif defined(PCBX9D)
   const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,0,   1,1,  1,  1};
 #elif defined(PCBX7)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -781,7 +781,7 @@
     #define ADC_GPIO_PIN_POT3           GPIO_Pin_11  // PD.11
     #define ADC_GPIOB_PINS              (ADC_GPIO_PIN_POT2)
     #define ADC_GPIOD_PINS              (ADC_GPIO_PIN_POT3)
-    #define ADC_CHANNEL_POT3            ADC_Channel_9
+    #define ADC_CHANNEL_POT3            ADC_Channel_4
     #define ADC_VREF_PREC2              300
   #endif
   #define ADC_GPIO_PIN_SLIDER1          GPIO_Pin_4  // PC.04

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -759,7 +759,7 @@
   #define HARDWARE_POT1
   #define HARDWARE_POT2
   #define HARDWARE_POT3
-  #define ADC_RCC_AHB1Periph            (RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB | RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_DMA2)
+  #define ADC_RCC_AHB1Periph            (RCC_AHB1Periph_GPIOA | RCC_AHB1Periph_GPIOB | RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_DMA2)
   #define ADC_RCC_APB1Periph            0
   #define ADC_RCC_APB2Periph            RCC_APB2Periph_ADC1
   #define ADC_GPIO_PIN_STICK_RV         GPIO_Pin_0  // PA.00

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -778,8 +778,10 @@
     #define ADC_CHANNEL_POT3            ADC_Channel_9
     #define ADC_VREF_PREC2              330
   #else
+    #define ADC_GPIO_PIN_POT3           GPIO_Pin_11  // PD.11
     #define ADC_GPIOB_PINS              (ADC_GPIO_PIN_POT2)
-    #define ADC_CHANNEL_POT3            0
+    #define ADC_GPIOD_PINS              (ADC_GPIO_PIN_POT3)
+    #define ADC_CHANNEL_POT3            ADC_Channel_9
     #define ADC_VREF_PREC2              300
   #endif
   #define ADC_GPIO_PIN_SLIDER1          GPIO_Pin_4  // PC.04


### PR DESCRIPTION
I am trying to add S3 (6 position) to the Taranis X9D+ 2019 SE transmitter. I know people say you have to replace one of the other pots but I think it can be done. I thought the easiest way to go about figuring out what to setup in the firmware, was to just add some code and put it up for PR. I have this marked as draft because it's not working properly, the TX is doing something strange...

When I go to the debug screen for analogs and turn pot S2 the field for S3 follows in the opposite direction... So if I turn the pot CW the value of S2 goes up and the value of S3 goes down. I verified that this voltage is not present on the input line. I verified that the proper voltage is present on pin 58 (PD11) and that it follows the switch. Turning S3 does nothing in the radio display.

Clearly I have missed something and I am at a loss as to how to go about debugging. I was hoping I could get some guidance, thanks. I'm new to this codebase.