### PR TITLE
Introduce YAML to Companion 2.4

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -59,7 +59,8 @@
 #define DFU_FILES_FILTER               "DFU " % CPN_STR_FILES % " (*.dfu);;"
 #define EEPE_FILES_FILTER              "EEPE " % CPN_STR_FILES % " (*.eepe);;"
 #define OTX_FILES_FILTER               "OpenTX " % CPN_STR_FILES % " (*.otx);;"
-#define EEPROM_FILES_FILTER            CPN_STR_RAD_MOD_SETTINGS % " " % CPN_STR_FILES % " (*.otx *.eepe *.bin *.hex);;" % OTX_FILES_FILTER % EEPE_FILES_FILTER % BIN_FILES_FILTER % HEX_FILES_FILTER
+#define YML_FILES_FILTER               "YAML " % CPN_STR_FILES % " (*.yml);;"
+#define EEPROM_FILES_FILTER            CPN_STR_RAD_MOD_SETTINGS % " " % CPN_STR_FILES % " (*.otx *.yml *.eepe *.bin *.hex);;" % OTX_FILES_FILTER % YML_FILES_FILTER % EEPE_FILES_FILTER % BIN_FILES_FILTER % HEX_FILES_FILTER
 #define FLASH_FILES_FILTER             "FLASH " % CPN_STR_FILES % " (*.bin *.hex *.dfu);;" % BIN_FILES_FILTER % HEX_FILES_FILTER % DFU_FILES_FILTER
 #define EXTERNAL_EEPROM_FILES_FILTER   "EEPROM " % CPN_STR_FILES % " (*.bin *.hex);;" % BIN_FILES_FILTER % HEX_FILES_FILTER
 #define ER9X_EEPROM_FILE_TYPE          "ER9X_EEPROM_FILE"

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -18,8 +18,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _BOARDS_H_
-#define _BOARDS_H_
+#pragma once
 
 #include <QtCore>
 #include <QObject>
@@ -362,4 +361,7 @@ inline bool IS_ACCESS_RADIO(Board::Type board, const QString & id)
           (IS_FAMILY_HORUS_OR_T16(board) && id.contains("internalaccess")));
 }
 
-#endif // _BOARDS_H_
+inline bool HAS_EEPROM_YAML(Board::Type board)
+{
+  return IS_FAMILY_HORUS_OR_T16(board);
+}

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1375,10 +1375,10 @@ bool MdiChild::saveAs(bool isNew)
 #ifdef __APPLE__
   QString filter;
 #else
-  QString filter(OTX_FILES_FILTER);
+  QString filter(OTX_FILES_FILTER % YML_FILES_FILTER);
 #endif
 
-  QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), g.eepromDir() + "/" +fi.fileName(), filter);
+  QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), g.eepromDir() + "/" + fi.fileName(), filter);
   if (fileName.isEmpty())
     return false;
   g.eepromDir( QFileInfo(fileName).dir().absolutePath() );

--- a/companion/src/storage/CMakeLists.txt
+++ b/companion/src/storage/CMakeLists.txt
@@ -13,6 +13,7 @@ set(storage_NAMES
   categorized
   sdcard
   otx
+  yaml
 )
 
 set(storage_SRCS

--- a/companion/src/storage/storage.cpp
+++ b/companion/src/storage/storage.cpp
@@ -22,6 +22,7 @@
 #include "eepe.h"
 #include "otx.h"
 #include "sdcard.h"
+#include "yaml.h"
 #include "firmwareinterface.h"
 #include "eeprominterface.h"
 #include <QFileInfo>
@@ -41,6 +42,8 @@ StorageType getStorageType(const QString & filename)
     return STORAGE_TYPE_XML;
   else if (suffix == "OTX")
     return STORAGE_TYPE_OTX;
+  else if (suffix == "YML")
+    return STORAGE_TYPE_YML;
   else
     return STORAGE_TYPE_UNKNOWN;
 }
@@ -61,6 +64,7 @@ void registerStorageFactories()
   registerStorageFactory(new DefaultStorageFactory<EepeFormat>("eepe"));
   registerStorageFactory(new DefaultStorageFactory<HexEepromFormat>("hex"));
   registerStorageFactory(new DefaultStorageFactory<OtxFormat>("otx"));
