### PR TITLE
Improve script error output for small lcds

### DIFF
--- a/radio/src/gui/128x64/popups.h
+++ b/radio/src/gui/128x64/popups.h
@@ -23,16 +23,16 @@
 
 #include <keys.h>
 
-#define MESSAGEBOX_X                   1
+#define MESSAGEBOX_X                   10
 #define MESSAGEBOX_Y                   16
-#define MESSAGEBOX_W                   (LCD_W - 2)
+#define MESSAGEBOX_W                   (LCD_W - 19)
 
 #define MENU_X                         MESSAGEBOX_X
 #define MENU_Y                         MESSAGEBOX_Y
 #define MENU_W                         MESSAGEBOX_W
 
 #define WARNING_LINE_LEN               20
-#define WARNING_LINE_X                 3
+#define WARNING_LINE_X                 16
 #define WARNING_LINE_Y                 3*FH
 
 #define POPUP_MENU_MAX_LINES         12

--- a/radio/src/gui/128x64/popups.h
+++ b/radio/src/gui/128x64/popups.h
@@ -23,16 +23,16 @@
 
 #include <keys.h>
 
-#define MESSAGEBOX_X                   10
+#define MESSAGEBOX_X                   1
 #define MESSAGEBOX_Y                   16
-#define MESSAGEBOX_W                   (LCD_W - 19)
+#define MESSAGEBOX_W                   (LCD_W - 2)
 
 #define MENU_X                         MESSAGEBOX_X
 #define MENU_Y                         MESSAGEBOX_Y
 #define MENU_W                         MESSAGEBOX_W
 
 #define WARNING_LINE_LEN               20
-#define WARNING_LINE_X                 16
+#define WARNING_LINE_X                 3
 #define WARNING_LINE_Y                 3*FH
 
 #define POPUP_MENU_MAX_LINES         12

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -745,11 +745,23 @@ void displayLuaError(const char * title)
   if (lua_warning_info[0]) {
     char * split = strstr(lua_warning_info, ": ");
     if (split) {
-      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y+FH+3, lua_warning_info, split-lua_warning_info, SMLSIZE);
-      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y+2*FH+2, split+2, lua_warning_info+LUA_WARNING_INFO_LEN-split, SMLSIZE);
+#if LCD_W == 128
+      if (strlen(split + 2) <= 20) {
+        lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + FH + 3, lua_warning_info, split - lua_warning_info, SMLSIZE);
+        lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + 2 * FH + 2, split + 2, strlen(split + 2), SMLSIZE);
+      }
+      else {
+        lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + FH, lua_warning_info, split - lua_warning_info, SMLSIZE);
+        lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + 2 * FH, split + 2, 20, SMLSIZE);
+        lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + 3 * FH, split + 22, strlen(split + 22), SMLSIZE);
+      }
+#else
+      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + FH + 3, lua_warning_info, split - lua_warning_info, SMLSIZE);
+      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + 2 * FH + 2, split + 2, lua_warning_info + LUA_WARNING_INFO_LEN - split, SMLSIZE);
+#endif
     }
     else {
-      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y+FH+3, lua_warning_info, 40, SMLSIZE);
+      lcdDrawSizedText(WARNING_LINE_X, WARNING_LINE_Y + FH + 3, lua_warning_info, 40, SMLSIZE);
     }
   }
 }
@@ -787,7 +799,11 @@ void luaError(lua_State * L, uint8_t error, bool acknowledge)
 #if defined(SIMU)
     if (!strncmp(msg, ".", 2)) msg += 1;
 #endif
+#if LCD_W == 128
+      msg = strrchr(msg, '/') + 1;
+#else
     if (!strncmp(msg, "/SCRIPTS/", 9)) msg += 9;
+#endif
     strncpy(lua_warning_info, msg, LUA_WARNING_INFO_LEN);
     lua_warning_info[LUA_WARNING_INFO_LEN] = '\0';
   }

--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -780,7 +780,7 @@
 #define TR_NO_MODELS_ON_SD             "žádný model" BREAKSPACE "na SD"
 #define TR_NO_BITMAPS_ON_SD            "žádné obrázky" BREAKSPACE "na SD"
 #define TR_NO_SCRIPTS_ON_SD            "žádný skript" BREAKSPACE "na SD"
-#define TR_SCRIPT_SYNTAX_ERROR         "Syntaktická chyba skriptu"
+#define TR_SCRIPT_SYNTAX_ERROR         TR("Syntaktická chyba", "Syntaktická chyba skriptu")
 #define TR_SCRIPT_PANIC                "Script zmaten"
 #define TR_SCRIPT_KILLED               "Script ukončen"
 #define TR_SCRIPT_ERROR                "Neznámá chyba"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -782,7 +782,7 @@
 #define TR_NO_MODELS_ON_SD              "Kein Modelle" BREAKSPACE "auf SD"
 #define TR_NO_BITMAPS_ON_SD             "Keine Bitmaps" BREAKSPACE "auf SD"
 #define TR_NO_SCRIPTS_ON_SD             "Keine Skripte" BREAKSPACE "auf SD"
