### PR TITLE
Silence warning on recent GCC

### DIFF
--- a/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.2.0/Libraries/STM32_USB_OTG_Driver/src/usb_core.c
+++ b/radio/src/thirdparty/STM32_USB-Host-Device_Lib_V2.2.0/Libraries/STM32_USB_OTG_Driver/src/usb_core.c
@@ -29,6 +29,19 @@
 #include "usb_core.h"
 #include "usb_bsp.h"
 
+// taken from https://github.com/ARMmbed/mbed-os/blob/master/cmsis/TARGET_CORTEX_M/cmsis_compiler.h
+#ifndef   __PACKED_STRUCT
+#define __PACKED_STRUCT                        struct __attribute__((packed))
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+__PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+#define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+__PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+#define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+
 
 /** @addtogroup USB_OTG_DRIVER
 * @{
@@ -180,7 +193,7 @@ USB_OTG_STS USB_OTG_WritePacket(USB_OTG_CORE_HANDLE *pdev,
     fifo = pdev->regs.DFIFO[ch_ep_num];
     for (i = 0; i < count32b; i++)
     {
-      USB_OTG_WRITE_REG32( fifo, *((__packed uint32_t *)src) );
+      USB_OTG_WRITE_REG32( fifo, __UNALIGNED_UINT32_READ(src) );
       src+=4;
     }
   }
@@ -206,7 +219,7 @@ void *USB_OTG_ReadPacket(USB_OTG_CORE_HANDLE *pdev,
   
   for( i = 0; i < count32b; i++)
   {
-    *(__packed uint32_t *)dest = USB_OTG_READ_REG32(fifo);
+    __UNALIGNED_UINT32_WRITE(dest, USB_OTG_READ_REG32(fifo));
     dest += 4 ;
   }
   return ((void *)dest);


### PR DESCRIPTION
Avoid error: 'packed' attribute ignored for type 'uint32_t *' {aka 'unsigned int *'} [-Werror=attributes]