### PR TITLE
[sd-card] X7 delta setup wizard fix scroll changing page rather than field

### DIFF
--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
@@ -93,11 +93,11 @@ local function navigate(event, fieldMax, prevPage, nextPage)
       dirty = blinkChanged()
     end
   else
-    if event == EVT_PAGE_BREAK or event == EVT_RIGHT_FIRST then
+    if event == EVT_VIRTUAL_NEXT_PAGE then
       page = nextPage
       field = 0
       dirty = true
-    elseif event == EVT_PAGE_LONG or event == EVT_LEFT_FIRST then
+    elseif event == EVT_VIRTUAL_PREV_PAGE then
       page = prevPage
       field = 0
       killEvents(event);
@@ -335,7 +335,7 @@ local function drawConfirmationMenu()
   if rudderMode == 1 then
     drawNextLine(x, y, "Rudder", rudCH1)
   end
-  lcd.drawText(48, LCD_H-8, "[Enter Long] to confirm", 0);
+  lcd.drawText(0, LCD_H-8, "[Enter Long] to confirm", 0);
   lcd.drawFilledRectangle(0, LCD_H-9, LCD_W, 9, 0)
   fieldsMax = 0
 end

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/delta.lua
@@ -52,10 +52,10 @@ end
 
 local function fieldIncDec(event, value, max, force)
   if edit or force==true then
-    if event == EVT_VIRTUAL_PREV or event == EVT_VIRTUAL_PREV_REPT then
+    if event == EVT_VIRTUAL_INC then
       value = (value + max)
       dirty = true
-    elseif event == EVT_VIRTUAL_NEXT or event == EVT_VIRTUAL_NEXT_REPT then
+    elseif event == EVT_VIRTUAL_DEC then
       value = (value + max + 2)
       dirty = true
     end
@@ -93,11 +93,11 @@ local function navigate(event, fieldMax, prevPage, nextPage)
       dirty = blinkChanged()
     end
   else
-    if event == EVT_VIRTUAL_NEXT then
+    if event == EVT_PAGE_BREAK or event == EVT_RIGHT_FIRST then
       page = nextPage
       field = 0
       dirty = true
-    elseif event == EVT_VIRTUAL_PREV then
+    elseif event == EVT_PAGE_LONG or event == EVT_LEFT_FIRST then
       page = prevPage
       field = 0
       killEvents(event);

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/multi.lua
@@ -99,11 +99,11 @@ local function navigate(event, fieldMax, prevPage, nextPage)
       dirty = blinkChanged()
     end
   else
-    if event == EVT_PAGE_BREAK or event == EVT_RIGHT_FIRST then
+    if event == EVT_VIRTUAL_NEXT_PAGE then
       page = nextPage
       field = 0
       dirty = true
-    elseif event == EVT_PAGE_LONG or event == EVT_LEFT_FIRST then
+    elseif event == EVT_VIRTUAL_PREV_PAGE then
       page = prevPage
       field = 0
       killEvents(event);

--- a/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/WIZARD/plane.lua
@@ -103,11 +103,11 @@ local function navigate(event, fieldMax, prevPage, nextPage)
       dirty = blinkChanged()
     end
   else
-    if event == EVT_PAGE_BREAK or event==EVT_RIGHT_BREAK then
+    if event == EVT_VIRTUAL_NEXT_PAGE then
       page = nextPage
       field = 0
       dirty = true
-    elseif event == EVT_PAGE_LONG or event==EVT_LEFT_BREAK then
+    elseif event == EVT_VIRTUAL_PREV_PAGE then
       page = prevPage
       field = 0
       killEvents(event);


### PR DESCRIPTION
The X7 script (and thus what's used on the Tango2) had a bug where when you scrolled down it changed page rather than changing between fields.
I compared with the multi script (most recently updated) and have tested that the changes work in the delta setup wizard.