### PR TITLE
Add space to SD edit name

### DIFF
--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -145,7 +145,7 @@ void editName(coord_t x, coord_t y, char * name, uint8_t size, event_t event, ui
           if (c <= 0) v = -v;
         }
         else {
-          v = checkIncDec(event, abs(v), '0', 'z', 0);
+          v = checkIncDec(event, abs(v), ' ', 'z', 0);
         }
       }
 


### PR DESCRIPTION
Fixes #8402. Only affects B&W radios

This PR allows up to the space character in SD rename file for B&W radios. This allows to shorten the file name.