### PR TITLE
Radio Setup: bug: sound mode & haptic mode not indented, TR_ should be STR_

### DIFF
--- a/radio/src/gui/480x272/radio_setup.cpp
+++ b/radio/src/gui/480x272/radio_setup.cpp
@@ -250,7 +250,7 @@ bool menuRadioSetup(event_t event)
         break;
 
       case ITEM_SETUP_BEEP_MODE:
-        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_SPEAKER);
+        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH, y, STR_SPEAKER);
         g_eeGeneral.beepMode = editChoice(RADIO_SETUP_2ND_COLUMN, y, STR_VBEEPMODE, g_eeGeneral.beepMode, -2, 1, attr, event);
         break;
 
@@ -280,7 +280,7 @@ bool menuRadioSetup(event_t event)
         break;
 
       case ITEM_SETUP_SPEAKER_PITCH:
-        lcdDrawText(MENUS_MARGIN_LEFT,  y, STR_SPKRPITCH);
+        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_SPKRPITCH);
         lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.speakerPitch*15, attr|LEFT, 0, "+", "Hz");
         if (attr) {
           CHECK_INCDEC_GENVAR(event, g_eeGeneral.speakerPitch, 0, 20);
@@ -292,7 +292,7 @@ bool menuRadioSetup(event_t event)
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_VARIO);
         break;
       case ITEM_SETUP_VARIO_VOLUME:
-        lcdDrawText(MENUS_MARGIN_LEFT, y, TR_SPEAKER_VOLUME);
+        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_SPEAKER_VOLUME);
         g_eeGeneral.varioVolume = editSlider(RADIO_SETUP_2ND_COLUMN, y, event, g_eeGeneral.varioVolume, -2, +2, attr);
         break;
       case ITEM_SETUP_VARIO_PITCH:
@@ -318,7 +318,7 @@ bool menuRadioSetup(event_t event)
         break;
 
       case ITEM_SETUP_HAPTIC_MODE:
-        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_MODE);
+        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH, y, STR_MODE);
         g_eeGeneral.hapticMode = editChoice(RADIO_SETUP_2ND_COLUMN, y, STR_VBEEPMODE, g_eeGeneral.hapticMode, -2, 1, attr, event);
         break;
 
@@ -371,7 +371,7 @@ bool menuRadioSetup(event_t event)
       }
 
       case ITEM_SETUP_INACTIVITY_ALARM:
-        lcdDrawText(MENUS_MARGIN_LEFT,  y,STR_INACTIVITYALARM);
+        lcdDrawText(MENUS_MARGIN_LEFT, y, STR_INACTIVITYALARM);
         lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.inactivityTimer, attr|LEFT, 0, NULL, "m");
         if (attr) g_eeGeneral.inactivityTimer = checkIncDec(event, g_eeGeneral.inactivityTimer, 0, 250, EE_GENERAL); //0..250minutes
         break;
@@ -381,7 +381,7 @@ bool menuRadioSetup(event_t event)
         break;
 
       case ITEM_SETUP_BACKLIGHT_MODE:
-        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH , y, STR_MODE);
+        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH, y, STR_MODE);
         g_eeGeneral.backlightMode = editChoice(RADIO_SETUP_2ND_COLUMN, y, STR_VBLMODE, g_eeGeneral.backlightMode, e_backlight_mode_off, e_backlight_mode_on, attr, event);
         break;
 
@@ -414,7 +414,7 @@ bool menuRadioSetup(event_t event)
 
 #if defined(KEYS_BACKLIGHT_GPIO)
       case ITEM_SETUP_KEYS_BACKLIGHT:
-        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH , y, STR_KEYS_BACKLIGHT);
+        lcdDrawText(MENUS_MARGIN_LEFT + INDENT_WIDTH, y, STR_KEYS_BACKLIGHT);
         g_eeGeneral.keysBacklight = editCheckBox(g_eeGeneral.keysBacklight, RADIO_SETUP_2ND_COLUMN, y, attr, event ) ;
         break;
 #endif


### PR DESCRIPTION
on the radio setup page, the mode fields for sound and haptic were not indented, producing somewhat ugly layout.
The PR also changes a TR_xxx to STR_xxx, and does few formatting bits.
