### PR TITLE
2.4: Use the same font all the way for a specific language

### DIFF
--- a/cmake/Bitmaps.cmake
+++ b/cmake/Bitmaps.cmake
@@ -34,14 +34,12 @@ macro(add_truetype_font_target name size subset effect)
   set(target font_${name})
   if(${effect} STREQUAL "bold")
     set(font ${FONT_BOLD})
-    set(cjk_font ${CJK_FONT_BOLD})
   else()
     set(font ${FONT})
-    set(cjk_font ${CJK_FONT})
   endif()
   add_custom_command(
     OUTPUT ${target}.png ${target}.specs ${target}.lbm
-    COMMAND ${PYTHON_EXECUTABLE} ${TOOLS_DIR}/build-font-bitmap.py --subset ${subset} --size ${size} --font ${font} --cjk-font ${cjk_font} --output ${target}
+    COMMAND ${PYTHON_EXECUTABLE} ${TOOLS_DIR}/build-font-bitmap.py --subset ${subset} --size ${size} --font ${font} --output ${target}
     COMMAND ${PYTHON_EXECUTABLE} ${LIBOPENUI_TOOLS_DIR}/encode-bitmap.py --format 8bits --rle --size-format 2 ${target}.png ${target}.lbm
     DEPENDS ${TOOLS_DIR}/build-font-bitmap.py ${TOOLS_DIR}/charset.py ${LIBOPENUI_TOOLS_DIR}/encode-bitmap.py ${RADIO_SRC_DIR}/translations/cn.h.txt ${RADIO_SRC_DIR}/fonts/extra_${size}px.png
   )

--- a/radio/src/fonts/CMakeLists.txt
+++ b/radio/src/fonts/CMakeLists.txt
@@ -1,15 +1,22 @@
-set(FONT "Roboto/Roboto-Regular")
-set(FONT_BOLD "Roboto/Roboto-Bold")
-set(CJK_FONT "Noto/NotoSansCJKsc-Regular")
-set(CJK_FONT_BOLD "Noto/NotoSansCJKsc-Bold")
-
-#set(FONT "Kanit/Kanit-Regular")
-#set(FONT_BOLD "Kanit/Kanit-Bold")
-
-#set(FONT "Ubuntu/Ubuntu-Regular")
-#set(FONT_BOLD "Ubuntu/Ubuntu-Bold")
-
 string(TOLOWER ${TRANSLATIONS} subset)
+
+if( (${subset} STREQUAL "cn") OR (${subset} STREQUAL "tw"))
+  # Use this font for CJK languages
+  set(FONT "Noto/NotoSansCJKsc-Regular")
+  set(FONT_BOLD "Noto/NotoSansCJKsc-Bold")
+  set(FONT_OFFSET -3)
+else()
+  # Use this font for non-CJK languages
+  set(FONT "Roboto/Roboto-Regular")
+  set(FONT_BOLD "Roboto/Roboto-Bold")
+  set(FONT_OFFSET 0)
+
+  #set(FONT "Kanit/Kanit-Regular")
+  #set(FONT_BOLD "Kanit/Kanit-Bold")
+
+  #set(FONT "Ubuntu/Ubuntu-Regular")
+  #set(FONT_BOLD "Ubuntu/Ubuntu-Bold")
+endif()
 
 add_truetype_font_target(9      9  ${subset} none)
 add_truetype_font_target(13     13 ${subset} none)

--- a/tools/build-font-bitmap.py
+++ b/tools/build-font-bitmap.py
@@ -107,7 +107,7 @@ class FontBitmap:
                     self.extra_bitmap = None
                 continue
             elif is_cjk_char(c):
-                w = self.draw_char(image, width, c, -3)
+                w = self.draw_char(image, width, c, 3)
             else:
                 w = self.draw_char(image, width, c)
 
@@ -118,7 +118,7 @@ class FontBitmap:
 
         _, top, _, bottom = self.get_real_size(image)
 
