### PR TITLE
Companion refactor of ui datamodels

### DIFF
--- a/companion/src/datamodels/rawitemdatamodels.cpp
+++ b/companion/src/datamodels/rawitemdatamodels.cpp
@@ -225,7 +225,8 @@ void CurveItemModel::update()
 //  CommonItemModels
 //
 
-CommonItemModels::CommonItemModels(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent)
+CommonItemModels::CommonItemModels(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent) :
+  QObject(parent)
 {
   m_rawSourceItemModel = new RawSourceItemModel(generalSettings, modelData, parent);
   m_rawSwitchItemModel = new RawSwitchItemModel(generalSettings, modelData, parent);

--- a/companion/src/datamodels/rawitemdatamodels.h
+++ b/companion/src/datamodels/rawitemdatamodels.h
@@ -36,6 +36,13 @@ class AbstractRawItemDataModel: public QStandardItemModel
     enum DataRoles { ItemIdRole = Qt::UserRole, ItemTypeRole, ItemFlagsRole, IsAvailableRole };
     Q_ENUM(DataRoles)
 
+    enum DataGroups {
+      NoneGroup     = 0x01,
+      NegativeGroup = 0x02,
+      PositiveGroup = 0x04
+    };
+    Q_ENUM(DataGroups)
+
     explicit AbstractRawItemDataModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr)  :
       QStandardItemModel(parent),
       generalSettings(generalSettings),
@@ -43,7 +50,11 @@ class AbstractRawItemDataModel: public QStandardItemModel
     {}
 
   public slots:
-    virtual void update() const = 0;
+    virtual void update() = 0;
+
+  signals:
+    void dataAboutToBeUpdated();
+    void dataUpdateComplete();
 
   protected:
     const GeneralSettings * generalSettings;
@@ -58,7 +69,7 @@ class RawSourceItemModel: public AbstractRawItemDataModel
     explicit RawSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr);
 
   public slots:
-    void update() const override;
+    void update() override;
 
   protected:
     void setDynamicItemData(QStandardItem * item, const RawSource & src) const;
@@ -73,12 +84,25 @@ class RawSwitchItemModel: public AbstractRawItemDataModel
     explicit RawSwitchItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr);
 
   public slots:
-    void update() const override;
+    void update() override;
 
   protected:
     void setDynamicItemData(QStandardItem * item, const RawSwitch & rsw) const;
     void addItems(const RawSwitchType & type, int count);
 };
 
+
+class CurveItemModel: public AbstractRawItemDataModel
+{
+    Q_OBJECT
+  public:
+    explicit CurveItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr);
+
+  public slots:
+    void update() override;
+
+  protected:
+    void setDynamicItemData(QStandardItem * item, int index) const;
+};
 
 #endif // RAWITEMDATAMODELS_H

--- a/companion/src/datamodels/rawitemdatamodels.h
+++ b/companion/src/datamodels/rawitemdatamodels.h
@@ -105,4 +105,36 @@ class CurveItemModel: public AbstractRawItemDataModel
     void setDynamicItemData(QStandardItem * item, int index) const;
 };
 
+
+class CommonItemModels: public QObject
+{
+    Q_OBJECT
+  public:
+    enum RadioModelObjects {
+      RMO_CHANNELS,
+      RMO_CURVES,
+      RMO_FLIGHT_MODES,
+      RMO_GLOBAL_VARIABLES,
+      RMO_INPUTS,
+      RMO_LOGICAL_SWITCHES,
+      RMO_SCRIPTS,
+      RMO_TELEMETRY_SENSORS,
+      RMO_TIMERS
+    };
+    Q_ENUM(RadioModelObjects)
+
+    explicit CommonItemModels(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr);
+    ~CommonItemModels();
+
+    void update(const RadioModelObjects radioModelObjects);
+    RawSourceItemModel * rawSourceItemModel() const { return m_rawSourceItemModel; }
+    RawSwitchItemModel * rawSwitchItemModel() const { return m_rawSwitchItemModel; }
+    CurveItemModel * curveItemModel() const { return m_curveItemModel; }
+
+  private:
+    RawSourceItemModel *m_rawSourceItemModel;
+    RawSwitchItemModel *m_rawSwitchItemModel;
+    CurveItemModel *m_curveItemModel;
+};
+
 #endif // RAWITEMDATAMODELS_H

--- a/companion/src/datamodels/rawitemfilteredmodel.cpp
+++ b/companion/src/datamodels/rawitemfilteredmodel.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "rawitemfilteredmodel.h"
-#include "rawitemdatamodels.h"
 
 RawItemFilteredModel::RawItemFilteredModel(QAbstractItemModel * sourceModel, int flags, QObject * parent) :
   QSortFilterProxyModel(parent),
@@ -31,10 +30,10 @@ RawItemFilteredModel::RawItemFilteredModel(QAbstractItemModel * sourceModel, int
   setDynamicSortFilter(true);
   setSourceModel(sourceModel);
 
-  AbstractRawItemDataModel * model = qobject_cast<AbstractRawItemDataModel *>(sourceModel);
-  if (model) {
-    connect(model, &AbstractRawItemDataModel::dataAboutToBeUpdated, this, &RawItemFilteredModel::onDataAboutToBeUpdated);
-    connect(model, &AbstractRawItemDataModel::dataUpdateComplete, this, &RawItemFilteredModel::onDataUpdateComplete);
+  AbstractRawItemDataModel * itemModel = qobject_cast<AbstractRawItemDataModel *>(sourceModel);
+  if (itemModel) {
+    connect(itemModel, &AbstractRawItemDataModel::dataAboutToBeUpdated, this, &RawItemFilteredModel::onDataAboutToBeUpdated);
+    connect(itemModel, &AbstractRawItemDataModel::dataUpdateComplete, this, &RawItemFilteredModel::onDataUpdateComplete);
   }
 }
 
@@ -62,9 +61,9 @@ bool RawItemFilteredModel::filterAcceptsRow(int sourceRow, const QModelIndex & s
 
 void RawItemFilteredModel::update() const
 {
-  AbstractRawItemDataModel * model = qobject_cast<AbstractRawItemDataModel *>(sourceModel());
-  if (model)
-    model->update();
+  AbstractRawItemDataModel * itemModel = qobject_cast<AbstractRawItemDataModel *>(sourceModel());
+  if (itemModel)
+    itemModel->update();
 }
 
 void RawItemFilteredModel::onDataAboutToBeUpdated()

--- a/companion/src/datamodels/rawitemfilteredmodel.cpp
+++ b/companion/src/datamodels/rawitemfilteredmodel.cpp
@@ -30,6 +30,12 @@ RawItemFilteredModel::RawItemFilteredModel(QAbstractItemModel * sourceModel, int
   setFilterFlags(flags);
   setDynamicSortFilter(true);
   setSourceModel(sourceModel);
+
+  AbstractRawItemDataModel * model = qobject_cast<AbstractRawItemDataModel *>(sourceModel);
+  if (model) {
+    connect(model, &AbstractRawItemDataModel::dataAboutToBeUpdated, this, &RawItemFilteredModel::onDataAboutToBeUpdated);
+    connect(model, &AbstractRawItemDataModel::dataUpdateComplete, this, &RawItemFilteredModel::onDataUpdateComplete);
+  }
 }
 
 void RawItemFilteredModel::setFilterFlags(int flags)
@@ -61,14 +67,12 @@ void RawItemFilteredModel::update() const
     model->update();
 }
 
-
-RawSourceFilterItemModel::RawSourceFilterItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, int flags, QObject * parent) :
-  RawItemFilteredModel(new RawSourceItemModel(generalSettings, modelData, parent), flags, parent)
+void RawItemFilteredModel::onDataAboutToBeUpdated()
 {
+  emit dataAboutToBeUpdated();
 }
 
-
-RawSwitchFilterItemModel::RawSwitchFilterItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, int context, QObject * parent) :
-  RawItemFilteredModel(new RawSwitchItemModel(generalSettings, modelData, parent), context, parent)
+void RawItemFilteredModel::onDataUpdateComplete()
 {
+  emit dataUpdateComplete();
 }

--- a/companion/src/datamodels/rawitemfilteredmodel.h
+++ b/companion/src/datamodels/rawitemfilteredmodel.h
@@ -27,8 +27,6 @@
 
 class GeneralSettings;
 class ModelData;
-class RawSourceItemModel;
-class RawSwitchItemModel;
 
 class RawItemFilteredModel: public QSortFilterProxyModel
 {
@@ -36,9 +34,11 @@ class RawItemFilteredModel: public QSortFilterProxyModel
   public:
     enum DataFilters {
       AllFilter = AbstractRawItemDataModel::NegativeGroup | AbstractRawItemDataModel::NoneGroup | AbstractRawItemDataModel::PositiveGroup,
-      HideNegativeFilter = AllFilter &~ AbstractRawItemDataModel::NegativeGroup,
-      NonePositiveFilter = AbstractRawItemDataModel::NoneGroup | AbstractRawItemDataModel::PositiveGroup,
-      PositiveFilter = AbstractRawItemDataModel::PositiveGroup
+      AllExcludeNoneFilter = AllFilter &~ AbstractRawItemDataModel::NoneGroup,
+      NegativeFilter = AbstractRawItemDataModel::NegativeGroup | AbstractRawItemDataModel::NoneGroup,
+      NegativeExcludeNoneFilter = AbstractRawItemDataModel::NegativeGroup,
+      PositiveFilter = AbstractRawItemDataModel::PositiveGroup | AbstractRawItemDataModel::NoneGroup,
+      PositiveExcludeNoneFilter = AbstractRawItemDataModel::PositiveGroup
     };
     Q_ENUM(DataFilters)
 

--- a/companion/src/datamodels/rawitemfilteredmodel.h
+++ b/companion/src/datamodels/rawitemfilteredmodel.h
@@ -21,6 +21,8 @@
 #ifndef RAWITEMFILTEREDMODEL_H
 #define RAWITEMFILTEREDMODEL_H
 
+#include "rawitemdatamodels.h"
+
 #include <QSortFilterProxyModel>
 
 class GeneralSettings;
@@ -32,43 +34,30 @@ class RawItemFilteredModel: public QSortFilterProxyModel
 {
     Q_OBJECT
   public:
+    enum DataFilters {
+      AllFilter = AbstractRawItemDataModel::NegativeGroup | AbstractRawItemDataModel::NoneGroup | AbstractRawItemDataModel::PositiveGroup,
+      HideNegativeFilter = AllFilter &~ AbstractRawItemDataModel::NegativeGroup,
+      NonePositiveFilter = AbstractRawItemDataModel::NoneGroup | AbstractRawItemDataModel::PositiveGroup,
+      PositiveFilter = AbstractRawItemDataModel::PositiveGroup
+    };
+    Q_ENUM(DataFilters)
+
     explicit RawItemFilteredModel(QAbstractItemModel * sourceModel, int flags, QObject * parent = nullptr);
     explicit RawItemFilteredModel(QAbstractItemModel * sourceModel, QObject * parent = nullptr) : RawItemFilteredModel(sourceModel, 0, parent) {}
 
   public slots:
     void setFilterFlags(int flags);
     void update() const;
+    void onDataAboutToBeUpdated();
+    void onDataUpdateComplete();
+
+  signals:
+    void dataAboutToBeUpdated();
+    void dataUpdateComplete();
 
   protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex & sourceParent) const override;
 
     int filterFlags;
 };
-
-
-// The specialized "convenience" types below can go away once centralalized RawSource/RawSwitch item models are established.
-// These proxy classes will automatically create a source model of the corresponding type.
-
-class RawSwitchFilterItemModel: public RawItemFilteredModel
-{
-    Q_OBJECT
-  public:
-    using RawItemFilteredModel::RawItemFilteredModel;
-
-    explicit RawSwitchFilterItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, int context, QObject * parent = nullptr);
-};
-
-
-class RawSourceFilterItemModel: public RawItemFilteredModel
-{
-    Q_OBJECT
-  public:
-    using RawItemFilteredModel::RawItemFilteredModel;
-
-    explicit RawSourceFilterItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, int flags, QObject * parent = nullptr);
-
-    explicit RawSourceFilterItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData, QObject * parent = nullptr) :
-      RawSourceFilterItemModel(generalSettings, modelData, 0, parent) {}
-};
-
 #endif // RAWITEMFILTEREDMODEL_H

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -36,6 +36,15 @@ class CurveReference {
       CURVE_REF_CUSTOM
     };
 
+    enum CurveRefGroups {
+      NoneGroup      = 0x001,
+      NegativeGroup  = 0x002,
+      PositiveGroup  = 0x004,
+
+      AllCurveRefGroups   = NoneGroup | NegativeGroup | PositiveGroup,
+      PositiveCurveRefGroups = AllCurveRefGroups &~ NegativeGroup
+    };
+
     CurveReference() { clear(); }
 
     CurveReference(CurveRefType type, int value):
@@ -51,6 +60,14 @@ class CurveReference {
 
     QString toString(const ModelData * model = NULL, bool verbose = true) const;
     bool isSet() const { return type != CURVE_REF_DIFF || value != 0; }
+
+    bool operator == ( const CurveReference & other) const {
+      return (this->type == other.type) && (this->value == other.value);
+    }
+
+    bool operator != ( const CurveReference & other) const {
+      return (this->type != other.type) || (this->value != other.value);
+    }
 };
 
 #endif // CURVEREFERENCE_H

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -126,20 +126,15 @@ void CustomFunctionData::populateResetParams(const ModelData * model, QComboBox 
     b->addItem(tr("REa"), val++);
     b->addItem(tr("REb"), val++);
   }
-  if ((int)value < b->count()) {
-    b->setCurrentIndex(value);
-  }
   if (model) {
-    for (unsigned i=0; i<CPN_MAX_SENSORS; ++i) {
+    for (int i = 0; i < firmware->getCapability(Sensors); ++i) {
       if (model->sensorData[i].isAvailable()) {
-        RawSource item = RawSource(SOURCE_TYPE_TELEMETRY, 3*i);
-        b->addItem(item.toString(model), val+i);
-        if (value == val+i) {
-          b->setCurrentIndex(b->count()-1);
-        }
+        RawSource item = RawSource(SOURCE_TYPE_TELEMETRY, 3 * i);
+        b->addItem(item.toString(model), val + i);
       }
     }
   }
+  b->setCurrentIndex(b->findData(value));
 }
 
 void CustomFunctionData::populatePlaySoundParams(QStringList & qs)

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -723,7 +723,8 @@ int ModelData::updateReference()
       updateAssignFunc(cfd);
       if (!cfd->isEmpty()) {
         updateSwitchRef(cfd->swtch);
-        if (cfd->func == FuncVolume || cfd->func == FuncBacklight || cfd->func == FuncPlayValue || (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE))) {
+        if (cfd->func == FuncVolume || cfd->func == FuncBacklight || cfd->func == FuncPlayValue ||
+            (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE))) {
           updateSourceIntRef(cfd->param);
           if (cfd->param == 0)
             cfd->clear();
@@ -1387,12 +1388,13 @@ void ModelData::updateResetParam(CustomFunctionData * cfd)
   const int invalidateRef = -1;
   int newRef = cfd->param;
   int idxAdj = 0;
+  Firmware *firmware = getCurrentFirmware();
 
   switch (updRefInfo.type)
   {
     case REF_UPD_TYPE_SENSOR:
-      idxAdj = 5/*3 Timers + Flight + Telemetery*/ + getCurrentFirmware()->getCapability(RotaryEncoders);
-      if (cfd->param < idxAdj)
+      idxAdj = 5/*3 Timers + Flight + Telemetery*/ + firmware->getCapability(RotaryEncoders);
+      if (cfd->param < idxAdj || cfd->param > (idxAdj + firmware->getCapability(Sensors)))
         return;
       break;
     default:

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -847,7 +847,7 @@ void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, c
         newRef.clear();
       else {
         newRef.type = (T)defType;
-        newRef.index = defIndex + idxAdj;
+        newRef.index = defIndex;
       }
       break;
     case REF_UPD_ACT_SHIFT:
@@ -904,7 +904,7 @@ void ModelData::updateTypeValueRef(R & curRef, const T type, const int idxAdj, c
         newRef.clear();
       else {
         newRef.type = (T)defType;
-        newRef.value = defValue + idxAdj;
+        newRef.value = defValue;
       }
       break;
     case REF_UPD_ACT_SHIFT:

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -321,7 +321,7 @@ class ModelData {
     void updateModuleFailsafes(ModuleData * md);
     inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType); }
     inline void updateSwitchRef(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1); }
-    inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, -1 /*adjusted by offset*/); }
+    inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, 0); }
     inline void updateSourceIntRef(int & value)
     {
       RawSource src = RawSource(value);

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -337,6 +337,7 @@ class ModelData {
         value = swtch.toValue();
     }
     void sortMixes();
+    void updateResetParam(CustomFunctionData * cfd);
 };
 
 #endif // MODELDATA_H

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -321,7 +321,7 @@ class ModelData {
     void updateModuleFailsafes(ModuleData * md);
     inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType); }
     inline void updateSwitchRef(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1); }
-    inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, 0); }
+    inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, -1 /*adjusted by offset*/); }
     inline void updateSourceIntRef(int & value)
     {
       RawSource src = RawSource(value);

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -59,7 +59,7 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
     tr("THs"), tr("TH%"), tr("THt")
   };
 
-  const QStringList directionIndicators = QStringList()
+  static const QStringList directionIndicators = QStringList()
       << CPN_STR_SW_INDICATOR_UP
       << CPN_STR_SW_INDICATOR_NEUT
       << CPN_STR_SW_INDICATOR_DN;

--- a/companion/src/generaledit/CMakeLists.txt
+++ b/companion/src/generaledit/CMakeLists.txt
@@ -28,4 +28,4 @@ qt5_wrap_ui(generaledit_SRCS ${generaledit_UIS})
 qt5_wrap_cpp(generaledit_SRCS ${generaledit_HDRS})
 
 add_library(generaledit ${generaledit_SRCS})
-target_link_libraries(generaledit PRIVATE ${CPN_COMMON_LIB} Qt5::Multimedia)
+target_link_libraries(generaledit PRIVATE datamodels ${CPN_COMMON_LIB} Qt5::Multimedia)

--- a/companion/src/generaledit/generaledit.cpp
+++ b/companion/src/generaledit/generaledit.cpp
@@ -28,6 +28,7 @@
 #include "hardware.h"
 #include "../modeledit/customfunctions.h"
 #include "verticalscrollarea.h"
+#include "rawitemdatamodels.h"
 
 GeneralEdit::GeneralEdit(QWidget * parent, RadioData & radioData, Firmware * firmware) :
   QDialog(parent),
@@ -55,8 +56,11 @@ GeneralEdit::GeneralEdit(QWidget * parent, RadioData & radioData, Firmware * fir
     }
   }
 
+  RawSourceItemModel *rawSourceModel = new RawSourceItemModel(&generalSettings, nullptr, this);
+  RawSwitchItemModel *rawSwitchModel = new RawSwitchItemModel(&generalSettings, nullptr, this);
+
   addTab(new GeneralSetupPanel(this, generalSettings, firmware), tr("Setup"));
-  addTab(new CustomFunctionsPanel(this, NULL, generalSettings, firmware), tr("Global Functions"));
+  addTab(new CustomFunctionsPanel(this, nullptr, generalSettings, firmware, rawSourceModel, rawSwitchModel), tr("Global Functions"));
   addTab(new TrainerPanel(this, generalSettings, firmware), tr("Trainer"));
   addTab(new HardwarePanel(this, generalSettings, firmware), tr("Hardware"));
   addTab(new CalibrationPanel(this, generalSettings, firmware), tr("Calibration"));

--- a/companion/src/generaledit/generaledit.cpp
+++ b/companion/src/generaledit/generaledit.cpp
@@ -56,11 +56,10 @@ GeneralEdit::GeneralEdit(QWidget * parent, RadioData & radioData, Firmware * fir
     }
   }
 
-  RawSourceItemModel *rawSourceModel = new RawSourceItemModel(&generalSettings, nullptr, this);
-  RawSwitchItemModel *rawSwitchModel = new RawSwitchItemModel(&generalSettings, nullptr, this);
+  commonItemModels = new CommonItemModels(&generalSettings, nullptr, this);
 
   addTab(new GeneralSetupPanel(this, generalSettings, firmware), tr("Setup"));
-  addTab(new CustomFunctionsPanel(this, nullptr, generalSettings, firmware, rawSourceModel, rawSwitchModel), tr("Global Functions"));
+  addTab(new CustomFunctionsPanel(this, nullptr, generalSettings, firmware, commonItemModels), tr("Global Functions"));
   addTab(new TrainerPanel(this, generalSettings, firmware), tr("Trainer"));
   addTab(new HardwarePanel(this, generalSettings, firmware), tr("Hardware"));
   addTab(new CalibrationPanel(this, generalSettings, firmware), tr("Calibration"));

--- a/companion/src/generaledit/generaledit.h
+++ b/companion/src/generaledit/generaledit.h
@@ -25,6 +25,8 @@
 #include "eeprominterface.h"
 #include "genericpanel.h"
 
+class CommonItemModels;
+
 namespace Ui {
   class GeneralEdit;
 }
@@ -56,7 +58,7 @@ class GeneralEdit : public QDialog
     void getGeneralSwitchDefPos(int i, bool val);
     void setSwitchDefPos();
     void updateVarioPitchRange();
-    
+
   signals:
     void modified();
 
@@ -71,7 +73,7 @@ class GeneralEdit : public QDialog
     QVector<GenericPanel *> panels;
     void addTab(GenericPanel *panel, QString text);
     void closeEvent(QCloseEvent *event);
-
+    CommonItemModels *commonItemModels;
 };
 
 #endif // _GENERALEDIT_H_

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -742,7 +742,8 @@ GpsCoord extractGpsCoordinates(const QString & position)
   return result;
 }
 
-TableLayout::TableLayout(QWidget * parent, int rowCount, const QStringList & headerLabels)
+TableLayout::TableLayout(QWidget * parent, int rowCount, const QStringList & headerLabels) :
+  QObject(parent)
 {
 #if defined(TABLE_LAYOUT)
   tableWidget = new QTableWidget(parent);

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -208,8 +208,9 @@ private:
 
 GpsCoord extractGpsCoordinates(const QString & position);
 
-class TableLayout
+class TableLayout: public QObject
 {
+    Q_OBJECT
 public:
   TableLayout(QWidget * parent, int rowCount, const QStringList & headerLabels);
   // ~TableLayout() ;

--- a/companion/src/modeledit/channels.cpp
+++ b/companion/src/modeledit/channels.cpp
@@ -20,6 +20,7 @@
 
 #include "channels.h"
 #include "helpers.h"
+#include "rawitemfilteredmodel.h"
 
 LimitsGroup::LimitsGroup(Firmware * firmware, TableLayout * tableLayout, int row, int col, int & value, const ModelData & model, int min, int max, int deflt, ModelPanel * panel):
   firmware(firmware),
@@ -95,14 +96,15 @@ void LimitsGroup::updateMinMax(int max)
     }
   }
 }
-
-Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
+ChannelsPanel::ChannelsPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CurveItemModel * curveItemModel):
   ModelPanel(parent, model, generalSettings, firmware)
 {
-  Stopwatch s1("Channels");
-
   chnCapability = firmware->getCapability(Outputs);
   int channelNameMaxLen = firmware->getCapability(ChannelsName);
+
+  curveModel = new RawItemFilteredModel(curveItemModel, RawItemFilteredModel::AllFilter, this);
+  connect(curveModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &ChannelsPanel::onModelDataAboutToBeUpdated);
+  connect(curveModel, &RawItemFilteredModel::dataUpdateComplete, this, &ChannelsPanel::onModelDataUpdateComplete);
 
   QStringList headerLabels;
   headerLabels << "#";
@@ -117,8 +119,6 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
   if (firmware->getCapability(SYMLimits))
     headerLabels << tr("Linear Subtrim");
   TableLayout *tableLayout = new TableLayout(this, chnCapability, headerLabels);
-
-  s1.report("header");
 
   for (int i = 0; i < chnCapability; i++) {
     int col = 0;
@@ -165,6 +165,7 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
       curveCB[i] = new QComboBox(this);
       curveCB[i]->setProperty("index", i);
+      curveCB[i]->setModel(curveModel);
       connect(curveCB[i], SIGNAL(currentIndexChanged(int)), this, SLOT(curveEdited()));
       tableLayout->addWidget(i, col++, curveCB[i]);
     }
@@ -193,15 +194,13 @@ Channels::Channels(QWidget * parent, ModelData & model, GeneralSettings & genera
     }
   }
   update();
