### PR TITLE
2.4: check YAML format is functional

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,7 @@ jobs:
           - XLITE
           - X9
           - COLORLCD
+          - YAML
     container:
       image: ghcr.io/raphaelcoeffic/opentx-commit-tests
       volumes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - FLAVOR=XLITE
     - FLAVOR=X9
     - FLAVOR=COLORLCD
+    - FLAVOR=YAML
 
 before_install:
   - docker pull ghcr.io/raphaelcoeffic/opentx-commit-tests

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -44,6 +44,7 @@ option(TEMPLATES "Model templates menu" OFF)
 option(TRACE_SIMPGMSPACE "Turn on traces in simpgmspace.cpp" ON)
 option(TRACE_LUA_INTERNALS "Turn on traces for Lua internals" OFF)
 option(DEBUG_WINDOWS "Turn on windows traces" OFF)
+option(DEBUG_YAML "Turn on YAML traces" OFF)
 option(FRSKY_STICKS "Reverse sticks for FrSky sticks" OFF)
 option(NANO "Use nano newlib and binalloc")
 option(TEST_BUILD_WARNING "Warn this is a test build" OFF)
@@ -332,6 +333,10 @@ endif()
 
 if(DEBUG_WINDOWS)
   add_definitions(-DDEBUG_WINDOWS)
