### PR TITLE
STM32 WordLength 9b -> 8b data + parity

### DIFF
--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -124,7 +124,7 @@ void auxSerialInit(unsigned int mode, unsigned int protocol)
       break;
 
     case UART_MODE_SBUS_TRAINER:
-      auxSerialSetup(SBUS_BAUDRATE, true, USART_WordLength_9b, USART_Parity_Even, USART_StopBits_2); // 2 stop bits requires USART_WordLength_9b
+      auxSerialSetup(SBUS_BAUDRATE, true, USART_WordLength_9b, USART_Parity_Even, USART_StopBits_2); // USART_WordLength_9b due to parity bit
       AUX_SERIAL_POWER_ON();
       break;
 


### PR DESCRIPTION
Fixed comment. STM32 WordLength 9b is here necessary due to parity bit (8b data + 1b parity) and not due to 2 stop bits.