### PR TITLE
Always display output channel name on mix screen

### DIFF
--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -481,7 +481,10 @@ void menuModelMixAll(event_t event)
           attr = INVERS;
           displayHeaderChannelName(ch - 1);
 #if LCD_W >= 212
-          lcdDrawFilledRect(MIX_HDR_GAUGE_POS_X - FWNUM * 5 - 50, 0, 50, MENU_HEADER_HEIGHT, SOLID, FILL_WHITE|GREY_DEFAULT);
+          if (g_model.limitData[ch - 1].name[0] != '\0') {
+            coord_t xPos = MIX_HDR_GAUGE_POS_X - FWNUM * 5 - 50;
+            lcdDrawFilledRect(lcdNextPos, 0, lcdNextPos - xPos, MENU_HEADER_HEIGHT, SOLID, FILL_WHITE | GREY_DEFAULT);
+          }
 #endif
         }
       }

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -479,6 +479,10 @@ void menuModelMixAll(event_t event)
         s_currCh = ch;
         if (!s_copyMode) {
           attr = INVERS;
+          displayHeaderChannelName(ch - 1);
+#if LCD_W >= 212
+          lcdDrawFilledRect(MIX_HDR_GAUGE_POS_X - FWNUM * 5 - 50, 0, 50, MENU_HEADER_HEIGHT, SOLID, FILL_WHITE|GREY_DEFAULT);
+#endif
         }
       }
       if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {


### PR DESCRIPTION
Currently, output name is shown on B&W LCD in mixer screen ONLY if a mixer lines exists.

This display the name also when one doesn't