-  s1.report("add elements");
 
   disableMouseScrolling();
   tableLayout->resizeColumnsToContents();
   tableLayout->pushRowsUp(chnCapability+1);
-  s1.report("end");
 }
 
-Channels::~Channels()
+ChannelsPanel::~ChannelsPanel()
 {
   // compiler warning if delete[]
   for (int i = 0; i < CPN_MAX_CHNOUT; i++) {
@@ -214,9 +213,10 @@ Channels::~Channels()
     delete centerSB[i];
     delete symlimitsChk[i];
   }
+  delete curveModel;
 }
 
-void Channels::symlimitsEdited()
+void ChannelsPanel::symlimitsEdited()
 {
   if (!lock) {
     QCheckBox *ckb = qobject_cast<QCheckBox*>(sender());
@@ -226,17 +226,20 @@ void Channels::symlimitsEdited()
   }
 }
 
-void Channels::nameEdited()
+void ChannelsPanel::nameEdited()
 {
   if (!lock) {
     QLineEdit *le = qobject_cast<QLineEdit*>(sender());
     int index = le->property("index").toInt();
-    strcpy(model->limitData[index].name, le->text().toLatin1());
-    emit modified();
+    if (model->limitData[index].name != le->text()) {
+      strcpy(model->limitData[index].name, le->text().toLatin1());
+      emit updateDataModels();
+      emit modified();
+    }
   }
 }
 
-void Channels::refreshExtendedLimits()
+void ChannelsPanel::refreshExtendedLimits()
 {
   int channelMax = model->getChannelsMax();
 
@@ -248,7 +251,7 @@ void Channels::refreshExtendedLimits()
   emit modified();
 }
 
-void Channels::invEdited()
+void ChannelsPanel::invEdited()
 {
   if (!lock) {
     QComboBox *cb = qobject_cast<QComboBox*>(sender());
@@ -258,17 +261,20 @@ void Channels::invEdited()
   }
 }
 
-void Channels::curveEdited()
+void ChannelsPanel::curveEdited()
 {
   if (!lock) {
     QComboBox *cb = qobject_cast<QComboBox*>(sender());
     int index = cb->property("index").toInt();
-    model->limitData[index].curve = CurveReference(CurveReference::CURVE_REF_CUSTOM, cb->itemData(cb->currentIndex()).toInt());
-    emit modified();
+    //  ignore unnecessary updates that could be triggered by updates to the data model
+    if (model->limitData[index].curve != CurveReference(CurveReference::CURVE_REF_CUSTOM, cb->itemData(cb->currentIndex()).toInt())) {
+      model->limitData[index].curve = CurveReference(CurveReference::CURVE_REF_CUSTOM, cb->itemData(cb->currentIndex()).toInt());
+      emit modified();
+    }
   }
 }
 
-void Channels::ppmcenterEdited()
+void ChannelsPanel::ppmcenterEdited()
 {
   if (!lock) {
     QSpinBox *sb = qobject_cast<QSpinBox*>(sender());
@@ -278,51 +284,49 @@ void Channels::ppmcenterEdited()
   }
 }
 
-void Channels::update()
+void ChannelsPanel::update()
 {
   for (int i = 0; i < chnCapability; i++) {
     updateLine(i);
   }
 }
 
-void Channels::updateLine(int i)
+void ChannelsPanel::updateLine(int i)
 {
   lock = true;
+  LimitData &chn = model->limitData[i];
+
   if (firmware->getCapability(ChannelsName) > 0) {
-    name[i]->setText(model->limitData[i].name);
+    name[i]->setText(chn.name);
   }
-  chnOffset[i]->setValue(model->limitData[i].offset);
-  chnMin[i]->setValue(model->limitData[i].min);
-  chnMax[i]->setValue(model->limitData[i].max);
-  invCB[i]->setCurrentIndex((model->limitData[i].revert) ? 1 : 0);
+  chnOffset[i]->setValue(chn.offset);
+  chnMin[i]->setValue(chn.min);
+  chnMax[i]->setValue(chn.max);
+  invCB[i]->setCurrentIndex((chn.revert) ? 1 : 0);
   if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-    int numcurves = firmware->getCapability(NumCurves);
-    curveCB[i]->clear();
-    for (int j = -numcurves; j <= numcurves; j++) {
-      curveCB[i]->addItem(CurveReference(CurveReference::CURVE_REF_CUSTOM, j).toString(model, false), j);
-    }
-    curveCB[i]->setCurrentIndex(model->limitData[i].curve.value + numcurves);
+    curveCB[i]->setCurrentIndex(curveCB[i]->findData(chn.curve.value));
   }
   if (firmware->getCapability(PPMCenter)) {
-    centerSB[i]->setValue(model->limitData[i].ppmCenter + 1500);
+    centerSB[i]->setValue(chn.ppmCenter + 1500);
   }
   if (firmware->getCapability(SYMLimits)) {
-    symlimitsChk[i]->setChecked(model->limitData[i].symetrical);
+    symlimitsChk[i]->setChecked(chn.symetrical);
   }
   lock = false;
 }
 
-void Channels::cmPaste()
+void ChannelsPanel::cmPaste()
 {
   QByteArray data;
   if (hasClipboardData(&data)) {
     memcpy(&model->limitData[selectedIndex], data.constData(), sizeof(LimitData));
     updateLine(selectedIndex);
+    emit updateDataModels();
     emit modified();
   }
 }
 
-void Channels::cmDelete()
+void ChannelsPanel::cmDelete()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -335,10 +339,11 @@ void Channels::cmDelete()
     updateLine(i);
   }
 
+  emit updateDataModels();
   emit modified();
 }
 
-void Channels::cmCopy()
+void ChannelsPanel::cmCopy()
 {
   QByteArray data;
   data.append((char*)&model->limitData[selectedIndex], sizeof(LimitData));
@@ -347,7 +352,7 @@ void Channels::cmCopy()
   QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
 }
 
-void Channels::cmCut()
+void ChannelsPanel::cmCut()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Cut Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -356,7 +361,7 @@ void Channels::cmCut()
   cmClear(false);
 }
 
-void Channels::onCustomContextMenuRequested(QPoint pos)
+void ChannelsPanel::onCustomContextMenuRequested(QPoint pos)
 {
   QLabel *label = (QLabel *)sender();
   selectedIndex = label->property("index").toInt();
@@ -378,7 +383,7 @@ void Channels::onCustomContextMenuRequested(QPoint pos)
   contextMenu.exec(globalPos);
 }
 
-bool Channels::hasClipboardData(QByteArray * data) const
+bool ChannelsPanel::hasClipboardData(QByteArray * data) const
 {
   const QClipboard * clipboard = QApplication::clipboard();
   const QMimeData * mimeData = clipboard->mimeData();
@@ -390,32 +395,32 @@ bool Channels::hasClipboardData(QByteArray * data) const
   return false;
 }
 
-bool Channels::insertAllowed() const
+bool ChannelsPanel::insertAllowed() const
 {
   return ((selectedIndex < chnCapability - 1) && (model->limitData[chnCapability - 1].isEmpty()));
 }
 
-bool Channels::moveDownAllowed() const
+bool ChannelsPanel::moveDownAllowed() const
 {
   return selectedIndex < chnCapability - 1;
 }
 
-bool Channels::moveUpAllowed() const
+bool ChannelsPanel::moveUpAllowed() const
 {
   return selectedIndex > 0;
 }
 
-void Channels::cmMoveUp()
+void ChannelsPanel::cmMoveUp()
 {
   swapData(selectedIndex, selectedIndex - 1);
 }
 
-void Channels::cmMoveDown()
+void ChannelsPanel::cmMoveDown()
 {
   swapData(selectedIndex, selectedIndex + 1);
 }
 
-void Channels::cmClear(bool prompt)
+void ChannelsPanel::cmClear(bool prompt)
 {
   if (prompt) {
     if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Channel. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
@@ -425,10 +430,11 @@ void Channels::cmClear(bool prompt)
   model->limitData[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   updateLine(selectedIndex);
+  emit updateDataModels();
   emit modified();
 }
 
-void Channels::cmClearAll()
+void ChannelsPanel::cmClearAll()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Channels. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -438,19 +444,21 @@ void Channels::cmClearAll()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_CLEAR, i);
     updateLine(i);
   }
+  emit updateDataModels();
   emit modified();
 }
 
-void Channels::cmInsert()
+void ChannelsPanel::cmInsert()
 {
   memmove(&model->limitData[selectedIndex + 1], &model->limitData[selectedIndex], (CPN_MAX_CHNOUT - (selectedIndex + 1)) * sizeof(LimitData));
   model->limitData[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
-void Channels::swapData(int idx1, int idx2)
+void ChannelsPanel::swapData(int idx1, int idx2)
 {
   if ((idx1 != idx2) && (!model->limitData[idx1].isEmpty() || !model->limitData[idx2].isEmpty())) {
     LimitData chntmp = model->limitData[idx2];
@@ -461,6 +469,17 @@ void Channels::swapData(int idx1, int idx2)
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CHANNEL, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     updateLine(idx1);
     updateLine(idx2);
+    emit updateDataModels();
     emit modified();
   }
+}
+
+void ChannelsPanel::onModelDataAboutToBeUpdated()
+{
+  lock = true;
+}
+
+void ChannelsPanel::onModelDataUpdateComplete()
+{
+  update();
 }

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -26,6 +26,9 @@
 
 #include <QtCore>
 
+class CurveItemModel;
+class RawItemFilteredModel;
+
 constexpr char MIMETYPE_CHANNEL[] = "application/x-companion-channel";
 
 class GVarGroup;
@@ -49,13 +52,13 @@ class LimitsGroup
     double displayStep;
 };
 
-class Channels : public ModelPanel
+class ChannelsPanel : public ModelPanel
 {
     Q_OBJECT
 
   public:
-    Channels(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
-    ~Channels();
+    ChannelsPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CurveItemModel * curveItemModel);
+    ~ChannelsPanel();
 
   public slots:
     void refreshExtendedLimits();
@@ -78,6 +81,11 @@ class Channels : public ModelPanel
     void cmClear(bool prompt = true);
     void cmClearAll();
     void onCustomContextMenuRequested(QPoint pos);
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
+
+  signals:
+    void updateDataModels();
 
   private:
     bool hasClipboardData(QByteArray * data = nullptr) const;
@@ -95,6 +103,7 @@ class Channels : public ModelPanel
     QCheckBox *symlimitsChk[CPN_MAX_CHNOUT];
     int selectedIndex;
     int chnCapability;
+    RawItemFilteredModel *curveModel;
 };
 
 #endif // _CHANNELS_H_

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -26,7 +26,7 @@
 
 #include <QtCore>
 
-class CurveItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 constexpr char MIMETYPE_CHANNEL[] = "application/x-companion-channel";
@@ -57,7 +57,7 @@ class ChannelsPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    ChannelsPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CurveItemModel * curveItemModel);
+    ChannelsPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     ~ChannelsPanel();
 
   public slots:
@@ -84,9 +84,6 @@ class ChannelsPanel : public ModelPanel
     void onModelDataAboutToBeUpdated();
     void onModelDataUpdateComplete();
 
-  signals:
-    void updateDataModels();
-
   private:
     bool hasClipboardData(QByteArray * data = nullptr) const;
     bool insertAllowed() const;
@@ -103,7 +100,9 @@ class ChannelsPanel : public ModelPanel
     QCheckBox *symlimitsChk[CPN_MAX_CHNOUT];
     int selectedIndex;
     int chnCapability;
-    RawItemFilteredModel *curveModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel *curveFilteredModel;
+    void updateItemModels();
 };
 
 #endif // _CHANNELS_H_

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -23,6 +23,7 @@
 #include "node.h"
 #include "edge.h"
 #include "helpers.h"
+#include "rawitemfilteredmodel.h"
 
 #define GFX_MARGIN 16
 
@@ -108,10 +109,11 @@ float curveSymmetricalX(float x, float coeff, float yMin, float yMid, float yMax
   return y;
 }
 
-CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
+CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels):
   ModelPanel(parent, model, generalSettings, firmware),
   ui(new Ui::Curves),
-  currentCurve(0)
+  currentCurve(0),
+  commonItemModels(commonItemModels)
 {
   ui->setupUi(this);
 
@@ -523,7 +525,7 @@ void CurvesPanel::on_curveName_editingFinished()
   if (ui->curveName->text() != model->curves[currentCurve].name) {
     memset(model->curves[currentCurve].name, 0, sizeof(model->curves[currentCurve].name));
     strcpy(model->curves[currentCurve].name, ui->curveName->text().toLatin1());
-    emit updateDataModels();
+    updateItemModels();
     emit modified();
   }
 }
@@ -712,7 +714,7 @@ void CurvesPanel::cmClear(bool prompt)
   model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   update();
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -726,7 +728,7 @@ void CurvesPanel::cmClearAll()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, i);
   }
   update();
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -756,7 +758,7 @@ void CurvesPanel::cmDelete()
   model->curves[maxCurves - 1].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -766,7 +768,7 @@ void CurvesPanel::cmInsert()
   model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -787,7 +789,7 @@ void CurvesPanel::cmPaste()
     CurveData *cd = &model->curves[selectedIndex];
     memcpy(cd, data.constData(), sizeof(CurveData));
     update();
-    emit updateDataModels();
+    updateItemModels();
     emit modified();
   }
 }
@@ -802,9 +804,14 @@ void CurvesPanel::swapData(int idx1, int idx2)
     memcpy(cd1, &cdtmp, sizeof(CurveData));
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     update();
-    emit updateDataModels();
+    updateItemModels();
     emit modified();
   }
+}
+
+void CurvesPanel::updateItemModels()
+{
+  commonItemModels->update(CommonItemModels::RMO_CURVES);
 }
 
 CustomScene::CustomScene(QGraphicsView * view) :

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -108,7 +108,7 @@ float curveSymmetricalX(float x, float coeff, float yMin, float yMid, float yMax
   return y;
 }
 
-Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
+CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
   ModelPanel(parent, model, generalSettings, firmware),
   ui(new Ui::Curves),
   currentCurve(0)
@@ -230,12 +230,12 @@ Curves::Curves(QWidget * parent, ModelData & model, GeneralSettings & generalSet
   lock = false;
 }
 
-Curves::~Curves()
+CurvesPanel::~CurvesPanel()
 {
   delete ui;
 }
 
-void Curves::editCurve()
+void CurvesPanel::editCurve()
 {
   QPushButton *button = (QPushButton *)sender();
   int index = button->property("index").toInt();
@@ -243,7 +243,7 @@ void Curves::editCurve()
   update();
 }
 
-void Curves::plotCurve(bool checked)
+void CurvesPanel::plotCurve(bool checked)
 {
   QCheckBox *chk = (QCheckBox *)sender();
   int index = chk->property("index").toInt();
@@ -251,7 +251,7 @@ void Curves::plotCurve(bool checked)
   updateCurve();
 }
 
-void Curves::update()
+void CurvesPanel::update()
 {
   lock = true;
 
@@ -266,12 +266,12 @@ void Curves::update()
   lock = false;
 }
 
-void Curves::setCurrentCurve(int index)
+void CurvesPanel::setCurrentCurve(int index)
 {
   currentCurve = index;
 }
 
-void Curves::updateCurveType()
+void CurvesPanel::updateCurveType()
 {
   lock = true;
 
@@ -297,7 +297,7 @@ void Curves::updateCurveType()
   lock = false;
 }
 
-void Curves::updateCurve()
+void CurvesPanel::updateCurve()
 {
   lock = true;
 
@@ -371,7 +371,7 @@ void Curves::updateCurve()
   lock = false;
 }
 
-void Curves::updateCurvePoints()
+void CurvesPanel::updateCurvePoints()
 {
   lock = true;
 
@@ -405,7 +405,7 @@ void Curves::updateCurvePoints()
   lock = false;
 }
 
-void Curves::onPointEdited()
+void CurvesPanel::onPointEdited()
 {
   if (!lock) {
     int index = sender()->property("index").toInt();
@@ -416,7 +416,7 @@ void Curves::onPointEdited()
   }
 }
 
-void Curves::onNodeMoved(int x, int y)
+void CurvesPanel::onNodeMoved(int x, int y)
 {
   if (!lock) {
     lock = true;
@@ -434,20 +434,20 @@ void Curves::onNodeMoved(int x, int y)
   }
 }
 
-void Curves::onNodeFocus()
+void CurvesPanel::onNodeFocus()
 {
   int index = sender()->property("index").toInt();
   spny[index]->setFocus();
 }
 
-void Curves::onNodeUnfocus()
+void CurvesPanel::onNodeUnfocus()
 {
   int index = sender()->property("index").toInt();
   spny[index]->clearFocus();
   updateCurve();
 }
 
-bool Curves::allowCurveType(int points, CurveData::CurveType type)
+bool CurvesPanel::allowCurveType(int points, CurveData::CurveType type)
 {
   int totalpoints = 0;
   for (int i = 0; i < maxCurves; i++) {
@@ -465,7 +465,7 @@ bool Curves::allowCurveType(int points, CurveData::CurveType type)
   }
 }
 
-void Curves::on_curvePoints_currentIndexChanged(int index)
+void CurvesPanel::on_curvePoints_currentIndexChanged(int index)
 {
   if (!lock) {
     int numpoints = ((QComboBox *)sender())->itemData(index).toInt();
@@ -488,7 +488,7 @@ void Curves::on_curvePoints_currentIndexChanged(int index)
   }
 }
 
-void Curves::on_curveCustom_currentIndexChanged(int index)
+void CurvesPanel::on_curveCustom_currentIndexChanged(int index)
 {
   if (!lock) {
     CurveData::CurveType type = (CurveData::CurveType)index;
@@ -512,20 +512,23 @@ void Curves::on_curveCustom_currentIndexChanged(int index)
   }
 }
 
-void Curves::on_curveSmooth_currentIndexChanged(int index)
+void CurvesPanel::on_curveSmooth_currentIndexChanged(int index)
 {
   model->curves[currentCurve].smooth = index;
   update();
 }
 
-void Curves::on_curveName_editingFinished()
+void CurvesPanel::on_curveName_editingFinished()
 {
-  memset(model->curves[currentCurve].name, 0, sizeof(model->curves[currentCurve].name));
-  strcpy(model->curves[currentCurve].name, ui->curveName->text().toLatin1());
-  emit modified();
+  if (ui->curveName->text() != model->curves[currentCurve].name) {
+    memset(model->curves[currentCurve].name, 0, sizeof(model->curves[currentCurve].name));
+    strcpy(model->curves[currentCurve].name, ui->curveName->text().toLatin1());
+    emit updateDataModels();
+    emit modified();
+  }
 }
 
-void Curves::resizeEvent(QResizeEvent *event)
+void CurvesPanel::resizeEvent(QResizeEvent *event)
 {
   QRect qr = ui->curvePreview->contentsRect();
   ui->curvePreview->scene()->setSceneRect(GFX_MARGIN, GFX_MARGIN, qr.width() - GFX_MARGIN * 2, qr.height() - GFX_MARGIN * 2);
@@ -533,7 +536,7 @@ void Curves::resizeEvent(QResizeEvent *event)
   ModelPanel::resizeEvent(event);
 }
 
-void Curves::on_curveType_currentIndexChanged(int index)
+void CurvesPanel::on_curveType_currentIndexChanged(int index)
 {
   unsigned int flags = templates[index].flags;
   ui->curveCoeffLabel->setVisible(flags & CURVE_COEFF_ENABLE);
@@ -547,7 +550,7 @@ void Curves::on_curveType_currentIndexChanged(int index)
   ui->yMin->setValue(-100);
 }
 
-void Curves::addTemplate(QString name, unsigned int flags, curveFunction function)
+void CurvesPanel::addTemplate(QString name, unsigned int flags, curveFunction function)
 {
   CurveCreatorTemplate tmpl;
   tmpl.name = name;
@@ -557,7 +560,7 @@ void Curves::addTemplate(QString name, unsigned int flags, curveFunction functio
   ui->curveType->addItem(name);
 }
 
-void Curves::on_curveApply_clicked()
+void CurvesPanel::on_curveApply_clicked()
 {
   int index = ui->curveType->currentIndex();
   int numpoints = model->curves[currentCurve].count;
@@ -594,14 +597,14 @@ void Curves::on_curveApply_clicked()
   emit modified();
 }
 
-void Curves::onPointSizeEdited()
+void CurvesPanel::onPointSizeEdited()
 {
   if (!lock) {
     update();
   }
 }
 
-void Curves::onNodeDelete()
+void CurvesPanel::onNodeDelete()
 {
   int index = sender()->property("index").toInt();
   int numpoints = model->curves[currentCurve].count;
@@ -619,7 +622,7 @@ void Curves::onNodeDelete()
   }
 }
 
-void Curves::onSceneNewPoint(int x, int y)
+void CurvesPanel::onSceneNewPoint(int x, int y)
 {
   if ((model->curves[currentCurve].type == CurveData::CURVE_TYPE_CUSTOM) && (model->curves[currentCurve].count < CPN_MAX_POINTS)) {
     int newidx = 0;
@@ -650,7 +653,7 @@ void Curves::onSceneNewPoint(int x, int y)
   }
 }
 
-void Curves::onCustomContextMenuRequested(QPoint pos)
+void CurvesPanel::onCustomContextMenuRequested(QPoint pos)
 {
   QPushButton *button = (QPushButton *)sender();
   selectedIndex = button->property("index").toInt();
@@ -672,7 +675,7 @@ void Curves::onCustomContextMenuRequested(QPoint pos)
   contextMenu.exec(globalPos);
 }
 
-bool Curves::hasClipboardData(QByteArray * data) const
+bool CurvesPanel::hasClipboardData(QByteArray * data) const
 {
   const QClipboard * clipboard = QApplication::clipboard();
   const QMimeData * mimeData = clipboard->mimeData();
@@ -684,22 +687,22 @@ bool Curves::hasClipboardData(QByteArray * data) const
   return false;
 }
 
-bool Curves::insertAllowed() const
+bool CurvesPanel::insertAllowed() const
 {
   return ((selectedIndex < maxCurves - 1) && (model->curves[maxCurves - 1].isEmpty()));
 }
 
-bool Curves::moveDownAllowed() const
+bool CurvesPanel::moveDownAllowed() const
 {
   return selectedIndex < maxCurves - 1;
 }
 
-bool Curves::moveUpAllowed() const
+bool CurvesPanel::moveUpAllowed() const
 {
   return selectedIndex > 0;
 }
 
-void Curves::cmClear(bool prompt)
+void CurvesPanel::cmClear(bool prompt)
 {
   if (prompt) {
     if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
@@ -709,10 +712,11 @@ void Curves::cmClear(bool prompt)
   model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
-void Curves::cmClearAll()
+void CurvesPanel::cmClearAll()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear all Curves. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -722,10 +726,11 @@ void Curves::cmClearAll()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_CLEAR, i);
   }
   update();
+  emit updateDataModels();
   emit modified();
 }
 
-void Curves::cmCopy()
+void CurvesPanel::cmCopy()
 {
   QByteArray data;
   data.append((char*)&model->curves[selectedIndex], sizeof(CurveData));
@@ -734,7 +739,7 @@ void Curves::cmCopy()
   QApplication::clipboard()->setMimeData(mimeData,QClipboard::Clipboard);
 }
 
-void Curves::cmCut()
+void CurvesPanel::cmCut()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Cut Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -742,7 +747,7 @@ void Curves::cmCut()
   cmClear(false);
 }
 
