### PR TITLE
Make radio profile choice synchronous in Companion startup

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -130,15 +130,9 @@ MainWindow::MainWindow():
   else {
     if (!g.previousVersion().isEmpty())
       g.warningId(g.warningId() | AppMessages::MSG_UPGRADED);
+    
     if (g.promptProfile()) {
-      QTimer::singleShot(updateDelay, this, SLOT(chooseProfile()));    // add an extra second to give mainwindow time to load
-      updateDelay += 5000;  //  give user time to select profile before warnings
-    }
-    else {
-      if (checkProfileRadioExists(g.sessionId()))
-        QTimer::singleShot(updateDelay, this, SLOT(doAutoUpdates()));
-      else
-        g.warningId(g.warningId() | AppMessages::MSG_NO_RADIO_TYPE);
+      chooseProfile();
     }
   }
   QTimer::singleShot(updateDelay, this, SLOT(displayWarnings()));
@@ -184,6 +178,11 @@ MainWindow::MainWindow():
   if (printing) {
     QTimer::singleShot(0, this, SLOT(autoClose()));
   }
+
+  if (checkProfileRadioExists(g.sessionId()))
+    QTimer::singleShot(updateDelay, this, SLOT(doAutoUpdates()));
+  else
+    g.warningId(g.warningId() | AppMessages::MSG_NO_RADIO_TYPE);
 }
 
 MainWindow::~MainWindow()
@@ -1805,10 +1804,8 @@ void MainWindow::chooseProfile()
     connect(pcd, &ProfileChooserDialog::profileChanged, this, &MainWindow::loadProfileId);
     pcd->exec();
     delete pcd;
-    //  doi here as need to wait until dialog dismissed and current radio type is set
-    if (checkProfileRadioExists(g.sessionId()))
-      doAutoUpdates();
-    else
+
+    if (!checkProfileRadioExists(g.sessionId()))
       g.warningId(g.warningId() | AppMessages::MSG_NO_RADIO_TYPE);
   }
 }

--- a/companion/src/profilechooser.cpp
+++ b/companion/src/profilechooser.cpp
@@ -28,6 +28,7 @@ ProfileChooserDialog::ProfileChooserDialog(QWidget * parent):
 {
   ui->setupUi(this);
   setWindowIcon(QIcon(":/icon.png"));
+  setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
   QComboBox *prof = ui->cboProfiles;
   prof->clear();
 


### PR DESCRIPTION
Makes the radio profile choice synchronous, and occur before the update check and OTX file load.  Alternative solution for #7806, could supersede #7808.

It makes more sense to me for the profile choice to occur synchronously, whether an OTX file is being loaded or not.  Otherwise the Companion window can become visible with a profile loaded before the user selects the radio profile that they want to use

This has two benefits:
1. Update checks only occur for the selected profile, not once for the previous profile, then again for the selected profile
1. If an OTX file is loaded the conversion prompt will only appear if the selected profile does not match the OTX file
