### PR TITLE
Delete REa switch from SKY9X

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -543,10 +543,6 @@ enum SwitchSources {
   SWSRC_TrimT6Up,
 #endif
 
-#if defined(PCBSKY9X)
-  SWSRC_REa,
-#endif
-
   SWSRC_FIRST_LOGICAL_SWITCH,
   SWSRC_SW1 = SWSRC_FIRST_LOGICAL_SWITCH,
   SWSRC_SW2,

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -342,12 +342,6 @@ bool isSwitchAvailable(int swtch, SwitchContext context)
   }
 #endif
 
-#if defined(PCBSKY9X) && defined(REVX)
-  if (swtch == SWSRC_REa) {
-    return false;
-  }
-#endif
-
   if (swtch >= SWSRC_FIRST_LOGICAL_SWITCH && swtch <= SWSRC_LAST_LOGICAL_SWITCH) {
     if (context == GeneralCustomFunctionsContext) {
       return false;

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -351,16 +351,9 @@ char * getSwitchPositionName(char * dest, swsrc_t idx)
   }
 #endif
 
-#if defined(PCBSKY9X)
-  else if (idx <= SWSRC_REa) {
-    getStringAtIndex(s, STR_VSWITCHES, IDX_TRIMS_IN_STR_VSWITCHES+idx-SWSRC_FIRST_TRIM);
-  }
-#else
   else if (idx <= SWSRC_LAST_TRIM) {
     getStringAtIndex(s, STR_VSWITCHES, IDX_TRIMS_IN_STR_VSWITCHES+idx-SWSRC_FIRST_TRIM);
   }
-#endif
-
   else if (idx <= SWSRC_LAST_LOGICAL_SWITCH) {
     *s++ = 'L';
     strAppendUnsigned(s, idx-SWSRC_FIRST_LOGICAL_SWITCH+1, 2);


### PR DESCRIPTION
This PR fixes #8012 

REa removed from SKY9X firmware to prevent switch list mismatch with companion

This was happening also with flight modes and special functions switches