-void Curves::cmDelete()
+void CurvesPanel::cmDelete()
 {
   if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Delete Curve. Are you sure?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
     return;
@@ -751,40 +756,43 @@ void Curves::cmDelete()
   model->curves[maxCurves - 1].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
-void Curves::cmInsert()
+void CurvesPanel::cmInsert()
 {
   memmove(&model->curves[selectedIndex + 1], &model->curves[selectedIndex], (CPN_MAX_CURVES - (selectedIndex + 1)) * sizeof(CurveData));
   model->curves[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
-void Curves::cmMoveDown()
+void CurvesPanel::cmMoveDown()
 {
   swapData(selectedIndex, selectedIndex + 1);
 }
 
-void Curves::cmMoveUp()
+void CurvesPanel::cmMoveUp()
 {
   swapData(selectedIndex, selectedIndex - 1);
 }
 
-void Curves::cmPaste()
+void CurvesPanel::cmPaste()
 {
   QByteArray data;
   if (hasClipboardData(&data)) {
     CurveData *cd = &model->curves[selectedIndex];
     memcpy(cd, data.constData(), sizeof(CurveData));
     update();
+    emit updateDataModels();
     emit modified();
   }
 }
 
-void Curves::swapData(int idx1, int idx2)
+void CurvesPanel::swapData(int idx1, int idx2)
 {
   if ((idx1 != idx2) && (!model->curves[idx1].isEmpty() || !model->curves[idx2].isEmpty())) {
     CurveData cdtmp = model->curves[idx2];
@@ -794,6 +802,7 @@ void Curves::swapData(int idx1, int idx2)
     memcpy(cd1, &cdtmp, sizeof(CurveData));
     model->updateAllReferences(ModelData::REF_UPD_TYPE_CURVE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     update();
+    emit updateDataModels();
     emit modified();
   }
 }

--- a/companion/src/modeledit/curves.h
+++ b/companion/src/modeledit/curves.h
@@ -54,13 +54,13 @@ class CustomScene : public QGraphicsScene
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent * event) override;
 };
 
-class Curves : public ModelPanel
+class CurvesPanel : public ModelPanel
 {
     Q_OBJECT
 
   public:
-    Curves(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
-    virtual ~Curves();
+    CurvesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    virtual ~CurvesPanel();
 
     virtual void update();
 
@@ -90,6 +90,9 @@ class Curves : public ModelPanel
     void cmPaste();
     void cmMoveDown();
     void cmMoveUp();
+
+  signals:
+    void updateDataModels();
 
   protected:
     virtual void resizeEvent(QResizeEvent *event);

--- a/companion/src/modeledit/curves.h
+++ b/companion/src/modeledit/curves.h
@@ -26,6 +26,8 @@
 #include <QGraphicsScene>
 #include <QGraphicsView>
 
+class CommonItemModels;
+
 constexpr char MIMETYPE_CURVE[] = "application/x-companion-curve";
 
 namespace Ui {
@@ -59,7 +61,7 @@ class CurvesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    CurvesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    CurvesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~CurvesPanel();
 
     virtual void update();
@@ -91,9 +93,6 @@ class CurvesPanel : public ModelPanel
     void cmMoveDown();
     void cmMoveUp();
 
-  signals:
-    void updateDataModels();
-
   protected:
     virtual void resizeEvent(QResizeEvent *event);
     void addTemplate(QString name, unsigned int flags, curveFunction function);
@@ -122,6 +121,8 @@ class CurvesPanel : public ModelPanel
     bool moveDownAllowed() const;
     bool moveUpAllowed() const;
     void swapData(int idx1, int idx2);
+    CommonItemModels * commonItemModels;
+    void updateItemModels();
 };
 
 #endif // _CURVES_H_

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -41,7 +41,7 @@ RepeatComboBox::RepeatComboBox(QWidget *parent, int & repeatParam):
 
   addItem(tr("No repeat"), 0);
 
-  for (unsigned int i=step; i<=60; i+=step) {
+  for (unsigned int i = step; i <= 60; i += step) {
     addItem(tr("%1s").arg(i), i);
   }
 
@@ -66,24 +66,36 @@ void RepeatComboBox::update()
   setCurrentIndex(value);
 }
 
-CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware):
+CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware,
+                                              RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel):
   GenericPanel(parent, model, generalSettings, firmware),
   functions(model ? model->customFn : generalSettings.customFn),
   mediaPlayerCurrent(-1),
-  mediaPlayer(nullptr)
+  mediaPlayer(nullptr),
+  modelsUpdateCnt(0)
 {
-  Stopwatch s1("CustomFunctionsPanel - populate");
   lock = true;
   fswCapability = model ? firmware->getCapability(CustomFunctions) : firmware->getCapability(GlobalFunctions);
 
-  rawSwitchItemModel = new RawSwitchFilterItemModel(&generalSettings, model, model ? RawSwitch::SpecialFunctionsContext : RawSwitch::GlobalFunctionsContext, this);
-  rawSrcAllItemModel = new RawSourceFilterItemModel(&generalSettings, model, this);
-  rawSrcInputsItemModel = new RawSourceFilterItemModel(rawSrcAllItemModel->sourceModel(), RawSource::InputSourceGroups, this);
-  rawSrcGVarsItemModel = new RawSourceFilterItemModel(rawSrcAllItemModel->sourceModel(), RawSource::GVarsGroup, this);
+  rawSwitchModel = new RawItemFilteredModel(rawSwitchItemModel, model ? RawSwitch::SpecialFunctionsContext : RawSwitch::GlobalFunctionsContext);
+  connect(rawSwitchModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &CustomFunctionsPanel::onModelDataAboutToBeUpdated);
+  connect(rawSwitchModel, &RawItemFilteredModel::dataUpdateComplete, this, &CustomFunctionsPanel::onModelDataUpdateComplete);
+
+  rawSrcAllModel = new RawItemFilteredModel(rawSourceItemModel);
+  connect(rawSrcAllModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &CustomFunctionsPanel::onModelDataAboutToBeUpdated);
+  connect(rawSrcAllModel, &RawItemFilteredModel::dataUpdateComplete, this, &CustomFunctionsPanel::onModelDataUpdateComplete);
+
+  rawSrcInputsModel = new RawItemFilteredModel(rawSourceItemModel, RawSource::InputSourceGroups);
+  connect(rawSrcInputsModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &CustomFunctionsPanel::onModelDataAboutToBeUpdated);
+  connect(rawSrcInputsModel, &RawItemFilteredModel::dataUpdateComplete, this, &CustomFunctionsPanel::onModelDataUpdateComplete);
+
+  rawSrcGVarsModel = new RawItemFilteredModel(rawSourceItemModel, RawSource::GVarsGroup);
+  connect(rawSrcGVarsModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &CustomFunctionsPanel::onModelDataAboutToBeUpdated);
+  connect(rawSrcGVarsModel, &RawItemFilteredModel::dataUpdateComplete, this, &CustomFunctionsPanel::onModelDataUpdateComplete);
 
   if (!firmware->getCapability(VoicesAsNumbers)) {
     tracksSet = getFilesSet(getSoundsPath(generalSettings), QStringList() << "*.wav" << "*.WAV", firmware->getCapability(VoicesMaxLength));
-    for (int i=0; i<fswCapability; i++) {
+    for (int i = 0; i < fswCapability; i++) {
       if (functions[i].func == FuncPlayPrompt || functions[i].func == FuncBackgroundMusic) {
         QString temp = functions[i].paramarm;
         if (!temp.isEmpty()) {
@@ -93,11 +105,9 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     }
   }
 
-  s1.report("get tracks");
-
   if (IS_STM32(firmware->getBoard())) {
     scriptsSet = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS/FUNCTIONS", QStringList() << "*.lua", firmware->getCapability(VoicesMaxLength));
-    for (int i=0; i<fswCapability; i++) {
+    for (int i = 0; i < fswCapability; i++) {
       if (functions[i].func == FuncPlayScript) {
         QString temp = functions[i].paramarm;
         if (!temp.isEmpty()) {
@@ -106,7 +116,6 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
       }
     }
   }
-  s1.report("get scripts");
 
   CompanionIcon playIcon("play.png");
   playIcon.addImage("stop.png", QIcon::Normal, QIcon::On);
@@ -115,7 +124,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   headerLabels << "#" << tr("Switch") << tr("Action") << tr("Parameters") << tr("Enable");
   TableLayout * tableLayout = new TableLayout(this, fswCapability, headerLabels);
 
-  for (int i=0; i<fswCapability; i++) {
+  for (int i = 0; i < fswCapability; i++) {
     // The label
     QLabel * label = new QLabel(this);
     label->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -123,9 +132,9 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     label->setMouseTracking(true);
     label->setProperty("index", i);
     if (model)
-      label->setText(tr("SF%1").arg(i+1));
+      label->setText(tr("SF%1").arg(i + 1));
     else
-      label->setText(tr("GF%1").arg(i+1));
+      label->setText(tr("GF%1").arg(i + 1));
     label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
     connect(label, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)));
     tableLayout->addWidget(i, 0, label);
@@ -133,7 +142,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
 
     // The switch
     fswtchSwtch[i] = new QComboBox(this);
-    fswtchSwtch[i]->setModel(rawSwitchItemModel);
+    fswtchSwtch[i]->setModel(rawSwitchModel);
     fswtchSwtch[i]->setCurrentIndex(fswtchSwtch[i]->findData(functions[i].swtch.toValue()));
     fswtchSwtch[i]->setProperty("index", i);
     fswtchSwtch[i]->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Minimum);
@@ -198,7 +207,6 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     fswtchParamArmT[i]->setEditable(true);
     fswtchParamArmT[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     paramLayout->addWidget(fswtchParamArmT[i]);
-
     connect(fswtchParamArmT[i], SIGNAL(currentIndexChanged(int)), this, SLOT(customFunctionEdited()));
     connect(fswtchParamArmT[i], SIGNAL(editTextChanged ( const QString)), this, SLOT(customFunctionEdited()));
 
@@ -221,46 +229,34 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     QHBoxLayout * repeatLayout = new QHBoxLayout();
     tableLayout->addLayout(i, 4, repeatLayout);
     fswtchRepeat[i] = new RepeatComboBox(this, functions[i].repeatParam);
-    repeatLayout->addWidget(fswtchRepeat[i], i+1);
-    connect(fswtchRepeat[i], SIGNAL(modified()), this, SLOT(onChildModified()));
+    repeatLayout->addWidget(fswtchRepeat[i], i + 1);
+    connect(fswtchRepeat[i], SIGNAL(modified()), this, SLOT(onRepeatModified()));
 
     fswtchEnable[i] = new QCheckBox(this);
     fswtchEnable[i]->setProperty("index", i);
     fswtchEnable[i]->setText(tr("ON"));
     fswtchEnable[i]->setFixedWidth(200);
-    repeatLayout->addWidget(fswtchEnable[i], i+1);
+    repeatLayout->addWidget(fswtchEnable[i], i + 1);
     connect(fswtchEnable[i], SIGNAL(stateChanged(int)), this, SLOT(customFunctionEdited()));
   }
 
-  s1.report("add items");
-
   disableMouseScrolling();
-  s1.report("disableMouseScrolling");
-
-  lock = false;
+  tableLayout->resizeColumnsToContents();
+  tableLayout->setColumnWidth(3, 300);
+  tableLayout->pushRowsUp(fswCapability + 1);
 
   update();
-  s1.report("update");
-  tableLayout->resizeColumnsToContents();
-  s1.report("resizeColumnsToContents");
-  tableLayout->setColumnWidth(3, 300);
-  tableLayout->pushRowsUp(fswCapability+1);
-  s1.report("end");
+  lock = false;
 }
 
 CustomFunctionsPanel::~CustomFunctionsPanel()
 {
   if (mediaPlayer)
     stopSound(mediaPlayerCurrent);
-}
-
-void CustomFunctionsPanel::updateDataModels()
-{
-  const bool oldLock = lock;
-  lock = true;
-  rawSwitchItemModel->update();
-  rawSrcAllItemModel->update();
-  lock = oldLock;
+  delete rawSwitchModel;
+  delete rawSrcAllModel;
+  delete rawSrcInputsModel;
+  delete rawSrcGVarsModel;
 }
 
 void CustomFunctionsPanel::onMediaPlayerStateChanged(QMediaPlayer::State state)
@@ -343,6 +339,7 @@ void CustomFunctionsPanel::toggleSound(bool play)
 #define CUSTOM_FUNCTION_BL_COLOR       (1<<9)
 #define CUSTOM_FUNCTION_SHOW_FUNC      (1<<10)
 
+
 void CustomFunctionsPanel::customFunctionEdited()
 {
   if (!lock) {
@@ -369,162 +366,151 @@ void CustomFunctionsPanel::functionEdited()
   }
 }
 
-void CustomFunctionsPanel::onChildModified()
+void CustomFunctionsPanel::onRepeatModified()
 {
   emit modified();
 }
 
 void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
 {
-    CustomFunctionData & cfn = functions[i];
-    AssignFunc func = (AssignFunc)fswtchFunc[i]->currentData().toInt();
+  CustomFunctionData & cfn = functions[i];
+  AssignFunc func = (AssignFunc)fswtchFunc[i]->currentData().toInt();
 
-    unsigned int widgetsMask = 0;
-    if (modified) {
-      cfn.swtch = RawSwitch(fswtchSwtch[i]->currentData().toInt());
-      cfn.func = func;
-      cfn.enabled = fswtchEnable[i]->isChecked();
-    }
+  unsigned int widgetsMask = 0;
+  if (modified) {
+    cfn.swtch = RawSwitch(fswtchSwtch[i]->currentData().toInt());
+    cfn.func = func;
+    cfn.enabled = fswtchEnable[i]->isChecked();
+  }
 
-    if (!cfn.isEmpty()) {
-      widgetsMask |= CUSTOM_FUNCTION_SHOW_FUNC;
+  if (!cfn.isEmpty()) {
+    widgetsMask |= CUSTOM_FUNCTION_SHOW_FUNC;
 
-      if (func >= FuncOverrideCH1 && func <= FuncOverrideCH32) {
-        if (model) {
-          int channelsMax = model->getChannelsMax(true);
-          fswtchParam[i]->setDecimals(0);
-          fswtchParam[i]->setSingleStep(1);
-          fswtchParam[i]->setMinimum(-channelsMax);
-          fswtchParam[i]->setMaximum(channelsMax);
-          if (modified) {
-            cfn.param = fswtchParam[i]->value();
-          }
-          fswtchParam[i]->setValue(cfn.param);
-          widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_ENABLE;
+    if (func >= FuncOverrideCH1 && func <= FuncOverrideCH32) {
+      if (model) {
+        int channelsMax = model->getChannelsMax(true);
+        fswtchParam[i]->setDecimals(0);
+        fswtchParam[i]->setSingleStep(1);
+        fswtchParam[i]->setMinimum(-channelsMax);
+        fswtchParam[i]->setMaximum(channelsMax);
+        if (modified) {
+          cfn.param = fswtchParam[i]->value();
         }
+        fswtchParam[i]->setValue(cfn.param);
+        widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_ENABLE;
       }
-      else if (func == FuncLogs) {
-        fswtchParam[i]->setDecimals(1);
-        fswtchParam[i]->setMinimum(0);
-        fswtchParam[i]->setMaximum(25.5);
-        fswtchParam[i]->setSingleStep(0.1);
+    }
+    else if (func == FuncLogs) {
+      fswtchParam[i]->setDecimals(1);
+      fswtchParam[i]->setMinimum(0);
+      fswtchParam[i]->setMaximum(25.5);
+      fswtchParam[i]->setSingleStep(0.1);
+      if (modified)
+        cfn.param = fswtchParam[i]->value() * 10.0;
+      fswtchParam[i]->setValue(cfn.param / 10.0);
+      widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM;
+    }
+    else if (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast) {
+      int gvidx = func - FuncAdjustGV1;
+      if (modified)
+        cfn.adjustMode = fswtchGVmode[i]->currentIndex();
+      fswtchGVmode[i]->setCurrentIndex(cfn.adjustMode);
+      widgetsMask |= CUSTOM_FUNCTION_GV_MODE | CUSTOM_FUNCTION_ENABLE;
+      if (cfn.adjustMode == FUNC_ADJUST_GVAR_CONSTANT || cfn.adjustMode == FUNC_ADJUST_GVAR_INCDEC) {
         if (modified)
-          cfn.param = fswtchParam[i]->value()*10.0;
-        fswtchParam[i]->setValue(cfn.param/10.0);
-        widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM;
-      }
-      else if (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast) {
-        int gvidx = func - FuncAdjustGV1;
-        if (modified)
-          cfn.adjustMode = fswtchGVmode[i]->currentIndex();
-        fswtchGVmode[i]->setCurrentIndex(cfn.adjustMode);
-        widgetsMask |= CUSTOM_FUNCTION_GV_MODE | CUSTOM_FUNCTION_ENABLE;
-        if (cfn.adjustMode == FUNC_ADJUST_GVAR_CONSTANT || cfn.adjustMode == FUNC_ADJUST_GVAR_INCDEC) {
-          if (modified)
-            cfn.param = fswtchParam[i]->value() * model->gvarData[gvidx].multiplierSet();
-          fswtchParam[i]->setDecimals(model->gvarData[gvidx].prec);
-          fswtchParam[i]->setSingleStep(model->gvarData[gvidx].multiplierGet());
-          fswtchParam[i]->setSuffix(model->gvarData[gvidx].unitToString());
-          if (cfn.adjustMode==FUNC_ADJUST_GVAR_INCDEC) {
-            double rng = abs(model->gvarData[gvidx].getMax() - model->gvarData[gvidx].getMin());
-            rng *= model->gvarData[gvidx].multiplierGet();
-            fswtchParam[i]->setMinimum(-rng);
-            fswtchParam[i]->setMaximum(rng);
-          }
-          else {
-            fswtchParam[i]->setMinimum(model->gvarData[gvidx].getMinPrec());
-            fswtchParam[i]->setMaximum(model->gvarData[gvidx].getMaxPrec());
-          }
-          fswtchParam[i]->setValue(cfn.param * model->gvarData[gvidx].multiplierGet());
-          widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM;
+          cfn.param = fswtchParam[i]->value() * model->gvarData[gvidx].multiplierSet();
+        fswtchParam[i]->setDecimals(model->gvarData[gvidx].prec);
+        fswtchParam[i]->setSingleStep(model->gvarData[gvidx].multiplierGet());
+        fswtchParam[i]->setSuffix(model->gvarData[gvidx].unitToString());
+        if (cfn.adjustMode == FUNC_ADJUST_GVAR_INCDEC) {
+          double rng = abs(model->gvarData[gvidx].getMax() - model->gvarData[gvidx].getMin());
+          rng *= model->gvarData[gvidx].multiplierGet();
+          fswtchParam[i]->setMinimum(-rng);
+          fswtchParam[i]->setMaximum(rng);
         }
         else {
-          if (modified)
-            cfn.param = fswtchParamT[i]->currentData().toInt();
-          populateFuncParamCB(fswtchParamT[i], func, cfn.param, cfn.adjustMode);
-          widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
+          fswtchParam[i]->setMinimum(model->gvarData[gvidx].getMinPrec());
+          fswtchParam[i]->setMaximum(model->gvarData[gvidx].getMaxPrec());
         }
+        fswtchParam[i]->setValue(cfn.param * model->gvarData[gvidx].multiplierGet());
+        widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM;
       }
-      else if (func == FuncReset) {
+      else {
+        if (modified)
+          cfn.param = fswtchParamT[i]->currentData().toInt();
+        populateFuncParamCB(fswtchParamT[i], func, cfn.param, cfn.adjustMode);
+        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
+      }
+    }
+    else if (func == FuncReset) {
+      if (modified)
+        cfn.param = fswtchParamT[i]->currentData().toInt();
+      populateFuncParamCB(fswtchParamT[i], func, cfn.param);
+      widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_ENABLE;
+    }
+    else if (func >= FuncSetTimer1 && func <= FuncSetTimer3) {
+      if (modified)
+        cfn.param = fswtchParamTime[i]->timeInSeconds();
+      RawSourceRange range = RawSource(SOURCE_TYPE_SPECIAL, func - FuncSetTimer1 + 2).getRange(model, generalSettings);
+      fswtchParamTime[i]->setTimeRange((int)range.min, (int)range.max);
+      fswtchParamTime[i]->setTime(cfn.param);
+      widgetsMask |= CUSTOM_FUNCTION_TIME_PARAM | CUSTOM_FUNCTION_ENABLE;
+    }
+    else if (func >= FuncSetFailsafeInternalModule && func <= FuncBindExternalModule) {
+      widgetsMask |= CUSTOM_FUNCTION_ENABLE;
+    }
+    else if (func == FuncVolume || func == FuncBacklight) {
+      if (modified)
+        cfn.param = fswtchParamT[i]->currentData().toInt();
+      populateFuncParamCB(fswtchParamT[i], func, cfn.param);
+      widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_ENABLE;
+    }
+    else if (func == FuncPlaySound || func == FuncPlayHaptic || func == FuncPlayValue || func == FuncPlayPrompt || func == FuncPlayBoth || func == FuncBackgroundMusic) {
+      if (func != FuncBackgroundMusic) {
+        widgetsMask |= CUSTOM_FUNCTION_REPEAT;
+        fswtchRepeat[i]->update();
+      }
+      if (func == FuncPlayValue) {
         if (modified)
           cfn.param = fswtchParamT[i]->currentData().toInt();
         populateFuncParamCB(fswtchParamT[i], func, cfn.param);
-        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_ENABLE;
+        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_REPEAT;
       }
-      else if (func >= FuncSetTimer1 && func <= FuncSetTimer3) {
-        if (modified)
-          cfn.param = fswtchParamTime[i]->timeInSeconds();
-        RawSourceRange range = RawSource(SOURCE_TYPE_SPECIAL, func - FuncSetTimer1 + 2).getRange(model, generalSettings);
-        fswtchParamTime[i]->setTimeRange((int)range.min, (int)range.max);
-        fswtchParamTime[i]->setTime(cfn.param);
-        widgetsMask |= CUSTOM_FUNCTION_TIME_PARAM | CUSTOM_FUNCTION_ENABLE;
-      }
-      else if (func >= FuncSetFailsafeInternalModule && func <= FuncBindExternalModule) {
-        widgetsMask |= CUSTOM_FUNCTION_ENABLE;
-      }
-      else if (func == FuncVolume || func == FuncBacklight) {
-        if (modified)
-          cfn.param = fswtchParamT[i]->currentData().toInt();
-        populateFuncParamCB(fswtchParamT[i], func, cfn.param);
-        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_ENABLE;
-      }
-      else if (func == FuncPlaySound || func == FuncPlayHaptic || func == FuncPlayValue || func == FuncPlayPrompt || func == FuncPlayBoth || func == FuncBackgroundMusic) {
-        if (func != FuncBackgroundMusic) {
-          widgetsMask |= CUSTOM_FUNCTION_REPEAT;
-          fswtchRepeat[i]->update();
-        }
-        if (func == FuncPlayValue) {
-          if (modified)
-            cfn.param = fswtchParamT[i]->currentData().toInt();
-          populateFuncParamCB(fswtchParamT[i], func, cfn.param);
-          widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM | CUSTOM_FUNCTION_REPEAT;
-        }
-        else if (func == FuncPlayPrompt || func == FuncPlayBoth) {
-          if (firmware->getCapability(VoicesAsNumbers)) {
-            fswtchParam[i]->setDecimals(0);
-            fswtchParam[i]->setSingleStep(1);
-            fswtchParam[i]->setMinimum(0);
-            if (func == FuncPlayPrompt) {
-              widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_REPEAT | CUSTOM_FUNCTION_GV_TOOGLE;
-            }
-            else {
-              widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_REPEAT;
-              fswtchParamGV[i]->setChecked(false);
-            }
-            fswtchParam[i]->setMaximum(func == FuncPlayBoth ? 254 : 255);
-            if (modified) {
-              if (fswtchParamGV[i]->isChecked()) {
-                fswtchParam[i]->setMinimum(1);
-                cfn.param = std::min(fswtchParam[i]->value(),5.0)+(fswtchParamGV[i]->isChecked() ? 250 : 0);
-              }
-              else {
-                cfn.param = fswtchParam[i]->value();
-              }
-            }
-            if (cfn.param>250 && (func!=FuncPlayBoth)) {
-              fswtchParamGV[i]->setChecked(true);
-              fswtchParam[i]->setValue(cfn.param-250);
-              fswtchParam[i]->setMaximum(5);
-            }
-            else {
-              fswtchParamGV[i]->setChecked(false);
-              fswtchParam[i]->setValue(cfn.param);
-            }
-            if (cfn.param < 251)
-              widgetsMask |= CUSTOM_FUNCTION_PLAY;
+      else if (func == FuncPlayPrompt || func == FuncPlayBoth) {
+        if (firmware->getCapability(VoicesAsNumbers)) {
+          fswtchParam[i]->setDecimals(0);
+          fswtchParam[i]->setSingleStep(1);
+          fswtchParam[i]->setMinimum(0);
+          if (func == FuncPlayPrompt) {
+            widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_REPEAT | CUSTOM_FUNCTION_GV_TOOGLE;
           }
           else {
-            widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM;
-            if (modified) {
-              Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, firmware->getCapability(VoicesMaxLength));
+            widgetsMask |= CUSTOM_FUNCTION_NUMERIC_PARAM | CUSTOM_FUNCTION_REPEAT;
+            fswtchParamGV[i]->setChecked(false);
+          }
+          fswtchParam[i]->setMaximum(func == FuncPlayBoth ? 254 : 255);
+          if (modified) {
+            if (fswtchParamGV[i]->isChecked()) {
+              fswtchParam[i]->setMinimum(1);
+              cfn.param = std::min(fswtchParam[i]->value(),5.0)+(fswtchParamGV[i]->isChecked() ? 250 : 0);
             }
-            Helpers::populateFileComboBox(fswtchParamArmT[i], tracksSet, cfn.paramarm);
-            if (fswtchParamArmT[i]->currentText() != "----") {
-              widgetsMask |= CUSTOM_FUNCTION_PLAY;
+            else {
+              cfn.param = fswtchParam[i]->value();
             }
           }
+          if (cfn.param > 250 && (func != FuncPlayBoth)) {
+            fswtchParamGV[i]->setChecked(true);
+            fswtchParam[i]->setValue(cfn.param - 250);
+            fswtchParam[i]->setMaximum(5);
+          }
+          else {
+            fswtchParamGV[i]->setChecked(false);
+            fswtchParam[i]->setValue(cfn.param);
+          }
+          if (cfn.param < 251)
+            widgetsMask |= CUSTOM_FUNCTION_PLAY;
         }
-        else if (func == FuncBackgroundMusic) {
+        else {
           widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM;
           if (modified) {
             Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, firmware->getCapability(VoicesMaxLength));
@@ -534,58 +520,68 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
             widgetsMask |= CUSTOM_FUNCTION_PLAY;
           }
         }
-        else if (func == FuncPlaySound) {
-          if (modified)
-            cfn.param = (uint8_t)fswtchParamT[i]->currentIndex();
-          populateFuncParamCB(fswtchParamT[i], func, cfn.param);
-          widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
-        }
-        else if (func == FuncPlayHaptic) {
-          if (modified)
-            cfn.param = (uint8_t)fswtchParamT[i]->currentIndex();
-          populateFuncParamCB(fswtchParamT[i], func, cfn.param);
-          widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
-        }
       }
-      else if (func == FuncPlayScript) {
+      else if (func == FuncBackgroundMusic) {
         widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM;
         if (modified) {
-          Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, 8);
+          Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, firmware->getCapability(VoicesMaxLength));
         }
-        Helpers::populateFileComboBox(fswtchParamArmT[i], scriptsSet, cfn.paramarm);
+        Helpers::populateFileComboBox(fswtchParamArmT[i], tracksSet, cfn.paramarm);
+        if (fswtchParamArmT[i]->currentText() != "----") {
+          widgetsMask |= CUSTOM_FUNCTION_PLAY;
+        }
       }
-      else {
+      else if (func == FuncPlaySound) {
         if (modified)
-          cfn.param = fswtchParam[i]->value();
-        fswtchParam[i]->setDecimals(0);
-        fswtchParam[i]->setSingleStep(1);
-        fswtchParam[i]->setValue(cfn.param);
-        if (func <= FuncInstantTrim) {
-          widgetsMask |= CUSTOM_FUNCTION_ENABLE;
-        }
+          cfn.param = (uint8_t)fswtchParamT[i]->currentIndex();
+        populateFuncParamCB(fswtchParamT[i], func, cfn.param);
+        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
+      }
+      else if (func == FuncPlayHaptic) {
+        if (modified)
+          cfn.param = (uint8_t)fswtchParamT[i]->currentIndex();
+        populateFuncParamCB(fswtchParamT[i], func, cfn.param);
+        widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
       }
     }
+    else if (func == FuncPlayScript) {
+      widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM;
+      if (modified) {
+        Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, 8);
+      }
+      Helpers::populateFileComboBox(fswtchParamArmT[i], scriptsSet, cfn.paramarm);
+    }
+    else {
+      if (modified)
+        cfn.param = fswtchParam[i]->value();
+      fswtchParam[i]->setDecimals(0);
+      fswtchParam[i]->setSingleStep(1);
+      fswtchParam[i]->setValue(cfn.param);
+      if (func <= FuncInstantTrim) {
+        widgetsMask |= CUSTOM_FUNCTION_ENABLE;
+      }
+    }
+  }
 
-    fswtchFunc[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_SHOW_FUNC);
-    fswtchParam[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_NUMERIC_PARAM);
-    fswtchParamTime[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_TIME_PARAM);
-    fswtchParamGV[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_GV_TOOGLE);
-    fswtchParamT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_SOURCE_PARAM);
-    fswtchParamArmT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_FILE_PARAM);
-    fswtchEnable[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_ENABLE);
-    if (widgetsMask & CUSTOM_FUNCTION_ENABLE)
-      fswtchEnable[i]->setChecked(cfn.enabled);
-    else
-      fswtchEnable[i]->setChecked(false);
-    fswtchRepeat[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_REPEAT);
-    fswtchGVmode[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_GV_MODE);
-    fswtchBLcolor[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_BL_COLOR);
-    playBT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_PLAY);
+  fswtchFunc[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_SHOW_FUNC);
+  fswtchParam[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_NUMERIC_PARAM);
+  fswtchParamTime[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_TIME_PARAM);
+  fswtchParamGV[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_GV_TOOGLE);
+  fswtchParamT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_SOURCE_PARAM);
+  fswtchParamArmT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_FILE_PARAM);
+  fswtchEnable[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_ENABLE);
+  if (widgetsMask & CUSTOM_FUNCTION_ENABLE)
+    fswtchEnable[i]->setChecked(cfn.enabled);
+  else
+    fswtchEnable[i]->setChecked(false);
+  fswtchRepeat[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_REPEAT);
+  fswtchGVmode[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_GV_MODE);
+  fswtchBLcolor[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_BL_COLOR);
+  playBT[i]->setVisible(widgetsMask & CUSTOM_FUNCTION_PLAY);
 }
 
 void CustomFunctionsPanel::update()
 {
-  updateDataModels();
   lock = true;
   for (int i = 0; i < fswCapability; i++) {
     refreshCustomFunction(i);
@@ -660,16 +656,16 @@ void CustomFunctionsPanel::populateFuncCB(QComboBox *b, unsigned int value)
 {
   b->clear();
   for (unsigned int i = 0; i < FuncCount; i++) {
-    if (((i>=FuncOverrideCH1 && i<=FuncOverrideCH32) && (!model || !firmware->getCapability(SafetyChannelCustomFunction))) ||
-        ((i==FuncVolume || i==FuncBackgroundMusic || i==FuncBackgroundMusicPause) && !firmware->getCapability(HasVolume)) ||
-        ((i==FuncPlayScript && !IS_HORUS_OR_TARANIS(firmware->getBoard()))) ||
-        ((i==FuncPlayHaptic) && !firmware->getCapability(Haptic)) ||
-        ((i==FuncPlayBoth) && !firmware->getCapability(HasBeeper)) ||
-        ((i==FuncLogs) && !firmware->getCapability(HasSDLogs)) ||
-        ((i==FuncSetTimer3) && firmware->getCapability(Timers) < 3) ||
-        ((i==FuncScreenshot) && !IS_HORUS_OR_TARANIS(firmware->getBoard())) ||
-        ((i>=FuncRangeCheckInternalModule && i<=FuncBindExternalModule) && (!model || !firmware->getCapability(DangerousFunctions))) ||
-        ((i>=FuncAdjustGV1 && i<=FuncAdjustGVLast) && (!model || !firmware->getCapability(Gvars)))
+    if (((i >= FuncOverrideCH1 && i <= FuncOverrideCH32) && (!model || !firmware->getCapability(SafetyChannelCustomFunction))) ||
+        ((i == FuncVolume || i == FuncBackgroundMusic || i == FuncBackgroundMusicPause) && !firmware->getCapability(HasVolume)) ||
+        ((i == FuncPlayScript && !IS_HORUS_OR_TARANIS(firmware->getBoard()))) ||
+        ((i == FuncPlayHaptic) && !firmware->getCapability(Haptic)) ||
+        ((i == FuncPlayBoth) && !firmware->getCapability(HasBeeper)) ||
+        ((i == FuncLogs) && !firmware->getCapability(HasSDLogs)) ||
+        ((i == FuncSetTimer3) && firmware->getCapability(Timers) < 3) ||
+        ((i == FuncScreenshot) && !IS_HORUS_OR_TARANIS(firmware->getBoard())) ||
+        ((i >= FuncRangeCheckInternalModule && i <= FuncBindExternalModule) && (!model || !firmware->getCapability(DangerousFunctions))) ||
+        ((i >= FuncAdjustGV1 && i <= FuncAdjustGVLast) && (!model || !firmware->getCapability(Gvars)))
         ) {
       // skipped
       continue;
@@ -711,21 +707,21 @@ void CustomFunctionsPanel::populateFuncParamCB(QComboBox *b, uint function, unsi
     CustomFunctionData::populateResetParams(model, b, value);
   }
   else if (function == FuncVolume || function == FuncBacklight) {
-    b->setModel(rawSrcInputsItemModel);
+    b->setModel(rawSrcInputsModel);
     b->setCurrentIndex(b->findData(value));
   }
   else if (function == FuncPlayValue) {
-    b->setModel(rawSrcAllItemModel);
+    b->setModel(rawSrcAllModel);
     b->setCurrentIndex(b->findData(value));
   }
   else if (function >= FuncAdjustGV1 && function <= FuncAdjustGVLast) {
     switch (adjustmode) {
       case 1:
-        b->setModel(rawSrcInputsItemModel);
+        b->setModel(rawSrcInputsModel);
         b->setCurrentIndex(b->findData(value));
         break;
       case 2:
-        b->setModel(rawSrcGVarsItemModel);
+        b->setModel(rawSrcGVarsModel);
         b->setCurrentIndex(b->findData(value));
         break;
     }
@@ -829,4 +825,22 @@ bool CustomFunctionsPanel::moveDownAllowed() const
 bool CustomFunctionsPanel::moveUpAllowed() const
 {
   return selectedIndex > 0;
+}
+
+void CustomFunctionsPanel::onModelDataAboutToBeUpdated()
+{
+  lock = true;
+  modelsUpdateCnt++;
+}
+
+void CustomFunctionsPanel::onModelDataUpdateComplete()
+{
+  modelsUpdateCnt--;
+  if (modelsUpdateCnt < 1)
+    lock = true;
+    for (int i = 0; i < fswCapability; i++) {
+      fswtchSwtch[i]->setCurrentIndex(fswtchSwtch[i]->findData(functions[i].swtch.toValue()));
+      fswtchFunc[i]->setCurrentIndex(fswtchFunc[i]->findData(functions[i].func));
+    }
+    update();
 }

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -378,6 +378,10 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
     cfn.func = func;
     cfn.enabled = fswtchEnable[i]->isChecked();
   }
+  else {
+    fswtchSwtch[i]->setCurrentIndex(fswtchSwtch[i]->findData(cfn.swtch.toValue()));
+    fswtchFunc[i]->setCurrentIndex(fswtchFunc[i]->findData(cfn.func));
+  }
 
   if (!cfn.isEmpty()) {
     widgetsMask |= CUSTOM_FUNCTION_SHOW_FUNC;

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -26,8 +26,7 @@
 
 #include <QMediaPlayer>
 
-class RawSourceItemModel;
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 class TimerEdit;
 
@@ -56,8 +55,7 @@ class CustomFunctionsPanel : public GenericPanel
   Q_OBJECT
 
   public:
-    CustomFunctionsPanel(QWidget *parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware,
-                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
+    CustomFunctionsPanel(QWidget *parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     ~CustomFunctionsPanel();
 
     virtual void update();
@@ -98,10 +96,11 @@ class CustomFunctionsPanel : public GenericPanel
     bool moveUpAllowed() const;
     void swapData(int idx1, int idx2);
     void resetCBsAndRefresh(int idx);
-    RawItemFilteredModel * rawSwitchModel;
-    RawItemFilteredModel * rawSrcAllModel;
-    RawItemFilteredModel * rawSrcInputsModel;
-    RawItemFilteredModel * rawSrcGVarsModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel * rawSwitchFilteredModel;
+    RawItemFilteredModel * rawSourceAllModel;
+    RawItemFilteredModel * rawSourceInputsModel;
+    RawItemFilteredModel * rawSourceGVarsModel;
 
     QSet<QString> tracksSet;
     QSet<QString> scriptsSet;

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -26,8 +26,9 @@
 
 #include <QMediaPlayer>
 
-class RawSourceFilterItemModel;
-class RawSwitchFilterItemModel;
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 class TimerEdit;
 
 constexpr char MIMETYPE_CUSTOM_FUNCTION[] = "application/x-companion-custom-function";
@@ -55,7 +56,8 @@ class CustomFunctionsPanel : public GenericPanel
   Q_OBJECT
 
   public:
-    CustomFunctionsPanel(QWidget *parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware);
+    CustomFunctionsPanel(QWidget *parent, ModelData * model, GeneralSettings & generalSettings, Firmware * firmware,
+                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
     ~CustomFunctionsPanel();
 
     virtual void update();
@@ -64,12 +66,11 @@ class CustomFunctionsPanel : public GenericPanel
     CustomFunctionData * functions;
 
   private slots:
-    void updateDataModels();
     void customFunctionEdited();
     void functionEdited();
     void onCustomContextMenuRequested(QPoint pos);
     void refreshCustomFunction(int index, bool modified=false);
-    void onChildModified();
+    void onRepeatModified();
     bool playSound(int index);
     void stopSound(int index);
     void toggleSound(bool play);
@@ -84,6 +85,8 @@ class CustomFunctionsPanel : public GenericPanel
     void cmInsert();
     void cmClear(bool prompt = true);
     void cmClearAll();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
 
   private:
     void populateFuncCB(QComboBox *b, unsigned int value);
@@ -95,10 +98,10 @@ class CustomFunctionsPanel : public GenericPanel
     bool moveUpAllowed() const;
     void swapData(int idx1, int idx2);
     void resetCBsAndRefresh(int idx);
-    RawSwitchFilterItemModel * rawSwitchItemModel;
-    RawSourceFilterItemModel * rawSrcAllItemModel;
-    RawSourceFilterItemModel * rawSrcInputsItemModel;
-    RawSourceFilterItemModel * rawSrcGVarsItemModel;
+    RawItemFilteredModel * rawSwitchModel;
+    RawItemFilteredModel * rawSrcAllModel;
+    RawItemFilteredModel * rawSrcInputsModel;
+    RawItemFilteredModel * rawSrcGVarsModel;
 
     QSet<QString> tracksSet;
     QSet<QString> scriptsSet;
@@ -119,7 +122,7 @@ class CustomFunctionsPanel : public GenericPanel
 
     int selectedIndex;
     int fswCapability;
-
+    int modelsUpdateCnt;
 };
 
 #endif // _CUSTOMFUNCTIONS_H_

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -38,9 +38,9 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
 {
   ui->setupUi(this);
 
-  QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0,ui->lb_FP1,ui->lb_FP2,ui->lb_FP3,ui->lb_FP4,ui->lb_FP5,ui->lb_FP6,ui->lb_FP7,ui->lb_FP8 };
-  QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0,ui->cb_FP1,ui->cb_FP2,ui->cb_FP3,ui->cb_FP4,ui->cb_FP5,ui->cb_FP6,ui->cb_FP7,ui->cb_FP8 };
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0, ui->lb_FP1, ui->lb_FP2, ui->lb_FP3, ui->lb_FP4, ui->lb_FP5, ui->lb_FP6, ui->lb_FP7, ui->lb_FP8 };
+  QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0, ui->cb_FP1, ui->cb_FP2, ui->cb_FP3, ui->cb_FP4, ui->cb_FP5, ui->cb_FP6, ui->cb_FP7, ui->cb_FP8 };
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i] = tmp[i];
   }
 
@@ -57,11 +57,11 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   ui->switchesCB->setModel(rawSwitchModel);
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(ed->swtch.toValue()));
 
-  ui->sideCB->setCurrentIndex(ed->mode-1);
+  ui->sideCB->setCurrentIndex(ed->mode - 1);
 
   if (!firmware->getCapability(FlightModes)) {
     ui->label_phases->hide();
-    for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+    for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
       lb_fp[i]->hide();
       cb_fp[i]->hide();
     }
@@ -71,13 +71,13 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->label_phases->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->label_phases, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(label_phases_customContextMenuRequested(const QPoint &)));
     int mask = 1;
-    for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+    for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
       if ((ed->flightModes & mask) == 0) {
         cb_fp[i]->setChecked(true);
       }
       mask <<= 1;
     }
-    for (int i=firmware->getCapability(FlightModes); i<CPN_MAX_FLIGHT_MODES; i++) {
+    for (int i = firmware->getCapability(FlightModes); i < CPN_MAX_FLIGHT_MODES; i++) {
       lb_fp[i]->hide();
       cb_fp[i]->hide();
     }
@@ -87,7 +87,6 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->inputName->setMaxLength(firmware->getCapability(InputsLength));
     ui->sourceCB->setModel(rawSourceModel);
     ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(ed->srcRaw.toValue()));
-    ui->sourceCB->removeItem(0);
     ui->inputName->setValidator(new QRegExpValidator(rx, this));
     ui->inputName->setText(inputName);
   }
@@ -100,8 +99,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->trimCB->hide();
   }
 
-  for(int i=0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
-    ui->trimCB->addItem(RawSource(SOURCE_TYPE_TRIM, i).toString(), i+1);
+  for(int i = 0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
+    ui->trimCB->addItem(RawSource(SOURCE_TYPE_TRIM, i).toString(), i + 1);
   }
   ui->trimCB->setCurrentIndex(1 - ed->carryTrim);
 
@@ -126,7 +125,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   connect(ui->trimCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
   connect(ui->switchesCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
   connect(ui->sideCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     connect(cb_fp[i], SIGNAL(toggled(bool)), this, SLOT(valuesChanged()));
   }
   if (firmware->getCapability(VirtualInputs)) {
@@ -183,7 +182,7 @@ void ExpoDialog::valuesChanged()
     }
 
     ed->flightModes = 0;
-    for (int i=CPN_MAX_FLIGHT_MODES-1; i>=0 ; i--) {
+    for (int i = CPN_MAX_FLIGHT_MODES - 1; i >= 0 ; i--) {
       if (!cb_fp[i]->checkState()) {
         ed->flightModes++;
       }
@@ -214,7 +213,7 @@ void ExpoDialog::label_phases_customContextMenuRequested(const QPoint & pos)
 void ExpoDialog::fmClearAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(false);
   }
   lock = false;
@@ -224,7 +223,7 @@ void ExpoDialog::fmClearAll()
 void ExpoDialog::fmSetAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(true);
   }
   lock = false;
@@ -234,7 +233,7 @@ void ExpoDialog::fmSetAll()
 void ExpoDialog::fmInvertAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(!cb_fp[i]->isChecked());
   }
   lock = false;

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -24,8 +24,8 @@
 #include "helpers.h"
 
 ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, GeneralSettings & generalSettings,
-                          Firmware * firmware, QString & inputName, RawSourceItemModel * rawSourceItemModel,
-                          RawSwitchItemModel * rawSwitchItemModel) :
+                          Firmware * firmware, QString & inputName, RawItemFilteredModel * rawSourceModel,
+                          RawItemFilteredModel * rawSwitchModel) :
   QDialog(parent),
   ui(new Ui::ExpoDialog),
   model(model),
@@ -37,8 +37,6 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   lock(false)
 {
   ui->setupUi(this);
-  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, (RawSource::InputSourceGroups & ~RawSource::InputsGroup) | RawSource::TelemGroup, this);
-  rawSwitchModel = new RawItemFilteredModel(rawSwitchItemModel, RawSwitch::MixesContext, this);
 
   QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0,ui->lb_FP1,ui->lb_FP2,ui->lb_FP3,ui->lb_FP4,ui->lb_FP5,ui->lb_FP6,ui->lb_FP7,ui->lb_FP8 };
   QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0,ui->cb_FP1,ui->cb_FP2,ui->cb_FP3,ui->cb_FP4,ui->cb_FP5,ui->cb_FP6,ui->cb_FP7,ui->cb_FP8 };

--- a/companion/src/modeledit/expodialog.h
+++ b/companion/src/modeledit/expodialog.h
@@ -27,6 +27,9 @@
 
 class GVarGroup;
 class CurveGroup;
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 namespace Ui {
   class ExpoDialog;
@@ -36,7 +39,8 @@ class ExpoDialog : public QDialog {
     Q_OBJECT
   public:
     ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expodata, GeneralSettings & generalSettings,
-                Firmware * firmware, QString & inputName);
+                Firmware * firmware, QString & inputName, RawSourceItemModel * rawSourceItemModel,
+                RawSwitchItemModel * rawSwitchItemModel);
     ~ExpoDialog();
 
   protected:
@@ -63,6 +67,8 @@ class ExpoDialog : public QDialog {
     ModelPrinter modelPrinter;
     bool lock;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
+    RawItemFilteredModel * rawSourceModel;
+    RawItemFilteredModel * rawSwitchModel;
 };
 
 #endif // _EXPODIALOG_H_

--- a/companion/src/modeledit/expodialog.h
+++ b/companion/src/modeledit/expodialog.h
@@ -27,8 +27,6 @@
 
 class GVarGroup;
 class CurveGroup;
-class RawSourceItemModel;
-class RawSwitchItemModel;
 class RawItemFilteredModel;
 
 namespace Ui {
@@ -39,8 +37,8 @@ class ExpoDialog : public QDialog {
     Q_OBJECT
   public:
     ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expodata, GeneralSettings & generalSettings,
-                Firmware * firmware, QString & inputName, RawSourceItemModel * rawSourceItemModel,
-                RawSwitchItemModel * rawSwitchItemModel);
+                Firmware * firmware, QString & inputName, RawItemFilteredModel * rawSourceItemModel,
+                RawItemFilteredModel * rawSwitchItemModel);
     ~ExpoDialog();
 
   protected:
@@ -67,8 +65,6 @@ class ExpoDialog : public QDialog {
     ModelPrinter modelPrinter;
     bool lock;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
-    RawItemFilteredModel * rawSourceModel;
-    RawItemFilteredModel * rawSwitchModel;
 };
 
 #endif // _EXPODIALOG_H_

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -24,14 +24,15 @@
 #include "helpers.h"
 #include "customdebug.h"
 
-FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseIdx, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchFilterItemModel * switchModel):
+FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseIdx, GeneralSettings & generalSettings, Firmware * firmware, RawItemFilteredModel * switchModel):
   ModelPanel(parent, model, generalSettings, firmware),
   ui(new Ui::FlightMode),
   phaseIdx(phaseIdx),
-  phase(model.flightModeData[phaseIdx]),
-  rawSwitchItemModel(NULL)
+  phase(model.flightModeData[phaseIdx])
 {
   ui->setupUi(this);
+  connect(switchModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &FlightModePanel::onModelDataAboutToBeUpdated);
+  connect(switchModel, &RawItemFilteredModel::dataUpdateComplete, this, &FlightModePanel::onModelDataUpdateComplete);
 
   ui->labelName->setContextMenuPolicy(Qt::CustomContextMenu);
   ui->labelName->setToolTip(tr("Popup menu available"));
@@ -316,8 +317,6 @@ void FlightModePanel::update()
   for (int i = 0; i < reCount; i++) {
     updateRotaryEncoder(i);
   }
-
-  emit nameModified();
 }
 
 void FlightModePanel::updateGVar(int index)
@@ -390,8 +389,8 @@ void FlightModePanel::phaseName_editingFinished()
 {
   QLineEdit *lineEdit = qobject_cast<QLineEdit*>(sender());
   strcpy(phase.name, lineEdit->text().toLatin1());
+  emit phaseNameChanged();
   emit modified();
-  emit nameModified();
 }
 
 void FlightModePanel::phaseSwitchChanged(int index)
@@ -401,6 +400,8 @@ void FlightModePanel::phaseSwitchChanged(int index)
     const RawSwitch rs(ui->swtch->itemData(index).toInt(&ok));
     if (ok && phase.swtch.toValue() != rs.toValue()) {
       phase.swtch = rs;
+      if (!rs.isSet())
+        emit phaseNoSwitchSet();
       emit modified();
     }
   }
@@ -457,7 +458,7 @@ void FlightModePanel::phaseGVValue_editingFinished()
     QDoubleSpinBox *spinBox = qobject_cast<QDoubleSpinBox*>(sender());
     int gvar = spinBox->property("index").toInt();
     phase.gvars[gvar] = spinBox->value() * model->gvarData[gvar].multiplierSet();
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
   }
 }
@@ -469,7 +470,7 @@ void FlightModePanel::GVName_editingFinished()
     int gvar = lineedit->property("index").toInt();
     memset(&model->gvarData[gvar].name, 0, sizeof(model->gvarData[gvar].name));
     strcpy(model->gvarData[gvar].name, lineedit->text().toLatin1());
-    emit datachanged();
+    emit gvNameChanged();
     emit modified();
   }
 }
