### PR TITLE
Wrap call to auxSerial function with define check

### DIFF
--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -89,7 +89,9 @@ void checkTrainerSettings()
 
 #if defined(TRAINER_BATTERY_COMPARTMENT)
       case TRAINER_MODE_MASTER_BATTERY_COMPARTMENT:
+#if defined(AUX_SERIAL)
         auxSerialStop();
+#endif
         break;
 #endif
     }


### PR DESCRIPTION
self explanatory

see https://github.com/opentx/opentx/blob/2.3/radio/src/trainer.cpp#L118-L122 for comparison

may not have bitten you so far since the combination of TRAINER_BATTERY_COMPARTMENT and not AUX_SERIAL didn't yet occur
(was found when trying to compile for the TX16S without AUX_SERIAL enabled)