### PR TITLE
Fix model navigation for rotary enc radios

### DIFF
--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -244,7 +244,7 @@ void menuModelSelect(event_t event)
 #endif
 #endif
 
-#if defined(ROTARY_ENCODER) && defined(NAVIGATION_X7)
+#if defined(ROTARY_ENCODER_NAVIGATION) && defined(NAVIGATION_X7)
     case EVT_ROTARY_LEFT:
     case EVT_ROTARY_RIGHT:
 #endif


### PR DESCRIPTION
This fixes #8488 