@@ -488,7 +489,7 @@ void FlightModePanel::phaseGVUse_currentIndexChanged(int index)
     }
     if (model->isGVarLinkedCircular(phaseIdx, gvar))
       QMessageBox::warning(this, "Companion", tr("Warning: Global variable links back to itself. Flight Mode 0 value used."));
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
     lock = false;
   }
@@ -500,7 +501,7 @@ void FlightModePanel::phaseGVUnit_currentIndexChanged(int index)
     QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
     int gvar = comboBox->property("index").toInt();
     model->gvarData[gvar].unit = index;
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
   }
 }
@@ -511,7 +512,7 @@ void FlightModePanel::phaseGVPrec_currentIndexChanged(int index)
     QComboBox *comboBox = qobject_cast<QComboBox*>(sender());
     int gvar = comboBox->property("index").toInt();
     model->gvarData[gvar].prec = index;
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
   }
 }
@@ -534,7 +535,7 @@ void FlightModePanel::phaseGVMin_editingFinished()
         }
       }
     }
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
   }
 }
@@ -557,7 +558,7 @@ void FlightModePanel::phaseGVMax_editingFinished()
         }
       }
     }
-    emit datachanged();
+    updateGVar(gvar);
     emit modified();
   }
 }
@@ -741,7 +742,8 @@ void FlightModePanel::cmClear(bool prompt)
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_CLEAR, phaseIdx);
 