-        top = 1
+        top = bottom - self.font_size - 2
         # bottom = self.font_size
         image = image.crop((0, top, width - 1, bottom))
         coords.insert(0, bottom - top + 1)

--- a/tools/build-font-bitmap.py
+++ b/tools/build-font-bitmap.py
@@ -5,18 +5,17 @@ import argparse
 import os
 import sys
 from PIL import Image, ImageDraw, ImageFont
-from charset import get_chars, special_chars, extra_chars, standard_chars
+from charset import get_chars, special_chars, extra_chars, standard_chars, is_cjk_char
 
 
 class FontBitmap:
-    def __init__(self, language, font_size, font_name, cjk_font_name, foreground, background):
+    def __init__(self, language, font_size, font_name, foreground, background):
         self.language = language
         self.chars = get_chars(language)
         self.font_size = font_size
         self.foreground = foreground
         self.background = background
         self.font = self.load_font(font_name)
-        self.cjk_font = self.load_font(cjk_font_name)
         self.extra_bitmap = self.load_extra_bitmap()
 
     def load_extra_bitmap(self):
@@ -77,7 +76,8 @@ class FontBitmap:
             bottom -= 1
         return left, top, right, bottom
 
-    def draw_char(self, image, x, c, font, offset_y=0):
+    def draw_char(self, image, x, c, offset_y=0):
+        font=self.font
         size = font.font.getsize(c)
         width = size[0][0]
         offset_x = size[1][0]
@@ -106,10 +106,10 @@ class FontBitmap:
                         width += coord
                     self.extra_bitmap = None
                 continue
-            elif c in special_chars[self.language]:
-                w = self.draw_char(image, width, c, self.cjk_font, -3)
+            elif is_cjk_char(c):
+                w = self.draw_char(image, width, c, -3)
             else:
-                w = self.draw_char(image, width, c, self.font)
+                w = self.draw_char(image, width, c)
 
             coords.append(width)
             width += w
@@ -139,10 +139,9 @@ def main():
     parser.add_argument('--subset', help="Subset")
     parser.add_argument('--size', type=int, help="Font size")
     parser.add_argument('--font', help="Font name")
-    parser.add_argument('--cjk-font', help="CJK font name")
     args = parser.parse_args()
 
-    font = FontBitmap(args.subset, args.size, args.font, args.cjk_font, (0, 0, 0), (255, 255, 255))
+    font = FontBitmap(args.subset, args.size, args.font, (0, 0, 0), (255, 255, 255))
     font.generate(args.output)
 
 

--- a/tools/charset.py
+++ b/tools/charset.py
@@ -9,6 +9,8 @@ standard_chars = """ !"#$%&'()*+,-./0123456789:;<=>?°ABCDEFGHIJKLMNOPQRSTUVWXYZ
 
 extra_chars = "".join([chr(0x10000+i) for i in range(21)])
 
+def is_cjk_char(c):
+    return 0x4E00 <= ord(c) <= 0x9FFF
 
 def cjk_chars(lang):
     charset = set()
@@ -16,7 +18,7 @@ def cjk_chars(lang):
     with open(os.path.join(tools_path, "../radio/src/translations/%s.h.txt" % lang), encoding='utf-8') as f:
         data = f.read()
         for c in data:
-            if 0x4E00 <= ord(c) <= 0x9FFF:
+            if is_cjk_char(c):
                 charset.add(c)
                 # print(ord(c))
     result = list(charset)


### PR DESCRIPTION
This is more complicated as it seems. So that we get consistent sizes across fonts and languages, we will have to have a look at this: https://stackoverflow.com/questions/43060479/how-to-get-the-font-pixel-height-using-pils-imagefont-class

And try to compute what we need to give PIL.ImageFont the proper pixel size.

TODO:
- [ ] find a way to have a consistent way to generate font bitmaps with consistent size across fonts & sizes.