### PR TITLE
More pulse sync fixes

### DIFF
--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -518,11 +518,6 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(HARDWARE_INTERNAL_MODULE) && defined(PXX1) && !defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePulsesData.pxx.setupFrame(INTERNAL_MODULE);
-#if defined(INTMODULE_HEARTBEAT)
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000 /* backup */);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
-#endif
       return true;
 #endif
 

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -457,12 +457,10 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePxx1PulsesStart();
 #if defined(INTMODULE_HEARTBEAT)
-      // use backup trigger (1 ms later)
       init_intmodule_heartbeat();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000/*us*/);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
+      // use backup trigger (1 ms later)
 #endif
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -470,12 +468,10 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       intmodulePxx1SerialStart();
 #if defined(INTMODULE_HEARTBEAT)
-      // use backup trigger (1 ms later)
       init_intmodule_heartbeat();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000/*us*/);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
+      // use backup trigger (1 ms later)
 #endif
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -523,7 +519,6 @@ bool setupPulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePulsesData.pxx.setupFrame(INTERNAL_MODULE);
 #if defined(INTMODULE_HEARTBEAT)
-      mixerSchedulerResetTimer();
       mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000 /* backup */);
 #else
       mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);

--- a/radio/src/pulses/pxx.h
+++ b/radio/src/pulses/pxx.h
@@ -38,12 +38,17 @@
 #define EXTMODULE_PXX1_SERIAL_PERIOD       4000/*us*/
 #define EXTMODULE_PXX1_SERIAL_BAUDRATE     420000
 
+#if defined(INTMODULE_HEARTBEAT)
+#define HEARTBEAT_BACKUP                    1000/*us*/
+#else
+#define HEARTBEAT_BACKUP                    0/*us*/
+#endif
 #if defined(PXX_FREQUENCY_HIGH)
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   450000
-  #define INTMODULE_PXX1_SERIAL_PERIOD     4000/*us*/
+  #define INTMODULE_PXX1_SERIAL_PERIOD     4000/*us*/ + HEARTBEAT_BACKUP
 #else
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   115200
-  #define INTMODULE_PXX1_SERIAL_PERIOD     9000/*us*/
+  #define INTMODULE_PXX1_SERIAL_PERIOD     9000/*us*/ + HEARTBEAT_BACKUP
 #endif
 
 // Used by the Sky9x family boards

--- a/radio/src/pulses/pxx.h
+++ b/radio/src/pulses/pxx.h
@@ -30,7 +30,7 @@
 #define PXX2_LOWSPEED_BAUDRATE             230400
 #define PXX2_HIGHSPEED_BAUDRATE            450000
 #define PXX2_NO_HEARTBEAT_PERIOD           4000/*us*/
-#define PXX2_MAX_HEARTBEAT_PERIOD          (7000 + 1000)/*us 7ms frame rate + 1ms heartbeat backup*/
+#define PXX2_MAX_HEARTBEAT_PERIOD          (9000 + 1000)/*us longest period (isrm/accst) + 1ms heartbeat backup*/
 #define PXX2_TOOLS_PERIOD                  1000/*us*/
 #define PXX2_FRAME_MAXLENGTH               64
 

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -79,6 +79,8 @@ void check_intmodule_heartbeat()
 #endif
     EXTI_ClearITPendingBit(INTMODULE_HEARTBEAT_EXTI_LINE);
 
+    mixerSchedulerResetTimer();
+
     mixerSchedulerISRTrigger();
   }
 }


### PR DESCRIPTION
Fix Horus iXJT where HB and expired timers where both trigering

Fix ISRM ACCST broken by 2.3.13. Duration set to 10ms which is the longuest one (9ms for ISRM/ACCST) + 1ms backup

This fixes #8585 
This fixes #8575