-  emit datachanged();
+  update();
+  emit phaseDataChanged();
   emit modified();
 }
 
@@ -767,7 +769,7 @@ void FlightModePanel::cmClearAll()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_GLOBAL_VARIABLE, ModelData::REF_UPD_ACT_CLEAR, i);
   }
 
-  emit datachanged();
+  emit phaseDataChanged();
   emit modified();
 }
 
@@ -846,7 +848,7 @@ void FlightModePanel::cmDelete()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_SHIFT, phaseIdx, 0, -1);
 
-  emit datachanged();
+  emit phaseDataChanged();
   emit modified();
 }
 
@@ -897,7 +899,7 @@ void FlightModePanel::cmInsert()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_SHIFT, phaseIdx, 0, 1);
 
-  emit datachanged();
+  emit phaseDataChanged();
   emit modified();
 }
 
@@ -946,7 +948,7 @@ void FlightModePanel::cmPaste()
       }
     }
 
-    emit datachanged();
+    emit phaseDataChanged();
     emit modified();
   }
 }
@@ -1035,7 +1037,7 @@ void FlightModePanel::swapData(int idx1, int idx2)
   }
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_FLIGHT_MODE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
-  emit datachanged();
+  emit phaseDataChanged();
   emit modified();
 }
 
@@ -1162,7 +1164,8 @@ void FlightModePanel::gvCmClear(bool prompt)
     }
     phase.gvars[gvIdx] = phase.linkedGVarFlightModeZero(phaseIdx);
   }
-  emit datachanged();
+  updateGVar(gvIdx);
+  emit gvNameChanged();
   emit modified();
 }
 
@@ -1186,7 +1189,10 @@ void FlightModePanel::gvCmClearAll()
       phase.gvars[i] = phase.linkedGVarFlightModeZero(phaseIdx);
     }
   }
-  emit datachanged();
+  for (int i = 0; i < gvCount; i++) {
+    updateGVar(i);
+  }
+  emit gvNameChanged();
   emit modified();
 }
 
@@ -1261,8 +1267,13 @@ void FlightModePanel::gvCmDelete()
   for (int j = 0; j < fmCount; j++) {
     model->flightModeData[j].gvars[maxidx] = model->flightModeData[j].linkedGVarFlightModeZero(j);
   }
+
   model->updateAllReferences(ModelData::REF_UPD_TYPE_GLOBAL_VARIABLE, ModelData::REF_UPD_ACT_SHIFT, gvIdx, 0, -1);
-  emit datachanged();
+
+  for (int i = 0; i < gvCount; i++) {
+    updateGVar(i);
+  }
+  emit gvNameChanged();
   emit modified();
 }
 
@@ -1279,7 +1290,10 @@ void FlightModePanel::gvCmInsert()
     model->flightModeData[j].gvars[gvIdx] = model->flightModeData[j].linkedGVarFlightModeZero(j);
   }
   model->updateAllReferences(ModelData::REF_UPD_TYPE_GLOBAL_VARIABLE, ModelData::REF_UPD_ACT_SHIFT, gvIdx, 0, 1);
-  emit datachanged();
+  for (int i = 0; i < gvCount; i++) {
+    updateGVar(i);
+  }
+  emit gvNameChanged();
   emit modified();
 }
 
@@ -1322,7 +1336,8 @@ void FlightModePanel::gvCmPaste()
     else
       phase.gvars[gvIdx] = val;
   }
-  emit datachanged();
+  updateGVar(gvIdx);
+  emit gvNameChanged();
   emit modified();
 }
 
@@ -1340,37 +1355,57 @@ void FlightModePanel::gvSwapData(int idx1, int idx2)
       model->flightModeData[j].gvars[idx1] = valtmp;
     }
     model->updateAllReferences(ModelData::REF_UPD_TYPE_GLOBAL_VARIABLE, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
-    emit datachanged();
+    updateGVar(idx1);
+    updateGVar(idx2);
+    emit gvNameChanged();
     emit modified();
   }
 }
 
+void FlightModePanel::onModelDataAboutToBeUpdated()
+{
+  lock = true;
+}
+
+void FlightModePanel::onModelDataUpdateComplete()
+{
+  update();
+  lock = false;
+}
+
 /**********************************************************/
 
-FlightModesPanel::FlightModesPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
-  ModelPanel(parent, model, generalSettings, firmware),
-  modesCount(firmware->getCapability(FlightModes))
+FlightModesPanel::FlightModesPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel):
+  ModelPanel(parent, model, generalSettings, firmware)
 {
-
-  RawSwitchFilterItemModel * swModel = new RawSwitchFilterItemModel(&generalSettings, &model, RawSwitch::MixesContext, this);
-  connect(this, &FlightModesPanel::updated, swModel, &RawSwitchFilterItemModel::update);
+  rawSwitchFilteredModel = new RawItemFilteredModel(rawSwitchItemModel, RawSwitch::MixesContext, this);
+  modesCount = firmware->getCapability(FlightModes);
 
   QGridLayout * gridLayout = new QGridLayout(this);
   tabWidget = new QTabWidget(this);
   for (int i = 0; i < modesCount; i++) {
-    FlightModePanel * tab = new FlightModePanel(tabWidget, model, i, generalSettings, firmware, swModel);
+    FlightModePanel * tab = new FlightModePanel(tabWidget, model, i, generalSettings, firmware, rawSwitchFilteredModel);
     tab->setProperty("index", i);
-    connect(tab,  &FlightModePanel::datachanged,  this, &FlightModesPanel::update);
-    connect(tab,  &FlightModePanel::modified,     this, &FlightModesPanel::modified);
-    connect(tab,  &FlightModePanel::nameModified, this, &FlightModesPanel::onPhaseNameChanged);
-    connect(this, &FlightModesPanel::updated,     tab,  &FlightModePanel::update);
+    connect(tab, &FlightModePanel::modified,         this, &FlightModesPanel::modified);
+    connect(tab, &FlightModePanel::phaseDataChanged, this, &FlightModesPanel::onPhaseNameChanged);
+    connect(tab, &FlightModePanel::phaseDataChanged, this, &FlightModesPanel::update);
+    connect(tab, &FlightModePanel::phaseDataChanged, this, &FlightModesPanel::refreshDataModels);
+    connect(tab, &FlightModePanel::phaseNameChanged, this, &FlightModesPanel::onPhaseNameChanged);
+    connect(tab, &FlightModePanel::phaseNoSwitchSet, this, &FlightModesPanel::refreshDataModels);
+    connect(tab, &FlightModePanel::gvNameChanged,    this, &FlightModesPanel::refreshDataModels);
+
+    connect(this, &FlightModesPanel::updated,         tab,  &FlightModePanel::update);
     tabWidget->addTab(tab, getTabName(i));
+    panels << tab;
   }
+  connect(tabWidget, &QTabWidget::currentChanged, this, &FlightModesPanel::onTabIndexChanged);
   gridLayout->addWidget(tabWidget, 0, 0, 1, 1);
+  onTabIndexChanged(0);
 }
 
 FlightModesPanel::~FlightModesPanel()
 {
+  delete rawSwitchFilteredModel;
 }
 
 QString FlightModesPanel::getTabName(int index)
@@ -1396,4 +1431,15 @@ void FlightModesPanel::onPhaseNameChanged()
 void FlightModesPanel::update()
 {
   emit updated();
+}
+
+void FlightModesPanel::refreshDataModels()
+{
+  emit updateDataModels();
+}
+
+void FlightModesPanel::onTabIndexChanged(int index)
+{
+  if (index < panels.size())
+    panels.at(index)->update();
 }

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -50,11 +50,11 @@ class FlightModePanel : public ModelPanel
     void gvNameChanged();
     void phaseDataChanged();
     void phaseNameChanged();
-    void phaseNoSwitchSet();
+    void phaseSwitchChanged();
 
   private slots:
     void phaseName_editingFinished();
-    void phaseSwitchChanged(int index);
+    void phaseSwitch_currentIndexChanged(int index);
     void phaseFadeIn_editingFinished();
     void phaseFadeOut_editingFinished();
     void phaseTrimUse_currentIndexChanged(int index);

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -24,7 +24,7 @@
 #include "modeledit.h"
 #include "eeprominterface.h"
 
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 constexpr char MIMETYPE_FLIGHTMODE[] = "application/x-companion-flightmode";
@@ -41,7 +41,7 @@ class FlightModePanel : public ModelPanel
     Q_OBJECT
 
   public:
-    FlightModePanel(QWidget *parent, ModelData &model, int modeIdx, GeneralSettings & generalSettings, Firmware * firmware, RawItemFilteredModel * switchModel);
+    FlightModePanel(QWidget *parent, ModelData &model, int modeIdx, GeneralSettings & generalSettings, Firmware * firmware, RawItemFilteredModel * rawSwitchFilteredModel);
     virtual ~FlightModePanel();
 
     virtual void update();
@@ -145,19 +145,17 @@ class FlightModesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    FlightModesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel);
+    FlightModesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~FlightModesPanel();
 
   public slots:
     virtual void update() override;
 
   signals:
-    void updateDataModels();
     void updated();
 
   private slots:
     void onPhaseNameChanged();
-    void refreshDataModels();
     void onTabIndexChanged(int index);
 
   private:
@@ -165,8 +163,10 @@ class FlightModesPanel : public ModelPanel
 
     int modesCount;
     QTabWidget *tabWidget;
+    CommonItemModels *commonItemModels;
     RawItemFilteredModel *rawSwitchFilteredModel;
     QVector<GenericPanel *> panels;
+    void updateItemModels();
 };
 
 #endif // _FLIGHTMODES_H_

--- a/companion/src/modeledit/flightmodes.h
+++ b/companion/src/modeledit/flightmodes.h
@@ -24,7 +24,8 @@
 #include "modeledit.h"
 #include "eeprominterface.h"
 
-class RawSwitchFilterItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 constexpr char MIMETYPE_FLIGHTMODE[] = "application/x-companion-flightmode";
 constexpr char MIMETYPE_GVAR_PARAMS[]  = "application/x-companion-gvar-params";
@@ -40,14 +41,16 @@ class FlightModePanel : public ModelPanel
     Q_OBJECT
 
   public:
-    FlightModePanel(QWidget *parent, ModelData &model, int modeIdx, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchFilterItemModel * switchModel);
+    FlightModePanel(QWidget *parent, ModelData &model, int modeIdx, GeneralSettings & generalSettings, Firmware * firmware, RawItemFilteredModel * switchModel);
     virtual ~FlightModePanel();
 
     virtual void update();
 
   signals:
-    void nameModified();
-    void datachanged();
+    void gvNameChanged();
+    void phaseDataChanged();
+    void phaseNameChanged();
+    void phaseNoSwitchSet();
 
   private slots:
     void phaseName_editingFinished();
@@ -87,6 +90,8 @@ class FlightModePanel : public ModelPanel
     void gvCmPaste();
     void gvCmMoveDown();
     void gvCmMoveUp();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
 
   private:
     Ui::FlightMode *ui;
@@ -111,7 +116,6 @@ class FlightModePanel : public ModelPanel
     QVector<QComboBox *> trimsUse;
     QVector<QSpinBox *> trimsValue;
     QVector<QSlider *> trimsSlider;
-    RawSwitchFilterItemModel * rawSwitchItemModel;
     Board::Type board;
 
     void trimUpdate(unsigned int trim);
@@ -141,24 +145,28 @@ class FlightModesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    FlightModesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    FlightModesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel);
     virtual ~FlightModesPanel();
 
   public slots:
     virtual void update() override;
 
   signals:
+    void updateDataModels();
     void updated();
 
   private slots:
     void onPhaseNameChanged();
+    void refreshDataModels();
+    void onTabIndexChanged(int index);
 
   private:
     QString getTabName(int index);
 
     int modesCount;
     QTabWidget *tabWidget;
-
+    RawItemFilteredModel *rawSwitchFilteredModel;
+    QVector<GenericPanel *> panels;
 };
 
 #endif // _FLIGHTMODES_H_

--- a/companion/src/modeledit/heli.h
+++ b/companion/src/modeledit/heli.h
@@ -23,7 +23,7 @@
 
 #include "modeledit.h"
 
-class RawSourceItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 namespace Ui {
@@ -35,7 +35,7 @@ class HeliPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    HeliPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSourceItemModel * rawSourceItemModel);
+    HeliPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     ~HeliPanel();
     void update();
 
@@ -46,7 +46,8 @@ class HeliPanel : public ModelPanel
 
   private:
     Ui::Heli *ui;
-    RawItemFilteredModel * rawSourceModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel * rawSourceFilteredModel;
 };
 
 #endif // _HELI_H_

--- a/companion/src/modeledit/heli.h
+++ b/companion/src/modeledit/heli.h
@@ -23,7 +23,8 @@
 
 #include "modeledit.h"
 
-class RawSourceFilterItemModel;
+class RawSourceItemModel;
+class RawItemFilteredModel;
 
 namespace Ui {
   class Heli;
@@ -34,17 +35,18 @@ class HeliPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    HeliPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    HeliPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSourceItemModel * rawSourceItemModel);
     ~HeliPanel();
     void update();
 
   private slots:
-    void updateDataModels();
     void edited();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
 
   private:
     Ui::Heli *ui;
-    RawSourceFilterItemModel * rawSourceItemModel;
+    RawItemFilteredModel * rawSourceModel;
 };
 
 #endif // _HELI_H_

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -190,8 +190,8 @@ void InputsPanel::gm_openExpo(int index)
   if (firmware->getCapability(VirtualInputs))
     inputName = model->inputNames[ed.chn];
 
-  ExpoDialog *g = new ExpoDialog(this, *model, &ed, generalSettings, firmware, inputName, rawSourceFilteredModel, rawSwitchFilteredModel);
-  if (g->exec())  {
+  ExpoDialog *dlg = new ExpoDialog(this, *model, &ed, generalSettings, firmware, inputName, rawSourceFilteredModel, rawSwitchFilteredModel);
+  if (dlg->exec())  {
     model->expoData[index] = ed;
     if (firmware->getCapability(VirtualInputs))
       strncpy(model->inputNames[ed.chn], inputName.toLatin1().data(), INPUT_NAME_LEN);
@@ -206,6 +206,7 @@ void InputsPanel::gm_openExpo(int index)
     expoInserted=false;
     update();
   }
+  delete dlg;
 }
 
 int InputsPanel::getExpoIndex(unsigned int dch)

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -22,10 +22,13 @@
 #include "expodialog.h"
 #include "helpers.h"
 
-InputsPanel::InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
+InputsPanel::InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel):
   ModelPanel(parent, model, generalSettings, firmware),
   expoInserted(false),
-  modelPrinter(firmware, generalSettings, model)
+  modelPrinter(firmware, generalSettings, model),
+  rawSourceItemModel(rawSourceItemModel),
+  rawSwitchItemModel(rawSwitchItemModel)
 {
   inputsCount = firmware->getCapability(VirtualInputs);
   if (inputsCount == 0)
@@ -180,11 +183,12 @@ void InputsPanel::gm_openExpo(int index)
   if (firmware->getCapability(VirtualInputs))
     inputName = model->inputNames[ed.chn];
 
-  ExpoDialog *g = new ExpoDialog(this, *model, &ed, generalSettings, firmware, inputName);
+  ExpoDialog *g = new ExpoDialog(this, *model, &ed, generalSettings, firmware, inputName, rawSourceItemModel, rawSwitchItemModel);
   if (g->exec())  {
     model->expoData[index] = ed;
     if (firmware->getCapability(VirtualInputs))
       strncpy(model->inputNames[ed.chn], inputName.toLatin1().data(), INPUT_NAME_LEN);
+    emit updateDataModels();
     emit modified();
     update();
   }

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -29,7 +29,7 @@ InputsPanel::InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & g
   expoInserted(false),
   modelPrinter(firmware, generalSettings, model)
 {
-  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, (RawSource::InputSourceGroups & ~RawSource::InputsGroup), this);
+  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, (RawSource::InputSourceGroups & ~ RawSource::NoneGroup & ~RawSource::InputsGroup), this);
   connect(rawSourceModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &InputsPanel::onModelDataAboutToBeUpdated);
   connect(rawSourceModel, &RawItemFilteredModel::dataUpdateComplete, this, &InputsPanel::onModelDataUpdateComplete);
 

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -197,9 +197,9 @@ void InputsPanel::gm_openExpo(int index)
     model->expoData[index] = ed;
     if (firmware->getCapability(VirtualInputs))
       strncpy(model->inputNames[ed.chn], inputName.toLatin1().data(), INPUT_NAME_LEN);
+    update();
     emit updateDataModels();
     emit modified();
-    update();
   }
   else {
     if (expoInserted) {
@@ -252,8 +252,9 @@ void InputsPanel::exposDelete(bool prompt)
   }
 
   exposDeleteList(list, prompt);
-  emit modified();
   update();
+  emit updateDataModels();
+  emit modified();
 }
 
 void InputsPanel::exposCut()
@@ -326,8 +327,9 @@ void InputsPanel::pasteExpoMimeData(const QMimeData * mimeData, int destIdx)
       i += sizeof(ExpoData);
     }
 
-    emit modified();
     update();
+    emit updateDataModels();
+    emit modified();
   }
 }
 
@@ -494,8 +496,9 @@ void InputsPanel::moveExpoList(bool down)
     }
   }
   if (mod) {
-    emit modified();
     update();
+    emit updateDataModels();
+    emit modified();
   }
   setSelectedByExpoList(highlightList);
 }
@@ -533,8 +536,9 @@ void InputsPanel::clearExpos()
     for (int i = 0; i < inputsCount; i++) {
       model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_CLEAR, i);
     }
-    emit modified();
     update();
+    emit updateDataModels();
+    emit modified();
   }
 }
 
@@ -582,6 +586,7 @@ void InputsPanel::cmInputClear()
   }
   model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_CLEAR, inputIdx);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
@@ -605,6 +610,7 @@ void InputsPanel::cmInputDelete()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_SHIFT, inputIdx, 0, -1);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
@@ -623,6 +629,7 @@ void InputsPanel::cmInputInsert()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_SHIFT, inputIdx, 0, 1);
   update();
+  emit updateDataModels();
   emit modified();
 }
 
@@ -684,6 +691,7 @@ void InputsPanel::cmInputSwapData(int idx1, int idx2)
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
   update();
+  emit updateDataModels();
   emit modified();
 }
 

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -24,6 +24,7 @@
 #include "modeledit.h"
 #include "mixerslistwidget.h"
 #include "modelprinter.h"
+#include "rawitemdatamodels.h"
 
 constexpr char MIMETYPE_EXPO[] = "application/x-companion-expo";
 
@@ -32,7 +33,8 @@ class InputsPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
     virtual ~InputsPanel();
 
     virtual void update();
@@ -60,6 +62,9 @@ class InputsPanel : public ModelPanel
     void cmInputMoveDown();
     void cmInputMoveUp();
 
+  signals:
+    void updateDataModels();
+
   private:
     bool expoInserted;
     MixersListWidget *ExposlistWidget;
@@ -67,6 +72,8 @@ class InputsPanel : public ModelPanel
     ModelPrinter modelPrinter;
     int selectedIdx;
     int inputIdx;
+    RawSourceItemModel *rawSourceItemModel;
+    RawSwitchItemModel *rawSwitchItemModel;
 
     int getExpoIndex(unsigned int dch);
     bool gm_insertExpo(int idx);

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -25,8 +25,7 @@
 #include "mixerslistwidget.h"
 #include "modelprinter.h"
 
-class RawSourceItemModel;
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 constexpr char MIMETYPE_EXPO[] = "application/x-companion-expo";
@@ -36,8 +35,7 @@ class InputsPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
-                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
+    InputsPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~InputsPanel();
 
     virtual void update();
@@ -67,9 +65,6 @@ class InputsPanel : public ModelPanel
     void onModelDataAboutToBeUpdated();
     void onModelDataUpdateComplete();
 
-  signals:
-    void updateDataModels();
-
   private:
     bool expoInserted;
     MixersListWidget *ExposlistWidget;
@@ -77,8 +72,9 @@ class InputsPanel : public ModelPanel
     ModelPrinter modelPrinter;
     int selectedIdx;
     int inputIdx;
-    RawItemFilteredModel *rawSourceModel;
-    RawItemFilteredModel *rawSwitchModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel *rawSourceFilteredModel;
+    RawItemFilteredModel *rawSwitchFilteredModel;
 
     int getExpoIndex(unsigned int dch);
     bool gm_insertExpo(int idx);
@@ -99,6 +95,7 @@ class InputsPanel : public ModelPanel
     bool isExpoIndex(const int index);
     int getIndexFromSelected();
     int getInputIndexFromSelected();
+    void updateItemModels();
 };
 
 #endif // _INPUTS_H_

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -24,7 +24,10 @@
 #include "modeledit.h"
 #include "mixerslistwidget.h"
 #include "modelprinter.h"
-#include "rawitemdatamodels.h"
+
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 constexpr char MIMETYPE_EXPO[] = "application/x-companion-expo";
 
@@ -61,6 +64,8 @@ class InputsPanel : public ModelPanel
     void cmInputInsert();
     void cmInputMoveDown();
     void cmInputMoveUp();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
 
   signals:
     void updateDataModels();
@@ -72,8 +77,8 @@ class InputsPanel : public ModelPanel
     ModelPrinter modelPrinter;
     int selectedIdx;
     int inputIdx;
-    RawSourceItemModel *rawSourceItemModel;
-    RawSwitchItemModel *rawSwitchItemModel;
+    RawItemFilteredModel *rawSourceModel;
+    RawItemFilteredModel *rawSwitchModel;
 
     int getExpoIndex(unsigned int dch);
     bool gm_insertExpo(int idx);

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -51,7 +51,6 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
 
   const int channelsMax = model.getChannelsMax(true);
 
