### PR TITLE
2.4 osx compile fixes

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -63,6 +63,12 @@ set(FIRMWARE_C_FLAGS_DEBUG "-g" CACHE STRING "Additional flags for firmware targ
 set(FIRMWARE_CXX_FLAGS "" CACHE STRING "Additional flags for firmware target c++ compiler (note: all CMAKE_CXX_FLAGS[_*] are ignored for firmware/bootloader).")
 set(FIRMWARE_CXX_FLAGS_DEBUG "-g" CACHE STRING "Additional flags for firmware target (Debug config) c++ compiler (note: CMAKE_CXX_FLAGS_DEBUG is ignored for firmware/bootloader).")
 
+set(FIRMWARE_C_COMPILER "arm-none-eabi-gcc" CACHE STRING "Specific C compiler for firmware target.")
+set(FIRMWARE_CXX_COMPILER "arm-none-eabi-g++" CACHE STRING "Specific C++ compiler for firmware target.")
+set(FIRMWARE_ASM_COMPILER "arm-none-eabi-as" CACHE STRING "Specific assembler for firmware target.")
+set(FIRMWARE_OBJCOPY "arm-none-eabi-objcopy" CACHE STRING "Specific objcopy for firmware target.")
+set(FIRMWARE_SIZE "arm-none-eabi-size" CACHE STRING "Specific size for firmware target.")
+
 set(THIRDPARTY_DIR thirdparty)
 set(LUA_DIR ${THIRDPARTY_DIR}/Lua/src)
 set(COOS_DIR ${THIRDPARTY_DIR}/CoOS)
@@ -497,9 +503,9 @@ if(NOT MSVC)
 
   if(ARCH STREQUAL ARM)
     enable_language(ASM)
-    set(CMAKE_C_COMPILER arm-none-eabi-gcc)
-    set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
-    set(CMAKE_ASM_COMPILER arm-none-eabi-as)
+    set(CMAKE_C_COMPILER ${FIRMWARE_C_COMPILER})
+    set(CMAKE_CXX_COMPILER ${FIRMWARE_CXX_COMPILER})
+    set(CMAKE_ASM_COMPILER ${FIRMWARE_ASM_COMPILER})
 
     set(CMAKE_SYSTEM_NAME Generic)
     set(CMAKE_SYSTEM_VERSION 1)
@@ -559,7 +565,7 @@ if(NOT MSVC)
 
     add_custom_command(
       TARGET firmware POST_BUILD
-      COMMAND arm-none-eabi-objcopy -O binary firmware.elf firmware.bin
+      COMMAND ${FIRMWARE_OBJCOPY} -O binary firmware.elf firmware.bin
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
@@ -572,7 +578,7 @@ if(NOT MSVC)
         )
     else()
       add_custom_target(firmware-size
-        COMMAND arm-none-eabi-size -A firmware.elf
+        COMMAND ${FIRMWARE_SIZE} -A firmware.elf
         DEPENDS firmware
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         )

--- a/radio/src/debug.h
+++ b/radio/src/debug.h
@@ -51,9 +51,7 @@ uint8_t aux2SerialTracesEnabled();
 #elif defined(DEBUG)
   #define debugPrintf(...) do { serialPrintf(__VA_ARGS__); } while(0)
 #else
-  inline void debugPrintf(const char *, ...)
-  {
-  }
+  #define debugPrintf(...)
 #endif
 
 #define TRACE_TIME_FORMAT     "%0.2f "

--- a/radio/src/targets/common/arm/stm32/board_common.h
+++ b/radio/src/targets/common/arm/stm32/board_common.h
@@ -136,7 +136,7 @@ static inline bool isVBatBridgeEnabled()
 extern "C" {
 #endif
 
-inline uint32_t ticksNow()
+static inline uint32_t ticksNow()
 {
 #if defined(SIMU)
   return 0;


### PR DESCRIPTION
This allows to use a cross-compiler not located in the PATH, which is really helpful. This fixes a linking error as well (no clue how this even links on any compiler....).