### PR TITLE
Fix 115k ghost menu

### DIFF
--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1615,8 +1615,8 @@
   #define SPORT_UPDATE_PWR_GPIO_PIN     GPIO_Pin_14 // PA.14
   #define GPIO_SPORT_UPDATE_PWR_GPIO_ON  GPIO_SetBits
   #define GPIO_SPORT_UPDATE_PWR_GPIO_OFF GPIO_ResetBits
-#elif defined(PCBX9D) || defined(PCBX9D)
-  #define SPORT_MAX_BAUDRATE            250000 // < 400000 some x9d have sloopy inverted and cannot sustain 400k
+#elif defined(PCBX9DP) || defined(PCBX9D)
+  #define SPORT_MAX_BAUDRATE            250000 // < 400000 some x9d have sloopy inverter and cannot sustain 400k
   #define SPORT_UPDATE_RCC_AHB1Periph   0
 #else
   #define SPORT_MAX_BAUDRATE            400000

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1615,6 +1615,9 @@
   #define SPORT_UPDATE_PWR_GPIO_PIN     GPIO_Pin_14 // PA.14
   #define GPIO_SPORT_UPDATE_PWR_GPIO_ON  GPIO_SetBits
   #define GPIO_SPORT_UPDATE_PWR_GPIO_OFF GPIO_ResetBits
+#elif defined(PCBX9D) || defined(PCBX9D)
+  #define SPORT_MAX_BAUDRATE            250000 // < 400000 some x9d have sloopy inverted and cannot sustain 400k
+  #define SPORT_UPDATE_RCC_AHB1Periph   0
 #else
   #define SPORT_MAX_BAUDRATE            400000
   #define SPORT_UPDATE_RCC_AHB1Periph   0

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -171,6 +171,15 @@ void processGhostTelemetryFrame()
       update_interval /= 10;
       offset /= 10;
 
+#if defined(GHOST) && SPORT_MAX_BAUDRATE < 400000
+      // Ghost telemetry frame are longer when in Ghost menu
+      // If telem baudrate is only at 115k, and pulse interval is less than 3ms, pulse and telem will conflict
+      if (isModuleGhost(EXTERNAL_MODULE) && g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_115K
+      && menuHandlers[menuLevel] == menuGhostModuleConfig && update_interval < 3000) {
+        update_interval = 3000;
+      }
+#endif
+
       getModuleSyncStatus(EXTERNAL_MODULE).update(update_interval, offset);
     }
     break;

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -174,8 +174,8 @@ void processGhostTelemetryFrame()
 #if SPORT_MAX_BAUDRATE < 400000
       // Ghost telemetry frame are longer when in Ghost menu
       // If telem baudrate is only at 115k, and pulse interval is less than 3ms, pulse and telem will conflict
-      if (isModuleGhost(EXTERNAL_MODULE) && g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_115K
-      && menuHandlers[menuLevel] == menuGhostModuleConfig && update_interval < 3000) {
+      if (isModuleGhost(EXTERNAL_MODULE) && g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_115K &&
+          menuHandlers[menuLevel] == menuGhostModuleConfig && update_interval < 3000) {
         update_interval = 3000;
       }
 #endif

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -171,7 +171,7 @@ void processGhostTelemetryFrame()
       update_interval /= 10;
       offset /= 10;
 
-#if defined(GHOST) && SPORT_MAX_BAUDRATE < 400000
+#if SPORT_MAX_BAUDRATE < 400000
       // Ghost telemetry frame are longer when in Ghost menu
       // If telem baudrate is only at 115k, and pulse interval is less than 3ms, pulse and telem will conflict
       if (isModuleGhost(EXTERNAL_MODULE) && g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_115K


### PR DESCRIPTION
- forces a miminum of 3ms between pulses when telem is at 115k AND we are displaying menu. This is done OTX side, but could/should be done module side too

- adds telem speed choice to x9d and x9d+, it seems some do have sloppy inverters too

This fixes #8641