### PR TITLE
Fixed 115200 bps soft serial on F2.

### DIFF
--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -52,7 +52,7 @@ void stop_intmodule_heartbeat()
 {
   heartbeatCapture.valid = false;
   
-  //Never disable EXTI_IRQ just remove INTMODULE_HEARTBEAT_EXTI_LINE from configuration as EXTI can be reused
+  // Never disable EXTI_IRQ, just remove INTMODULE_HEARTBEAT_EXTI_LINE from configuration as EXTI can be reused
   
   EXTI_InitTypeDef EXTI_InitStructure;
   EXTI_StructInit(&EXTI_InitStructure);
@@ -82,11 +82,11 @@ void check_intmodule_heartbeat()
 #if defined(INTMODULE_HEARTBEAT) && !defined(INTMODULE_HEARTBEAT_REUSE_INTERRUPT_ROTARY_ENCODER)
 extern "C" void INTMODULE_HEARTBEAT_EXTI_IRQHandler()
 {
-  //Check as first because it is most critcal one
+  // Check as first because it is the most critical one
 #if defined(TELEMETRY_EXTI_REUSE_INTERRUPT_INTMODULE_HEARTBEAT)
   check_telemetry_exti();
 #endif
-  check_intmodule_heartbeat();
 
+  check_intmodule_heartbeat();
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -51,11 +51,9 @@ void init_intmodule_heartbeat()
 void stop_intmodule_heartbeat()
 {
   heartbeatCapture.valid = false;
-
-#if !defined(INTMODULE_HEARTBEAT_REUSE_INTERRUPT_ROTARY_ENCODER)
-  NVIC_DisableIRQ(INTMODULE_HEARTBEAT_EXTI_IRQn);
-#endif
-
+  
+  //Never disable EXTI_IRQ just remove INTMODULE_HEARTBEAT_EXTI_LINE from configuration as EXTI can be reused
+  
   EXTI_InitTypeDef EXTI_InitStructure;
   EXTI_StructInit(&EXTI_InitStructure);
   EXTI_InitStructure.EXTI_Line = INTMODULE_HEARTBEAT_EXTI_LINE;
@@ -84,9 +82,11 @@ void check_intmodule_heartbeat()
 #if defined(INTMODULE_HEARTBEAT) && !defined(INTMODULE_HEARTBEAT_REUSE_INTERRUPT_ROTARY_ENCODER)
 extern "C" void INTMODULE_HEARTBEAT_EXTI_IRQHandler()
 {
+  //Check as first because it is most critcal one
+#if defined(TELEMETRY_EXTI_REUSE_INTERRUPT_INTMODULE_HEARTBEAT)
+  check_telemetry_exti();
+#endif
   check_intmodule_heartbeat();
-  #if defined(TELEMETRY_EXTI_REUSE_INTERRUPT_INTMODULE_HEARTBEAT)
-    check_telemetry_exti();
-  #endif
+
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
@@ -118,6 +118,10 @@ void rotaryEncoderStartDelay()
 
 extern "C" void ROTARY_ENCODER_EXTI_IRQHandler1(void)
 {
+  //Check as first because it is most critcal one
+#if !defined(BOOT) && defined(TELEMETRY_EXTI_REUSE_INTERRUPT_ROTARY_ENCODER)
+  check_telemetry_exti();
+#endif
   if (EXTI_GetITStatus(ROTARY_ENCODER_EXTI_LINE1) != RESET) {
     rotaryEncoderStartDelay();
     EXTI_ClearITPendingBit(ROTARY_ENCODER_EXTI_LINE1);
@@ -132,10 +136,6 @@ extern "C" void ROTARY_ENCODER_EXTI_IRQHandler1(void)
 
 #if !defined(BOOT) && defined(INTMODULE_HEARTBEAT_REUSE_INTERRUPT_ROTARY_ENCODER)
   check_intmodule_heartbeat();
-#endif
-
-#if !defined(BOOT) && defined(TELEMETRY_EXTI_REUSE_INTERRUPT_ROTARY_ENCODER)
-  check_telemetry_exti();
 #endif
 }
 

--- a/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
@@ -118,10 +118,11 @@ void rotaryEncoderStartDelay()
 
 extern "C" void ROTARY_ENCODER_EXTI_IRQHandler1(void)
 {
-  //Check as first because it is most critcal one
+  // Check as first because it is the most critical one
 #if !defined(BOOT) && defined(TELEMETRY_EXTI_REUSE_INTERRUPT_ROTARY_ENCODER)
   check_telemetry_exti();
 #endif
+
   if (EXTI_GetITStatus(ROTARY_ENCODER_EXTI_LINE1) != RESET) {
     rotaryEncoderStartDelay();
     EXTI_ClearITPendingBit(ROTARY_ENCODER_EXTI_LINE1);

--- a/radio/src/targets/taranis/telemetry_driver.cpp
+++ b/radio/src/targets/taranis/telemetry_driver.cpp
@@ -94,17 +94,17 @@ static uint16_t probeTimeFromStartBit;
 uint32_t oldPriority = 0xFFFF;
 void telemetryPortInvertedInit(uint32_t baudrate)
 {
-  //TODO:
+  // TODO
   // - handle conflict with HEARTBEAT disabled for trainer input...
   // - probably need to stop trainer input/output and restore after this is closed
   // - There is no need to stop trainer - we need to just enable EXT IRQ if not enabled by HEARTBEAT handling
-  //   see code below, but it is always nescesary to configure EXTI_Line for software uart.
+  //   see code below, but it is always necessary to configure EXTI_Line for software uart.
 
   if (baudrate == 0) {
     if (oldPriority != 0xFFFF) {
       NVIC_SetPriority(TELEMETRY_EXTI_IRQn, oldPriority);
     }
-    //Never disable EXTI_IRQ just remove TELEMETRY_EXTI_LINE from configuration as EXTI can be reused
+
     NVIC_DisableIRQ(TELEMETRY_TIMER_IRQn);
 
     EXTI_InitTypeDef EXTI_InitStructure;
@@ -122,7 +122,7 @@ void telemetryPortInvertedInit(uint32_t baudrate)
   switch(baudrate) {
     case 115200:
       bitLength = 17;
-      probeTimeFromStartBit = 23; //because pin is not probed immediately 
+      probeTimeFromStartBit = 23; // because pin is not probed immediately
       break;
     case 57600:
       bitLength = 35; //34 was used before - I prefer to use use 35 because of lower error
@@ -165,12 +165,13 @@ void telemetryPortInvertedInit(uint32_t baudrate)
   EXTI_InitStructure.EXTI_Trigger = TELEMETRY_EXTI_TRIGGER;
   EXTI_InitStructure.EXTI_LineCmd = ENABLE;
   EXTI_Init(&EXTI_InitStructure);
+
+  // Overwrite priority
   oldPriority = NVIC_GetPriority(TELEMETRY_EXTI_IRQn);
-  //Overwrite priority
   NVIC_SetPriority(TELEMETRY_EXTI_IRQn, 0);
-  //In case shared IRQ is not enabled 
+
+  // In case shared IRQ is not enabled
   if ((NVIC->ISER[(uint32_t)((int32_t)TELEMETRY_EXTI_IRQn) >> 5] & (uint32_t)(1 << ((uint32_t)((int32_t)TELEMETRY_EXTI_IRQn) & (uint32_t)0x1F))) == 0) {
-    
     NVIC_EnableIRQ(TELEMETRY_EXTI_IRQn);
   }
 }

--- a/radio/src/targets/taranis/telemetry_driver.cpp
+++ b/radio/src/targets/taranis/telemetry_driver.cpp
@@ -91,17 +91,20 @@ static uint8_t rxByte;
 // single bit length expresses in half us
 static uint16_t bitLength;
 static uint16_t probeTimeFromStartBit;
-
+uint32_t oldPriority = 0xFFFF;
 void telemetryPortInvertedInit(uint32_t baudrate)
 {
-  if (baudrate == 0) {
+  //TODO:
+  // - handle conflict with HEARTBEAT disabled for trainer input...
+  // - probably need to stop trainer input/output and restore after this is closed
+  // - There is no need to stop trainer - we need to just enable EXT IRQ if not enabled by HEARTBEAT handling
+  //   see code below, but it is always nescesary to configure EXTI_Line for software uart.
 
-    //TODO:
-    // - handle conflict with HEARTBEAT disabled for trainer input...
-    // - probably need to stop trainer input/output and restore after this is closed
-#if !defined(TELEMETRY_EXTI_REUSE_INTERRUPT_ROTARY_ENCODER) && !defined(TELEMETRY_EXTI_REUSE_INTERRUPT_INTMODULE_HEARTBEAT)
-    NVIC_DisableIRQ(TELEMETRY_EXTI_IRQn);
-#endif
+  if (baudrate == 0) {
+    if (oldPriority != 0xFFFF) {
+      NVIC_SetPriority(TELEMETRY_EXTI_IRQn, oldPriority);
+    }
+    //Never disable EXTI_IRQ just remove TELEMETRY_EXTI_LINE from configuration as EXTI can be reused
     NVIC_DisableIRQ(TELEMETRY_TIMER_IRQn);
 
     EXTI_InitTypeDef EXTI_InitStructure;
@@ -119,7 +122,7 @@ void telemetryPortInvertedInit(uint32_t baudrate)
   switch(baudrate) {
     case 115200:
       bitLength = 17;
-      probeTimeFromStartBit = 25;
+      probeTimeFromStartBit = 23; //because pin is not probed immediately 
       break;
     case 57600:
       bitLength = 35; //34 was used before - I prefer to use use 35 because of lower error
@@ -162,17 +165,17 @@ void telemetryPortInvertedInit(uint32_t baudrate)
   EXTI_InitStructure.EXTI_Trigger = TELEMETRY_EXTI_TRIGGER;
   EXTI_InitStructure.EXTI_LineCmd = ENABLE;
   EXTI_Init(&EXTI_InitStructure);
-
-  //TODO:
-  // - handle conflict with HEARTBEAT disabled for trainer input...
-  // - probably need to stop trainer input/output and restore after this is closed
-#if !defined(TELEMETRY_EXTI_REUSE_INTERRUPT_ROTARY_ENCODER) && !defined(TELEMETRY_EXTI_REUSE_INTERRUPT_INTMODULE_HEARTBEAT)
+  oldPriority = NVIC_GetPriority(TELEMETRY_EXTI_IRQn);
+  //Overwrite priority
   NVIC_SetPriority(TELEMETRY_EXTI_IRQn, 0);
-  NVIC_EnableIRQ(TELEMETRY_EXTI_IRQn);
-#endif
+  //In case shared IRQ is not enabled 
+  if ((NVIC->ISER[(uint32_t)((int32_t)TELEMETRY_EXTI_IRQn) >> 5] & (uint32_t)(1 << ((uint32_t)((int32_t)TELEMETRY_EXTI_IRQn) & (uint32_t)0x1F))) == 0) {
+    
+    NVIC_EnableIRQ(TELEMETRY_EXTI_IRQn);
+  }
 }
 
-void telemetryPortInvertedRxBit()
+inline void telemetryPortInvertedRxBit()
 {
   if (rxBitCount < 8) {
     if (rxBitCount == 0) {
@@ -189,15 +192,12 @@ void telemetryPortInvertedRxBit()
     ++rxBitCount;
   }
   else if (rxBitCount == 8) {
-
-    telemetryFifo.push(rxByte);
-    rxBitCount = 0;
-
     // disable timer
     TELEMETRY_TIMER->CR1 &= ~TIM_CR1_CEN;
-
+    telemetryFifo.push(rxByte);
+    rxBitCount = 0;
     // re-enable start bit interrupt
-    EXTI->IMR |= EXTI_IMR_MR6;
+    EXTI->IMR |= TELEMETRY_EXTI_LINE;
   }
 }
 
@@ -361,7 +361,7 @@ void check_telemetry_exti()
       TELEMETRY_TIMER->CR1 |= TIM_CR1_CEN;
     
       // disable start bit interrupt
-      EXTI->IMR &= ~EXTI_IMR_MR6;
+      EXTI->IMR &= ~TELEMETRY_EXTI_LINE;
     }
 
     EXTI_ClearITPendingBit(TELEMETRY_EXTI_LINE);


### PR DESCRIPTION
While checking implementation of non inverted software serial I spotted few problems, that are addressed in this commit.
First of all handling of shared EXTI was not correct, in case when shared IRQ was used we should avoid disabling it just disable source. Other problem was using to low priority when used with rotary encoder, so the priority must be set when soft serial is started. For higher speeds also order of handling inside handler method was import, handling soft serial as first.