### PR TITLE
Rationalize baudrate display

### DIFF
--- a/radio/src/gui/480x272/radio_hardware.cpp
+++ b/radio/src/gui/480x272/radio_hardware.cpp
@@ -126,7 +126,7 @@ void onHardwareAntennaSwitchConfirm(const char * result)
 #define EXTERNAL_ANTENNA_ROW
 #endif
 
-#if (defined(CROSSFIRE) || defined(GHOST))
+#if (defined(CROSSFIRE) || defined(GHOST)) && (SPORT_MAX_BAUDRATE < 400000 || defined(DEBUG))
   #define MAX_BAUDRATE_ROW          0
 #else
   #define MAX_BAUDRATE_ROW          HIDDEN_ROW

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -284,7 +284,7 @@ enum {
   #define TX_CAPACITY_MEASUREMENT_ROWS
 #endif
 
-#if (defined(CROSSFIRE) || defined(GHOST)) && SPORT_MAX_BAUDRATE < 400000
+#if (defined(CROSSFIRE) || defined(GHOST)) && (SPORT_MAX_BAUDRATE < 400000 || defined(DEBUG))
   #define MAX_BAUD_ROWS                  0,
 #else
   #define MAX_BAUD_ROWS

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -102,7 +102,7 @@ const uint8_t CROSSFIRE_PERIODS[] = {
   4,
   16,
 };
-#if SPORT_MAX_BAUDRATE < 400000
+#if SPORT_MAX_BAUDRATE < 400000 || defined(DEBUG)
 #define CROSSFIRE_BAUDRATE    CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate]
 #define CROSSFIRE_PERIOD      CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate]
 #else


### PR DESCRIPTION
Display CRSF/Ghost baudrate choice only on radio that need it (or on debug builds)