### PR TITLE
Provide a way to add pot S3 to Taranis X9D+ 2019

### DIFF
--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TIMERS 3 CACHE STRING "Timers count (2 or 3)")
 set_property(CACHE TIMERS PROPERTY STRINGS 2 3)
 option(CLI "Command Line Interface" OFF)
 option(DEBUG "Debug mode" OFF)
+option(S3_HACK "Setup S3 Hack" OFF)
 option(LOG_TELEMETRY "Telemetry Logs on SD card" OFF)
 option(LOG_BLUETOOTH "Bluetooth Logs on SD card" OFF)
 option(TRACE_SD_CARD "Traces SD enabled" OFF)
@@ -100,6 +101,10 @@ endif()
 
 if(DEBUG)
   add_definitions(-DDEBUG)
+endif()
+
+if(S3_HACK)
+  add_definitions(-DS3_HACK)
 endif()
 
 if(HAPTIC)

--- a/radio/src/targets/common/arm/stm32/adc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/adc_driver.cpp
@@ -39,7 +39,7 @@
                                             12 /*SLIDER1*/, 13 /*SLIDER2*/, 7 /*SLIDER3*/, 8 /*SLIDER4*/,
                                             9 /*TX_VOLTAGE*/, 10 /*TX_VBAT*/ };
 #elif defined(PCBX9DP)
-  const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,-1,  1,1,  1,  1};
+  const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,1,  1,1,  1,  1};
 #elif defined(PCBX9D)
   const int8_t adcDirection[NUM_ANALOGS] = {1,-1,1,-1,  1,1,0,   1,1,  1,  1};
 #elif defined(PCBX7)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -259,8 +259,13 @@
   #define TRIMS_GPIO_PIN_RVU            GPIO_Pin_2  // PC.02
   #define TRIMS_GPIO_REG_RHL            GPIOC->IDR
   #define TRIMS_GPIO_PIN_RHL            GPIO_Pin_13 // PC.13
-  #define TRIMS_GPIO_REG_RHR            GPIOC->IDR
-  #define TRIMS_GPIO_PIN_RHR            GPIO_Pin_1  // PC.01
+  #if defined(S3_HACK)
+    #define TRIMS_GPIO_REG_RHR          GPIOD->IDR
+    #define TRIMS_GPIO_PIN_RHR          GPIO_Pin_11  // PD.11
+  #else
+    #define TRIMS_GPIO_REG_RHR          GPIOC->IDR
+    #define TRIMS_GPIO_PIN_RHR          GPIO_Pin_1  // PC.01
+  #endif
 #else
   #define TRIMS_GPIO_REG_LHL            GPIOE->IDR
   #define TRIMS_GPIO_PIN_LHL            GPIO_Pin_4  // PE.04
@@ -640,7 +645,11 @@
   #define KEYS_GPIOA_PINS               (GPIO_Pin_5)
   #define KEYS_GPIOB_PINS               (GPIO_Pin_3 | GPIO_Pin_4 | GPIO_Pin_5)
   #define KEYS_GPIOC_PINS               (GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3 | GPIO_Pin_13)
-  #define KEYS_GPIOD_PINS               (GPIO_Pin_2 | GPIO_Pin_3 | GPIO_Pin_7 | GPIO_Pin_10 | GPIO_Pin_14)
+  #if defined(S3_HACK)
+    #define KEYS_GPIOD_PINS             (GPIO_Pin_2 | GPIO_Pin_3 | GPIO_Pin_7 | GPIO_Pin_10 | GPIO_Pin_14 | GPIO_Pin_11)
+  #else
+    #define KEYS_GPIOD_PINS             (GPIO_Pin_2 | GPIO_Pin_3 | GPIO_Pin_7 | GPIO_Pin_10 | GPIO_Pin_14)
+  #endif
   #define KEYS_GPIOE_PINS               (GPIO_Pin_0 | GPIO_Pin_1 | GPIO_Pin_2 | GPIO_Pin_3 | GPIO_Pin_4 | GPIO_Pin_5 | GPIO_Pin_6 | GPIO_Pin_7 | GPIO_Pin_8 | GPIO_Pin_9 | GPIO_Pin_10 | GPIO_Pin_11 | GPIO_Pin_12 | GPIO_Pin_13 | GPIO_Pin_14 | GPIO_Pin_15)
 #elif defined(PCBX9DP)
   #define KEYS_RCC_AHB1Periph           (RCC_AHB1Periph_GPIOA|RCC_AHB1Periph_GPIOB|RCC_AHB1Periph_GPIOC|RCC_AHB1Periph_GPIOD|RCC_AHB1Periph_GPIOE)
@@ -778,15 +787,24 @@
     #define ADC_CHANNEL_POT3            ADC_Channel_9
     #define ADC_VREF_PREC2              330
   #else
+    #if defined(S3_HACK)
+      #define ADC_GPIO_PIN_POT3         GPIO_Pin_1  // PC.01
+      #define ADC_CHANNEL_POT3          ADC_Channel_11
+    #else
+      #define ADC_CHANNEL_POT3          0
+    #endif
     #define ADC_GPIOB_PINS              (ADC_GPIO_PIN_POT2)
-    #define ADC_CHANNEL_POT3            0
     #define ADC_VREF_PREC2              300
   #endif
   #define ADC_GPIO_PIN_SLIDER1          GPIO_Pin_4  // PC.04
   #define ADC_GPIO_PIN_SLIDER2          GPIO_Pin_5  // PC.05
   #define ADC_GPIO_PIN_BATT             GPIO_Pin_0  // PC.00
   #define ADC_GPIOA_PINS                (ADC_GPIO_PIN_STICK_RV | ADC_GPIO_PIN_STICK_RH | ADC_GPIO_PIN_STICK_LH | ADC_GPIO_PIN_STICK_LV | ADC_GPIO_PIN_POT1)
-  #define ADC_GPIOC_PINS                (ADC_GPIO_PIN_SLIDER1 | ADC_GPIO_PIN_SLIDER2 | ADC_GPIO_PIN_BATT)
+  #if defined(S3_HACK)
+    #define ADC_GPIOC_PINS                (ADC_GPIO_PIN_SLIDER1 | ADC_GPIO_PIN_SLIDER2 | ADC_GPIO_PIN_BATT | ADC_GPIO_PIN_POT3)
+  #else
+    #define ADC_GPIOC_PINS                (ADC_GPIO_PIN_SLIDER1 | ADC_GPIO_PIN_SLIDER2 | ADC_GPIO_PIN_BATT)
+  #endif
   #define ADC_CHANNEL_POT1              ADC_Channel_6
   #define ADC_CHANNEL_POT2              ADC_Channel_8
   #define ADC_CHANNEL_SLIDER1           ADC_Channel_14


### PR DESCRIPTION
FrSky removed the pads for S3 and rearranged the GPIO usage to make it a bit difficult to add the extra pot (or 6 position switch) to the radio. This change set provides a `cmake` switch to swap a couple GPIO's around to make the required analog input available. I switched the right horizontal trim right from `PC.01` to `PD.11`. Then the newly available analog input `ADC_Channel_11` which is connected to `PC.01` gets used for the S3 input.

__NOTE: This requires a modification to the hardware to work !__

I have tested this on target and verified that both the trim and analog input function properly.