### PR TITLE
Fix companion "Trainer" to "Trainer Sticks" to match radio

### DIFF
--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -46,7 +46,7 @@ QString CustomFunctionData::funcToString(const ModelData * model) const
   if (func >= FuncOverrideCH1 && func <= FuncOverrideCH32)
     return tr("Override %1").arg(RawSource(SOURCE_TYPE_CH, func).toString(model));
   else if (func == FuncTrainer)
-    return tr("Trainer");
+    return tr("Trainer Sticks");
   else if (func == FuncTrainerRUD)
     return tr("Trainer RUD");
   else if (func == FuncTrainerELE)


### PR DESCRIPTION
This fixes #7859

There would be a much more work intensive alternative to replicate the two collumns in Compantion, but then that would also affect Set Timers, Override, Adjust GV,....