### PR TITLE
Stop Companion crash when conversion switch index out of range

### DIFF
--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -191,7 +191,10 @@ RawSwitch RawSwitch::convert(RadioDataConversionState & cstate)
     QStringList fromSwitchList(getSwitchList(cstate.fromBoard));
     QStringList toSwitchList(getSwitchList(cstate.toBoard));
     // set to -1 if no match found
-    newIdx = toSwitchList.indexOf(fromSwitchList.at(swtch.quot));
+    if (swtch.quot < fromSwitchList.count())
+      newIdx = toSwitchList.indexOf(fromSwitchList.at(swtch.quot));
+    else
+      newIdx = -1;
     // perform forced mapping
     if (newIdx < 0) {
       if (IS_TARANIS_X7(cstate.toType) && (IS_TARANIS_X9(cstate.fromType) || IS_FAMILY_HORUS_OR_T16(cstate.fromType))) {


### PR DESCRIPTION
Fixes #8466 
Fixes #8403
Conversion unable to identifying the correct sub board type from FourCC that have differing hardware capabilities. eg X9D+ 2019 has one more switch than other X9D boards.
