### PR TITLE
new LUA function disableTelemetryPopop

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1916,6 +1916,24 @@ static int luaSerialRead(lua_State * L)
 
   return 1;
 }
+#if !defined(COLORLCD)
+/*luadoc
+@function disableTelemetryPopup()
+ 
+This function disables the Telemetry Popup Menu for the current key event.
+It is intended for Key Long Enter event handlers in telemtry foreground scripts.
+
+@status current Introduced in X.X.X
+
+@notice Only available on Taranis
+*/
+static int luaDisableTelemetryPopup(lua_State *L)
+{
+  disableTelemetryPopup= true;
+  return 0;
+}
+#endif
+
 
 const luaL_Reg opentxLib[] = {
   { "getTime", luaGetTime },
@@ -1977,6 +1995,9 @@ const luaL_Reg opentxLib[] = {
   { "setSerialBaudrate", luaSetSerialBaudrate },
   { "serialWrite", luaSerialWrite },
   { "serialRead", luaSerialRead },
+#if !defined(COLORLCD)
+  { "disableTelemetryPopup",luaDisableTelemetryPopup },
+#endif
   { nullptr, nullptr }  /* sentinel */
 };
 

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -50,6 +50,8 @@ char lua_warning_info[LUA_WARNING_INFO_LEN+1];
 struct our_longjmp * global_lj = 0;
 #if defined(COLORLCD)
 uint32_t luaExtraMemoryUsage = 0;
+#else
+bool disableTelemetryPopup = 0;
 #endif
 
 #if defined(LUA_ALLOCATOR_TRACER)
@@ -1182,3 +1184,13 @@ bool isRadioScriptTool(const char * filename)
   const char * ext = getFileExtension(filename);
   return ext && !strcasecmp(ext, SCRIPT_EXT);
 }
+#if !defined(COLORLCD)
+bool isTelemetryPopupDisabled(event_t event)
+{
+   bool ret;
+   ret=disableTelemetryPopup && event==EVT_KEY_LONG(KEY_ENTER);
+   disableTelemetryPopup=false;
+   return (ret);
+}
+#endif
+

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -138,6 +138,11 @@ void luaDoGc(lua_State * L, bool full);
 void luaError(lua_State * L, uint8_t error, bool acknowledge=true);
 uint32_t luaGetMemUsed(lua_State * L);
 void luaGetValueAndPush(lua_State * L, int src);
+#if !defined(COLORLCD)
+extern bool disableTelemetryPopup;
+bool isTelemetryPopupDisabled(event_t event);
+#endif
+
 #define luaGetCpuUsed(idx) scriptInternalData[idx].instructions
 uint8_t isTelemetryScriptAvailable(uint8_t index);
 #define LUA_LOAD_MODEL_SCRIPTS()   luaState |= INTERPRETER_RELOAD_PERMANENT_SCRIPTS

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -507,8 +507,11 @@ void handleGui(event_t event) {
     // standalone script is active
   }
   else if (luaTask(event, RUN_TELEM_FG_SCRIPT, true)) {
-    // the telemetry screen is active
-    menuHandlers[menuLevel](event);
+    // the telemetry screen is active, do not call menu handler for KEY_LONG_ENTER
+    // events, if disabled by LUA function 'disableTelemetryPopup()'
+    if(!isTelemetryPopupDisabled(event)) {
+       menuHandlers[menuLevel](event);
+    }
   }
   else
 #endif


### PR DESCRIPTION
On Taranis the KEY LONG ENTER event calls the telemetry popup menu which is not  
wanted in some use cases. Therefore, the LUA function "disableTelemetryPopup()"
was added that disables the call of the telemetry popup for the            
current execution of the telemetry script run function.

Thus, the KEY LONG ENTER event can be finally handled in the LUA script.

My use case is a telemetry script which realizes a lot of additional "software
switches" along with a mixer script. This is necessary for RC ship models with 
many special remote controlled features where the number of Taranis hardware
switches is insufficient.

The LUA function enables the implementation of pus buttons and prevent the call 
of the telemetry popup for switches if the ENTER key was pressed too long      
by mistake.

Generally it would be desirable to have full control in LUA key event handlers 
whether an event is finally handled by OpenTx or not.

