### PR TITLE
Update companion_de.ts -Some words incomprehensible

### DIFF
--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -5660,17 +5660,17 @@ Sind Sie sicher?</translation>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
         <source>Timer</source>
-        <translation>Takt</translation>
+        <translation>Timer</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
         <source>Sticky</source>
-        <translation>SRFF</translation>
+        <translation>Sticky</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
         <source>Edge</source>
-        <translation>Puls</translation>
+        <translation>Edge</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
@@ -7997,17 +7997,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     <message>
         <location filename="../modelprinter.cpp" line="548"/>
         <source>Edge</source>
-        <translation>Puls</translation>
+        <translation>Edge</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="551"/>
         <source>Sticky</source>
-        <translation>SRFF</translation>
+        <translation>Sticky</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="554"/>
         <source>Timer</source>
-        <translation>Takt</translation>
+        <translation>Timer</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="581"/>


### PR DESCRIPTION
The reason for the change:
Incomprehensible!

In my opinion the wrong German words were chosen.

Timer = "Takt" - english - "clock"
Edge = "Puls"  - english  - "pulse"
Sticky = "SRFF" (absolutely incomprehensible)

The correct translation would normally be:

Timer = Zeitgeber, Zeitmesser
Edge = Kante, Schwellwert
Sticky = Kurzzeitig Ein

Background, I wanted to select a momentary switch for arming, and I just couldn't find the parameter "Sticky" in the logic switch ...
I found out by switching from German to English, I found the words.

Very cumbersome and not understandable what the translator was thinking ...

It is also easier to understand in German if you leave these words as they are.

Greetings