### PR TITLE
Remove superfluous trainerSbusFifo

### DIFF
--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -21,10 +21,6 @@
 #include "opentx.h"
 #include "targets/horus/board.h"
 
-#if defined(SBUS)
-extern Fifo<uint8_t, 32> trainerSbusFifo;
-#endif
-
 #if defined(AUX_SERIAL)
 uint8_t auxSerialMode = UART_MODE_COUNT;  // Prevent debug output before port is setup
 Fifo<uint8_t, 512> auxSerialTxFifo;

--- a/radio/src/targets/horus/trainer_driver.cpp
+++ b/radio/src/targets/horus/trainer_driver.cpp
@@ -20,10 +20,6 @@
 
 #include "opentx.h"
 
-#if defined(SBUS_TRAINER)
-Fifo<uint8_t, 32> trainerSbusFifo;
-#endif
-
 void trainerSendNextFrame();
 
 void init_trainer_ppm()


### PR DESCRIPTION
Removes superfluous trainerSbusFifo in aux_serial_driver.cpp and horus/trainer_driver.cpp.

in aux_serial_driver.cpp the trainerSbusFifo was declared external but not used in aux_serial_driver

in horus/trainer_driver.cpp the trainerSbusFifo was declared, but not used for horus type transmitters

as a comment note that a trainerSbusFifo is declared in taranis/trainer_driver.cpp, but the define conditions for its use are somewhat strange:
* a trainerSbusFifo is declared if defined(TRAINER_MODULE_SBUS_USART)
* a trainerSbusFifo is called in init_trainer_module_sbus() if defined(TRAINER_MODULE_SBUS)
* a trainerSbusFifo is called in sbusGetByte() if if defined(SBUS_TRAINER) AND defined(TRAINER_MODULE_SBUS_USART)
so, if TRAINER_MODULE_SBUS is defined but not also TRAINER_MODULE_SBUS_USART a issue is possible. I don't know if that is a possible constellation or if that is avoided by the CMake stuff. I would think the defines in that file could maybe need an update to not depend on well behavior.