### PR TITLE
new LUA function getAvailableMemory

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1535,6 +1535,7 @@ static int luaGetUsage(lua_State * L)
   lua_pushinteger(L, instructionsPercent);
   return 1;
 }
+
 /*luadoc
 @function getAvailableMemory()
 
@@ -1549,6 +1550,7 @@ static int luaGetAvailableMemory(lua_State * L)
   lua_pushunsigned(L, availableMemory());
   return 1;
 }
+
 /*luadoc
 @function resetGlobalTimer([type])
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1535,7 +1535,20 @@ static int luaGetUsage(lua_State * L)
   lua_pushinteger(L, instructionsPercent);
   return 1;
 }
+/*luadoc
+@function getMemory()
 
+Get available memory remaining in the Heap for Lua.
+
+@retval usage (number) a value returned in b
+
+@status current Introduced in 2.4
+*/
+static int luaGetMemory(lua_State * L)
+{
+  lua_pushinteger(L, availableMemory());
+  return 1;
+}
 /*luadoc
 @function resetGlobalTimer([type])
 
@@ -1763,6 +1776,7 @@ const luaL_Reg opentxLib[] = {
   { "chdir", luaChdir },
   { "loadScript", luaLoadScript },
   { "getUsage", luaGetUsage },
+  { "getMemory", luaGetMemory },
   { "resetGlobalTimer", luaResetGlobalTimer },
 #if LCD_DEPTH > 1 && !defined(COLORLCD)
   { "GREY", luaGrey },

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1546,7 +1546,7 @@ Get available memory remaining in the Heap for Lua.
 */
 static int luaGetMemory(lua_State * L)
 {
-  lua_pushinteger(L, availableMemory());
+  lua_pushunsigned(L, availableMemory());
   return 1;
 }
 /*luadoc

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1536,7 +1536,7 @@ static int luaGetUsage(lua_State * L)
   return 1;
 }
 /*luadoc
-@function getMemory()
+@function getAvailableMemory()
 
 Get available memory remaining in the Heap for Lua.
 
@@ -1544,7 +1544,7 @@ Get available memory remaining in the Heap for Lua.
 
 @status current Introduced in 2.4
 */
-static int luaGetMemory(lua_State * L)
+static int luaGetAvailableMemory()(lua_State * L)
 {
   lua_pushunsigned(L, availableMemory());
   return 1;
@@ -1776,7 +1776,7 @@ const luaL_Reg opentxLib[] = {
   { "chdir", luaChdir },
   { "loadScript", luaLoadScript },
   { "getUsage", luaGetUsage },
-  { "getMemory", luaGetMemory },
+  { "getAvailableMemory", luaGetAvailableMemory },
   { "resetGlobalTimer", luaResetGlobalTimer },
 #if LCD_DEPTH > 1 && !defined(COLORLCD)
   { "GREY", luaGrey },

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1544,7 +1544,7 @@ Get available memory remaining in the Heap for Lua.
 
 @status current Introduced in 2.4
 */
-static int luaGetAvailableMemory()(lua_State * L)
+static int luaGetAvailableMemory(lua_State * L)
 {
   lua_pushunsigned(L, availableMemory());
   return 1;


### PR DESCRIPTION
added LUA function to get radio available memory remaining for display in telemetry/widgets scripts or for LUA staging to save memory