### PR TITLE
Add drawHudRectangle() function to lua lcd

### DIFF
--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -586,9 +586,9 @@ void lcdDrawHudRectangle(float pitch, float roll, coord_t xmin, coord_t xmax, co
     if (roll > 0.0f) {
       for (int32_t s = 0; s < ywidth; s++) {
         int32_t yy = ymin + s;
-        int32_t xx = ox + ((float)yy - oy) / angle; // + 0.5f; rounding not needed
+        int32_t xx = ox + ((float)yy - oy) / angle;
         if (xx >= xmin && xx <= xmax) {
-       	  lcd->drawSolidHorizontalLine(xx, yy, xmax - xx + 1, flags);
+       	  lcdDrawSolidHorizontalLine(xx, yy, xmax - xx + 1, flags);
         }
         else if (xx < xmin) {
           ybot = (inverted) ? max(yy, ybot) + 1 : min(yy, ybot);
@@ -599,9 +599,9 @@ void lcdDrawHudRectangle(float pitch, float roll, coord_t xmin, coord_t xmax, co
     else {
       for (int32_t s = 0; s < ywidth; s++) {
         int32_t yy = ymin + s;
-        int32_t xx = ox + ((float)yy - oy) / angle; // + 0.5f; rounding not needed
+        int32_t xx = ox + ((float)yy - oy) / angle;
         if (xx >= xmin && xx <= xmax) {
-          lcd->drawSolidHorizontalLine(xmin, yy, xx - xmin, flags);
+          lcdDrawSolidHorizontalLine(xmin, yy, xx - xmin, flags);
         }
         else if (xx > xmax) {
           ybot = (inverted) ? max(yy, ybot) + 1 : min(yy, ybot);

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -558,3 +558,63 @@ void DMABitmapConvert(uint16_t * dest, const uint8_t * src, uint16_t w, uint16_t
   }
 }
 #endif
+
+void lcdDrawHudRectangle(float pitch, float roll, coord_t xmin, coord_t xmax, coord_t ymin, coord_t ymax, LcdFlags flags)
+{
+  constexpr float GRADTORAD = 0.017453293f;
+
+  float dx = sinf(GRADTORAD*roll) * pitch;
+  float dy = cosf(GRADTORAD*roll) * pitch * 1.85f;
+  float angle = tanf(-GRADTORAD*roll);
+  float ox = 0.5f * (xmin + xmax) + dx;
+  float oy = 0.5f * (ymin + ymax) + dy;
+  int32_t ywidth = (ymax - ymin);
+
+  if (roll == 0.0f) { // prevent divide by zero
+	lcdDrawFilledRect(
+      xmin, max(ymin, ymin + (coord_t)(ywidth/2 + (int32_t)dy)),
+      xmax - xmin, min(ywidth, ywidth/2 - (int32_t)dy + (dy != 0.0f ? 1 : 0)), SOLID, flags);
+  }
+  else if (fabs(roll) >= 180.0f) {
+    lcdDrawFilledRect(xmin, ymin, xmax - xmin, min(ywidth, ywidth/2 + (int32_t)fabsf(dy)), SOLID, flags);
+  }
+  else {
+    bool inverted = (fabsf(roll) > 90.0f);
+    bool fillNeeded = false;
+    int32_t ybot = (inverted) ? 0 : LCD_H;
+
+    if (roll > 0.0f) {
+      for (int32_t s = 0; s < ywidth; s++) {
+        int32_t yy = ymin + s;
+        int32_t xx = ox + ((float)yy - oy) / angle; // + 0.5f; rounding not needed
+        if (xx >= xmin && xx <= xmax) {
+       	  lcd->drawSolidHorizontalLine(xx, yy, xmax - xx + 1, flags);
+        }
+        else if (xx < xmin) {
+          ybot = (inverted) ? max(yy, ybot) + 1 : min(yy, ybot);
+          fillNeeded = true;
+        }
+      }
+    }
+    else {
+      for (int32_t s = 0; s < ywidth; s++) {
+        int32_t yy = ymin + s;
+        int32_t xx = ox + ((float)yy - oy) / angle; // + 0.5f; rounding not needed
+        if (xx >= xmin && xx <= xmax) {
+          lcd->drawSolidHorizontalLine(xmin, yy, xx - xmin, flags);
+        }
+        else if (xx > xmax) {
+          ybot = (inverted) ? max(yy, ybot) + 1 : min(yy, ybot);
+          fillNeeded = true;
+        }
+      }
+    }
+
+    if (fillNeeded) {
+      int32_t ytop = (inverted) ? ymin : ybot;
+      int32_t height = (inverted) ? ybot - ymin : ymax - ybot;
+      lcdDrawFilledRect(xmin, ytop, xmax - xmin, height, SOLID, flags);
+    }
+  }
+}
+

--- a/radio/src/gui/480x272/lcd.h
+++ b/radio/src/gui/480x272/lcd.h
@@ -261,4 +261,6 @@ inline void lcdDrawBitmapPattern(coord_t x, coord_t y, const uint8_t * img, LcdF
   #define SLOW_BLINK_ON_PHASE          (g_blinkTmr10ms & (1<<7))
 #endif
 
+void lcdDrawHudRectangle(float pitch, float roll, coord_t xmin, coord_t xmax, coord_t ymin, coord_t ymax, LcdFlags flags=0);
+
 #endif // _LCD_H_

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -911,7 +911,6 @@ static int luaRGB(lua_State *L)
   lua_pushinteger(L, RGB(r, g, b));
   return 1;
 }
-#endif
 
 /*luadoc
 @function lcd.drawHudRectangleLine(pitch, roll, xmin, xmax, ymin, ymax, flags)
@@ -941,6 +940,7 @@ static int luaLcdDrawHudRectangle(lua_State *L)
   lcdDrawHudRectangle(pitch, roll, xmin, xmax, ymin, ymax, flags);
   return 0;
 }
+#endif
 
 const luaL_Reg lcdLib[] = {
   { "refresh", luaLcdRefresh },
@@ -962,6 +962,7 @@ const luaL_Reg lcdLib[] = {
   { "setColor", luaLcdSetColor },
   { "getColor", luaLcdGetColor },
   { "RGB", luaRGB },
+  { "drawHudRectangle", luaLcdDrawHudRectangle },
 #else
   { "getLastPos", luaLcdGetLastPos },
   { "getLastRightPos", luaLcdGetLastPos },
@@ -970,6 +971,5 @@ const luaL_Reg lcdLib[] = {
   { "drawScreenTitle", luaLcdDrawScreenTitle },
   { "drawCombobox", luaLcdDrawCombobox },
 #endif
-  { "drawHudRectangle", luaLcdDrawHudRectangle },
   { NULL, NULL }  /* sentinel */
 };

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -911,6 +911,7 @@ static int luaRGB(lua_State *L)
   lua_pushinteger(L, RGB(r, g, b));
   return 1;
 }
+#endif
 
 /*luadoc
 @function lcd.drawHudRectangleLine(pitch, roll, xmin, xmax, ymin, ymax, flags)
@@ -940,7 +941,6 @@ static int luaLcdDrawHudRectangle(lua_State *L)
   lcdDrawHudRectangle(pitch, roll, xmin, xmax, ymin, ymax, flags);
   return 0;
 }
-#endif
 
 const luaL_Reg lcdLib[] = {
   { "refresh", luaLcdRefresh },
@@ -962,7 +962,6 @@ const luaL_Reg lcdLib[] = {
   { "setColor", luaLcdSetColor },
   { "getColor", luaLcdGetColor },
   { "RGB", luaRGB },
-  { "drawHudRectangle", luaLcdDrawHudRectangle },
 #else
   { "getLastPos", luaLcdGetLastPos },
   { "getLastRightPos", luaLcdGetLastPos },
@@ -971,5 +970,6 @@ const luaL_Reg lcdLib[] = {
   { "drawScreenTitle", luaLcdDrawScreenTitle },
   { "drawCombobox", luaLcdDrawCombobox },
 #endif
+  { "drawHudRectangle", luaLcdDrawHudRectangle },
   { NULL, NULL }  /* sentinel */
 };

--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -913,6 +913,35 @@ static int luaRGB(lua_State *L)
 }
 #endif
 
+/*luadoc
+@function lcd.drawHudRectangleLine(pitch, roll, xmin, xmax, ymin, ymax, flags)
+
+Draw a HUD
+
+@param pitch,roll (real numbers) pitch and roll angles in degrees
+
+@param xmin,xmax,ymin,ymax (positive numbers) drawing rectangle
+
+@param flags lcdflags
+
+@notice The flags specify the color of the earth. The sky is not drawn and should be created by drawing an appropriately sized rectangle with the sky's color before the HUD is drawn.
+
+@status current Introduced in 2.3.12
+*/
+static int luaLcdDrawHudRectangle(lua_State *L)
+{
+  if (!luaLcdAllowed) return 0;
+  float pitch = luaL_checknumber(L, 1);
+  float roll = luaL_checknumber(L, 2);
+  coord_t xmin = luaL_checkunsigned(L, 3);
+  coord_t xmax = luaL_checkunsigned(L, 4);
+  coord_t ymin = luaL_checkunsigned(L, 5);
+  coord_t ymax = luaL_checkunsigned(L, 6);
+  LcdFlags flags = luaL_checkunsigned(L, 7);
+  lcdDrawHudRectangle(pitch, roll, xmin, xmax, ymin, ymax, flags);
+  return 0;
+}
+
 const luaL_Reg lcdLib[] = {
   { "refresh", luaLcdRefresh },
   { "clear", luaLcdClear },
@@ -941,5 +970,6 @@ const luaL_Reg lcdLib[] = {
   { "drawScreenTitle", luaLcdDrawScreenTitle },
   { "drawCombobox", luaLcdDrawCombobox },
 #endif
+  { "drawHudRectangle", luaLcdDrawHudRectangle },
   { NULL, NULL }  /* sentinel */
 };


### PR DESCRIPTION
I just have seen @3djc 's post at rcgroups that 2.3.12 is getting close. Maybe somewhat late but I'd like with this PR suggest to add to 2.3.12 a HUD drawing function to lua scripts.

I'm using this since, well, I guess, a year or so, and found it to work well. I've added it to my branch since it massively speeds up lua scripts which draw a HUD compared to doing it in lua. I've observed values between 1.5 and 2 of speed up. It recently was also PR-ed to edgetx and found to speed up yappu in a similar range. 

The function should be more generally useful, since scripts with a HUD are among the most widely used scripts (yappu and alike).

Comment: For said purpose it would be also very useful to have line drawing function which clips to a user-specified rectangle. I can provide such a function quickly using CohenSutherland clipping. This might be however not what you want, hence I've not included it here but kind of ask if I should also PR this.