### PR TITLE
Fix compilation of arm9x flavor

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -21,6 +21,10 @@
 #include <io/frsky_firmware_update.h>
 #include "opentx.h"
 
+#if defined(PCBSKY9X)
+#include "audio_driver.h"
+#endif
+
 RadioData  g_eeGeneral;
 ModelData  g_model;
 

--- a/radio/src/targets/sky9x/audio_driver.h
+++ b/radio/src/targets/sky9x/audio_driver.h
@@ -21,6 +21,8 @@
 #ifndef _AUDIO_DRIVER_H_
 #define _AUDIO_DRIVER_H_
 
+#include <inttypes.h>
+
 void audioInit( void ) ;
 void audioEnd( void ) ;
 void audioConsumeCurrentBuffer();


### PR DESCRIPTION
Fix for the failing compilation of FLAVOR=ARM9X