### PR TITLE
Do not use DMA on x12s for multi firmware update

### DIFF
--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -118,7 +118,11 @@ class MultiExternalUpdateDriver: public MultiFirmwareUpdateDriver
       if (inverted)
         telemetryPortInvertedInit(57600);
       else
+#if defined(PCBX12S)
+        telemetryPortInit(57600, TELEMETRY_SERIAL_WITHOUT_DMA);
+#else
         telemetryPortInit(57600, TELEMETRY_SERIAL_DEFAULT);
+#endif
     }
 
     bool getByte(uint8_t & byte) const override
@@ -164,7 +168,11 @@ class MultiExtSportUpdateDriver: public MultiFirmwareUpdateDriver
 
     void init(bool inverted) const override
     {
+#if defined(PCBX12S)
+      telemetryPortInit(57600, TELEMETRY_SERIAL_WITHOUT_DMA);
+#else
       telemetryPortInit(57600, TELEMETRY_SERIAL_DEFAULT);
+#endif
     }
 
     bool getByte(uint8_t & byte) const override


### PR DESCRIPTION
Fixes #8477 (and possibly #7221)

Not enabling DMA seems to allow the x12s to flash the external module correctly.

Verified with R9M ACCST, flashed with ExpressLRS.

I patched both classes (MultiExternalUpdateDriver and MultiExtSportUpdateDriver) as the issue happens with ELRS and MPM, but I haven't verified flashing MPM as I do not have such module.