### PR TITLE
Add OS name to lua luaGetVersion()

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -87,7 +87,7 @@ Return OpenTX version
 
 @retval string OpenTX version (ie "2.1.5")
 
-@retval multiple (available since 2.1.7) returns 5 values:
+@retval multiple (available since 2.1.7) returns 6 values:
  * (string) OpenTX version (ie "2.1.5")
  * (string) radio type: `x12s`, `x10`, `x9e`, `x9d+`, `x9d` or `x7`.
 If running in simulator the "-simu" is added
@@ -104,12 +104,13 @@ This example also runs in OpenTX versions where the function returned only one v
 
 ```lua
 local function run(event)
-  local ver, radio, maj, minor, rev = getVersion()
+  local ver, radio, maj, minor, rev, osname = getVersion()
   print("version: "..ver)
   if radio then print ("radio: "..radio) end
   if maj then print ("maj: "..maj) end
   if minor then print ("minor: "..minor) end
   if rev then print ("rev: "..rev) end
+  if osname then print ("osname: "..osname) end
   return 1
 end
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -66,6 +66,8 @@
   #define RADIO_VERSION FLAVOUR
 #endif
 
+#define VERSION_OSNAME "OpenTX"
+
 #define FIND_FIELD_DESC  0x01
 
 #define KEY_EVENTS(xxx, yyy)  \
@@ -92,8 +94,9 @@ If running in simulator the "-simu" is added
  * (number) major version (ie 2 if version 2.1.5)
  * (number) minor version (ie 1 if version 2.1.5)
  * (number) revision number (ie 5 if version 2.1.5)
+ * (string) OS name (ie "OpenTX" if OpenTX)
 
-@status current Introduced in 2.0.0, expanded in 2.1.7, radio type strings changed in 2.2.0
+@status current Introduced in 2.0.0, expanded in 2.1.7, radio type strings changed in 2.2.0, OS name added in 2.3.14
 
 ### Example
 
@@ -114,11 +117,12 @@ return {  run=run }
 ```
 Output of the above script in simulator:
 ```
-version: 2.1.7
+version: 2.3.14
 radio: taranis-simu
 maj: 2
-minor: 1
-rev: 7
+minor: 3
+rev: 14
+osname: OpenTX
 ```
 */
 static int luaGetVersion(lua_State * L)
@@ -128,7 +132,8 @@ static int luaGetVersion(lua_State * L)
   lua_pushnumber(L, VERSION_MAJOR);
   lua_pushnumber(L, VERSION_MINOR);
   lua_pushnumber(L, VERSION_REVISION);
-  return 5;
+  lua_pushstring(L, VERSION_OSNAME);
+  return 6;
 }
 
 /*luadoc


### PR DESCRIPTION
adds OS name string to the lua luaGetVersion() function
this allows to discriminate between OpenTx and EdgeTx, which is potentially highly useful for scripts
this mirrors the change done by EdgeTx (https://github.com/EdgeTX/edgetx/blob/2.4/radio/src/lua/api_general.cpp#L136-L145)

no idea if it needs a change in simulator/companion, I have no knowledge here

tested on tx16s