### PR TITLE
Update ModuleSyncStatus::update signature with proper type

### DIFF
--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -398,7 +398,7 @@ ModuleSyncStatus::ModuleSyncStatus()
   memset(this, 0, sizeof(ModuleSyncStatus));
 }
 
-void ModuleSyncStatus::update(uint16_t newRefreshRate, uint16_t newInputLag)
+void ModuleSyncStatus::update(uint16_t newRefreshRate, int16_t newInputLag)
 {
   if (!newRefreshRate)
     return;
@@ -449,13 +449,12 @@ void ModuleSyncStatus::getRefreshString(char * statusText)
   char * tmp = statusText;
 #if defined(DEBUG)
   *tmp++ = 'L';
-  tmp = strAppendUnsigned(tmp, inputLag, 5);
-  tmp = strAppend(tmp, "us R ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (refreshRate / 1000), 5);
-  tmp = strAppend(tmp, "us");
+  tmp = strAppendSigned(tmp, inputLag, 5);
+  tmp = strAppend(tmp, "R");
+  tmp = strAppendUnsigned(tmp, refreshRate, 5);
 #else
-  tmp = strAppend(tmp, "Sync at ");
-  tmp = strAppendUnsigned(tmp, (uint32_t) (refreshRate / 1000000));
-  tmp = strAppend(tmp, " ms");
+  tmp = strAppend(tmp, "Sync ");
+  tmp = strAppendUnsigned(tmp, refreshRate);
 #endif
+  tmp = strAppend(tmp, "us");
 }

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -306,7 +306,7 @@ struct ModuleSyncStatus
   }
 
   // Set feedback from RF module
-  void update(uint16_t newRefreshRate, uint16_t newInputLag);
+  void update(uint16_t newRefreshRate, int16_t newInputLag);
 
   // Get computed settings for scheduler
   uint16_t getAdjustedRefreshRate();


### PR DESCRIPTION
The function prototype for `ModuleSyncStatus::update()` takes the newInputLag parameter as unsigned, when all Multiprotocol, CRSF, and Ghost pass a signed value. The [member variable](https://github.com/opentx/opentx/blob/2.3/radio/src/telemetry/telemetry.h#L298) update() puts this value in is also signed, as it should be because the offset can be negative.

This is pedantic cleanup because I not believe it is causing any issues. I've not seen any sync delayed by (uint16_t)(-1) us if our value goes negative (I work on ExpressLRS). I do think it is important enough to match the signedness through the entire call chain though.

It also updates getRefreshString to use the proper signed types, and display correctly scaled values, since the refreshRate is in us and the existing code appears to think it is in ns?