-  lock = true;
   for (int i = 0; i < lsCapability; i++) {
     // The label
     QLabel * label = new QLabel(this);
@@ -156,7 +155,6 @@ LogicalSwitchesPanel::LogicalSwitchesPanel(QWidget * parent, ModelData & model, 
   }
 
   disableMouseScrolling();
-  lock = false;
   tableLayout->resizeColumnsToContents();
   tableLayout->pushRowsUp(lsCapability+1);
 }
@@ -176,12 +174,11 @@ void LogicalSwitchesPanel::onFunctionChanged()
     if (model->logicalSw[i].func == newFunc)
       return;
 
-    const unsigned oldFunc = model->logicalSw[i].func;
     CSFunctionFamily oldFuncFamily = model->logicalSw[i].getFunctionFamily();
     model->logicalSw[i].func = newFunc;
     CSFunctionFamily newFuncFamily = model->logicalSw[i].getFunctionFamily();
 
-    if (oldFuncFamily != newFuncFamily) {
+    if (oldFuncFamily != newFuncFamily || newFunc == LS_FN_OFF) {
       model->logicalSw[i].clear();
       model->logicalSw[i].func = newFunc;
       if (newFuncFamily == LS_FAMILY_TIMER) {
@@ -345,15 +342,12 @@ void LogicalSwitchesPanel::updateTimerParam(QDoubleSpinBox *sb, int timer, doubl
 void LogicalSwitchesPanel::updateLine(int i)
 {
   lock = true;
-  unsigned int mask;
+  unsigned int mask = 0;
 
   cbFunction[i]->setCurrentIndex(cbFunction[i]->findData(model->logicalSw[i].func));
   cbAndSwitch[i]->setCurrentIndex(cbAndSwitch[i]->findData(RawSwitch(model->logicalSw[i].andsw).toValue()));
 
-  if (model->logicalSw[i].isEmpty()) {
-    mask = 0;
-  }
-  else {
+  //if (!model->logicalSw[i].isEmpty()) {
     mask = LINE_ENABLED | DELAY_ENABLED | DURATION_ENABLED;
 
     switch (model->logicalSw[i].getFunctionFamily())
@@ -423,7 +417,7 @@ void LogicalSwitchesPanel::updateLine(int i)
         updateTimerParam(dsbOffset[i], model->logicalSw[i].val2, 0.1);
         break;
     }
-  }
+  //}
 
   cbSource1[i]->setVisible(mask & SOURCE1_VISIBLE);
   cbSource2[i]->setVisible(mask & SOURCE2_VISIBLE);

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -172,6 +172,7 @@ void LogicalSwitchesPanel::onFunctionChanged()
     if (model->logicalSw[i].func == newFunc)
       return;
 
+    unsigned oldFunc = model->logicalSw[i].func;
     CSFunctionFamily oldFuncFamily = model->logicalSw[i].getFunctionFamily();
     model->logicalSw[i].func = newFunc;
     CSFunctionFamily newFuncFamily = model->logicalSw[i].getFunctionFamily();
@@ -189,6 +190,10 @@ void LogicalSwitchesPanel::onFunctionChanged()
     }
 
     updateLine(i);
+
+    if (oldFunc == LS_FN_OFF || newFunc == LS_FN_OFF)
+      updateItemModels();
+
     emit modified();
   }
 }
@@ -487,7 +492,7 @@ void LogicalSwitchesPanel::cmPaste()
   if (hasClipboardData(&data)) {
     memcpy(&model->logicalSw[selectedIndex], data.constData(), sizeof(LogicalSwitchData));
     updateLine(selectedIndex);
-    updateCBLists();
+    updateItemModels();
     emit modified();
   }
 }
@@ -502,7 +507,7 @@ void LogicalSwitchesPanel::cmDelete()
 
   model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
   update();
-  updateCBLists();
+  updateItemModels();
   emit modified();
 }
 
@@ -592,7 +597,7 @@ void LogicalSwitchesPanel::cmClear(bool prompt)
   model->logicalSw[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   updateLine(selectedIndex);
-  updateCBLists();
+  updateItemModels();
   emit modified();
 }
 
@@ -606,7 +611,7 @@ void LogicalSwitchesPanel::cmClearAll()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_CLEAR, i);
   }
   update();
-  updateCBLists();
+  updateItemModels();
   emit modified();
 }
 
@@ -616,7 +621,7 @@ void LogicalSwitchesPanel::cmInsert()
   model->logicalSw[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
   update();
-  updateCBLists();
+  updateItemModels();
   emit modified();
 }
 
@@ -631,20 +636,9 @@ void LogicalSwitchesPanel::swapData(int idx1, int idx2)
     model->updateAllReferences(ModelData::REF_UPD_TYPE_LOGICAL_SWITCH, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
     updateLine(idx1);
     updateLine(idx2);
-    updateCBLists();
+    updateItemModels();
     emit modified();
   }
-}
-
-void LogicalSwitchesPanel::updateCBLists()
-{
-  //  We need to update the data models as (de)activating the current LS needs to be reflected in all LS source and switch lists
-  //  However triggering after the input or mix edit dialogs displayed causes the application to crash
-  //  So this workaround gives time for other events to be processed before refreshing
-  //  Not sure if this an OS related issue or a QT bug in QT 5.7 (and higher?)
-  //  The delay is abitary
-  //QTimer::singleShot(1000, this, &LogicalSwitchesPanel::updateItemModels);
-  updateItemModels();
 }
 
 void LogicalSwitchesPanel::updateItemModels()

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -169,36 +169,33 @@ LogicalSwitchesPanel::~LogicalSwitchesPanel()
 
 void LogicalSwitchesPanel::onFunctionChanged()
 {
-  int i = sender()->property("index").toInt();
-  unsigned newFunc = cbFunction[i]->currentData().toUInt();
+  if (!lock) {
+    int i = sender()->property("index").toInt();
+    unsigned newFunc = cbFunction[i]->currentData().toUInt();
 
-  if (model->logicalSw[i].func == newFunc)
-    return;
+    if (model->logicalSw[i].func == newFunc)
+      return;
 
-  const unsigned oldFunc = model->logicalSw[i].func;
-  CSFunctionFamily oldFuncFamily = model->logicalSw[i].getFunctionFamily();
-  model->logicalSw[i].func = newFunc;
-  CSFunctionFamily newFuncFamily = model->logicalSw[i].getFunctionFamily();
-
-  if (oldFuncFamily != newFuncFamily) {
-    model->logicalSw[i].clear();
+    const unsigned oldFunc = model->logicalSw[i].func;
+    CSFunctionFamily oldFuncFamily = model->logicalSw[i].getFunctionFamily();
     model->logicalSw[i].func = newFunc;
-    if (newFuncFamily == LS_FAMILY_TIMER) {
-      model->logicalSw[i].val1 = -119;
-      model->logicalSw[i].val2 = -119;
-    }
-    else if (newFuncFamily == LS_FAMILY_EDGE) {
-      model->logicalSw[i].val2 = -129;
-    }
-  }
-  if (bool(oldFunc) != bool(newFunc)) {
-    emit updateDataModels();
-    update();
-  }
-  else
-    updateLine(i);
+    CSFunctionFamily newFuncFamily = model->logicalSw[i].getFunctionFamily();
 
-  emit modified();
+    if (oldFuncFamily != newFuncFamily) {
+      model->logicalSw[i].clear();
+      model->logicalSw[i].func = newFunc;
+      if (newFuncFamily == LS_FAMILY_TIMER) {
+        model->logicalSw[i].val1 = -119;
+        model->logicalSw[i].val2 = -119;
+      }
+      else if (newFuncFamily == LS_FAMILY_EDGE) {
+        model->logicalSw[i].val2 = -129;
+      }
+    }
+
+    updateLine(i);
+    emit modified();
+  }
 }
 
 void LogicalSwitchesPanel::onV1Changed(int value)
@@ -353,7 +350,7 @@ void LogicalSwitchesPanel::updateLine(int i)
   cbFunction[i]->setCurrentIndex(cbFunction[i]->findData(model->logicalSw[i].func));
   cbAndSwitch[i]->setCurrentIndex(cbAndSwitch[i]->findData(RawSwitch(model->logicalSw[i].andsw).toValue()));
 
-  if (!model->logicalSw[i].func) {
+  if (model->logicalSw[i].isEmpty()) {
     mask = 0;
   }
   else {

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -408,7 +408,7 @@ void LogicalSwitchesPanel::updateLine(int i)
         cbSource1[i]->setModel(rawSwitchModel);
         cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(model->logicalSw[i].val1));
         updateTimerParam(dsbOffset[i], model->logicalSw[i].val2, 0.0);
-        updateTimerParam(dsbOffset2[i], model->logicalSw[i].val2+model->logicalSw[i].val3, ValToTim(TimToVal(dsbOffset[i]->value())-1));
+        updateTimerParam(dsbOffset2[i], model->logicalSw[i].val2 + model->logicalSw[i].val3, ValToTim(TimToVal(dsbOffset[i]->value()) - 1));
         dsbOffset2[i]->setSuffix((model->logicalSw[i].val3) ? "" : tr(" (infinite)"));
         break;
 

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -193,26 +193,10 @@ void LogicalSwitchesPanel::onFunctionChanged()
 
     if (oldFunc == LS_FN_OFF || newFunc == LS_FN_OFF)
       updateCBLists();
+    else
+      updateLine(i);
     emit modified();
   }
-}
-
-void LogicalSwitchesPanel::updateCBLists()
-{
-  //  We need to update the data models as (de)activating the current LS needs to be reflected in all LS source and switch lists
-  //  However triggering after the input or mix edit dialogs displayed causes the application to crash
-  //  So this workaround gives time for other events to be processed before refreshing
-  //  Not sure if this an OS related issue or a QT bug in QT 5.7 (and higher?)
-  //  The delay is abitary
-  QTimer::singleShot(1000, this, &LogicalSwitchesPanel::updateDataModels);
-}
-
-void LogicalSwitchesPanel::updateDataModels()
-{
-  //  This is inconsistent but needed as part of the workaround
-  //emit updateCBLists();  adds to the event stack so call direct
-  rawSourceModel->update();
-  rawSwitchModel->update();
 }
 
 void LogicalSwitchesPanel::onV1Changed(int value)
@@ -649,6 +633,24 @@ void LogicalSwitchesPanel::swapData(int idx1, int idx2)
     updateCBLists();
     emit modified();
   }
+}
+
+void LogicalSwitchesPanel::updateCBLists()
+{
+  //  We need to update the data models as (de)activating the current LS needs to be reflected in all LS source and switch lists
+  //  However triggering after the input or mix edit dialogs displayed causes the application to crash
+  //  So this workaround gives time for other events to be processed before refreshing
+  //  Not sure if this an OS related issue or a QT bug in QT 5.7 (and higher?)
+  //  The delay is abitary
+  QTimer::singleShot(1000, this, &LogicalSwitchesPanel::updateDataModels);
+}
+
+void LogicalSwitchesPanel::updateDataModels()
+{
+  //  This is inconsistent but needed as part of the workaround
+  //emit updateCBLists();  adds to the event stack so call direct
+  rawSourceModel->update();
+  rawSwitchModel->update();
 }
 
 void LogicalSwitchesPanel::onModelDataAboutToBeUpdated()

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -24,8 +24,7 @@
 #include "modeledit.h"
 #include "radiodata.h"
 
-class RawSourceItemModel;
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 class TimerEdit;
 
@@ -36,8 +35,7 @@ class LogicalSwitchesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    LogicalSwitchesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
-                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
+    LogicalSwitchesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~LogicalSwitchesPanel();
 
     virtual void update();
@@ -76,8 +74,9 @@ class LogicalSwitchesPanel : public ModelPanel
     QDoubleSpinBox * dsbDelay[CPN_MAX_LOGICAL_SWITCHES];
     QComboBox * cbSource1[CPN_MAX_LOGICAL_SWITCHES];
     QComboBox * cbSource2[CPN_MAX_LOGICAL_SWITCHES];
-    RawItemFilteredModel * rawSwitchModel;
-    RawItemFilteredModel * rawSourceModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel * rawSwitchFilteredModel;
+    RawItemFilteredModel * rawSourceFilteredModel;
     int selectedIndex;
     void populateFunctionCB(QComboBox *b);
     void updateTimerParam(QDoubleSpinBox *sb, int timer, double minimum=0);
@@ -90,7 +89,7 @@ class LogicalSwitchesPanel : public ModelPanel
     bool moveUpAllowed() const;
     int modelsUpdateCnt;
     void updateCBLists();
-    void updateDataModels();
+    void updateItemModels();
 };
 
 #endif // _LOGICALSWITCHES_H_

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -88,7 +88,6 @@ class LogicalSwitchesPanel : public ModelPanel
     bool moveDownAllowed() const;
     bool moveUpAllowed() const;
     int modelsUpdateCnt;
-    void updateCBLists();
     void updateItemModels();
 };
 

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -65,9 +65,6 @@ class LogicalSwitchesPanel : public ModelPanel
     void onModelDataAboutToBeUpdated();
     void onModelDataUpdateComplete();
 
-  signals:
-    void updateDataModels();
-
   private:
     QComboBox * cbFunction[CPN_MAX_LOGICAL_SWITCHES];
     QDoubleSpinBox * dsbValue[CPN_MAX_LOGICAL_SWITCHES];
@@ -92,6 +89,8 @@ class LogicalSwitchesPanel : public ModelPanel
     bool moveDownAllowed() const;
     bool moveUpAllowed() const;
     int modelsUpdateCnt;
+    void updateCBLists();
+    void updateDataModels();
 };
 
 #endif // _LOGICALSWITCHES_H_

--- a/companion/src/modeledit/logicalswitches.h
+++ b/companion/src/modeledit/logicalswitches.h
@@ -24,8 +24,9 @@
 #include "modeledit.h"
 #include "radiodata.h"
 
-class RawSwitchFilterItemModel;
-class RawSourceFilterItemModel;
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 class TimerEdit;
 
 constexpr char MIMETYPE_LOGICAL_SWITCH[] = "application/x-companion-logical-switch";
@@ -35,13 +36,13 @@ class LogicalSwitchesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    LogicalSwitchesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    LogicalSwitchesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
     virtual ~LogicalSwitchesPanel();
 
     virtual void update();
 
   private slots:
-    void updateDataModels();
     void onFunctionChanged();
     void onV1Changed(int value);
     void onV2Changed(int value);
@@ -61,6 +62,11 @@ class LogicalSwitchesPanel : public ModelPanel
     void cmInsert();
     void cmClear(bool prompt = true);
     void cmClearAll();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
+
+  signals:
+    void updateDataModels();
 
   private:
     QComboBox * cbFunction[CPN_MAX_LOGICAL_SWITCHES];
@@ -73,11 +79,10 @@ class LogicalSwitchesPanel : public ModelPanel
     QDoubleSpinBox * dsbDelay[CPN_MAX_LOGICAL_SWITCHES];
     QComboBox * cbSource1[CPN_MAX_LOGICAL_SWITCHES];
     QComboBox * cbSource2[CPN_MAX_LOGICAL_SWITCHES];
-    RawSwitchFilterItemModel * rawSwitchItemModel;
-    RawSourceFilterItemModel * rawSourceItemModel;
+    RawItemFilteredModel * rawSwitchModel;
+    RawItemFilteredModel * rawSourceModel;
     int selectedIndex;
     void populateFunctionCB(QComboBox *b);
-    void populateAndSwitchCB(QComboBox *b);
     void updateTimerParam(QDoubleSpinBox *sb, int timer, double minimum=0);
     int lsCapability;
     int lsCapabilityExt;
@@ -86,6 +91,7 @@ class LogicalSwitchesPanel : public ModelPanel
     bool insertAllowed() const;
     bool moveDownAllowed() const;
     bool moveUpAllowed() const;
+    int modelsUpdateCnt;
 };
 
 #endif // _LOGICALSWITCHES_H_

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -154,6 +154,8 @@ MixerDialog::~MixerDialog()
   delete gvWeightGroup;
   delete gvOffsetGroup;
   delete curveGroup;
+  delete rawSourceModel;
+  delete rawSwitchModel;
   delete ui;
 }
 

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -24,7 +24,8 @@
 #include "rawitemfilteredmodel.h"
 #include "helpers.h"
 
-MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, GeneralSettings & generalSettings, Firmware * firmware) :
+MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, GeneralSettings & generalSettings, Firmware * firmware,
+                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel) :
   QDialog(parent),
   ui(new Ui::MixerDialog),
   model(model),
@@ -34,6 +35,9 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   lock(false)
 {
   ui->setupUi(this);
+  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, RawSource::InputSourceGroups | RawSource::ScriptsGroup, this);
+  rawSwitchModel = new RawItemFilteredModel(rawSwitchItemModel, RawSwitch::MixesContext, this);
+
   QRegExp rx(CHAR_FOR_NAMES_REGEX);
   QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0,ui->lb_FP1,ui->lb_FP2,ui->lb_FP3,ui->lb_FP4,ui->lb_FP5,ui->lb_FP6,ui->lb_FP7,ui->lb_FP8 };
   QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0,ui->cb_FP1,ui->cb_FP2,ui->cb_FP3,ui->cb_FP4,ui->cb_FP5,ui->cb_FP6,ui->cb_FP7,ui->cb_FP8 };
@@ -43,7 +47,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   this->setWindowTitle(tr("DEST -> %1").arg(RawSource(SOURCE_TYPE_CH, md->destCh-1).toString(&model, &generalSettings)));
 
-  ui->sourceCB->setModel(new RawSourceFilterItemModel(&generalSettings, &model, RawSource::InputSourceGroups | RawSource::ScriptsGroup, this));
+  ui->sourceCB->setModel(rawSourceModel);
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
   ui->sourceCB->removeItem(0);
 
@@ -104,7 +108,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
     }
   }
 
-  ui->switchesCB->setModel(new RawSwitchFilterItemModel(&generalSettings, &model, RawSwitch::MixesContext, this));
+  ui->switchesCB->setModel(rawSwitchModel);
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(md->swtch.toValue()));
   ui->warningCB->setCurrentIndex(md->mixWarn);
   ui->mltpxCB->setCurrentIndex(md->mltpx);

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -47,7 +47,6 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   ui->sourceCB->setModel(rawSourceModel);
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
-  ui->sourceCB->removeItem(0);
 
   int limit = firmware->getCapability(OffsetWeight);
 
@@ -191,7 +190,7 @@ void MixerDialog::valuesChanged()
     strcpy(md->name, ui->mixerName->text().toLatin1());
 
     md->flightModes = 0;
-    for (int i = CPN_MAX_FLIGHT_MODES-1; i >= 0 ; i--) {
+    for (int i = CPN_MAX_FLIGHT_MODES - 1; i >= 0 ; i--) {
       if (!cb_fp[i]->checkState()) {
         md->flightModes++;
       }

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -25,7 +25,7 @@
 #include "helpers.h"
 
 MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, GeneralSettings & generalSettings, Firmware * firmware,
-                            RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel) :
+                            RawItemFilteredModel * rawSourceModel, RawItemFilteredModel * rawSwitchModel) :
   QDialog(parent),
   ui(new Ui::MixerDialog),
   model(model),
@@ -35,17 +35,15 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   lock(false)
 {
   ui->setupUi(this);
-  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, RawSource::InputSourceGroups | RawSource::ScriptsGroup, this);
-  rawSwitchModel = new RawItemFilteredModel(rawSwitchItemModel, RawSwitch::MixesContext, this);
 
   QRegExp rx(CHAR_FOR_NAMES_REGEX);
-  QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0,ui->lb_FP1,ui->lb_FP2,ui->lb_FP3,ui->lb_FP4,ui->lb_FP5,ui->lb_FP6,ui->lb_FP7,ui->lb_FP8 };
-  QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0,ui->cb_FP1,ui->cb_FP2,ui->cb_FP3,ui->cb_FP4,ui->cb_FP5,ui->cb_FP6,ui->cb_FP7,ui->cb_FP8 };
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0, ui->lb_FP1, ui->lb_FP2, ui->lb_FP3, ui->lb_FP4, ui->lb_FP5, ui->lb_FP6, ui->lb_FP7, ui->lb_FP8 };
+  QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0, ui->cb_FP1, ui->cb_FP2, ui->cb_FP3, ui->cb_FP4, ui->cb_FP5, ui->cb_FP6, ui->cb_FP7, ui->cb_FP8 };
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i] = tmp[i];
   }
 
-  this->setWindowTitle(tr("DEST -> %1").arg(RawSource(SOURCE_TYPE_CH, md->destCh-1).toString(&model, &generalSettings)));
+  this->setWindowTitle(tr("DEST -> %1").arg(RawSource(SOURCE_TYPE_CH, md->destCh - 1).toString(&model, &generalSettings)));
 
   ui->sourceCB->setModel(rawSourceModel);
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
@@ -66,7 +64,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   }
 
   if (!firmware->getCapability(VirtualInputs)) {
-    for(int i=0; i < CPN_MAX_STICKS; i++) {
+    for(int i = 0; i < CPN_MAX_STICKS; i++) {
       ui->trimCB->addItem(firmware->getAnalogInputName(i));
     }
   }
@@ -86,7 +84,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   if (!firmware->getCapability(FlightModes)) {
     ui->label_phases->hide();
-    for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+    for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
       lb_fp[i]->hide();
       cb_fp[i]->hide();
     }
@@ -96,13 +94,13 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
     ui->label_phases->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->label_phases, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(label_phases_customContextMenuRequested(const QPoint &)));
     int mask = 1;
-    for (int i=0; i<CPN_MAX_FLIGHT_MODES ; i++) {
+    for (int i = 0; i < CPN_MAX_FLIGHT_MODES ; i++) {
       if ((md->flightModes & mask) == 0) {
         cb_fp[i]->setChecked(true);
       }
       mask <<= 1;
     }
-    for (int i=firmware->getCapability(FlightModes); i<CPN_MAX_FLIGHT_MODES; i++) {
+    for (int i = firmware->getCapability(FlightModes); i < CPN_MAX_FLIGHT_MODES; i++) {
       lb_fp[i]->hide();
       cb_fp[i]->hide();
     }
@@ -114,22 +112,22 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   ui->mltpxCB->setCurrentIndex(md->mltpx);
   int scale=firmware->getCapability(SlowScale);
   float range=firmware->getCapability(SlowRange);
-  ui->slowDownSB->setMaximum(range/scale);
-  ui->slowDownSB->setSingleStep(1.0/scale);
-  ui->slowDownSB->setDecimals((scale==1 ? 0 :1));
+  ui->slowDownSB->setMaximum(range / scale);
+  ui->slowDownSB->setSingleStep(1.0 / scale);
+  ui->slowDownSB->setDecimals((scale == 1 ? 0 : 1));
   ui->slowDownSB->setValue((float)md->speedDown/scale);
-  ui->slowUpSB->setMaximum(range/scale);
-  ui->slowUpSB->setSingleStep(1.0/scale);
-  ui->slowUpSB->setDecimals((scale==1 ? 0 :1));
+  ui->slowUpSB->setMaximum(range / scale);
+  ui->slowUpSB->setSingleStep(1.0 / scale);
+  ui->slowUpSB->setDecimals((scale == 1 ? 0 : 1));
   ui->slowUpSB->setValue((float)md->speedUp/scale);
-  ui->delayDownSB->setMaximum(range/scale);
-  ui->delayDownSB->setSingleStep(1.0/scale);
-  ui->delayDownSB->setDecimals((scale==1 ? 0 :1));
-  ui->delayDownSB->setValue((float)md->delayDown/scale);
-  ui->delayUpSB->setMaximum(range/scale);
-  ui->delayUpSB->setSingleStep(1.0/scale);
-  ui->delayUpSB->setDecimals((scale==1 ? 0 :1));
-  ui->delayUpSB->setValue((float)md->delayUp/scale);
+  ui->delayDownSB->setMaximum(range / scale);
+  ui->delayDownSB->setSingleStep(1.0 / scale);
+  ui->delayDownSB->setDecimals((scale == 1 ? 0 : 1));
+  ui->delayDownSB->setValue((float)md->delayDown / scale);
+  ui->delayUpSB->setMaximum(range / scale);
+  ui->delayUpSB->setSingleStep(1.0 / scale);
+  ui->delayUpSB->setDecimals((scale == 1 ? 0 : 1));
+  ui->delayUpSB->setValue((float)md->delayUp / scale);
   QTimer::singleShot(0, this, SLOT(shrink()));
 
   valuesChanged();
@@ -154,8 +152,6 @@ MixerDialog::~MixerDialog()
   delete gvWeightGroup;
   delete gvOffsetGroup;
   delete curveGroup;
-  delete rawSourceModel;
-  delete rawSwitchModel;
   delete ui;
 }
 
@@ -182,20 +178,20 @@ void MixerDialog::valuesChanged()
       ui->MixDR_CB->setEnabled(drVisible);
       ui->label_MixDR->setEnabled(drVisible);
     }
