### PR TITLE
dfu-util 0.10 compatibility

### DIFF
--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -50,7 +50,7 @@ QStringList getDfuArgs(const QString & cmd, const QString & filename)
   if (cmd == "-U")
     args.last().append(":" % QString::number(Boards::getFlashSize(getCurrentBoard())));
   args << "--device" << "0483:df11";
-  args << "" << cmd % filename;
+  args << cmd % filename;
   return args;
 }
 


### PR DESCRIPTION
Fixes #8200 by removing an empty element that generated extra whitespace in the actual command invocation, considered illegal by dfu-util v0.10.

I tried to trace back the addition of the incriminated empty string but the blames stop [here](https://github.com/nmaggioni/opentx/blame/e1b7848a91df7b9c854d68d44c9f8754c40bab6e/companion/src/radiointerface.cpp#L74), giving no evident reason as to why that change was needed. Perhaps an older implicit type conversion issue?

Tested by flashing an Horus X10S with a fresh build of the companion.