### PR TITLE
Handle volume correctly also for HELLO

### DIFF
--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -531,10 +531,9 @@ void audioTask(void * pdata)
 
   if (!globalData.unexpectedShutdown) {
     while (!s_mixer_first_run_done) { // wait until the first mixer run was completed
-      RTOS_WAIT_MS(25);
+      RTOS_WAIT_MS(1);
     }
-    RTOS_WAIT_MS(25);
-    AUDIO_HELLO();
+    RTOS_WAIT_MS(100); // give it some time to update currentSpeakerVolume
   }
 
   while (1) {

--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -530,6 +530,10 @@ void audioTask(void * pdata)
 #endif
 
   if (!globalData.unexpectedShutdown) {
+    while (!s_mixer_first_run_done) { // wait until the first mixer run was completed
+      RTOS_WAIT_MS(25);
+    }
+    RTOS_WAIT_MS(25);
     AUDIO_HELLO();
   }
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2028,6 +2028,9 @@ void opentxInit()
 #endif
 
   referenceSystemAudioFiles();
+  if (!globalData.unexpectedShutdown) {
+    AUDIO_HELLO();
+  }
   audioQueue.start();
   BACKLIGHT_ENABLE();
 


### PR DESCRIPTION
this one really annoyed me forever and made me not use that feature as it made it pointless:

While with a special function the speaker volume can be made adjustable, e.g., with a poti, this did NOT affect also the HELLO startup sound, which was played at full volume (kicking out your ears)

This is because the special functions mixer has not yet run at the time the HELLO was played. Hence, this PR makes the audio thread wait for the mixer to have run at least once if the HELLO should be played. Some additional delay was needed to get a smooth sound, which was determined a bit experimentally. 

Works great for me on Tx16S and T16.