### PR TITLE
Add basic support for Github Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,23 @@
+name: OpenTX Commit Tests
+on:
+  push:
+    branches: [ 2.4 ]
+  pull_request:
+    branches: [ 2.4 ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/raphaelcoeffic/opentx-commit-tests
+      volumes:
+        - ${{ github.workspace }}:/src
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Test COLORLCD
+        run: |
+          echo "Running commit tests for COLORLCD"
+          FLAVOR=COLORLCD ./tools/commit-tests.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           submodules: true
       -
+        name: Test COMPANION
+        run: |
+          echo "Running commit tests for COMPANION"
+          FLAVOR=COMPANION ./tools/commit-tests.sh
+      -
         name: Test COLORLCD
         run: |
           echo "Running commit tests for COLORLCD"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,4 +27,4 @@ jobs:
         name: Test X7
         run: |
           echo "Running commit tests for X7"
-          FLAVOR=COLORLCD ./tools/commit-tests.sh
+          FLAVOR=X7 ./tools/commit-tests.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - COMPANION
+          - ARM9X
+          - X9LITE
+          - X7
+          - XLITE
+          - X9
+          - COLORLCD
     container:
       image: ghcr.io/raphaelcoeffic/opentx-commit-tests
       volumes:
@@ -19,17 +29,9 @@ jobs:
         with:
           submodules: true
       -
-        name: Test COMPANION
+        name: Test ${{ matrix.target }}
+        env:
+          FLAVOR: ${{ matrix.target }}
         run: |
-          echo "Running commit tests for COMPANION"
-          FLAVOR=COMPANION ./tools/commit-tests.sh
-      -
-        name: Test COLORLCD
-        run: |
-          echo "Running commit tests for COLORLCD"
-          FLAVOR=COLORLCD ./tools/commit-tests.sh
-      -
-        name: Test X7
-        run: |
-          echo "Running commit tests for X7"
-          FLAVOR=X7 ./tools/commit-tests.sh
+          echo "Running commit tests"
+          ./tools/commit-tests.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,3 +21,8 @@ jobs:
         run: |
           echo "Running commit tests for COLORLCD"
           FLAVOR=COLORLCD ./tools/commit-tests.sh
+      -
+        name: Test X7
+        run: |
+          echo "Running commit tests for X7"
+          FLAVOR=COLORLCD ./tools/commit-tests.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          submodules: true
       -
         name: Test COLORLCD
         run: |


### PR DESCRIPTION
This is based on the [opentx-commit-tests docker image](https://github.com/raphaelcoeffic/build-opentx).

Please that this is only the start, it is still missing some stuff:
- adding other targets
- use matrix strategy instead of multiple steps (see [here](https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix))

Further useful informations on Travis conversion can be read [here](https://docs.github.com/en/actions/learn-github-actions/migrating-from-travis-ci-to-github-actions).

**Please note:** it seems that GH Actions, the way it's configured right now, does the tests on the **merged version of the MR**, and **not on the MR's HEAD commit** (see [this github issue](https://github.com/actions/checkout/issues/15#issuecomment-524093065) for more details).