### PR TITLE
Companion special function reset fixes

### DIFF
--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -444,7 +444,7 @@ CustomFuncResetParamItemModel::CustomFuncResetParamItemModel(const GeneralSettin
     AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType)
 {
   setId(IMID_CustomFuncResetParam);
-  setUpdateMask(IMUE_TeleSensors);
+  setUpdateMask(IMUE_TeleSensors | IMUE_Timers);
 
   for (int i = 0; i < CustomFunctionData::resetParamCount(); i++) {
     QStandardItem * modelItem = new QStandardItem();

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1405,8 +1405,6 @@ void ModelData::updateResetParam(CustomFunctionData * cfd)
       return;
   }
 
-  qDebug() << "index1" << updRefInfo.index1 << "shift:" << updRefInfo.shift << "cfd->param:" << cfd->param << "idxAdj:" << idxAdj;
-
   switch (updRefInfo.action)
   {
     case REF_UPD_ACT_CLEAR:

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1381,7 +1381,6 @@ void ModelData::sortMixes()
 
 void ModelData::updateResetParam(CustomFunctionData * cfd)
 {
-
   if (cfd->func != FuncReset)
     return;
 
@@ -1392,6 +1391,11 @@ void ModelData::updateResetParam(CustomFunctionData * cfd)
 
   switch (updRefInfo.type)
   {
+    case REF_UPD_TYPE_TIMER:
+      if (cfd->param < 0 || cfd->param > 2)
+        return;
+      idxAdj = -2;   //  reverse earlier offset required for rawsource
+      break;
     case REF_UPD_TYPE_SENSOR:
       idxAdj = 5/*3 Timers + Flight + Telemetery*/ + firmware->getCapability(RotaryEncoders);
       if (cfd->param < idxAdj || cfd->param > (idxAdj + firmware->getCapability(Sensors)))
@@ -1400,6 +1404,8 @@ void ModelData::updateResetParam(CustomFunctionData * cfd)
     default:
       return;
   }
+
+  qDebug() << "index1" << updRefInfo.index1 << "shift:" << updRefInfo.shift << "cfd->param:" << cfd->param << "idxAdj:" << idxAdj;
 
   switch (updRefInfo.action)
   {


### PR DESCRIPTION
Fixes #8383
Refresh reset target list on update to timers.
Update functions when model upd timer refs.