### PR TITLE
Remove retry timer for set trim on simulator

### DIFF
--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -213,17 +213,7 @@ void OpenTxSimulator::setTrim(unsigned int idx, int value)
   if (i < 4)  // swap axes
     i = modn12x3[4 * getStickMode() + idx];
   uint8_t phase = getTrimFlightMode(getFlightMode(), i);
-
-  if (!setTrimValue(phase, i, value)) {
-    QTimer *timer = new QTimer(this);
-    timer->setSingleShot(true);
-    connect(timer, &QTimer::timeout, [=]() {
-      emit trimValueChange(idx, 0);
-      emit outputValueChange(OUTPUT_SRC_TRIM_VALUE, idx, 0);
-      timer->deleteLater();
-    });
-    timer->start(50);
-  }
+  setTrimValue(phase, i, value);
 }
 
 void OpenTxSimulator::setTrainerInput(unsigned int inputNumber, int16_t value)

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -222,7 +222,7 @@ void OpenTxSimulator::setTrim(unsigned int idx, int value)
       emit outputValueChange(OUTPUT_SRC_TRIM_VALUE, idx, 0);
       timer->deleteLater();
     });
-    timer->start(350);
+    timer->start(50);
   }
 }
 


### PR DESCRIPTION
Fixes #7722

The issue only affects the simulator, not the firmware

The delay timer applied to the trim is too long, so it may be applied to the wrong flight mode when switching fast between flight modes in the simulator

BTW... why is needed a delay for the trim on the simulator?