### PR TITLE
Uniform CLI stackinfo output in bytes

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -699,11 +699,11 @@ int cliTrace(const char ** argv)
 
 int cliStackInfo(const char ** argv)
 {
-  serialPrint("[MAIN] %d available / %d", stackAvailable(), stackSize());
-  serialPrint("[MENUS] %d available / %d", menusStack.available(), menusStack.size());
-  serialPrint("[MIXER] %d available / %d", mixerStack.available(), mixerStack.size());
-  serialPrint("[AUDIO] %d available / %d", audioStack.available(), audioStack.size());
-  serialPrint("[CLI] %d available / %d", cliStack.available(), cliStack.size());
+  serialPrint("[MAIN] %d available / %d bytes", stackAvailable()*4, stackSize()*4);
+  serialPrint("[MENUS] %d available / %d bytes", menusStack.available()*4, menusStack.size());
+  serialPrint("[MIXER] %d available / %d bytes", mixerStack.available()*4, mixerStack.size());
+  serialPrint("[AUDIO] %d available / %d bytes", audioStack.available()*4, audioStack.size());
+  serialPrint("[CLI] %d available / %d bytes", cliStack.available()*4, cliStack.size());
   return 0;
 }
 


### PR DESCRIPTION
By issuing _stackinfo_ in cli, we get stack info about the tasks:
https://github.com/opentx/opentx/blob/eaa972cd2fbe2db5b975661227ba92022a752449/radio/src/cli.cpp#L700-L708

Whereas for menusTask, mixerTask, AudioTask and cliTask the output on serial terminal is in bytes:
https://github.com/opentx/opentx/blob/eaa972cd2fbe2db5b975661227ba92022a752449/radio/src/rtos.h#L250-L253

the output values for main task are non-uniformly in double words (4 byte units):
https://github.com/opentx/opentx/blob/eaa972cd2fbe2db5b975661227ba92022a752449/radio/src/rtos.h#L221-L224

For the sake of uniformity, the output for main task could be multiplied by 4 as well.
