### PR TITLE
Added AFHDS3 flag in Companion for radio X-Lite

### DIFF
--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1239,7 +1239,7 @@ void registerOpenTxFirmwares()
   // firmware->addOption("stdr9m", Firmware::tr("Use JR-sized R9M module"));
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
-  addOpenTxRfOptions(firmware, EU + FLEX);
+  addOpenTxRfOptions(firmware, EU + FLEX + AFHDS3);
 
   /* FrSky X10 board */
   firmware = new OpenTxFirmware("opentx-x10", Firmware::tr("FrSky Horus X10 / X10S"), BOARD_X10);


### PR DESCRIPTION
The AFHDS3 flag was missing in Companion  for the X-Lite Radio.
This PR is adding necessary flag.