### PR TITLE
telemetry dir pin init missed definining OType

### DIFF
--- a/radio/src/targets/horus/telemetry_driver.cpp
+++ b/radio/src/targets/horus/telemetry_driver.cpp
@@ -34,6 +34,7 @@ static void telemetryInitDirPin()
   GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_OUT;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
   GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
   GPIO_InitStructure.GPIO_Pin   = TELEMETRY_DIR_GPIO_PIN;
   GPIO_Init(TELEMETRY_DIR_GPIO, &GPIO_InitStructure);
   GPIO_ResetBits(TELEMETRY_DIR_GPIO, TELEMETRY_DIR_GPIO_PIN);


### PR DESCRIPTION
Added missing OType definition to telemetry direction pin.