### PR TITLE
Move adcRead() to mixer scheduler IRQ to reduce sample jitter

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1101,10 +1101,6 @@ void getADC()
   }
 #endif
 
-  DEBUG_TIMER_START(debugTimerAdcRead);
-  adcRead();
-  DEBUG_TIMER_STOP(debugTimerAdcRead);
-
   for (uint8_t x=0; x<NUM_ANALOGS; x++) {
     uint16_t v;
 

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -74,6 +74,11 @@ extern "C" void MIXER_SCHEDULER_TIMER_IRQHandler(void)
   // set next period
   MIXER_SCHEDULER_TIMER->ARR = 2 * getMixerSchedulerPeriod() - 1;
 
+  //read ADCs 
+  DEBUG_TIMER_START(debugTimerAdcRead);
+  adcRead();
+  DEBUG_TIMER_STOP(debugTimerAdcRead);
+
   // trigger mixer start
   mixerSchedulerISRTrigger();
 }


### PR DESCRIPTION
Currently the callback stack for reading the ADCs looks like this. doMixerCalculations() -> getADC() -> adcRead(). 

The function doMixerCalculations() triggered by releasing a mixerMutex lock. While the lock itself is released precisely by the hardware timer IRQ there is a variable jitter in when the adcRead() task gets around to actually sampling the sticks depending on what the RTOS is doing. 

The adcRead() can be moved into the mixer scheduler IRQ ensuring that the samples take more precisely and stored to the global array, afterwards the variable jitter in when the doMixerCalculations() actually runs is not relevant as long as the data is processed within the frame window. 

Minimising sampling jitter is very important for Betaflight and particularly high refresh rate links, some initial testing on the bench has shown that this can significantly the smoothness of feedforward traces. 

![image](https://user-images.githubusercontent.com/22009829/116787831-c5595500-aae9-11eb-9f58-b1b3f8587f73.png)

(left old, right new)
