### PR TITLE
Model edit update references fixes

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -723,7 +723,8 @@ int ModelData::updateReference()
       updateAssignFunc(cfd);
       if (!cfd->isEmpty()) {
         updateSwitchRef(cfd->swtch);
-        if (cfd->func == FuncVolume || cfd->func == FuncBacklight || cfd->func == FuncPlayValue || (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE))) {
+        if (cfd->func == FuncVolume || cfd->func == FuncBacklight || cfd->func == FuncPlayValue ||
+            (cfd->func >= FuncAdjustGV1 && cfd->func <= FuncAdjustGVLast && (cfd->adjustMode == FUNC_ADJUST_GVAR_GVAR || cfd->adjustMode == FUNC_ADJUST_GVAR_SOURCE))) {
           updateSourceIntRef(cfd->param);
           if (cfd->param == 0)
             cfd->clear();
@@ -1387,12 +1388,13 @@ void ModelData::updateResetParam(CustomFunctionData * cfd)
   const int invalidateRef = -1;
   int newRef = cfd->param;
   int idxAdj = 0;
+  Firmware *firmware = getCurrentFirmware();
 
   switch (updRefInfo.type)
   {
     case REF_UPD_TYPE_SENSOR:
-      idxAdj = 5/*3 Timers + Flight + Telemetery*/ + getCurrentFirmware()->getCapability(RotaryEncoders);
-      if (cfd->param < idxAdj)
+      idxAdj = 5/*3 Timers + Flight + Telemetery*/ + firmware->getCapability(RotaryEncoders);
+      if (cfd->param < idxAdj || cfd->param > (idxAdj + firmware->getCapability(Sensors)))
         return;
       break;
     default:

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -847,7 +847,7 @@ void ModelData::updateTypeIndexRef(R & curRef, const T type, const int idxAdj, c
         newRef.clear();
       else {
         newRef.type = (T)defType;
-        newRef.index = defIndex + idxAdj;
+        newRef.index = defIndex;
       }
       break;
     case REF_UPD_ACT_SHIFT:
@@ -904,7 +904,7 @@ void ModelData::updateTypeValueRef(R & curRef, const T type, const int idxAdj, c
         newRef.clear();
       else {
         newRef.type = (T)defType;
-        newRef.value = defValue + idxAdj;
+        newRef.value = defValue;
       }
       break;
     case REF_UPD_ACT_SHIFT:
@@ -989,7 +989,7 @@ void ModelData::updateAssignFunc(CustomFunctionData * cfd)
     case REF_UPD_TYPE_TIMER:
       if (cfd->func < FuncSetTimer1 || cfd->func > FuncSetTimer3) //  TODO refactor to FuncSetTimerLast
         return;
-      idxAdj = FuncSetTimer1 - 2;   //  reverse earlier offset requiured for rawsource
+      idxAdj = FuncSetTimer1 - 2;   //  reverse earlier offset required for rawsource
       break;
     default:
       return;

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -337,6 +337,7 @@ class ModelData {
         value = swtch.toValue();
     }
     void sortMixes();
+    void updateResetParam(CustomFunctionData * cfd);
 };
 
 #endif // MODELDATA_H


### PR DESCRIPTION
This reverts part of an early change.
Add missing reference updates for function reset telemetry post a telemetry edit.