### PR TITLE
Prevent running crossfire.lua if crossfire not available

### DIFF
--- a/radio/sdcard/horus/SCRIPTS/TOOLS/crossfire.lua
+++ b/radio/sdcard/horus/SCRIPTS/TOOLS/crossfire.lua
@@ -30,6 +30,11 @@ local function run(event)
     return 2
   end
 
+  if crossfireTelemetryPush() == nil then
+    error("Crossfire not available!")
+    return 2
+  end
+
   chdir("/SCRIPTS/TOOLS/CROSSFIRE")
   return "crossfire.lua"
 end

--- a/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/crossfire.lua
+++ b/radio/sdcard/taranis-x7/SCRIPTS/TOOLS/crossfire.lua
@@ -30,6 +30,11 @@ local function run(event)
     return 2
   end
 
+  if crossfireTelemetryPush() == nil then
+    error("Crossfire not available!")
+    return 2
+  end
+  
   chdir("/SCRIPTS/TOOLS/CROSSFIRE")
   return "crossfire.lua"
 end

--- a/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/crossfire.lua
+++ b/radio/sdcard/taranis-x9/SCRIPTS/TOOLS/crossfire.lua
@@ -30,6 +30,11 @@ local function run(event)
     return 2
   end
 
+  if crossfireTelemetryPush() == nil then
+    error("Crossfire not available!")
+    return 2
+  end
+
   chdir("/SCRIPTS/TOOLS/CROSSFIRE")
   return "crossfire.lua"
 end


### PR DESCRIPTION
Checks if crossfire is available before running crossfire.lua. Exits the script and shows an error message if not.

I'm using smartport and discovered that if I accidentally run crossfire.lua from the tools menu it will prevent other scripts using smartport from working(betaflight lua in this case) afterwards. I have to reboot the radio to make it work again. I think in crossfire.lua crossfireTelemetryPush puts data in the output telemetry buffer even if crossfire is not being used. Then maybe we end up with data that never get's sent and the telemetry buffer remains unavailable until the radio is rebooted. This could probably be fixed at a lower level but I think doing this check in the lua script and showing the user an error message is a good change anyway. 

I have done multiple tests with and without this change and it works.