### PR TITLE
#if #endif clauses look screwed up

### DIFF
--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -217,8 +217,8 @@ extern "C" void AUX_SERIAL_USART_IRQHandler(void)
     }
     status = AUX_SERIAL_USART->SR;
   }
-#endif
 }
+#endif
 #endif
 
 #if defined(AUX2_SERIAL)
@@ -400,7 +400,6 @@ extern "C" void AUX2_SERIAL_USART_IRQHandler(void)
     }
   }
 #endif
-#if defined(AUX2_SERIAL)
   // Receive
   uint32_t status = AUX2_SERIAL_USART->SR;
   while (status & (USART_FLAG_RXNE | USART_FLAG_ERRORS)) {
@@ -416,7 +415,5 @@ extern "C" void AUX2_SERIAL_USART_IRQHandler(void)
     status = AUX2_SERIAL_USART->SR;
   }
 }
-#endif
-
 #endif
 #endif // AUX_SERIAL


### PR DESCRIPTION
the #if #endif clauses seem to be intertwined and not properly located. I tried to decorrelate according to what I think the intention would be. 

I tried to add code at the end of the file and it gave compile errors with AUX2_SERIAL disabled, that's how I found that.