### PR TITLE
Add output value on output screen to match b&w behaviour

### DIFF
--- a/radio/src/gui/480x272/model_outputs.cpp
+++ b/radio/src/gui/480x272/model_outputs.cpp
@@ -96,6 +96,14 @@ bool menuModelLimits(event_t event)
 
   uint32_t sub = menuVerticalPosition;
 
+  if (sub < MAX_OUTPUT_CHANNELS) {
+#if defined(PPM_CENTER_ADJUSTABLE) || defined(PPM_UNIT_US)
+    lcdDrawNumber(LCD_W / 2, MENU_TITLE_TOP + 1, PPM_CH_CENTER(sub)+channelOutputs[sub]/2, MENU_TITLE_COLOR, 0, "", STR_US);
+#else
+    lcdDrawNumber(LCD_W / 2, MENU_TITLE_TOP + 1, calcRESXto1000(channelOutputs[sub]), PREC1 | MENU_TITLE_COLOR);
+#endif
+  }
+
   if (sub<MAX_OUTPUT_CHANNELS && menuHorizontalPosition>=0) {
     drawColumnHeader(STR_LIMITS_HEADERS, NULL, menuHorizontalPosition);
   }


### PR DESCRIPTION
b&w 2.3.10
![image](https://user-images.githubusercontent.com/5167938/101160225-f4e55d80-362e-11eb-99c0-23f807263d0b.png)

colorlcd with this PR
![image](https://user-images.githubusercontent.com/5167938/101160355-3413ae80-362f-11eb-9d7a-5893e9178901.png)
