### PR TITLE
Resolve two sets of repeated warnings when built with VS2019

### DIFF
--- a/radio/src/gui/480x272/layouts/layout4+2.cpp
+++ b/radio/src/gui/480x272/layouts/layout4+2.cpp
@@ -20,11 +20,11 @@
 
 #include "opentx.h"
 
-#define HAS_TOPBAR()      (persistentData->options[0].boolValue == true)
-#define HAS_FM()          (persistentData->options[1].boolValue == true)
-#define HAS_SLIDERS()     (persistentData->options[2].boolValue == true)
-#define HAS_TRIMS()       (persistentData->options[3].boolValue == true)
-#define IS_MIRRORED()     (persistentData->options[4].boolValue == true)
+#define HAS_TOPBAR()      (OPTION_VALUE_BOOL(persistentData->options[0].boolValue) == true)
+#define HAS_FM()          (OPTION_VALUE_BOOL(persistentData->options[1].boolValue) == true)
+#define HAS_SLIDERS()     (OPTION_VALUE_BOOL(persistentData->options[2].boolValue) == true)
+#define HAS_TRIMS()       (OPTION_VALUE_BOOL(persistentData->options[3].boolValue) == true)
+#define IS_MIRRORED()     (OPTION_VALUE_BOOL(persistentData->options[4].boolValue) == true)
 
 const uint8_t LBM_LAYOUT_4P2[] = {
 #include "mask_layout4+2.lbm"

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -320,7 +320,7 @@ void memswap(void * a, void * b, uint8_t size);
 #define MASK_CFN_TYPE  uint64_t  // current max = 64 function switches
 #define MASK_FUNC_TYPE uint32_t  // current max = 32 functions
 
-typedef struct {
+typedef struct _CustomFunctionsContext {
   MASK_FUNC_TYPE activeFunctions;
   MASK_CFN_TYPE  activeSwitches;
   tmr10ms_t lastFunctionTime[MAX_SPECIAL_FUNCTIONS];


### PR DESCRIPTION
These warnings are clearly a minor nuisance but given i don't see any other warnings during the build i presume that the goal is to have zero warnings.  

The first in opentx.h(323,16): warning C5208 appears to be "new" to VS2019 and i resolved it by simply naming the struct based on the resulting typedef name (see: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-160)

The second in layout4+2.cpp(68,32): warning C4805 is somewhat more interesting and its unclear to me why it doesn't like that comparison but allows coercion from bool to uint32_t (and vice-versa) in other places without any complaints - i saw there was a macro to cast the uint32_t value to bool so i wrapped all the offending compare operands with that macro. (see: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4805?view=msvc-160)