### PR TITLE
RTOS_MS_PER_TICK calculation simplification

### DIFF
--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -155,7 +155,7 @@ template<int SIZE>
   }
 #endif
 
-  #define RTOS_MS_PER_TICK              ((CFG_CPU_FREQ / CFG_SYSTICK_FREQ) / (CFG_CPU_FREQ / 1000))  // RTOS timer tick length in ms (currently 2)
+  #define RTOS_MS_PER_TICK              (1000 / CFG_SYSTICK_FREQ)  // RTOS timer tick length in ms (currently 1 for STM32, 2 for others)
 
   typedef OS_TID RTOS_TASK_HANDLE;
   typedef OS_MutexID RTOS_MUTEX_HANDLE;


### PR DESCRIPTION
CFG_CPU_FREQ cancels itself out in the original equation: ((CFG_CPU_FREQ / CFG_SYSTICK_FREQ) / (CFG_CPU_FREQ / 1000)) 
In addition, comment is now fixed - 1ms is used for STM32, 2ms was used for other chips:
[https://github.com/opentx/opentx/blob/e94f6c0ccdc1ecd800f2ef27a28120878bc9ec41/radio/src/thirdparty/CoOS/OsConfig.h#L88-L92](https://github.com/opentx/opentx/blob/e94f6c0ccdc1ecd800f2ef27a28120878bc9ec41/radio/src/thirdparty/CoOS/OsConfig.h#L88-L92)