### PR TITLE
Allow backlight function to turn off backlight entirely

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -358,7 +358,10 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
           {
             getvalue_t raw = getValue(CFN_PARAM(cfn));
 #if defined(COLORLCD)
-            requiredBacklightBright = (1024 - raw) * (BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN) / 2048;
+            if (raw == -1024)
+              requiredBacklightBright = 100;
+            else
+              requiredBacklightBright = (1024 - raw) * (BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN) / 2048;
 #else
             requiredBacklightBright = (1024 - raw) * 100 / 2048;
 #endif


### PR DESCRIPTION
This change allow you to turn off screen when backlight function is feed with -MAX value
If user want to have the function to fully take control of backlight, set backlight mode to ON
If user want to adjust level, but keep auto dimming feature, then set backlight mode to keys/controls or both