+endif()
+
+if(DEBUG_YAML)
+  add_definitions(-DDEBUG_YAML)
 endif()
 
 if(FRSKY_STICKS)

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -95,7 +95,7 @@ PACK(struct MixData {
 PACK(struct ExpoData {
   uint16_t mode:2;
   uint16_t scale:14;
-  uint16_t srcRaw:10 ENUM(MixSources);
+  uint16_t srcRaw:10 ENUM(MixSources) CUST(r_mixSrcRaw,w_mixSrcRaw);
   int16_t  carryTrim:6;
   uint32_t chn:5;
   int32_t  swtch:9 CUST(r_swtchSrc,w_swtchSrc);

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -581,6 +581,11 @@ PACK(struct CustomScreenData {
   #define SCRIPT_DATA
 #endif
 
+PACK(struct PartialModel {
+  ModelHeader header;
+  TimerData timers[MAX_TIMERS];
+});
+
 PACK(struct ModelData {
   ModelHeader header;
   TimerData timers[MAX_TIMERS];

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -538,7 +538,7 @@ typedef uint8_t swarnenable_t;
 
 #if defined(COLORLCD)
   #define SWITCHES_WARNING_DATA \
-    NOBACKUP(swarnstate_t  switchWarningState);
+    NOBACKUP(swarnstate_t  switchWarningState CUST(r_swtchWarn,w_swtchWarn));
 #else
   #define SWITCHES_WARNING_DATA \
     swarnstate_t  switchWarningState; \

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -439,7 +439,7 @@ PACK(struct ModuleData {
       int8_t optionValue;
       uint8_t receiverTelemetryOff:1;
       uint8_t receiverHigherChannels:1;
-      uint8_t spare:6;
+      uint8_t spare:6 SKIP;
     } multi);
     NOBACKUP(struct {
       uint8_t power:2;                  // 0=10 mW, 1=100 mW, 2=500 mW, 3=1W
@@ -626,7 +626,7 @@ PACK(struct ModelData {
 
   NOBACKUP(RssiAlarmData rssiAlarms);
 
-  uint8_t spare1:3;
+  uint8_t spare1:3 SKIP;
   uint8_t thrTrimSw:3;
   uint8_t potsWarnMode:2;
 
@@ -700,9 +700,9 @@ PACK(struct TrainerData {
 });
 
 #if defined(COLORLCD)
-  #define SPLASH_MODE uint8_t splashSpares:3
+  #define SPLASH_MODE uint8_t splashSpares:3 SKIP
 #else
-  #define SPLASH_MODE uint8_t splashMode:1; uint8_t splashSpare:2
+  #define SPLASH_MODE uint8_t splashMode:1; uint8_t splashSpare:2 SKIP
 #endif
 
 #if defined(PCBXLITES)

--- a/radio/src/debug.h
+++ b/radio/src/debug.h
@@ -92,6 +92,12 @@ uint8_t aux2SerialTracesEnabled();
   #define TRACE_LUA_INTERNALS_WITH_LINEINFO(L, f_, ...)
 #endif
 
+#if defined(DEBUG_YAML)
+#define TRACE_YAML(f_, ...) TRACE(f_, ##__VA_ARGS__)
+#else
+#define TRACE_YAML(f_, ...)
+#endif
+
 #if defined(DEBUG) && !defined(SIMU)
 #define TIME_MEASURE_START(id) uint16_t t0 ## id = getTmr2MHz()
 #define TIME_MEASURE_STOP(id)  TRACE("Measure(" # id ") = %.1fus", float((uint16_t)(getTmr2MHz() - t0 ## id))/2)

--- a/radio/src/gui/colorlcd/layout.h
+++ b/radio/src/gui/colorlcd/layout.h
@@ -32,7 +32,14 @@ constexpr uint32_t LAYOUT_REFRESH = 1000 / 2; // 2 Hz
 
 class BitmapBuffer;
 
+#if !defined(YAML_GENERATOR)
 typedef WidgetsContainerPersistentData<MAX_LAYOUT_ZONES,MAX_LAYOUT_OPTIONS> LayoutPersistentData;
+#else
+struct LayoutPersistentData {
+  ZonePersistentData   zones[MAX_LAYOUT_ZONES];
+  ZoneOptionValueTyped options[MAX_LAYOUT_OPTIONS];
+};
+#endif
 
 class LayoutFactory
 {

--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -133,7 +133,7 @@ class BaseLayoutFactory: public LayoutFactory
 
     Layout * create(Layout::PersistentData * persistentData) const override
     {
-      initPersistentData(persistentData);
+      initPersistentData(persistentData, true);
       Layout * layout = new T(this, persistentData);
       if (layout) {
         layout->create();
@@ -143,6 +143,7 @@ class BaseLayoutFactory: public LayoutFactory
 
     Layout * load(Layout::PersistentData * persistentData) const override
     {
+      initPersistentData(persistentData, false);
       Layout * layout = new T(this, persistentData);
       if (layout) {
         layout->load();
@@ -150,16 +151,21 @@ class BaseLayoutFactory: public LayoutFactory
       return layout;
     }
 
-    void initPersistentData(Layout::PersistentData * persistentData) const
+    void initPersistentData(Layout::PersistentData * persistentData, bool setDefault) const
     {
-      memset(persistentData, 0, sizeof(Layout::PersistentData));
+      if (setDefault) {
+        memset(persistentData, 0, sizeof(Layout::PersistentData));
+      }
       if (options) {
         int i = 0;
         for (const ZoneOption * option = options; option->name; option++, i++) {
           TRACE("LayoutFactory::initPersistentData() setting option '%s'", option->name);
           // TODO compiler bug? The CPU freezes ... persistentData->options[i++] = option->deflt;
-          memcpy(&persistentData->options[i].value, &option->deflt, sizeof(ZoneOptionValue));
-          persistentData->options[i].type = zoneValueEnumFromType(option->type);
+          auto optVal = &persistentData->options[i];
+          if (setDefault) {
+            memcpy(&optVal->value, &option->deflt, sizeof(ZoneOptionValue));
+          }
+          optVal->type = zoneValueEnumFromType(option->type);
         }
       }
     }

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -147,6 +147,11 @@ class ModelButton: public Button {
       }
       else {
         char timerName[LEN_TIMER_STRING];
+        if (modelCell->modelName[0] == '\0'
+            && partialModel.header.name[0] != '\0') {
+          strncpy(modelCell->modelName, partialModel.header.name, LEN_MODEL_NAME);
+          modelCell->modelName[LEN_MODEL_NAME] = '\0';
+        }
         buffer->drawSizedText(5, 2, modelCell->modelName, LEN_MODEL_NAME, FONT(XS) | DEFAULT_COLOR);
         getTimerString(timerName, 0);
         for (auto & timer : partialModel.timers) {

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -117,10 +117,7 @@ class ModelButton: public Button {
     {
       uint8_t version;
 
-      PACK(struct {
-        ModelHeader header;
-        TimerData timers[MAX_TIMERS];
-      }) partialModel;
+      PartialModel partialModel;
       const char * error = nullptr;
 
       if (strncmp(modelCell->modelFilename, g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME) == 0) {

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -817,6 +817,8 @@ class ModuleWindow : public FormGroup {
                 return 1;
               }
 #endif
+              // silence compiler warning...
+              return 0;
           });
           bindButton->setCheckHandler([=]() {
               if (moduleState[moduleIdx].mode != MODULE_MODE_BIND) {

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -120,16 +120,22 @@ class WidgetFactory
       return options;
     }
 
-    void initPersistentData(Widget::PersistentData * persistentData) const
+    void initPersistentData(Widget::PersistentData * persistentData, bool setDefault) const
     {
-      memset(persistentData, 0, sizeof(Widget::PersistentData));
+      if (setDefault) {
+        memset(persistentData, 0, sizeof(Widget::PersistentData));
+      }
       if (options) {
         int i = 0;
         for (const ZoneOption * option = options; option->name; option++, i++) {
           TRACE("WidgetFactory::initPersistentData() setting option '%s'", option->name);
           // TODO compiler bug? The CPU freezes ... persistentData->options[i++] = option->deflt;
-          memcpy(&persistentData->options[i].value, &option->deflt, sizeof(ZoneOptionValue));
-          persistentData->options[i].type = zoneValueEnumFromType(option->type);
+          auto optVal = &persistentData->options[i];
+          if (setDefault) {
+            // reset to default value
+            memcpy(&optVal->value, &option->deflt, sizeof(ZoneOptionValue));
+          }
+          optVal->type = zoneValueEnumFromType(option->type);
         }
       }
     }

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -157,10 +157,7 @@ class BaseWidgetFactory: public WidgetFactory
 
     Widget * create(FormGroup * parent, const rect_t & rect, Widget::PersistentData * persistentData, bool init = true) const override
     {
-      if (init) {
-        initPersistentData(persistentData);
-      }
-
+      initPersistentData(persistentData, init);
       return new T(this, parent, rect, persistentData);
     }
 };

--- a/radio/src/gui/colorlcd/widgets_container.h
+++ b/radio/src/gui/colorlcd/widgets_container.h
@@ -62,7 +62,14 @@ struct WidgetsContainerPersistentData {
   ZoneOptionValueTyped options[O];
 };
 
+#if !defined(YAML_GENERATOR)
 typedef WidgetsContainerPersistentData<MAX_TOPBAR_ZONES, MAX_TOPBAR_OPTIONS> TopBarPersistentData;
+#else
+struct TopBarPersistentData {
+  ZonePersistentData   zones[MAX_TOPBAR_ZONES];
+  ZoneOptionValueTyped options[MAX_TOPBAR_OPTIONS];
+};
+#endif
 
 class WidgetsContainer: public FormGroup
 {

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -337,9 +337,10 @@ void ModelsCategory::save(FIL * file)
   f_puts("]", file);
   f_putc('\n', file);
 #else
-  f_puts("- name: ", file);
+  f_puts("- ", file);
   f_puts(name, file);
   f_putc('\n', file);
+  //f_puts("  models:\n", file);
 #endif
   for (list<ModelCell *>::iterator it = begin(); it != end(); ++it) {
     (*it)->save(file);

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -137,18 +137,23 @@ const char * readModel(const char * filename, uint8_t * buffer, uint32_t size, u
     // YAML reader
     TRACE("YAML model reader");
 
-    if (size < sizeof(g_model)) {
-        // TODO: Partial load for ModelButton::load()
-        //  -> maybe we should have a summary in modelslist.yml? 
-        memset(buffer, 0, size);
-        return nullptr;
+    const YamlNode* data_nodes = nullptr;
+    if (size == sizeof(g_model)) {
+        data_nodes = get_modeldata_nodes();
+    }
+    else if (size == sizeof(PartialModel)) {
+        data_nodes = get_partialmodel_nodes();
+    }
+    else {
+        TRACE("cannot find YAML data nodes for object size (size=%d)", size);
+        return "YAML size error";
     }
     
     char path[256];
     getModelPath(path, filename);
 
     YamlTreeWalker tree;
-    tree.reset(get_modeldata_nodes(), buffer);
+    tree.reset(data_nodes, buffer);
 
     // wipe memory before reading YAML
     memset(buffer,0,size);

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -168,7 +168,8 @@ const char * readModel(const char * filename, uint8_t * buffer, uint32_t size, u
         }
     }
     //#endif
-    
+
+    *version = 255; // max version number
     return readYamlFile(path, YamlTreeWalker::get_parser_calls(), &tree);
 }
 

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -137,6 +137,13 @@ const char * readModel(const char * filename, uint8_t * buffer, uint32_t size, u
     // YAML reader
     TRACE("YAML model reader");
 
+    if (size < sizeof(g_model)) {
+        // TODO: Partial load for ModelButton::load()
+        //  -> maybe we should have a summary in modelslist.yml? 
+        memset(buffer, 0, size);
+        return nullptr;
+    }
+    
     char path[256];
     getModelPath(path, filename);
 

--- a/radio/src/storage/yaml/CMakeLists.txt
+++ b/radio/src/storage/yaml/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 set(YAML_GEN          ${RADIO_DIRECTORY}/util/generate_yaml.py)
 set(YAML_GEN_TEMPLATE ${RADIO_DIRECTORY}/util/yaml_parser.tmpl)
 
-SET(YAML_NODES        "\"RadioData,ModelData\"")
+SET(YAML_NODES        "\"RadioData,ModelData,PartialModel\"")
 set(YAML_GEN_ARGS     myeeprom.h ${YAML_GEN_TEMPLATE} ${YAML_NODES} -DYAML_GENERATOR)
 
 get_property(flags DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY COMPILE_DEFINITIONS)

--- a/radio/src/storage/yaml/yaml_datastructs.h
+++ b/radio/src/storage/yaml/yaml_datastructs.h
@@ -5,5 +5,6 @@ struct YamlNode;
 
 const YamlNode* get_radiodata_nodes();
 const YamlNode* get_modeldata_nodes();
+const YamlNode* get_partialmodel_nodes();
 
 #endif

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -359,3 +359,24 @@ static bool fmd_is_active(uint8_t* data, uint32_t bitoffs)
 
     return is_active;
 }
+
+static uint32_t r_swtchWarn(const YamlNode* node, const char* val, uint8_t val_len)
+{
+    //TODO: read from string like 'AdBuC-'
+    // -> reads:
+    //    - Switch A: must be DOWN
+    //    - Switch B: must be UP
+    //    - Switch C: must be MIDDLE
+    //
+    // -> switches not in the list shall not be checked
+    //
+    // -> refer to getSwitchWarningString() (strhelpers.cpp)
+    return 0;
+}
+
+static bool w_swtchWarn(const YamlNode* node, uint32_t val, yaml_writer_func wf, void* opaque)
+{
+    //TODO:
+    // -> refer to getSwitchWarningString() (strhelpers.cpp)
+    return true;
+}

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -129,7 +129,7 @@ static uint8_t select_mod_type(uint8_t* data, uint32_t bitoffs)
     case MODULE_TYPE_XJT_PXX1:
     case MODULE_TYPE_R9M_PXX1:
     case MODULE_TYPE_R9M_LITE_PXX1:
-    case MODULE_TYPE_R9M_LITE_PRO_PXX1:
+    //case MODULE_TYPE_R9M_LITE_PRO_PXX1:
         return 3;
     case MODULE_TYPE_SBUS:
         return 4;

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -188,11 +188,11 @@ const struct YamlIdStr enum_ModuleType[] = {
   {  MODULE_TYPE_R9M_PXX2, "TYPE_R9M_PXX2"  },
   {  MODULE_TYPE_R9M_LITE_PXX1, "TYPE_R9M_LITE_PXX1"  },
   {  MODULE_TYPE_R9M_LITE_PXX2, "TYPE_R9M_LITE_PXX2"  },
-  {  MODULE_TYPE_R9M_LITE_PRO_PXX1, "TYPE_R9M_LITE_PRO_PXX1"  },
+  {  MODULE_TYPE_GHOST, "TYPE_GHOST"  },
   {  MODULE_TYPE_R9M_LITE_PRO_PXX2, "TYPE_R9M_LITE_PRO_PXX2"  },
   {  MODULE_TYPE_SBUS, "TYPE_SBUS"  },
   {  MODULE_TYPE_XJT_LITE_PXX2, "TYPE_XJT_LITE_PXX2"  },
-  {  MODULE_TYPE_FLYSKY, "TYPE_FLYSKY"  },
+  {  MODULE_TYPE_AFHDS3, "TYPE_AFHDS3"  },
   {  MODULE_TYPE_COUNT, "TYPE_COUNT"  },
   {  MODULE_TYPE_MAX, "TYPE_MAX"  },
   {  0, NULL  }
@@ -274,7 +274,7 @@ static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
-static const struct YamlNode struct_ThemeBase__PersistentData[] = {
+static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
   YAML_ARRAY("options", 96, 5, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
@@ -288,7 +288,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "backlightMode", 3 ),
   YAML_SIGNED( "antennaMode", 2 ),
   YAML_UNSIGNED( "disableRtcWarning", 1 ),
-  YAML_PADDING( 2 ),
+  YAML_UNSIGNED( "keysBacklight", 1 ),
+  YAML_PADDING( 1 ),
   YAML_STRUCT("trainer", 128, struct_TrainerData, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_PADDING( 2 ),
@@ -339,7 +340,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED( "varioRange", 8 ),
   YAML_SIGNED( "varioRepeat", 8 ),
   YAML_ARRAY("customFn", 72, 64, struct_CustomFunctionData, cfn_is_active),
-  YAML_UNSIGNED( "auxSerialMode", 8 ),
+  YAML_UNSIGNED( "auxSerialMode", 4 ),
+  YAML_UNSIGNED( "aux2SerialMode", 4 ),
   YAML_ARRAY("switchConfig", 2, 16, struct_switchConfig, nullptr),
   YAML_ARRAY("potsConfig", 2, 8, struct_potConfig, nullptr),
   YAML_ARRAY("slidersConfig", 1, 8, struct_sliderConfig, nullptr),
@@ -350,7 +352,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "blOffBright", 7 ),
   YAML_STRING("bluetoothName", 10),
   YAML_STRING("themeName", 8),
-  YAML_STRUCT("themeData", 480, struct_ThemeBase__PersistentData, NULL),
+  YAML_STRUCT("themeData", 480, struct_OpenTxTheme__PersistentData, NULL),
   YAML_STRING("ownerRegistrationID", 8),
   YAML_END
 };
@@ -522,12 +524,16 @@ static const struct YamlNode struct_anonymous_5[] = {
   YAML_END
 };
 static const struct YamlNode struct_anonymous_6[] = {
-  YAML_UNSIGNED( "rfProtocolExtra", 2 ),
-  YAML_PADDING( 3 ),
+  YAML_UNSIGNED( "rfProtocolExtra", 3 ),
+  YAML_UNSIGNED( "disableTelemetry", 1 ),
+  YAML_UNSIGNED( "disableMapping", 1 ),
   YAML_UNSIGNED( "customProto", 1 ),
   YAML_UNSIGNED( "autoBindMode", 1 ),
   YAML_UNSIGNED( "lowPowerMode", 1 ),
   YAML_SIGNED( "optionValue", 8 ),
+  YAML_UNSIGNED( "receiverTelemetryOff", 1 ),
+  YAML_UNSIGNED( "receiverHigherChannels", 1 ),
+  YAML_UNSIGNED( "spare", 6 ),
   YAML_END
 };
 static const struct YamlNode struct_anonymous_7[] = {
@@ -556,13 +562,23 @@ static const struct YamlNode struct_anonymous_9[] = {
   YAML_ARRAY("receiverName", 64, 3, struct_string_64, NULL),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_10[] = {
+  YAML_UNSIGNED( "bindPower", 3 ),
+  YAML_UNSIGNED( "runPower", 3 ),
+  YAML_UNSIGNED( "emi", 1 ),
+  YAML_UNSIGNED( "telemetry", 1 ),
+  YAML_UNSIGNED( "failsafeTimeout", 16 ),
+  YAML_ARRAY("rx_freq", 8, 2, struct_unsigned_8, NULL),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
-  YAML_STRUCT("multi", 16, struct_anonymous_6, NULL),
+  YAML_STRUCT("multi", 24, struct_anonymous_6, NULL),
   YAML_STRUCT("pxx", 16, struct_anonymous_7, NULL),
   YAML_STRUCT("sbus", 16, struct_anonymous_8, NULL),
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
+  YAML_STRUCT("afhds3", 48, struct_anonymous_10, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -578,8 +594,7 @@ static const struct YamlNode struct_ModuleData[] = {
   YAML_END
 };
 static const struct YamlNode struct_TrainerModuleData[] = {
-  YAML_UNSIGNED( "mode", 3 ),
-  YAML_PADDING( 5 ),
+  YAML_UNSIGNED( "mode", 8 ),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED( "channelsCount", 8 ),
   YAML_SIGNED( "frameLength", 8 ),
@@ -610,61 +625,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_10_elmts[] = {
+static const struct YamlNode union_anonymous_11_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_12[] = {
+static const struct YamlNode struct_anonymous_13[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_11_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_12, NULL),
+static const struct YamlNode union_anonymous_12_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_13, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_UNSIGNED( "formula", 8 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_15[] = {
+static const struct YamlNode struct_anonymous_16[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_14, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_15, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_18, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_15, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_16, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_19, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_10_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_11_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_11_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_12_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_UNSIGNED( "type", 1 ),
@@ -677,20 +692,20 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_13_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_14_elmts, select_sensor_cfg),
   YAML_END
 };
-static const struct YamlNode struct_Widget__PersistentData[] = {
+static const struct YamlNode struct_WidgetPersistentData[] = {
   YAML_ARRAY("options", 96, 5, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 10),
-  YAML_STRUCT("widgetData", 480, struct_Widget__PersistentData, NULL),
+  YAML_STRUCT("widgetData", 480, struct_WidgetPersistentData, NULL),
   YAML_END
 };
-static const struct YamlNode struct_Layout__PersistentData[] = {
+static const struct YamlNode struct_LayoutPersistentData[] = {
   YAML_ARRAY("zones", 576, 10, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
@@ -698,10 +713,10 @@ static const struct YamlNode struct_Layout__PersistentData[] = {
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 10),
-  YAML_STRUCT("layoutData", 6720, struct_Layout__PersistentData, NULL),
+  YAML_STRUCT("layoutData", 6720, struct_LayoutPersistentData, NULL),
   YAML_END
 };
-static const struct YamlNode struct_Topbar__PersistentData[] = {
+static const struct YamlNode struct_TopBarPersistentData[] = {
   YAML_ARRAY("zones", 576, 4, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
@@ -736,7 +751,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),
   YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
-  YAML_PADDING( 6 ),
+  YAML_UNSIGNED( "spare1", 3 ),
+  YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_UNSIGNED( "potsWarnMode", 2 ),
   YAML_ARRAY("moduleData", 232, 2, struct_ModuleData, NULL),
   YAML_ARRAY("failsafeChannels", 16, 32, struct_signed_16, NULL),
@@ -747,7 +763,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("potsWarnPosition", 8, 9, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 2400, struct_Topbar__PersistentData, NULL),
+  YAML_STRUCT("topbarData", 2400, struct_TopBarPersistentData, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),
   YAML_END

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -303,7 +303,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "adjustRTC", 1 ),
   YAML_UNSIGNED( "inactivityTimer", 8 ),
   YAML_UNSIGNED( "telemetryBaudrate", 3 ),
-  YAML_UNSIGNED( "splashSpares", 3 ),
+  YAML_PADDING( 3 ),
   YAML_SIGNED( "hapticMode", 2 ),
   YAML_SIGNED( "switchesDelay", 8 ),
   YAML_UNSIGNED( "lightAutoOff", 8 ),
@@ -533,7 +533,7 @@ static const struct YamlNode struct_anonymous_6[] = {
   YAML_SIGNED( "optionValue", 8 ),
   YAML_UNSIGNED( "receiverTelemetryOff", 1 ),
   YAML_UNSIGNED( "receiverHigherChannels", 1 ),
-  YAML_UNSIGNED( "spare", 6 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_anonymous_7[] = {
@@ -751,7 +751,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),
   YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
-  YAML_UNSIGNED( "spare1", 3 ),
+  YAML_PADDING( 3 ),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_UNSIGNED( "potsWarnMode", 2 ),
   YAML_ARRAY("moduleData", 232, 2, struct_ModuleData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -768,8 +768,13 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRING("modelRegistrationID", 8),
   YAML_END
 };
+static const struct YamlNode struct_PartialModel[] = {
+  YAML_STRUCT("header", 248, struct_ModelHeader, NULL),
+  YAML_ARRAY("timers", 128, 3, struct_TimerData, NULL),
+  YAML_END
+};
 
-#define MAX_RADIODATA_MODELDATA_STR_LEN 24
+#define MAX_RADIODATA_MODELDATA_PARTIALMODEL_STR_LEN 24
 
 static const struct YamlNode __RadioData_root_node = YAML_ROOT( struct_RadioData );
 
@@ -782,5 +787,11 @@ static const struct YamlNode __ModelData_root_node = YAML_ROOT( struct_ModelData
 const YamlNode* get_modeldata_nodes()
 {
    return &__ModelData_root_node;
+}
+static const struct YamlNode __PartialModel_root_node = YAML_ROOT( struct_PartialModel );
+
+const YamlNode* get_partialmodel_nodes()
+{
+   return &__PartialModel_root_node;
 }
 

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -746,7 +746,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("swashR", 64, struct_SwashRingData, NULL),
   YAML_ARRAY("flightModeData", 352, 9, struct_FlightModeData, fmd_is_active),
   YAML_UNSIGNED( "thrTraceSrc", 8 ),
-  YAML_UNSIGNED( "switchWarningState", 32 ),
+  YAML_UNSIGNED_CUST( "switchWarningState", 32, r_swtchWarn, w_swtchWarn ),
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -422,7 +422,7 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_IDX,
   YAML_UNSIGNED( "mode", 2 ),
   YAML_UNSIGNED( "scale", 14 ),
-  YAML_ENUM("srcRaw", 10, enum_MixSources),
+  YAML_UNSIGNED_CUST( "srcRaw", 10, r_mixSrcRaw, w_mixSrcRaw ),
   YAML_SIGNED( "carryTrim", 6 ),
   YAML_UNSIGNED( "chn", 5 ),
   YAML_SIGNED_CUST( "swtch", 9, r_swtchSrc, w_swtchSrc ),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -189,11 +189,11 @@ const struct YamlIdStr enum_ModuleType[] = {
   {  MODULE_TYPE_R9M_PXX2, "TYPE_R9M_PXX2"  },
   {  MODULE_TYPE_R9M_LITE_PXX1, "TYPE_R9M_LITE_PXX1"  },
   {  MODULE_TYPE_R9M_LITE_PXX2, "TYPE_R9M_LITE_PXX2"  },
-  {  MODULE_TYPE_R9M_LITE_PRO_PXX1, "TYPE_R9M_LITE_PRO_PXX1"  },
+  {  MODULE_TYPE_GHOST, "TYPE_GHOST"  },
   {  MODULE_TYPE_R9M_LITE_PRO_PXX2, "TYPE_R9M_LITE_PRO_PXX2"  },
   {  MODULE_TYPE_SBUS, "TYPE_SBUS"  },
   {  MODULE_TYPE_XJT_LITE_PXX2, "TYPE_XJT_LITE_PXX2"  },
-  {  MODULE_TYPE_FLYSKY, "TYPE_FLYSKY"  },
+  {  MODULE_TYPE_AFHDS3, "TYPE_AFHDS3"  },
   {  MODULE_TYPE_COUNT, "TYPE_COUNT"  },
   {  MODULE_TYPE_MAX, "TYPE_MAX"  },
   {  0, NULL  }
@@ -275,7 +275,7 @@ static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
-static const struct YamlNode struct_ThemeBase__PersistentData[] = {
+static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
   YAML_ARRAY("options", 96, 5, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
@@ -289,7 +289,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "backlightMode", 3 ),
   YAML_SIGNED( "antennaMode", 2 ),
   YAML_UNSIGNED( "disableRtcWarning", 1 ),
-  YAML_PADDING( 2 ),
+  YAML_UNSIGNED( "keysBacklight", 1 ),
+  YAML_PADDING( 1 ),
   YAML_STRUCT("trainer", 128, struct_TrainerData, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_PADDING( 2 ),
@@ -340,7 +341,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED( "varioRange", 8 ),
   YAML_SIGNED( "varioRepeat", 8 ),
   YAML_ARRAY("customFn", 72, 64, struct_CustomFunctionData, cfn_is_active),
-  YAML_UNSIGNED( "auxSerialMode", 8 ),
+  YAML_UNSIGNED( "auxSerialMode", 4 ),
+  YAML_UNSIGNED( "aux2SerialMode", 4 ),
   YAML_ARRAY("switchConfig", 2, 16, struct_switchConfig, nullptr),
   YAML_ARRAY("potsConfig", 2, 8, struct_potConfig, nullptr),
   YAML_ARRAY("slidersConfig", 1, 8, struct_sliderConfig, nullptr),
@@ -351,7 +353,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "blOffBright", 7 ),
   YAML_STRING("bluetoothName", 10),
   YAML_STRING("themeName", 8),
-  YAML_STRUCT("themeData", 480, struct_ThemeBase__PersistentData, NULL),
+  YAML_STRUCT("themeData", 480, struct_OpenTxTheme__PersistentData, NULL),
   YAML_STRING("ownerRegistrationID", 8),
   YAML_END
 };
@@ -523,12 +525,16 @@ static const struct YamlNode struct_anonymous_5[] = {
   YAML_END
 };
 static const struct YamlNode struct_anonymous_6[] = {
-  YAML_UNSIGNED( "rfProtocolExtra", 2 ),
-  YAML_PADDING( 3 ),
+  YAML_UNSIGNED( "rfProtocolExtra", 3 ),
+  YAML_UNSIGNED( "disableTelemetry", 1 ),
+  YAML_UNSIGNED( "disableMapping", 1 ),
   YAML_UNSIGNED( "customProto", 1 ),
   YAML_UNSIGNED( "autoBindMode", 1 ),
   YAML_UNSIGNED( "lowPowerMode", 1 ),
   YAML_SIGNED( "optionValue", 8 ),
+  YAML_UNSIGNED( "receiverTelemetryOff", 1 ),
+  YAML_UNSIGNED( "receiverHigherChannels", 1 ),
+  YAML_UNSIGNED( "spare", 6 ),
   YAML_END
 };
 static const struct YamlNode struct_anonymous_7[] = {
@@ -557,13 +563,23 @@ static const struct YamlNode struct_anonymous_9[] = {
   YAML_ARRAY("receiverName", 64, 3, struct_string_64, NULL),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_10[] = {
+  YAML_UNSIGNED( "bindPower", 3 ),
+  YAML_UNSIGNED( "runPower", 3 ),
+  YAML_UNSIGNED( "emi", 1 ),
+  YAML_UNSIGNED( "telemetry", 1 ),
+  YAML_UNSIGNED( "failsafeTimeout", 16 ),
+  YAML_ARRAY("rx_freq", 8, 2, struct_unsigned_8, NULL),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
-  YAML_STRUCT("multi", 16, struct_anonymous_6, NULL),
+  YAML_STRUCT("multi", 24, struct_anonymous_6, NULL),
   YAML_STRUCT("pxx", 16, struct_anonymous_7, NULL),
   YAML_STRUCT("sbus", 16, struct_anonymous_8, NULL),
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
+  YAML_STRUCT("afhds3", 48, struct_anonymous_10, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -579,8 +595,7 @@ static const struct YamlNode struct_ModuleData[] = {
   YAML_END
 };
 static const struct YamlNode struct_TrainerModuleData[] = {
-  YAML_UNSIGNED( "mode", 3 ),
-  YAML_PADDING( 5 ),
+  YAML_UNSIGNED( "mode", 8 ),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED( "channelsCount", 8 ),
   YAML_SIGNED( "frameLength", 8 ),
@@ -611,61 +626,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_10_elmts[] = {
+static const struct YamlNode union_anonymous_11_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_12[] = {
+static const struct YamlNode struct_anonymous_13[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_11_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_12, NULL),
+static const struct YamlNode union_anonymous_12_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_13, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_UNSIGNED( "formula", 8 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_15[] = {
+static const struct YamlNode struct_anonymous_16[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_14, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_15, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_18, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_15, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_16, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_19, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_10_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_11_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_11_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_12_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_UNSIGNED( "type", 1 ),
@@ -678,20 +693,20 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_13_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_14_elmts, select_sensor_cfg),
   YAML_END
 };
-static const struct YamlNode struct_Widget__PersistentData[] = {
+static const struct YamlNode struct_WidgetPersistentData[] = {
   YAML_ARRAY("options", 96, 5, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 10),
-  YAML_STRUCT("widgetData", 480, struct_Widget__PersistentData, NULL),
+  YAML_STRUCT("widgetData", 480, struct_WidgetPersistentData, NULL),
   YAML_END
 };
-static const struct YamlNode struct_Layout__PersistentData[] = {
+static const struct YamlNode struct_LayoutPersistentData[] = {
   YAML_ARRAY("zones", 576, 10, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
@@ -699,10 +714,10 @@ static const struct YamlNode struct_Layout__PersistentData[] = {
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 10),
-  YAML_STRUCT("layoutData", 6720, struct_Layout__PersistentData, NULL),
+  YAML_STRUCT("layoutData", 6720, struct_LayoutPersistentData, NULL),
   YAML_END
 };
-static const struct YamlNode struct_Topbar__PersistentData[] = {
+static const struct YamlNode struct_TopBarPersistentData[] = {
   YAML_ARRAY("zones", 576, 4, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
@@ -737,7 +752,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),
   YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
-  YAML_PADDING( 6 ),
+  YAML_UNSIGNED( "spare1", 3 ),
+  YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_UNSIGNED( "potsWarnMode", 2 ),
   YAML_ARRAY("moduleData", 232, 2, struct_ModuleData, NULL),
   YAML_ARRAY("failsafeChannels", 16, 32, struct_signed_16, NULL),
@@ -748,7 +764,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("potsWarnPosition", 8, 9, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 2400, struct_Topbar__PersistentData, NULL),
+  YAML_STRUCT("topbarData", 2400, struct_TopBarPersistentData, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),
   YAML_END

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -304,7 +304,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "adjustRTC", 1 ),
   YAML_UNSIGNED( "inactivityTimer", 8 ),
   YAML_UNSIGNED( "telemetryBaudrate", 3 ),
-  YAML_UNSIGNED( "splashSpares", 3 ),
+  YAML_PADDING( 3 ),
   YAML_SIGNED( "hapticMode", 2 ),
   YAML_SIGNED( "switchesDelay", 8 ),
   YAML_UNSIGNED( "lightAutoOff", 8 ),
@@ -534,7 +534,7 @@ static const struct YamlNode struct_anonymous_6[] = {
   YAML_SIGNED( "optionValue", 8 ),
   YAML_UNSIGNED( "receiverTelemetryOff", 1 ),
   YAML_UNSIGNED( "receiverHigherChannels", 1 ),
-  YAML_UNSIGNED( "spare", 6 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_anonymous_7[] = {
@@ -752,7 +752,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),
   YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
-  YAML_UNSIGNED( "spare1", 3 ),
+  YAML_PADDING( 3 ),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_UNSIGNED( "potsWarnMode", 2 ),
   YAML_ARRAY("moduleData", 232, 2, struct_ModuleData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -747,7 +747,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("swashR", 64, struct_SwashRingData, NULL),
   YAML_ARRAY("flightModeData", 352, 9, struct_FlightModeData, fmd_is_active),
   YAML_UNSIGNED( "thrTraceSrc", 8 ),
-  YAML_UNSIGNED( "switchWarningState", 32 ),
+  YAML_UNSIGNED_CUST( "switchWarningState", 32, r_swtchWarn, w_swtchWarn ),
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED( "rssiSource", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -423,7 +423,7 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_IDX,
   YAML_UNSIGNED( "mode", 2 ),
   YAML_UNSIGNED( "scale", 14 ),
-  YAML_ENUM("srcRaw", 10, enum_MixSources),
+  YAML_UNSIGNED_CUST( "srcRaw", 10, r_mixSrcRaw, w_mixSrcRaw ),
   YAML_SIGNED( "carryTrim", 6 ),
   YAML_UNSIGNED( "chn", 5 ),
   YAML_SIGNED_CUST( "swtch", 9, r_swtchSrc, w_swtchSrc ),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -769,8 +769,13 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRING("modelRegistrationID", 8),
   YAML_END
 };
+static const struct YamlNode struct_PartialModel[] = {
+  YAML_STRUCT("header", 248, struct_ModelHeader, NULL),
+  YAML_ARRAY("timers", 128, 3, struct_TimerData, NULL),
+  YAML_END
+};
 
-#define MAX_RADIODATA_MODELDATA_STR_LEN 24
+#define MAX_RADIODATA_MODELDATA_PARTIALMODEL_STR_LEN 24
 
 static const struct YamlNode __RadioData_root_node = YAML_ROOT( struct_RadioData );
 
@@ -783,5 +788,11 @@ static const struct YamlNode __ModelData_root_node = YAML_ROOT( struct_ModelData
 const YamlNode* get_modeldata_nodes()
 {
    return &__ModelData_root_node;
+}
+static const struct YamlNode __PartialModel_root_node = YAML_ROOT( struct_PartialModel );
+
+const YamlNode* get_partialmodel_nodes()
+{
+   return &__PartialModel_root_node;
 }
 

--- a/radio/src/storage/yaml/yaml_modelslist.cpp
+++ b/radio/src/storage/yaml/yaml_modelslist.cpp
@@ -88,6 +88,12 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
     memcpy(mi->current_attr, buf, len);
     mi->current_attr[len] = '\0';
 
+    list<ModelsCategory *>& cats = mi->root->getCategories();
+    if (mi->level == modelslist_iter::Category) {
+        ModelsCategory* cat = new ModelsCategory(buf,len);
+        cats.push_back(cat);
+    }
+
     return true;
 }
 
@@ -96,10 +102,6 @@ static void set_attr(void* ctx, char* buf, uint8_t len)
     modelslist_iter* mi = (modelslist_iter*)ctx;
     list<ModelsCategory *>& cats = mi->root->getCategories();
     switch(mi->level) {
-    case modelslist_iter::Category: {
-        ModelsCategory* cat = new ModelsCategory(buf,len);
-        cats.push_back(cat);
-    } break;
 
     case modelslist_iter::Model:
         if (!strcmp(mi->current_attr,"filename")) {

--- a/radio/src/storage/yaml/yaml_parser.cpp
+++ b/radio/src/storage/yaml/yaml_parser.cpp
@@ -59,7 +59,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
         if(s_len < MAX_STR)                     \
             s[s_len++] = c;                     \
         else {                                  \
-            TRACE("STRING_OVERFLOW");           \
+            TRACE_YAML("STRING_OVERFLOW");      \
             return STRING_OVERFLOW;             \
         }                                       \
     }
@@ -88,7 +88,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 // go up as many levels as necessary
                 do {
                     if (!toParent()) {
-                        TRACE("STOP (no parent)!\n");
+                        TRACE_YAML("STOP (no parent)!\n");
                         return DONE_PARSING;
                     }
                 } while (indent < getLastIndent());
@@ -102,7 +102,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
             // go down one level
             else if (indent > getLastIndent()) {
                 if (!toChild()) {
-                    TRACE("STOP (stack full)!\n");
+                    TRACE_YAML("STOP (stack full)!\n");
                     return DONE_PARSING; // ERROR
                 }
             }
@@ -121,7 +121,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
             if (*c == ' ') {// assumes nothing else comes after spaces start
                 node_found = calls->find_node(ctx, scratch_buf, scratch_len);
                 if (!node_found) {
-                    TRACE("YAML_PARSER: Could not find node '%.*s' (1)\n",
+                    TRACE_YAML("YAML_PARSER: Could not find node '%.*s' (1)\n",
                           scratch_len, scratch_buf);
                 }
                 state = ps_AttrSP;
@@ -135,7 +135,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 if (state == ps_Attr) {
                     node_found = calls->find_node(ctx, scratch_buf, scratch_len);
                     if (!node_found) {
-                        TRACE("YAML_PARSER: Could not find node '%.*s' (2)\n",
+                        TRACE_YAML("YAML_PARSER: Could not find node '%.*s' (2)\n",
                               scratch_len, scratch_buf);
                     }
                 }
@@ -146,7 +146,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 if (state == ps_Attr) {
                     node_found = calls->find_node(ctx, scratch_buf, scratch_len);
                     if (!node_found) {
-                        TRACE("YAML_PARSER: Could not find node '%.*s' (3)\n",
+                        TRACE_YAML("YAML_PARSER: Could not find node '%.*s' (3)\n",
                               scratch_len, scratch_buf);
                     }
                 }
@@ -189,12 +189,12 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 break;
             }
             //TODO: more escapes needed???
-            TRACE("unknown escape char '%c'",*c);
+            TRACE_YAML("unknown escape char '%c'",*c);
             return DONE_PARSING;
 
         case ps_ValEsc2:
             if(scratch_len >= MAX_STR) {
-                TRACE("STRING_OVERFLOW");
+                TRACE_YAML("STRING_OVERFLOW");
                 return STRING_OVERFLOW;
             }
             else if (*c >= '0' && *c <= '9') {
@@ -207,7 +207,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 state = ps_ValEsc3;
                 break;
             }
-            TRACE("wrong hex digit '%c'",*c);
+            TRACE_YAML("wrong hex digit '%c'",*c);
             return DONE_PARSING;
 
         case ps_ValEsc3:
@@ -221,7 +221,7 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 state = ps_ValQuo;
                 break;
             }
-            TRACE("wrong hex digit '%c'",*c);
+            TRACE_YAML("wrong hex digit '%c'",*c);
             return DONE_PARSING;
             
         case ps_Val:

--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -338,7 +338,7 @@ bool YamlTreeWalker::isElmtEmpty(uint8_t* data)
 
         bit_ofs = getLevelOfs();
 
-        TRACE("<not empty>");
+        TRACE_YAML("<not empty>");
         return false;//node->u._array.u.select_member; //TODO!
             // // assume structs aligned on 8bit boundaries
             // && !node->_array.is_active(data + (bit_ofs >> 3));

--- a/radio/util/generate_yaml.py
+++ b/radio/util/generate_yaml.py
@@ -484,7 +484,7 @@ CLANG_LIB_LOCATIONS = [
     '/usr/local/Cellar/llvm/6.0.0/lib/libclang.dylib',
     '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib',
     '/Library/Developer/CommandLineTools/usr/lib/libclang.dylib',
-    '/usr/lib/x86_64-linux-gnu/libclang-3.8.so.1'
+    '/usr/lib/x86_64-linux-gnu/libclang-6.0.so.1'
 ]
 
 # set clang lib file

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -281,3 +281,12 @@ if [[ " COMPANION ALL " =~ \ ${FLAVOR}\  ]] ; then
   make -j"${CORES}" companion24 simulator24
   make -j"${CORES}" tests-companion
 fi
+
+if [[ " YAML ALL " =~ \ ${FLAVOR}\  ]] ; then
+  # OpenTX on TX16S boards
+  rm -rf ./* || true
+  cmake "${COMMON_OPTIONS}" -DPCB=X10 -DPCBREV=TX16S -DHELI=YES -DLUA=YES -DGVARS=YES -DYAML_STORAGE=ON "${SRCDIR}"
+  make -j"${CORES}" yaml_data
+  make -j"${CORES}" ${FIRMARE_TARGET}
+  make -j"${CORES}" tests-radio
+fi


### PR DESCRIPTION
This feature can be activated by adding `-DYAML_STORAGE=ON` to the `cmake` command line. Please beware that this has only be tested with `COLORLCD` targets, not with any of the B/W radios (X7, X9..., T12, etc).

<details>
<summary>As it seems, it is still working, and not that bad.</summary>

A very simple model file then looks like this:
<p>

```yaml
header: 
 - name: "AAAAAAA"
   bitmap: ""
telemetryProtocol: 0
thrTrim: 0
noGlobalFunctions: 0
displayTrims: 0
ignoreSensorIds: 0
trimInc: 0
disableThrottleWarning: 0
displayChecklist: 0
extendedLimits: 0
extendedTrims: 0
throttleReversed: 0
beepANACenter: 0
mixData: 
 - idx: 0
   weight: 100
   destCh: 0
   srcRaw: I0
   carryTrim: 0
   mixWarn: 0
   mltpx: 0
   offset: 0
   swtch: NONE
   flightModes: 0
   delayUp: 0
   delayDown: 0
   speedUp: 0
   speedDown: 0
   name: ""
 - idx: 1
   weight: 100
   destCh: 1
   srcRaw: I1
   carryTrim: 0
   mixWarn: 0
   mltpx: 0
   offset: 0
   swtch: NONE
   flightModes: 0
   delayUp: 0
   delayDown: 0
   speedUp: 0
   speedDown: 0
   name: ""
 - idx: 2
   weight: 100
   destCh: 2
   srcRaw: I2
   carryTrim: 0
   mixWarn: 0
   mltpx: 0
   offset: 0
   swtch: NONE
   flightModes: 0
   delayUp: 0
   delayDown: 0
   speedUp: 0
   speedDown: 0
   name: ""
 - idx: 3
   weight: 100
   destCh: 3
   srcRaw: I3
   carryTrim: 0
   mixWarn: 0
   mltpx: 0
   offset: 0
   swtch: NONE
   flightModes: 0
   delayUp: 0
   delayDown: 0
   speedUp: 0
   speedDown: 0
   name: ""
expoData: 
 - idx: 0
   mode: 3
   scale: 0
   srcRaw: Ail
   carryTrim: 0
   chn: 0
   swtch: NONE
   flightModes: 0
   weight: 100
   name: ""
   offset: 0
   curve: 
    - type: 1
      value: 0
 - idx: 1
   mode: 3
   scale: 0
   srcRaw: Ele
   carryTrim: 0
   chn: 1
   swtch: NONE
   flightModes: 0
   weight: 100
   name: ""
   offset: 0
   curve: 
    - type: 1
      value: 0
 - idx: 2
   mode: 3
   scale: 0
   srcRaw: Thr
   carryTrim: 0
   chn: 2
   swtch: NONE
   flightModes: 0
   weight: 100
   name: ""
   offset: 0
   curve: 
    - type: 1
      value: 0
 - idx: 3
   mode: 3
   scale: 0
   srcRaw: Rud
   carryTrim: 0
   chn: 3
   swtch: NONE
   flightModes: 0
   weight: 100
   name: ""
   offset: 0
   curve: 
    - type: 1
      value: 0
thrTraceSrc: 0
switchWarningState: 153391689
rssiSource: 0
spare1: 0
thrTrimSw: 0
potsWarnMode: 0
inputNames: 
 - idx: 0
   val: "Ail"
 - idx: 1
   val: "Ele"
 - idx: 2
   val: "Thr"
 - idx: 3
   val: "Rud"
potsWarnEnabled: 0
screenData: 
 - idx: 0
   LayoutId: "Layout2P1"
   layoutData: 
      zones: 
       - idx: 0
         widgetName: "ModelBmp"
       - idx: 1
         widgetName: "Timer"
      options: 
       - idx: 0
         type: Bool
         value: 
            boolValue: 1
       - idx: 1
         type: Bool
         value: 
            boolValue: 1
       - idx: 2
         type: Bool
         value: 
            boolValue: 1
       - idx: 3
         type: Bool
         value: 
            boolValue: 1
       - idx: 4
         type: Bool
         value: 
            boolValue: 0
 - idx: 1
   LayoutId: "Layout2x1"
   layoutData: 
      zones: 
       - idx: 0
         widgetName: "Outputs"
         widgetData: 
            options: 
             - idx: 0
               type: 
               value: 
                  unsignedValue: 65536
             - idx: 1
               type: 
               value: 
                  unsignedValue: 0
             - idx: 4
               type: Unsigned
               value: 
                  unsignedValue: 3048603648
       - idx: 1
         widgetName: "Timer"
      options: 
       - idx: 0
         type: Bool
         value: 
            boolValue: 1
       - idx: 1
         type: Bool
         value: 
            boolValue: 0
       - idx: 2
         type: Bool
         value: 
            boolValue: 0
       - idx: 3
         type: Bool
         value: 
            boolValue: 1
       - idx: 4
         type: Bool
         value: 
            boolValue: 0
 - idx: 2
   LayoutId: "Layout1x1"
   layoutData: 
      options: 
       - idx: 0
         type: Bool
         value: 
            boolValue: 1
       - idx: 1
         type: Bool
         value: 
            boolValue: 1
       - idx: 2
         type: Bool
         value: 
            boolValue: 1
       - idx: 3
         type: Bool
         value: 
            boolValue: 1
       - idx: 4
         type: Bool
         value: 
            boolValue: 0
 - idx: 3
   LayoutId: "Layout2P1"
   layoutData: 
      options: 
       - idx: 0
         type: Bool
         value: 
            boolValue: 1
       - idx: 1
         type: Bool
         value: 
            boolValue: 0
       - idx: 2
         type: Bool
         value: 
            boolValue: 1
       - idx: 3
         type: Bool
         value: 
            boolValue: 1
       - idx: 4
         type: Bool
         value: 
            boolValue: 0
view: 0
modelRegistrationID: ""
```
</p>
</details>


TODO:
- [ ] rebase against `2.4` once #8442 has been merged.
- [ ] add YAML related unit tests (load / save + verifying data)