### PR TITLE
new Lua function getAvailableMemory

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1533,6 +1533,19 @@ static int luaGetUsage(lua_State * L)
 }
 
 /*luadoc
+@function getAvailableMemory()
+
+Get available memory remaining in the Heap for Lua.
+
+@retval usage (number) a value returned in b
+*/
+static int luaGetAvailableMemory(lua_State * L)
+{
+  lua_pushunsigned(L, availableMemory());
+  return 1;
+}
+
+/*luadoc
 @function resetGlobalTimer([type])
 
  Resets the radio global timer to 0.
@@ -1759,6 +1772,7 @@ const luaL_Reg opentxLib[] = {
   { "chdir", luaChdir },
   { "loadScript", luaLoadScript },
   { "getUsage", luaGetUsage },
+  { "getAvailableMemory", luaGetAvailableMemory },
   { "resetGlobalTimer", luaResetGlobalTimer },
 #if LCD_DEPTH > 1 && !defined(COLORLCD)
   { "GREY", luaGrey },


### PR DESCRIPTION
Hookup for LUA to the same function call by OTX that shows the bytes remaining on the debug statistics page, that way, any LUA scripts created by users can take into account mem remaining on the radio (heap) to prevent itself from being killed (by staging scripts i.e unload and loadscript) or for debugging without needed to exit the telemetry page (If running custom Telemetry Screen).

Rebased from #8494 df79cc5