### PR TITLE
Avoid compile warning for t18

### DIFF
--- a/radio/src/targets/horus/lcd_driver.cpp
+++ b/radio/src/targets/horus/lcd_driver.cpp
@@ -142,6 +142,7 @@ static void LCD_NRSTConfig(void)
 }
 
 // TODO delay function
+#if !defined(RADIO_T18)
 static void delay3(uint32_t nCount)
 {
   uint32_t index = 0;
@@ -150,6 +151,7 @@ static void delay3(uint32_t nCount)
     __asm("nop\n");
   }
 }
+#endif
 
 static void lcd_reset(void)
 {


### PR DESCRIPTION
this avoids a compile warning of unused function for Jumper T18