+  registerStorageFactory(new DefaultStorageFactory<YamlFormat>("yml"));
   registerStorageFactory(new SdcardStorageFactory());
 }
 

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -36,7 +36,8 @@ enum StorageType
   STORAGE_TYPE_EEPM,
   STORAGE_TYPE_XML,
   STORAGE_TYPE_SDCARD,
-  STORAGE_TYPE_OTX
+  STORAGE_TYPE_OTX,
+  STORAGE_TYPE_YML
 };
 
 StorageType getStorageType(const QString & filename);

--- a/companion/src/storage/yaml.cpp
+++ b/companion/src/storage/yaml.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "yaml.h"
+#include "../../../radio/src/storage/yaml/yaml_tree_walker.h" // just to confirm valid compiler path
+
+#include <QFile>
+#include <QDir>
+
+bool YamlFormat::loadFile(QByteArray & filedata, const QString & filename)
+{
+  QString path = this->filename + "/" + filename;
+  QFile file(path);
+  if (!file.open(QFile::ReadOnly)) {
+    setError(tr("Error opening file %1:\n%2.").arg(path).arg(file.errorString()));
+    return false;
+  }
+  filedata = file.readAll();
+  qDebug() << "File" << path << "read, size:" << filedata.size();
+  file.close();
+  return true;
+}
+
+bool YamlFormat::writeFile(const QByteArray & filedata, const QString & filename)
+{
+  QString path = this->filename + "/" + filename;
+  QFile file(path);
+  if (!file.open(QFile::WriteOnly)) {
+    setError(tr("Error opening file %1 in write mode:\n%2.").arg(path).arg(file.errorString()));
+    return false;
+  }
+  file.write(filedata.data(), filedata.size());
+  file.close();
+  qDebug() << "File" << path << "written, size:" << filedata.size();
+  return true;
+}
+
+bool YamlFormat::load(RadioData & radioData)
+{
+  QByteArray radioSettingsBuffer;
+  if (!loadFile(radioSettingsBuffer, "RADIO/radio.yml")) {
+    setError(tr("Can't extract RADIO/radio.yml"));
+    return false;
+  }
+
+  qDebug() << "Warning: format ignored - under development";
+  return false; // force failure until fully developed
+}
+
+bool YamlFormat::write(const RadioData & radioData)
+{
+  /*  Need this test in case of a new sdcard
+  Board::Type board = getCurrentBoard();
+  if (!HAS_EEPROM_YAML(board)) {
+    qDebug() << "Board does not support YAML format";
+    return false;
+  }
+
+  // ensure directories exist on sd card
+  QDir dir(filename);
+  dir.mkdir("RADIO");
+  dir.mkdir("MODELS");
+  */
+
+  qDebug() << "Warning: format ignored - under development";
+  return false; // force failure until fully developed
+}

--- a/companion/src/storage/yaml.h
+++ b/companion/src/storage/yaml.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "storage.h"
+
+#include <QtCore>
+
+class YamlFormat : public StorageFormat
+{
+  Q_DECLARE_TR_FUNCTIONS(YamlFormat)
+
+  public:
+    YamlFormat(const QString & filename):
+      StorageFormat(filename)
+    {
+    }
+
+    virtual QString name() { return "yml"; }
+    virtual bool load(RadioData & radioData);
+    virtual bool write(const RadioData & radioData);
+
+  protected:
+    bool loadFile(QByteArray & fileData, const QString & fileName);
+    bool writeFile(const QByteArray & fileData, const QString & fileName);
+};


### PR DESCRIPTION
Add a YAML format stub to Companion.
The YAML format needs to be able to read and write to the radio sd card plus import and export computer yml files. These computer files could be incomplete eg just a single model without general settings.
May need to develop a new interface class that is radio agnostic for constructing and reading the byte arrays. At the same time the interface needs to know the source and destination radio firmware type and version for conversions and upgrades.
Probably best to wait until the radio side is developed as some of these challenges are common.
Also Companion manipulates its generic data structures and byte array data with after import and before export functions.