-#define TR_SCRIPT_SYNTAX_ERROR          "Skript Syntaxfehler"
+#define TR_SCRIPT_SYNTAX_ERROR          TR("Syntaxfehler", "Skript Syntaxfehler")
 #define TR_SCRIPT_PANIC                 "Skript Panik"
 #define TR_SCRIPT_KILLED                "Skript beendet"
 #define TR_SCRIPT_ERROR                 "Unbekannter Fehler"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -786,7 +786,7 @@
 #define TR_NO_MODELS_ON_SD             "No models" BREAKSPACE "on SD"
 #define TR_NO_BITMAPS_ON_SD            "No bitmaps" BREAKSPACE "on SD"
 #define TR_NO_SCRIPTS_ON_SD            "No scripts" BREAKSPACE "on SD"
-#define TR_SCRIPT_SYNTAX_ERROR         "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR         TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC                "Script panic"
 #define TR_SCRIPT_KILLED               "Script killed"
 #define TR_SCRIPT_ERROR                "Unknown error"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -783,7 +783,7 @@
 #define TR_NO_MODELS_ON_SD     "Sin modelos en SD"
 #define TR_NO_BITMAPS_ON_SD    "Sin imágenes en SD"
 #define TR_NO_SCRIPTS_ON_SD    "No scripts en SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script killed"
 #define TR_SCRIPT_ERROR        "Error desconocido"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -799,7 +799,7 @@
 #define TR_NO_MODELS_ON_SD     "No Models on SD"
 #define TR_NO_BITMAPS_ON_SD    "No Bitmaps on SD"
 #define TR_NO_SCRIPTS_ON_SD    "No Scripts on SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script killed"
 #define TR_SCRIPT_ERROR        "Unknown error"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -802,7 +802,7 @@
 #define TR_NO_MODELS_ON_SD             "Aucun modèle SD"
 #define TR_NO_BITMAPS_ON_SD            "Aucun Bitmap SD"
 #define TR_NO_SCRIPTS_ON_SD            "Aucun Script SD"
-#define TR_SCRIPT_SYNTAX_ERROR         "Erreur syntaxe script"
+#define TR_SCRIPT_SYNTAX_ERROR          TR("Erreur syntaxe", "Erreur syntaxe script")
 #define TR_SCRIPT_PANIC                "Script bloqué"
 #define TR_SCRIPT_KILLED               "Script interrompu"
 #define TR_SCRIPT_ERROR                "Erreur inconnue"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -801,7 +801,7 @@
 #define TR_NO_MODELS_ON_SD     "No Model." BREAKSPACE "su SD"
 #define TR_NO_BITMAPS_ON_SD    "No Immag." BREAKSPACE "su SD"
 #define TR_NO_SCRIPTS_ON_SD    "No Scripts" BREAKSPACE "su SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script errore sintassi"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Errore sintassi", "Script errore sintassi")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script fermato"
 #define TR_SCRIPT_ERROR        "Errore sconosciuto"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -787,7 +787,7 @@
 #define TR_NO_MODELS_ON_SD     "Geen Modellen" BREAKSPACE "op SD"
 #define TR_NO_BITMAPS_ON_SD    "Geen Bitmaps" BREAKSPACE "op SD"
 #define TR_NO_SCRIPTS_ON_SD    "Geen Scripts" BREAKSPACE "op SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script killed"
 #define TR_SCRIPT_ERROR        "Unknown error"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -800,7 +800,7 @@
 #define TR_NO_MODELS_ON_SD     "Brak modelu na SD"
 #define TR_NO_BITMAPS_ON_SD    "Brak obrazków na SD"
 #define TR_NO_SCRIPTS_ON_SD    "Brak skryptów na SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Skrypt:syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Syntax error", "Skrypt:syntax error")
 #define TR_SCRIPT_PANIC        "Skrypt:panic"
 #define TR_SCRIPT_KILLED       "Skrypt:killed"
 #define TR_SCRIPT_ERROR        "Nieznany błąd"

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -801,7 +801,7 @@
 #define TR_NO_MODELS_ON_SD     "Sem Modelo no SD"
 #define TR_NO_BITMAPS_ON_SD    "No Bitmaps on SD"
 #define TR_NO_SCRIPTS_ON_SD    "No Scripts on SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script killed"
 #define TR_SCRIPT_ERROR        "Unknown error"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -800,7 +800,7 @@
 #define TR_NO_MODELS_ON_SD     "Ingen modell i SD"
 #define TR_NO_BITMAPS_ON_SD    "Ikoner saknas på SD"
 #define TR_NO_SCRIPTS_ON_SD    "Programkod saknas på SD"
-#define TR_SCRIPT_SYNTAX_ERROR "Script syntax error"
+#define TR_SCRIPT_SYNTAX_ERROR  TR("Syntax error", "Script syntax error")
 #define TR_SCRIPT_PANIC        "Script panic"
 #define TR_SCRIPT_KILLED       "Script killed"
 #define TR_SCRIPT_ERROR        "Unknown error"


### PR DESCRIPTION
This PR improves the output for script errors:

- Adds a TR for small lcds to translatables
- Removes the script path
- Adds a second error line only if the error len is bigger than 20. No changes on the popup menu size

Before:

![screenshot_x7_20-12-22_08-33-07](https://user-images.githubusercontent.com/33811722/102861740-63e4f380-4430-11eb-85a4-28983bf71237.png)

After:

![captura_x7_20-12-22_08-18-57](https://user-images.githubusercontent.com/33811722/102861301-bbcf2a80-442f-11eb-8e5b-73701c0e3a24.png)
![captura_x7_20-12-22_08-24-32](https://user-images.githubusercontent.com/33811722/102861304-be318480-442f-11eb-9b71-46b77e606ba9.png)