-    md->carryTrim = -(ui->trimCB->currentIndex()-1);
+    md->carryTrim = -(ui->trimCB->currentIndex() - 1);
     md->noExpo    = ui->MixDR_CB->checkState() ? 0 : 1;
     md->swtch     = RawSwitch(ui->switchesCB->itemData(ui->switchesCB->currentIndex()).toInt());
     md->mixWarn   = ui->warningCB->currentIndex();
     md->mltpx     = (MltpxValue)ui->mltpxCB->currentIndex();
     int scale = firmware->getCapability(SlowScale);
-    md->delayDown = round(ui->delayDownSB->value()*scale);
-    md->delayUp   = round(ui->delayUpSB->value()*scale);
-    md->speedDown = round(ui->slowDownSB->value()*scale);
-    md->speedUp   = round(ui->slowUpSB->value()*scale);
+    md->delayDown = round(ui->delayDownSB->value() * scale);
+    md->delayUp   = round(ui->delayUpSB->value() * scale);
+    md->speedDown = round(ui->slowDownSB->value() * scale);
+    md->speedUp   = round(ui->slowUpSB->value() * scale);
     strcpy(md->name, ui->mixerName->text().toLatin1());
 
     md->flightModes = 0;
-    for (int i=CPN_MAX_FLIGHT_MODES-1; i>=0 ; i--) {
+    for (int i = CPN_MAX_FLIGHT_MODES-1; i >= 0 ; i--) {
       if (!cb_fp[i]->checkState()) {
         md->flightModes++;
       }
@@ -226,7 +222,7 @@ void MixerDialog::label_phases_customContextMenuRequested(const QPoint & pos)
 void MixerDialog::fmClearAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(false);
   }
   lock = false;
@@ -236,7 +232,7 @@ void MixerDialog::fmClearAll()
 void MixerDialog::fmSetAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(true);
   }
   lock = false;
@@ -246,7 +242,7 @@ void MixerDialog::fmSetAll()
 void MixerDialog::fmInvertAll()
 {
   lock = true;
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
     cb_fp[i]->setChecked(!cb_fp[i]->isChecked());
   }
   lock = false;

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -148,10 +148,10 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
 MixerDialog::~MixerDialog()
 {
+  delete ui;
   delete gvWeightGroup;
   delete gvOffsetGroup;
   delete curveGroup;
-  delete ui;
 }
 
 void MixerDialog::changeEvent(QEvent *e)

--- a/companion/src/modeledit/mixerdialog.h
+++ b/companion/src/modeledit/mixerdialog.h
@@ -26,8 +26,6 @@
 
 class GVarGroup;
 class CurveGroup;
-class RawSourceItemModel;
-class RawSwitchItemModel;
 class RawItemFilteredModel;
 
 namespace Ui {
@@ -38,7 +36,7 @@ class MixerDialog : public QDialog {
     Q_OBJECT
   public:
     MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, GeneralSettings & generalSettings, Firmware * firmware,
-                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
+                  RawItemFilteredModel * rawSourceModel, RawItemFilteredModel * rawSwitchModel);
     ~MixerDialog();
 
   protected:
@@ -63,8 +61,6 @@ class MixerDialog : public QDialog {
     GVarGroup * gvOffsetGroup;
     CurveGroup * curveGroup;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
-    RawItemFilteredModel * rawSourceModel;
-    RawItemFilteredModel * rawSwitchModel;
 };
 
 #endif // _MIXERDIALOG_H_

--- a/companion/src/modeledit/mixerdialog.h
+++ b/companion/src/modeledit/mixerdialog.h
@@ -26,6 +26,9 @@
 
 class GVarGroup;
 class CurveGroup;
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 namespace Ui {
   class MixerDialog;
@@ -34,7 +37,8 @@ namespace Ui {
 class MixerDialog : public QDialog {
     Q_OBJECT
   public:
-    MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, GeneralSettings & generalSettings, Firmware * firmware);
+    MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, GeneralSettings & generalSettings, Firmware * firmware,
+                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
     ~MixerDialog();
 
   protected:
@@ -59,6 +63,8 @@ class MixerDialog : public QDialog {
     GVarGroup * gvOffsetGroup;
     CurveGroup * curveGroup;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
+    RawItemFilteredModel * rawSourceModel;
+    RawItemFilteredModel * rawSwitchModel;
 };
 
 #endif // _MIXERDIALOG_H_

--- a/companion/src/modeledit/mixes.cpp
+++ b/companion/src/modeledit/mixes.cpp
@@ -21,11 +21,14 @@
 #include "mixes.h"
 #include "helpers.h"
 
-MixesPanel::MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware):
+MixesPanel::MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                          RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel):
   ModelPanel(parent, model, generalSettings, firmware),
   mixInserted(false),
   highlightedSource(0),
-  modelPrinter(firmware, generalSettings, model)
+  modelPrinter(firmware, generalSettings, model),
+  rawSourceItemModel(rawSourceItemModel),
+  rawSwitchItemModel(rawSwitchItemModel)
 {
   QGridLayout * mixesLayout = new QGridLayout(this);
 
@@ -175,7 +178,7 @@ void MixesPanel::gm_openMix(int index)
 
   MixData mixd(model->mixData[index]);
 
-  MixerDialog *g = new MixerDialog(this, *model, &mixd, generalSettings, firmware);
+  MixerDialog *g = new MixerDialog(this, *model, &mixd, generalSettings, firmware, rawSourceItemModel, rawSwitchItemModel);
   if(g->exec()) {
     model->mixData[index] = mixd;
     emit modified();

--- a/companion/src/modeledit/mixes.cpp
+++ b/companion/src/modeledit/mixes.cpp
@@ -185,8 +185,8 @@ void MixesPanel::gm_openMix(int index)
 
   MixData mixd(model->mixData[index]);
 
-  MixerDialog *g = new MixerDialog(this, *model, &mixd, generalSettings, firmware, rawSourceFilteredModel, rawSwitchFilteredModel);
-  if(g->exec()) {
+  MixerDialog *dlg = new MixerDialog(this, *model, &mixd, generalSettings, firmware, rawSourceFilteredModel, rawSwitchFilteredModel);
+  if(dlg->exec()) {
     model->mixData[index] = mixd;
     emit modified();
     update();
@@ -198,6 +198,7 @@ void MixesPanel::gm_openMix(int index)
     mixInserted = false;
     update();
   }
+  delete dlg;
 }
 
 int MixesPanel::getMixerIndex(unsigned int dch)

--- a/companion/src/modeledit/mixes.cpp
+++ b/companion/src/modeledit/mixes.cpp
@@ -29,7 +29,7 @@ MixesPanel::MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & gen
   highlightedSource(0),
   modelPrinter(firmware, generalSettings, model)
 {
-  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, RawSource::InputSourceGroups | RawSource::ScriptsGroup, this);
+  rawSourceModel = new RawItemFilteredModel(rawSourceItemModel, ((RawSource::InputSourceGroups | RawSource::ScriptsGroup) & ~ RawSource::NoneGroup), this);
   connect(rawSourceModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &MixesPanel::onModelDataAboutToBeUpdated);
   connect(rawSourceModel, &RawItemFilteredModel::dataUpdateComplete, this, &MixesPanel::onModelDataUpdateComplete);
 

--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -25,13 +25,15 @@
 #include "mixerslistwidget.h"
 #include "mixerdialog.h"
 #include "modelprinter.h"
+#include "rawitemdatamodels.h"
 
 class MixesPanel : public ModelPanel
 {
     Q_OBJECT
 
   public:
-    MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
     virtual ~MixesPanel();
 
     virtual void update();
@@ -63,6 +65,8 @@ class MixesPanel : public ModelPanel
     bool mixInserted;
     unsigned int highlightedSource;
     ModelPrinter modelPrinter;
+    RawSourceItemModel *rawSourceItemModel;
+    RawSwitchItemModel *rawSwitchItemModel;
 
     int getMixerIndex(unsigned int dch);
     bool gm_insertMix(int idx);

--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -25,7 +25,10 @@
 #include "mixerslistwidget.h"
 #include "mixerdialog.h"
 #include "modelprinter.h"
-#include "rawitemdatamodels.h"
+
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 class MixesPanel : public ModelPanel
 {
@@ -52,7 +55,6 @@ class MixesPanel : public ModelPanel
     void moveMixDown();
     void mixerHighlight();
 
-
     void mixerlistWidget_customContextMenuRequested(QPoint pos);
     void mixerlistWidget_doubleClicked(QModelIndex index);
     void mixerlistWidget_KeyPress(QKeyEvent *event);
@@ -60,13 +62,16 @@ class MixesPanel : public ModelPanel
     void mimeMixerDropped(int index, const QMimeData *data, Qt::DropAction action);
     void pasteMixerMimeData(const QMimeData * mimeData, int destIdx);
 
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
+
   private:
     MixersListWidget * mixersListWidget;
     bool mixInserted;
     unsigned int highlightedSource;
     ModelPrinter modelPrinter;
-    RawSourceItemModel *rawSourceItemModel;
-    RawSwitchItemModel *rawSwitchItemModel;
+    RawItemFilteredModel *rawSourceModel;
+    RawItemFilteredModel *rawSwitchModel;
 
     int getMixerIndex(unsigned int dch);
     bool gm_insertMix(int idx);

--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -26,8 +26,7 @@
 #include "mixerdialog.h"
 #include "modelprinter.h"
 
-class RawSourceItemModel;
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 class MixesPanel : public ModelPanel
@@ -35,8 +34,7 @@ class MixesPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
-                  RawSourceItemModel * rawSourceItemModel, RawSwitchItemModel * rawSwitchItemModel);
+    MixesPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~MixesPanel();
 
     virtual void update();
@@ -70,8 +68,9 @@ class MixesPanel : public ModelPanel
     bool mixInserted;
     unsigned int highlightedSource;
     ModelPrinter modelPrinter;
-    RawItemFilteredModel *rawSourceModel;
-    RawItemFilteredModel *rawSwitchModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel *rawSourceFilteredModel;
+    RawItemFilteredModel *rawSwitchFilteredModel;
 
     int getMixerIndex(unsigned int dch);
     bool gm_insertMix(int idx);

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -122,9 +122,6 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
 
   connect(curvesPanel, &CurvesPanel::updateDataModels, curveModel, &CurveItemModel::update);
 
-  connect(logicalSwitchesPanel, &LogicalSwitchesPanel::updateDataModels, rawSourceModel, &RawSourceItemModel::update);
-  connect(logicalSwitchesPanel, &LogicalSwitchesPanel::updateDataModels, rawSwitchModel, &RawSwitchItemModel::update);
-
   connect(ui->tabWidget, &QTabWidget::currentChanged, this, &ModelEdit::onTabIndexChanged);
   connect(ui->pushButton, &QPushButton::clicked, this, &ModelEdit::launchSimulation);
 

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -61,47 +61,38 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   s1.report("Setup");
 
   if (firmware->getCapability(Heli)) {
-    HeliPanel * heliPanel = new HeliPanel(this, model, generalSettings, firmware, commonItemModels);
-    addTab(heliPanel, tr("Heli"));
+    addTab(new HeliPanel(this, model, generalSettings, firmware, commonItemModels), tr("Heli"));
     s1.report("Heli");
   }
 
-  FlightModesPanel * flightModesPanel = new FlightModesPanel(this, model, generalSettings, firmware, commonItemModels);
-  addTab(flightModesPanel, tr("Flight Modes"));
+  addTab(new FlightModesPanel(this, model, generalSettings, firmware, commonItemModels), tr("Flight Modes"));
   s1.report("Flight Modes");
 
-  InputsPanel * inputsPanel = new InputsPanel(this, model, generalSettings, firmware, commonItemModels);
-  addTab(inputsPanel, tr("Inputs"));
+  addTab(new InputsPanel(this, model, generalSettings, firmware, commonItemModels), tr("Inputs"));
   s1.report("Inputs");
 
-  MixesPanel * mixesPanel = new MixesPanel(this, model, generalSettings, firmware, commonItemModels);
-  addTab(mixesPanel, tr("Mixes"));
+  addTab(new MixesPanel(this, model, generalSettings, firmware, commonItemModels), tr("Mixes"));
   s1.report("Mixes");
 
   ChannelsPanel * channelsPanel = new ChannelsPanel(this, model, generalSettings, firmware, commonItemModels);
   addTab(channelsPanel, tr("Outputs"));
   s1.report("Outputs");
 
-  CurvesPanel * curvesPanel = new CurvesPanel(this, model, generalSettings, firmware, commonItemModels);
-  addTab(curvesPanel, tr("Curves"));
+  addTab(new CurvesPanel(this, model, generalSettings, firmware, commonItemModels), tr("Curves"));
   s1.report("Curves");
 
-  LogicalSwitchesPanel * logicalSwitchesPanel = new LogicalSwitchesPanel(this, model, generalSettings, firmware, commonItemModels);
-  addTab(logicalSwitchesPanel, tr("Logical Switches"));
+  addTab(new LogicalSwitchesPanel(this, model, generalSettings, firmware, commonItemModels), tr("Logical Switches"));
   s1.report("Logical Switches");
 
-  CustomFunctionsPanel * customFunctionsPanel = new CustomFunctionsPanel(this, &model, generalSettings, firmware, commonItemModels);
-  addTab(customFunctionsPanel, tr("Special Functions"));
+  addTab(new CustomFunctionsPanel(this, &model, generalSettings, firmware, commonItemModels), tr("Special Functions"));
   s1.report("Special Functions");
 
   if (firmware->getCapability(Telemetry)) {
-    TelemetryPanel * telemetryPanel = new TelemetryPanel(this, model, generalSettings, firmware, commonItemModels);
-    addTab(telemetryPanel, tr("Telemetry"));
+    addTab(new TelemetryPanel(this, model, generalSettings, firmware, commonItemModels), tr("Telemetry"));
     s1.report("Telemetry");
   }
 
   connect(setupPanel, &SetupPanel::extendedLimitsToggled, channelsPanel, &ChannelsPanel::refreshExtendedLimits);
-
   connect(ui->tabWidget, &QTabWidget::currentChanged, this, &ModelEdit::onTabIndexChanged);
   connect(ui->pushButton, &QPushButton::clicked, this, &ModelEdit::launchSimulation);
 

--- a/companion/src/modeledit/modeledit.h
+++ b/companion/src/modeledit/modeledit.h
@@ -25,6 +25,9 @@
 #include "genericpanel.h"
 
 class RadioData;
+class RawSourceItemModel;
+class RawSwitchItemModel;
+class CurveItemModel;
 
 namespace Ui {
   class ModelEdit;
@@ -62,6 +65,9 @@ class ModelEdit : public QDialog
     RadioData & radioData;
     Firmware * firmware;
     QVector<GenericPanel *> panels;
+    RawSourceItemModel *rawSourceModel;
+    RawSwitchItemModel *rawSwitchModel;
+    CurveItemModel *curveModel;
 
     void addTab(GenericPanel *panel, QString text);
     void launchSimulation();

--- a/companion/src/modeledit/modeledit.h
+++ b/companion/src/modeledit/modeledit.h
@@ -25,9 +25,7 @@
 #include "genericpanel.h"
 
 class RadioData;
-class RawSourceItemModel;
-class RawSwitchItemModel;
-class CurveItemModel;
+class CommonItemModels;
 
 namespace Ui {
   class ModelEdit;
@@ -65,9 +63,7 @@ class ModelEdit : public QDialog
     RadioData & radioData;
     Firmware * firmware;
     QVector<GenericPanel *> panels;
-    RawSourceItemModel *rawSourceModel;
-    RawSwitchItemModel *rawSwitchModel;
-    CurveItemModel *curveModel;
+    CommonItemModels * commonItemModels;
 
     void addTab(GenericPanel *panel, QString text);
     void launchSimulation();

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -31,15 +31,14 @@
 
 #include <QDir>
 
-TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, GeneralSettings & generalSettings, Firmware * firmware, QWidget * prevFocus, RawItemFilteredModel * rawSwitchModel):
+TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, GeneralSettings & generalSettings, Firmware * firmware, QWidget * prevFocus, RawItemFilteredModel * rawSwitchFilteredModel):
   ModelPanel(parent, model, generalSettings, firmware),
   timer(timer),
   ui(new Ui::Timer)
 {
-
   ui->setupUi(this);
-  connect(rawSwitchModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &TimerPanel::onModelDataAboutToBeUpdated);
-  connect(rawSwitchModel, &RawItemFilteredModel::dataUpdateComplete, this, &TimerPanel::onModelDataUpdateComplete);
+  connect(rawSwitchFilteredModel, &RawItemFilteredModel::dataAboutToBeUpdated, this, &TimerPanel::onModelDataAboutToBeUpdated);
+  connect(rawSwitchFilteredModel, &RawItemFilteredModel::dataUpdateComplete, this, &TimerPanel::onModelDataUpdateComplete);
 
   lock = true;
 
@@ -50,11 +49,10 @@ TimerPanel::TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, Ge
   }
   else {
     ui->name->setMaxLength(length);
-    //ui->name->setText(timer.name);
   }
 
   // Mode
-  ui->mode->setModel(rawSwitchModel);
+  ui->mode->setModel(rawSwitchFilteredModel);
   ui->mode->setCurrentIndex(ui->mode->findData(timer.mode.toValue()));
   connect(ui->mode, SIGNAL(activated(int)), this, SLOT(onModeChanged(int)));
 
@@ -96,6 +94,7 @@ TimerPanel::~TimerPanel()
 void TimerPanel::update()
 {
   lock = true;
+
   ui->name->setText(timer.name);
 
   int hour = timer.val / 3600;
@@ -116,7 +115,7 @@ void TimerPanel::update()
     pvalue -= hours * 3600;
     int minutes = pvalue / 60;
     int seconds = pvalue % 60;
-    ui->persistentValue->setText(QString(" %1(%2:%3:%4)").arg(sign<0 ? "-" :" ").arg(hours, 2, 10, QLatin1Char('0')).arg(minutes, 2, 10, QLatin1Char('0')).arg(seconds, 2, 10, QLatin1Char('0')));
+    ui->persistentValue->setText(QString(" %1(%2:%3:%4)").arg(sign < 0 ? "-" :" ").arg(hours, 2, 10, QLatin1Char('0')).arg(minutes, 2, 10, QLatin1Char('0')).arg(seconds, 2, 10, QLatin1Char('0')));
   }
 
   ui->countdownBeep->updateValue();
@@ -133,7 +132,7 @@ QWidget * TimerPanel::getLastFocus()
 void TimerPanel::on_value_editingFinished()
 {
   if (!lock) {
-    unsigned val = ui->value->time().hour()*3600 + ui->value->time().minute()*60 + ui->value->time().second();
+    unsigned val = ui->value->time().hour() * 3600 + ui->value->time().minute() * 60 + ui->value->time().second();
     if (timer.val != val) {
       timer.val = val;
       emit modified();
@@ -181,6 +180,7 @@ void TimerPanel::onModelDataAboutToBeUpdated()
 void TimerPanel::onModelDataUpdateComplete()
 {
   update();
+  lock = false;
 }
 
 /******************************************************************************/
@@ -250,19 +250,19 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
   }
 
   // The protocols available on this board
-  for (unsigned int i=0; i<PULSES_PROTOCOL_LAST; i++) {
+  for (unsigned int i = 0; i < PULSES_PROTOCOL_LAST; i++) {
     if (firmware->isAvailable((PulsesProtocol) i, moduleIdx)) {
       ui->protocol->addItem(ModuleData::protocolToString(i), i);
       if (i == module.protocol)
-        ui->protocol->setCurrentIndex(ui->protocol->count()-1);
+        ui->protocol->setCurrentIndex(ui->protocol->count() - 1);
     }
   }
-  for (int i=0; i<=MODULE_SUBTYPE_MULTI_LAST; i++) {
+  for (int i = 0; i <= MODULE_SUBTYPE_MULTI_LAST; i++) {
     if (i == MODULE_SUBTYPE_MULTI_SCANNER)
       continue;
     ui->multiProtocol->addItem(Multiprotocols::protocolToString(i), i);
   }
-  for (int i=MODULE_SUBTYPE_MULTI_LAST + 1; i <= 124; i++) {
+  for (int i = MODULE_SUBTYPE_MULTI_LAST + 1; i <= 124; i++) {
     ui->multiProtocol->addItem(QString::number(i + 3), i);
   }
 
@@ -340,7 +340,7 @@ void ModulePanel::setupFailsafes()
     else {
       QLabel * label = new QLabel(this);
       label->setProperty("index", i);
-      label->setText(QString::number(i+1));
+      label->setText(QString::number(i + 1));
 
       QComboBox * combo = new QComboBox(this);
       combo->setProperty("index", i);
@@ -519,7 +519,7 @@ void ModulePanel::update()
   ui->ppmFrameLength->setVisible(mask & MASK_SBUSPPM_FIELDS);
   ui->ppmFrameLength->setMinimum(module.channelsCount * (model->extendedLimits ? 2.250 : 2)+3.5);
   ui->ppmFrameLength->setMaximum(firmware->getCapability(PPMFrameLength));
-  ui->ppmFrameLength->setValue(22.5+((double)module.ppm.frameLength)*0.5);
+  ui->ppmFrameLength->setValue(22.5 + ((double)module.ppm.frameLength) * 0.5);
 
   // Antenna mode on Horus and XLite
   if (mask & MASK_ANTENNA) {
@@ -613,17 +613,17 @@ void ModulePanel::update()
   ui->registrationIdLabel->setVisible(mask & MASK_ACCESS);
   ui->registrationId->setVisible(mask & MASK_ACCESS);
 
-  ui->rx1Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<0)));
-  ui->clearRx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<0)));
-  ui->rx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<0)));
+  ui->rx1Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
+  ui->clearRx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
+  ui->rx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
 
-  ui->rx2Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<1)));
-  ui->clearRx2->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<1)));
-  ui->rx2->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<1)));
+  ui->rx2Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 1)));
+  ui->clearRx2->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 1)));
+  ui->rx2->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 1)));
 
-  ui->rx3Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<2)));
-  ui->clearRx3->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<2)));
-  ui->rx3->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1<<2)));
+  ui->rx3Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 2)));
+  ui->clearRx3->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 2)));
+  ui->rx3->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 2)));
 
   // Failsafes
   ui->label_failsafeMode->setVisible(mask & MASK_FAILSAFES);
