### PR TITLE
Update DSM autobind behavior

### DIFF
--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -504,8 +504,8 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
         break;
       case 0x12:
         g_model.moduleData[module].subType = MM_RF_DSM2_SUBTYPE_DSM2_11;
-        if(channels==7) {
-            channels=12;    // change the number of channels if 7
+        if (channels == 7) {
+          channels = 12;    // change the number of channels if 7
         }
         break;
       case 0x01:
@@ -514,8 +514,8 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
         break;
       default: // 0xb2 or unknown
         g_model.moduleData[module].subType = MM_RF_DSM2_SUBTYPE_DSMX_11;
-        if(channels==7) {
-            channels=12;    // change the number of channels if 7
+        if (channels == 7) {
+          channels = 12;    // change the number of channels if 7
         }
         break;
     }

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -497,7 +497,6 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
     else if (channels < 3) {
       channels = 3;
     }
-    g_model.moduleData[module].channelsCount = channels - 8;
 
     switch(packet[6]) {
       case 0xa2:
@@ -505,6 +504,9 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
         break;
       case 0x12:
         g_model.moduleData[module].subType = MM_RF_DSM2_SUBTYPE_DSM2_11;
+        if(channels==7) {
+            channels=12;    // change the number of channels if 7
+        }
         break;
       case 0x01:
       case 0x02:
@@ -512,8 +514,15 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
         break;
       default: // 0xb2 or unknown
         g_model.moduleData[module].subType = MM_RF_DSM2_SUBTYPE_DSMX_11;
+        if(channels==7) {
+            channels=12;    // change the number of channels if 7
+        }
         break;
     }
+
+    g_model.moduleData[module].channelsCount = channels - 8;
+    g_model.moduleData[module].multi.optionValue &= 0xFD;    // clear the 11ms servo refresh rate flag
+
     storageDirty(EE_MODEL);
   }
 


### PR DESCRIPTION
Changes for the DSM AUTO protocol:
- if RX requests 7 channels in 11ms frame rate modes change the value to 12 channels
- reset servo refresh rate to the default 22ms
