### PR TITLE
Fix mixer overflow

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -947,7 +947,7 @@ void evalMixes(uint8_t tick10ms)
         mixerCurrentFlightMode = p;
         evalFlightModeMixes(p==fm ? e_perout_mode_normal : e_perout_mode_inactive_flight_mode, p==fm ? tick10ms : 0);
         for (uint8_t i=0; i<MAX_OUTPUT_CHANNELS; i++)
-          sum_chans512[i] += (chans[i] >> 4) * fp_act[p];
+          sum_chans512[i] += limit<int32_t>(-0x6fff, chans[i] >> 4, 0x6fff) * fp_act[p];
         weight += fp_act[p];
       }
     }

--- a/radio/src/tests/gtests.h
+++ b/radio/src/tests/gtests.h
@@ -65,6 +65,7 @@ inline void MODEL_RESET()
   memset(&anaInValues, 0, sizeof(anaInValues));
   extern uint8_t s_mixer_first_run_done;
   s_mixer_first_run_done = false;
+  evalMixes(1);  // this is needed to reset fp_act
   lastFlightMode = 255;
 }
 

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -47,6 +47,22 @@ class MixerTest : public OpenTxTest {};
       } \
     } while (0)
 
+#define CHECK_FLIGHT_MODE_TRANSITION(channel, duration, initValue, endValue) \
+    do { \
+      uint32_t delta = 0xffff / duration; \
+      int32_t weightInit = 0xffff; \
+      int32_t weightEnd = 0; \
+      for (int i = 0; i <= (duration); i++) { \
+        evalMixes(1); \
+        GTEST_ASSERT_LE( abs(((initValue) * weightInit + (endValue) * weightEnd) / 0xffff - channelOutputs[(channel)]), 1); \
+        weightInit = weightInit - delta; \
+        weightEnd = weightEnd + delta; \
+      } \
+      for (int i = 0; i < 100; i++) { /* be sure the transition is finished*/ \
+        evalMixes(1); \
+      } \
+    } while (0)
+
 TEST_F(TrimsTest, throttleTrim)
 {
   g_model.thrTrim = 1;
@@ -658,4 +674,49 @@ TEST(Trainer, UnpluggedTest)
   ppmInputValidityTimer = 0;
   ppmInput[0] = 1024;
   CHECK_DELAY(0, 5000);
+}
+
+TEST_F(MixerTest, flightModeTransition)
+{
+  SYSTEM_RESET();
+  MODEL_RESET();
+  MIXER_RESET();
+  modelDefault(0);
+  g_model.flightModeData[1].swtch = TR(SWSRC_ID2, SWSRC_SA2);
+  g_model.flightModeData[0].fadeIn = 100;
+  g_model.flightModeData[0].fadeOut = 100;
+  g_model.flightModeData[1].fadeIn = 100;
+  g_model.flightModeData[1].fadeOut = 100;
+  g_model.mixData[0].destCh = 0;
+  g_model.mixData[0].mltpx = MLTPX_REP;
+  g_model.mixData[0].srcRaw = MIXSRC_MAX;
+  g_model.mixData[0].flightModes = 0b11110;
+  g_model.mixData[0].weight = 100;
+  g_model.mixData[1].destCh = 0;
+  g_model.mixData[1].mltpx = MLTPX_REP;
+  g_model.mixData[1].srcRaw = MIXSRC_MAX;
+  g_model.mixData[1].flightModes = 0b11101;
+  g_model.mixData[1].weight = -10;
+  evalMixes(1);
+  simuSetSwitch(0, 1);
+  CHECK_FLIGHT_MODE_TRANSITION(0, 1000, 1024, -102);
+}
+
+TEST_F(MixerTest, flightModeOverflow)
+{
+  SYSTEM_RESET();
+  MODEL_RESET();
+  MIXER_RESET();
+  modelDefault(0);
+  g_model.flightModeData[1].swtch = TR(SWSRC_ID2, SWSRC_SA2);
+  g_model.flightModeData[0].fadeIn = 100;
+  g_model.flightModeData[0].fadeOut = 100;
+  g_model.mixData[0].destCh = 0;
+  g_model.mixData[0].mltpx = MLTPX_REP;
+  g_model.mixData[0].srcRaw = MIXSRC_MAX;
+  g_model.mixData[0].flightModes = 0;
+  g_model.mixData[0].weight = 250;
+  evalMixes(1);
+  simuSetSwitch(0, 1);
+  CHECK_FLIGHT_MODE_TRANSITION(0, 1000, 1024, 1024);
 }


### PR DESCRIPTION
Fixes mixer overflow #7623 by limiting the chans values when fading flightmodes

Added two non regresion tests for mixer modes transitions:

- _flightModeOverflow_ evaluates the initial overflow error (where current mixer fails) 
- _flightModeTransition_ evaluates the transition between two values (where dynamic bit shift fails)