@@ -751,7 +751,7 @@ void ModulePanel::on_rxNumber_editingFinished()
 
 void ModulePanel::on_ppmFrameLength_editingFinished()
 {
-  int val = (ui->ppmFrameLength->value()-22.5) / 0.5;
+  int val = (ui->ppmFrameLength->value() - 22.5) / 0.5;
   if (module.ppm.frameLength != val) {
     module.ppm.frameLength = val;
     emit modified();
@@ -775,8 +775,8 @@ void ModulePanel::onMultiProtocolChanged(int index)
     module.multi.rfProtocol = (unsigned int)rfProtocol;
     unsigned int maxSubTypes = multiProtocols.getProtocol(index).numSubTypes();
     if (rfProtocol > MODULE_SUBTYPE_MULTI_LAST)
-      maxSubTypes=8;
-    module.subType = std::min(module.subType, maxSubTypes -1);
+      maxSubTypes = 8;
+    module.subType = std::min(module.subType, maxSubTypes - 1);
     module.channelsCount = module.getMaxChannelCount();
     update();
     emit modified();
@@ -970,19 +970,19 @@ void ModulePanel::onClearAccessRxClicked()
   QPushButton *button = qobject_cast<QPushButton *>(sender());
 
   if (button == ui->clearRx1) {
-    module.access.receivers &= ~(1<<0);
+    module.access.receivers &= ~(1 << 0);
     ui->rx1->clear();
     update();
     emit modified();
   }
   else if (button == ui->clearRx2) {
-    module.access.receivers &= ~(1<<1);
+    module.access.receivers &= ~(1 << 1);
     ui->rx2->clear();
     update();
     emit modified();
   }
   else if (button == ui->clearRx3) {
-    module.access.receivers &= ~(1<<2);
+    module.access.receivers &= ~(1 << 2);
     ui->rx3->clear();
     update();
     emit modified();
@@ -991,17 +991,19 @@ void ModulePanel::onClearAccessRxClicked()
 
 /******************************************************************************/
 
-SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel):
+SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels):
   ModelPanel(parent, model, generalSettings, firmware),
-  ui(new Ui::Setup)
+  ui(new Ui::Setup),
+  commonItemModels(commonItemModels)
 {
+  ui->setupUi(this);
+  rawSwitchFilteredModel = new RawItemFilteredModel(commonItemModels->rawSwitchItemModel(), RawSwitch::TimersContext, this);
+
   Board::Type board = firmware->getBoard();
 
   lock = true;
 
   memset(modules, 0, sizeof(modules));
-
-  ui->setupUi(this);
 
   QRegExp rx(CHAR_FOR_NAMES_REGEX);
   ui->name->setValidator(new QRegExpValidator(rx, this));
@@ -1020,7 +1022,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
         foreach ( QString file, qd.entryList(filters, QDir::Files) ) {
           QFileInfo fi(file);
           QString temp = fi.fileName();
-          if (!items.contains(temp) && temp.length() <= 6+4) {
+          if (!items.contains(temp) && temp.length() <= 6 + 4) {
             items.append(temp);
           }
         }
@@ -1030,7 +1032,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
         foreach (QString file, qd.entryList(filters, QDir::Files)) {
           QFileInfo fi(file);
           QString temp = fi.completeBaseName();
-          if (!items.contains(temp) && temp.length() <= 10+4) {
+          if (!items.contains(temp) && temp.length() <= 10 + 4) {
             items.append(temp);
           }
         }
@@ -1043,7 +1045,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
     foreach (QString file, items) {
       ui->image->addItem(file);
       if (file == model.bitmap) {
-        ui->image->setCurrentIndex(ui->image->count()-1);
+        ui->image->setCurrentIndex(ui->image->count() - 1);
         QString fileName = path;
         fileName.append(model.bitmap);
         if (!IS_FAMILY_HORUS_OR_T16(board))
@@ -1075,7 +1077,6 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   }
 
   QWidget * prevFocus = ui->image;
-  rawSwitchFilteredModel = new RawItemFilteredModel(rawSwitchItemModel, RawSwitch::TimersContext, this);
 
   timersCount = firmware->getCapability(Timers);
 
@@ -1107,7 +1108,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   if (firmware->getCapability(HasTopLcd)) {
     ui->toplcdTimer->setField(model.toplcdTimer, this);
     for (int i = 0; i < CPN_MAX_TIMERS; i++) {
-      if (i<timersCount) {
+      if (i < timersCount) {
         ui->toplcdTimer->addItem(tr("Timer %1").arg(i + 1), i);
       }
     }
@@ -1130,12 +1131,12 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   prevFocus = ui->trimsDisplay;
   int analogs = CPN_MAX_STICKS + getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders);
   int genAryIdx = 0;
-  for (int i=0; i < analogs + firmware->getCapability(RotaryEncoders); i++) {
+  for (int i = 0; i < analogs + firmware->getCapability(RotaryEncoders); i++) {
     RawSource src((i < analogs) ? SOURCE_TYPE_STICK : SOURCE_TYPE_ROTARY_ENCODER, (i < analogs) ? i : analogs - i);
     QCheckBox * checkbox = new QCheckBox(this);
     checkbox->setProperty("index", i);
     checkbox->setText(src.toString(&model, &generalSettings));
-    ui->centerBeepLayout->addWidget(checkbox, 0, i+1);
+    ui->centerBeepLayout->addWidget(checkbox, 0, i + 1);
     connect(checkbox, SIGNAL(toggled(bool)), this, SLOT(onBeepCenterToggled(bool)));
     centerBeepCheckboxes << checkbox;
     if (IS_HORUS_OR_TARANIS(board)) {
@@ -1151,7 +1152,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   }
 
   // Startup switches warnings
-  for (int i=0; i<getBoardCapability(board, Board::Switches); i++) {
+  for (int i = 0; i < getBoardCapability(board, Board::Switches); i++) {
     Board::SwitchInfo switchInfo = Boards::getSwitchInfo(board, i);
     switchInfo.config = Board::SwitchType(generalSettings.switchConfig[i]);
     if (switchInfo.config == Board::SWITCH_NOT_AVAILABLE || switchInfo.config == Board::SWITCH_TOGGLE) {
@@ -1175,11 +1176,11 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
     label->setText(src.toString(&model, &generalSettings));
     slider->setMaximum(switchInfo.config == Board::SWITCH_3POS ? 2 : 1);
     cb->setProperty("index", i);
-    ui->switchesStartupLayout->addWidget(label, 0, i+1);
+    ui->switchesStartupLayout->addWidget(label, 0, i + 1);
     ui->switchesStartupLayout->setAlignment(label, Qt::AlignCenter);
-    ui->switchesStartupLayout->addWidget(slider, 1, i+1);
+    ui->switchesStartupLayout->addWidget(slider, 1, i + 1);
     ui->switchesStartupLayout->setAlignment(slider, Qt::AlignCenter);
-    ui->switchesStartupLayout->addWidget(cb, 2, i+1);
+    ui->switchesStartupLayout->addWidget(cb, 2, i + 1);
     ui->switchesStartupLayout->setAlignment(cb, Qt::AlignCenter);
     connect(slider, SIGNAL(valueChanged(int)), this, SLOT(startupSwitchEdited(int)));
     connect(cb, SIGNAL(toggled(bool)), this, SLOT(startupSwitchToggled(bool)));
@@ -1193,12 +1194,12 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   // Pot warnings
   prevFocus = ui->potWarningMode;
   if (IS_HORUS_OR_TARANIS(board)) {
-    for (int i=0; i<getBoardCapability(board, Board::Pots)+getBoardCapability(board, Board::Sliders); i++) {
+    for (int i = 0; i < getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders); i++) {
       RawSource src(SOURCE_TYPE_STICK, CPN_MAX_STICKS + i);
       QCheckBox * cb = new QCheckBox(this);
       cb->setProperty("index", i);
       cb->setText(src.toString(&model, &generalSettings));
-      ui->potWarningLayout->addWidget(cb, 0, i+1);
+      ui->potWarningLayout->addWidget(cb, 0, i + 1);
       connect(cb, SIGNAL(toggled(bool)), this, SLOT(potWarningToggled(bool)));
       potWarningCheckboxes << cb;
       if (src.isPot(&genAryIdx) && !generalSettings.isPotAvailable(genAryIdx)) {
@@ -1246,7 +1247,6 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
 
 SetupPanel::~SetupPanel()
 {
-  delete rawSwitchFilteredModel;
   delete ui;
 }
 
@@ -1277,7 +1277,7 @@ void SetupPanel::on_extendedTrims_toggled(bool checked)
 
 void SetupPanel::on_trimIncrement_currentIndexChanged(int index)
 {
-  model->trimInc = index-2;
+  model->trimInc = index - 2;
   emit modified();
 }
 
@@ -1346,13 +1346,13 @@ void SetupPanel::populateThrottleSourceCB()
   ui->throttleSource->clear();
   ui->throttleSource->addItem(tr("THR"), 0);
 
-  int idx=1;
-  for (int i=0; i<getBoardCapability(board, Board::Pots)+getBoardCapability(board, Board::Sliders); i++, idx++) {
-    if (RawSource(SOURCE_TYPE_STICK,4+i).isAvailable(model,&generalSettings,board)) {
-      ui->throttleSource->addItem(firmware->getAnalogInputName(4+i), idx);
+  int idx = 1;
+  for (int i = 0; i < getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders); i++, idx++) {
+    if (RawSource(SOURCE_TYPE_STICK, 4 + i).isAvailable(model, &generalSettings, board)) {
+      ui->throttleSource->addItem(firmware->getAnalogInputName(4 + i), idx);
     }
   }
-  for (int i=0; i<firmware->getCapability(Outputs); i++, idx++) {
+  for (int i = 0; i < firmware->getCapability(Outputs); i++, idx++) {
     ui->throttleSource->addItem(RawSource(SOURCE_TYPE_CH, i).toString(model, &generalSettings), idx);
   }
 
@@ -1381,7 +1381,7 @@ void SetupPanel::update()
     updatePotWarnings();
   }
 
-  for (int i=0; i<CPN_MAX_MODULES+1; i++) {
+  for (int i = 0; i < CPN_MAX_MODULES + 1; i++) {
     if (modules[i]) {
       modules[i]->update();
     }
@@ -1392,7 +1392,7 @@ void SetupPanel::update()
 
 void SetupPanel::updateBeepCenter()
 {
-  for (int i=0; i<centerBeepCheckboxes.size(); i++) {
+  for (int i = 0; i < centerBeepCheckboxes.size(); i++) {
     centerBeepCheckboxes[i]->setChecked(model->beepANACenter & (0x01 << i));
   }
 }
@@ -1404,20 +1404,20 @@ void SetupPanel::updateStartupSwitches()
   uint64_t switchStates = model->switchWarningStates;
   uint64_t value;
 
-  for (int i=0; i<startupSwitchesSliders.size(); i++) {
+  for (int i = 0; i < startupSwitchesSliders.size(); i++) {
     QSlider * slider = startupSwitchesSliders[i];
     QCheckBox * cb = startupSwitchesCheckboxes[i];
     int index = slider->property("index").toInt();
     bool enabled = !(model->switchWarningEnable & (1 << index));
     if (IS_HORUS_OR_TARANIS(firmware->getBoard())) {
-      value = (switchStates >> (2*index)) & 0x03;
+      value = (switchStates >> (2 * index)) & 0x03;
       if (generalSettings.switchConfig[index] != Board::SWITCH_3POS && value == 2) {
         value = 1;
       }
     }
     else {
-      value = (i==0 ? switchStates & 0x3 : switchStates & 0x1);
-      switchStates >>= (i==0 ? 2 : 1);
+      value = (i == 0 ? switchStates & 0x3 : switchStates & 0x1);
+      switchStates >>= (i == 0 ? 2 : 1);
     }
     slider->setValue(value);
     slider->setEnabled(enabled);
@@ -1443,7 +1443,7 @@ void SetupPanel::startupSwitchEdited(int value)
         mask = 0x03;
       }
       else {
-        shift = index+1;
+        shift = index + 1;
         mask = 0x01ull << shift;
       }
     }
@@ -1484,7 +1484,7 @@ void SetupPanel::updatePotWarnings()
 {
   lock = true;
   ui->potWarningMode->setCurrentIndex(model->potsWarningMode);
-  for (int i=0; i<potWarningCheckboxes.size(); i++) {
+  for (int i = 0; i < potWarningCheckboxes.size(); i++) {
     QCheckBox *checkbox = potWarningCheckboxes[i];
     int index = checkbox->property("index").toInt();
     checkbox->setChecked(!model->potsWarnEnabled[index]);
@@ -1614,7 +1614,7 @@ void SetupPanel::cmTimerClear(bool prompt)
 
   model->timers[selectedTimerIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_CLEAR, selectedTimerIndex);
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -1627,7 +1627,7 @@ void SetupPanel::cmTimerClearAll()
     model->timers[i].clear();
     model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_CLEAR, i);
   }
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -1661,7 +1661,7 @@ void SetupPanel::cmTimerDelete()
   }
   model->timers[maxidx].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SHIFT, selectedTimerIndex, 0, -1);
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -1674,7 +1674,7 @@ void SetupPanel::cmTimerInsert()
   }
   model->timers[selectedTimerIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SHIFT, selectedTimerIndex, 0, 1);
-  emit updateDataModels();
+  updateItemModels();
   emit modified();
 }
 
@@ -1694,7 +1694,7 @@ void SetupPanel::cmTimerPaste()
   if (hasTimerClipboardData(&data)) {
     TimerData *td = &model->timers[selectedTimerIndex];
     memcpy(td, data.constData(), sizeof(TimerData));
-    emit updateDataModels();
+    updateItemModels();
     emit modified();
   }
 }
@@ -1708,12 +1708,17 @@ void SetupPanel::swapTimerData(int idx1, int idx2)
     memcpy(td2, td1, sizeof(TimerData));
     memcpy(td1, &tdtmp, sizeof(TimerData));
     model->updateAllReferences(ModelData::REF_UPD_TYPE_TIMER, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
-    emit updateDataModels();
+    updateItemModels();
     emit modified();
   }
 }
 
 void SetupPanel::onTimerNameChanged()
 {
-  emit updateDataModels();
+  updateItemModels();
+}
+
+void SetupPanel::updateItemModels()
+{
+  commonItemModels->update(CommonItemModels::RMO_TIMERS);
 }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -716,8 +716,8 @@ void ModulePanel::on_channelsCount_editingFinished()
 {
   if (!lock && module.channelsCount != ui->channelsCount->value()) {
     module.channelsCount = ui->channelsCount->value();
-    update();
     emit channelsRangeChanged();
+    update();
     emit modified();
   }
 }
@@ -726,8 +726,8 @@ void ModulePanel::on_channelsStart_editingFinished()
 {
   if (!lock && module.channelsStart != (unsigned)ui->channelsStart->value() - 1) {
     module.channelsStart = (unsigned)ui->channelsStart->value() - 1;
-    update();
     emit channelsRangeChanged();
+    update();
     emit modified();
   }
 }

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -26,7 +26,8 @@
 
 constexpr char MIMETYPE_TIMER[] = "application/x-companion-timer";
 
-class RawSwitchFilterItemModel;
+class RawSwitchItemModel;
+class RawItemFilteredModel;
 
 namespace Ui {
   class Setup;
@@ -39,7 +40,7 @@ class TimerPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, GeneralSettings & generalSettings, Firmware * firmware, QWidget *prevFocus, RawSwitchFilterItemModel * switchModel);
+    TimerPanel(QWidget *parent, ModelData & model, TimerData & timer, GeneralSettings & generalSettings, Firmware * firmware, QWidget *prevFocus, RawItemFilteredModel * switchModel);
     virtual ~TimerPanel();
 
     virtual void update();
@@ -50,6 +51,11 @@ class TimerPanel : public ModelPanel
     void on_value_editingFinished();
     void on_minuteBeep_toggled(bool checked);
     void on_name_editingFinished();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
+
+  signals:
+    void nameChanged();
 
   private:
     TimerData & timer;
@@ -125,7 +131,7 @@ class SetupPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    SetupPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    SetupPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel);
     virtual ~SetupPanel();
 
     virtual void update();
@@ -133,7 +139,7 @@ class SetupPanel : public ModelPanel
   signals:
     void extendedLimitsToggled();
     void updated();
-    void timerUpdated();
+    void updateDataModels();
 
   private slots:
     void on_name_editingFinished();
@@ -163,6 +169,7 @@ class SetupPanel : public ModelPanel
     void cmTimerPaste();
     void cmTimerMoveDown();
     void cmTimerMoveUp();
+    void onTimerNameChanged();
 
   private:
     Ui::Setup *ui;
@@ -183,6 +190,7 @@ class SetupPanel : public ModelPanel
     bool moveTimerDownAllowed() const;
     bool moveTimerUpAllowed() const;
     void swapTimerData(int idx1, int idx2);
-};
+    RawItemFilteredModel * rawSwitchFilteredModel;
+  };
 
 #endif // _SETUP_H_

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -26,7 +26,7 @@
 
 constexpr char MIMETYPE_TIMER[] = "application/x-companion-timer";
 
-class RawSwitchItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 
 namespace Ui {
@@ -131,7 +131,7 @@ class SetupPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    SetupPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSwitchItemModel * rawSwitchItemModel);
+    SetupPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~SetupPanel();
 
     virtual void update();
@@ -139,7 +139,6 @@ class SetupPanel : public ModelPanel
   signals:
     void extendedLimitsToggled();
     void updated();
-    void updateDataModels();
 
   private slots:
     void on_name_editingFinished();
@@ -190,7 +189,9 @@ class SetupPanel : public ModelPanel
     bool moveTimerDownAllowed() const;
     bool moveTimerUpAllowed() const;
     void swapTimerData(int idx1, int idx2);
+    CommonItemModels * commonItemModels;
     RawItemFilteredModel * rawSwitchFilteredModel;
+    void updateItemModels();
   };
 
 #endif // _SETUP_H_

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -519,7 +519,6 @@ void TelemetrySensorPanel::on_name_editingFinished()
   if (!lock) {
     strcpy(sensor.label, ui->name->text().toLatin1());
     emit dataModified();
-    emit modified();
   }
 }
 
@@ -549,7 +548,6 @@ void TelemetrySensorPanel::on_formula_currentIndexChanged(int index)
       sensor.unit = SensorData::UNIT_METERS;
     }
     emit dataModified();
-    emit modified();
   }
 }
 
@@ -645,7 +643,6 @@ void TelemetrySensorPanel::cmPaste()
   if (hasClipboardData(&data)) {
     memcpy(&sensor, data.constData(), sizeof(SensorData));
     emit dataModified();
-    emit modified();
   }
 }
 
@@ -659,7 +656,6 @@ void TelemetrySensorPanel::cmClear(bool prompt)
   sensor.clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_SENSOR, ModelData::REF_UPD_ACT_CLEAR, selectedIndex);
   emit dataModified();
-  emit modified();
 }
 
 void TelemetrySensorPanel::cmClearAll()
@@ -717,7 +713,7 @@ TelemetryPanel::TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettin
     TelemetrySensorPanel * panel = new TelemetrySensorPanel(this, model.sensorData[i], i, sensorCapability, model, generalSettings, firmware);
     ui->sensorsLayout->addWidget(panel);
     sensorPanels[i] = panel;
-    connect(panel, SIGNAL(dataModified()), this, SLOT(update()));
+    connect(panel, SIGNAL(dataModified()), this, SLOT(on_dataModifiedSensor()));
     connect(panel, SIGNAL(modified()), this, SLOT(onModified()));
     connect(panel, SIGNAL(clearAllSensors()), this, SLOT(on_clearAllSensors()));
     connect(panel, SIGNAL(insertSensor(int)), this, SLOT(on_insertSensor(int)));
@@ -984,8 +980,8 @@ void TelemetryPanel::on_clearAllSensors()
     model->updateAllReferences(ModelData::REF_UPD_TYPE_SENSOR, ModelData::REF_UPD_ACT_CLEAR, i);
   }
 
-  update();
   updateItemModels();
+  update();
   emit modified();
 }
 
@@ -995,8 +991,8 @@ void TelemetryPanel::on_insertSensor(int selectedIndex)
   model->sensorData[selectedIndex].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_SENSOR, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, 1);
 
-  update();
   updateItemModels();
+  update();
   emit modified();
 }
 
@@ -1009,8 +1005,8 @@ void TelemetryPanel::on_deleteSensor(int selectedIndex)
   model->sensorData[CPN_MAX_SENSORS - 1].clear();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_SENSOR, ModelData::REF_UPD_ACT_SHIFT, selectedIndex, 0, -1);
 
-  update();
   updateItemModels();
+  update();
   emit modified();
 }
 
@@ -1033,10 +1029,17 @@ void TelemetryPanel::swapData(int idx1, int idx2)
     memcpy(sd2, sd1, sizeof(SensorData));
     memcpy(sd1, &sdtmp, sizeof(SensorData));
     model->updateAllReferences(ModelData::REF_UPD_TYPE_SENSOR, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
-    update();
     updateItemModels();
+    update();
     emit modified();
   }
+}
+
+void TelemetryPanel::on_dataModifiedSensor()
+{
+  updateItemModels();
+  update();
+  emit modified();
 }
 
 void TelemetryPanel::updateItemModels()

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -318,6 +318,7 @@ TelemetrySensorPanel::TelemetrySensorPanel(QWidget *parent, SensorData & sensor,
   QFontMetrics *f = new QFontMetrics(QFont());
   QSize sz;
   sz = f->size(Qt::TextSingleLine, "TELE00");
+  delete f;
   ui->numLabel->setMinimumWidth(sz.width());
   ui->numLabel->setContextMenuPolicy(Qt::CustomContextMenu);
   ui->numLabel->setToolTip(tr("Popup menu available"));

--- a/companion/src/modeledit/telemetry.h
+++ b/companion/src/modeledit/telemetry.h
@@ -27,7 +27,7 @@
 constexpr char MIMETYPE_TELE_SENSOR[] = "application/x-companion-tele-sensor";
 
 class AutoComboBox;
-class RawSourceItemModel;
+class CommonItemModels;
 class RawItemFilteredModel;
 class TimerEdit;
 
@@ -125,14 +125,12 @@ class TelemetryPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSourceItemModel * rawSourceItemModel);
+    TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, CommonItemModels * commonItemModels);
     virtual ~TelemetryPanel();
     virtual void update();
 
   signals:
     void updated();
-    void updateDataModels();
-
 
   private slots:
     void on_telemetryProtocol_currentIndexChanged(int index);
@@ -159,7 +157,8 @@ class TelemetryPanel : public ModelPanel
     TelemetryCustomScreen * telemetryCustomScreens[4];
     TelemetrySensorPanel * sensorPanels[CPN_MAX_SENSORS];
     int sensorCapability;
-    RawItemFilteredModel * rawSourceModel;
+    CommonItemModels * commonItemModels;
+    RawItemFilteredModel * rawSourceFilteredModel;
 
     void setup();
     void telBarUpdate();
@@ -167,6 +166,7 @@ class TelemetryPanel : public ModelPanel
     void populateCurrentSource();
     void populateVarioSource();
     void swapData(int idx1, int idx2);
+    void updateItemModels();
 };
 
 #endif // _TELEMETRY_H_

--- a/companion/src/modeledit/telemetry.h
+++ b/companion/src/modeledit/telemetry.h
@@ -151,6 +151,7 @@ class TelemetryPanel : public ModelPanel
     void on_deleteSensor(int index);
     void on_moveUpSensor(int index);
     void on_moveDownSensor(int index);
+    void on_dataModifiedSensor();
 
   private:
     Ui::Telemetry *ui;

--- a/companion/src/modeledit/telemetry.h
+++ b/companion/src/modeledit/telemetry.h
@@ -27,7 +27,8 @@
 constexpr char MIMETYPE_TELE_SENSOR[] = "application/x-companion-tele-sensor";
 
 class AutoComboBox;
-class RawSourceFilterItemModel;
+class RawSourceItemModel;
+class RawItemFilteredModel;
 class TimerEdit;
 
 namespace Ui {
@@ -41,7 +42,7 @@ class TelemetryCustomScreen: public ModelPanel
     Q_OBJECT
 
   public:
-    TelemetryCustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings, Firmware * firmware, RawSourceFilterItemModel * srcModel);
+    TelemetryCustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings, Firmware * firmware, RawItemFilteredModel * rawSourceModel);
     ~TelemetryCustomScreen();
     void update();
 
@@ -53,6 +54,8 @@ class TelemetryCustomScreen: public ModelPanel
     void barMinChanged(double value);
     void barMaxChanged(double value);
     void barTimeChanged();
+    void onModelDataAboutToBeUpdated();
+    void onModelDataUpdateComplete();
 
   private:
     void updateBar(int line);
@@ -122,12 +125,14 @@ class TelemetryPanel : public ModelPanel
     Q_OBJECT
 
   public:
-    TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware);
+    TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware, RawSourceItemModel * rawSourceItemModel);
     virtual ~TelemetryPanel();
     virtual void update();
 
   signals:
     void updated();
+    void updateDataModels();
+
 
   private slots:
     void on_telemetryProtocol_currentIndexChanged(int index);
@@ -154,6 +159,7 @@ class TelemetryPanel : public ModelPanel
     TelemetryCustomScreen * telemetryCustomScreens[4];
     TelemetrySensorPanel * sensorPanels[CPN_MAX_SENSORS];
     int sensorCapability;
+    RawItemFilteredModel * rawSourceModel;
 
     void setup();
     void telBarUpdate();


### PR DESCRIPTION
Moves from per tab to per model ui datamodels to improve performance, reduce memory and simplify refreshing across tabs for sources, switches and channel curves.
There a many other places where ui datamodels can be implemented for performance and memory reduction. They will be incorporated as part of other housekeeping.