### PR TITLE
Move telemetry custom screens from telemetry tab to own tab

### DIFF
--- a/companion/src/modeledit/CMakeLists.txt
+++ b/companion/src/modeledit/CMakeLists.txt
@@ -25,6 +25,7 @@ set(modeledit_SRCS
   mixerslistwidget.cpp
   # node.cpp  ## node and edge are built in common lib because also used by simulator
   # edge.cpp  ## commenting them here avoids a "duplicate target" warning eg. from ninja
+  telemetry_customscreens.cpp
 )
 
 set(modeledit_HDRS
@@ -36,6 +37,7 @@ set(modeledit_HDRS
   customfunctions.h
   mixerslistwidget.h
   # node.h
+  telemetry_customscreens.h
 )
 
 set(modeledit_UIS

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -32,6 +32,7 @@
 #include "logicalswitches.h"
 #include "customfunctions.h"
 #include "telemetry.h"
+#include "telemetry_customscreens.h"
 #include "appdata.h"
 #include "compounditemmodels.h"
 
@@ -102,6 +103,11 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   if (firmware->getCapability(Telemetry)) {
     addTab(new TelemetryPanel(this, model, generalSettings, firmware, sharedItemModels), tr("Telemetry"));
     s1.report("Telemetry");
+  }
+
+  if (firmware->getCapability(TelemetryCustomScreens)) {
+    addTab(new TelemetryCustomScreensPanel(this, model, generalSettings, firmware, sharedItemModels), tr("Custom Screens"));
+    s1.report("Telemetry Custom Screens");
   }
 
   connect(setupPanel, &SetupPanel::extendedLimitsToggled, channelsPanel, &ChannelsPanel::refreshExtendedLimits);

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -20,12 +20,9 @@
 
 #include "telemetry.h"
 #include "ui_telemetry.h"
-#include "ui_telemetry_customscreen.h"
 #include "ui_telemetry_sensor.h"
 #include "helpers.h"
 #include "appdata.h"
-
-#include <TimerEdit>
 
 constexpr char FIM_RAWSOURCE[]       {"Raw Source"};
 constexpr char FIM_TELEALLSRC[]      {"Tele All Source"};
@@ -36,294 +33,6 @@ constexpr char FIM_SENSORCELLINDEX[] {"Sensor.CellIndex"};
 constexpr char FIM_SENSORUNIT[]      {"Sensor.Unit"};
 constexpr char FIM_SENSORPRECISION[] {"Sensor.Precision"};
 constexpr char FIM_RSSISOURCE[]      {"Rssi Source"};
-
-TelemetryCustomScreen::TelemetryCustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings,
-                                             Firmware * firmware, const bool & parentLock, FilteredItemModelFactory * panelFilteredItemModels):
-  ModelPanel(parent, model, generalSettings, firmware),
-  ui(new Ui::TelemetryCustomScreen),
-  screen(screen),
-  modelsUpdateCnt(0),
-  parentLock(parentLock)
-{
-  ui->setupUi(this);
-
-  FilteredItemModel * rawSourceFilteredModel = panelFilteredItemModels->getItemModel(FIM_RAWSOURCE);
-  connectItemModelEvents(rawSourceFilteredModel);
-
-  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensLines); l++) {
-    for (int c = 0; c < firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
-      fieldsCB[l][c] = new QComboBox(this);
-      fieldsCB[l][c]->setProperty("index", c + (l << 8));
-      fieldsCB[l][c]->setModel(rawSourceFilteredModel);
-      ui->screenNumsLayout->addWidget(fieldsCB[l][c], l, c, 1, 1);
-      connect(fieldsCB[l][c], SIGNAL(activated(int)), this, SLOT(customFieldChanged(int)));
-    }
-  }
-
-  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensBars); l++) {
-    barsCB[l] = new QComboBox(this);
-    barsCB[l]->setProperty("index", l);
-    barsCB[l]->setModel(rawSourceFilteredModel);
-    connect(barsCB[l], SIGNAL(activated(int)), this, SLOT(barSourceChanged(int)));
-    ui->screenBarsLayout->addWidget(barsCB[l], l, 0, 1, 1);
-
-    minSB[l] = new QDoubleSpinBox(this);
-    minSB[l]->setProperty("index", l);
-    connect(minSB[l], SIGNAL(valueChanged(double)), this, SLOT(barMinChanged(double)));
-    ui->screenBarsLayout->addWidget(minSB[l], l, 1, 1, 1);
-
-    minTime[l] = new TimerEdit(this);
-    minTime[l]->setProperty("index", l);
-    minTime[l]->setProperty("type", "min");
-    connect(minTime[l], SIGNAL(editingFinished()), this, SLOT(barTimeChanged()));
-    ui->screenBarsLayout->addWidget(minTime[l], l, 1, 1, 1);
-    minTime[l]->hide();
-
-    QLabel * label = new QLabel(this);
-    label->setAutoFillBackground(false);
-    label->setStyleSheet(QString::fromUtf8("Background:qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 rgba(0, 0, 128, 255), stop:0.339795 rgba(0, 0, 128, 255), stop:0.339799 rgba(255, 255, 255, 255), stop:0.662444 rgba(255, 255, 255, 255),)\n"""));
-    label->setFrameShape(QFrame::Panel);
-    label->setFrameShadow(QFrame::Raised);
-    label->setAlignment(Qt::AlignCenter);
-    ui->screenBarsLayout->addWidget(label, l, 2, 1, 1);
-
-    maxSB[l] = new QDoubleSpinBox(this);
-    maxSB[l]->setProperty("index", l);
-    connect(maxSB[l], SIGNAL(valueChanged(double)), this, SLOT(barMaxChanged(double)));
-    ui->screenBarsLayout->addWidget(maxSB[l], l, 3, 1, 1);
-
-    maxTime[l] = new TimerEdit(this);
-    maxTime[l]->setProperty("index", l);
-    maxTime[l]->setProperty("type", "max");
-    connect(maxTime[l], SIGNAL(editingFinished()), this, SLOT(barTimeChanged()));
-    ui->screenBarsLayout->addWidget(maxTime[l], l, 3, 1, 1);
-    maxTime[l]->hide();
-  }
-
-  disableMouseScrolling();
-
-  lock = true;
-  ui->screenType->addItem(tr("None"), TELEMETRY_SCREEN_NONE);
-  ui->screenType->addItem(tr("Numbers"), TELEMETRY_SCREEN_NUMBERS);
-  ui->screenType->addItem(tr("Bars"), TELEMETRY_SCREEN_BARS);
-  if (IS_TARANIS(firmware->getBoard()))
-    ui->screenType->addItem(tr("Script"), TELEMETRY_SCREEN_SCRIPT);
-  ui->screenType->setField(screen.type, this);
-  lock = false;
-
-  if (IS_TARANIS(firmware->getBoard())) {
-    QSet<QString> scriptsSet = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS/TELEMETRY", QStringList() << "*.lua", 6);
-    Helpers::populateFileComboBox(ui->scriptName, scriptsSet, screen.body.script.filename);
-    connect(ui->scriptName, SIGNAL(currentIndexChanged(int)), this, SLOT(scriptNameEdited()));
-    connect(ui->scriptName, SIGNAL(editTextChanged ( const QString)), this, SLOT(scriptNameEdited()));
-  }
-
-  update();
-}
-
-TelemetryCustomScreen::~TelemetryCustomScreen()
-{
-  delete ui;
-}
-
-void TelemetryCustomScreen::update()
-{
-  lock = true;
-
-  ui->scriptName->setVisible(screen.type == TELEMETRY_SCREEN_SCRIPT);
-  ui->screenNums->setVisible(screen.type == TELEMETRY_SCREEN_NUMBERS);
-  ui->screenBars->setVisible(screen.type == TELEMETRY_SCREEN_BARS);
-
-  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensLines); l++) {
-    for (int c = 0; c < firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
-      fieldsCB[l][c]->setCurrentIndex(fieldsCB[l][c]->findData(screen.body.lines[l].source[c].toValue()));
-    }
-  }
-
-  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensBars); l++) {
-    barsCB[l]->setCurrentIndex(barsCB[l]->findData(screen.body.bars[l].source.toValue()));
-  }
-
-  if (screen.type == TELEMETRY_SCREEN_BARS) {
-    for (int i = 0; i < firmware->getCapability(TelemetryCustomScreensBars); i++) {
-      updateBar(i);
-    }
-  }
-
-  lock = false;
-}
-
-void TelemetryCustomScreen::updateBar(int line)
-{
-  lock = true;
-
-  RawSource source = screen.body.bars[line].source;
-
-  minTime[line]->setVisible(false);
-  maxTime[line]->setVisible(false);
-
-  if (source.type != SOURCE_TYPE_NONE) {
-    RawSourceRange range = source.getRange(model, generalSettings);
-    float minVal = range.getValue(screen.body.bars[line].barMin);
-    float maxVal = screen.body.bars[line].barMax;
-    maxVal = range.getValue(maxVal);
-
-    if (source.isTimeBased()) {
-      minTime[line]->setVisible(true);
-      minTime[line]->setTimeRange(range.min, range.max);
-      minTime[line]->setSingleStep(range.step);
-      minTime[line]->setPageStep(range.step * 60);
-      minTime[line]->setShowSeconds(range.step != 60);
-      minTime[line]->setTime((int)minVal);
-
-      maxTime[line]->setVisible(true);
-      maxTime[line]->setTimeRange(range.min, range.max);
-      maxTime[line]->setSingleStep(range.step);
-      maxTime[line]->setPageStep(range.step * 60);
-      maxTime[line]->setShowSeconds(range.step != 60);
-      maxTime[line]->setTime((int)maxVal);
-
-      minSB[line]->setVisible(false);
-      maxSB[line]->setVisible(false);
-    }
-    else {
-      minSB[line]->setVisible(true);
-      minSB[line]->setEnabled(true);
-      minSB[line]->setDecimals(range.decimals);
-      minSB[line]->setMinimum(range.min);
-      minSB[line]->setMaximum(range.max);
-      minSB[line]->setSingleStep(range.step);
-      minSB[line]->setSuffix(" " + range.unit);
-      minSB[line]->setValue(minVal);
-
-      maxSB[line]->setVisible(true);
-      maxSB[line]->setEnabled(true);
-      maxSB[line]->setDecimals(range.decimals);
-      maxSB[line]->setMinimum(range.min);
-      maxSB[line]->setMaximum(range.max);
-      maxSB[line]->setSingleStep(range.step);
-      maxSB[line]->setSuffix(" " + range.unit);
-      maxSB[line]->setValue(maxVal);
-    }
-  }
-  else {
-    minSB[line]->setDisabled(true);
-    maxSB[line]->setDisabled(true);
-  }
-
-  lock = false;
-}
-
-void TelemetryCustomScreen::on_screenType_currentIndexChanged(int index)
-{
-  if (!isLocked()) {
-    memset(reinterpret_cast<void *>(&screen.body), 0, sizeof(screen.body));
-    update();
-    emit modified();
-  }
-}
-
-void TelemetryCustomScreen::scriptNameEdited()
-{
-  if (!isLocked()) {
-    lock = true;
-    Helpers::getFileComboBoxValue(ui->scriptName, screen.body.script.filename, 8);
-    emit modified();
-    lock = false;
-  }
-}
-
-void TelemetryCustomScreen::customFieldChanged(int value)
-{
-  if (isLocked() || !sender() || !qobject_cast<QComboBox *>(sender()))
-    return;
-
-  bool ok;
-  const int index = sender()->property("index").toInt(&ok),
-      i = index / 256,
-      m = index % 256;
-  const RawSource src(qobject_cast<QComboBox *>(sender())->itemData(value).toInt());
-  if (ok && screen.body.lines[i].source[m].toValue() != src.toValue()) {
-    screen.body.lines[i].source[m] = src;
-    emit modified();
-  }
-}
-
-void TelemetryCustomScreen::barSourceChanged(int value)
-{
-  if (isLocked() || !sender() || !qobject_cast<QComboBox *>(sender()))
-    return;
-
-  bool ok;
-  const int index = sender()->property("index").toInt(&ok);
-  const RawSource src(qobject_cast<QComboBox *>(sender())->itemData(value).toInt());
-  if (!ok || screen.body.bars[index].source.toValue() == src.toValue())
-    return;
-
-  screen.body.bars[index].source = src;
-  screen.body.bars[index].barMin = 0;
-  screen.body.bars[index].barMax = 0;
-  updateBar(index);
-  emit modified();
-}
-
-void TelemetryCustomScreen::barMinChanged(double value)
-{
-  if (!isLocked()) {
-    int line = sender()->property("index").toInt();
-    screen.body.bars[line].barMin = round(value / minSB[line]->singleStep());
-    // TODO set min (maxSB)
-    emit modified();
-  }
-}
-
-void TelemetryCustomScreen::barMaxChanged(double value)
-{
-  if (!isLocked()) {
-    int line = sender()->property("index").toInt();
-    screen.body.bars[line].barMax = round((value) / maxSB[line]->singleStep());
-    // TODO set max (minSB)
-    emit modified();
-  }
-}
-
-void TelemetryCustomScreen::barTimeChanged()
-{
-  if (!isLocked()) {
-    int line = sender()->property("index").toInt();
-    int & valRef = (sender()->property("type").toString() == "min" ? screen.body.bars[line].barMin : screen.body.bars[line].barMax);
-    TimerEdit * te = qobject_cast<TimerEdit *>(sender());
-    if (!te)
-      return;
-
-    valRef = round(te->timeInSeconds() / te->singleStep());
-
-    emit modified();
-  }
-}
-
-void TelemetryCustomScreen::connectItemModelEvents(const FilteredItemModel * itemModel)
-{
-  connect(itemModel, &FilteredItemModel::aboutToBeUpdated, this, &TelemetryCustomScreen::onItemModelAboutToBeUpdated);
-  connect(itemModel, &FilteredItemModel::updateComplete, this, &TelemetryCustomScreen::onItemModelUpdateComplete);
-}
-
-void TelemetryCustomScreen::onItemModelAboutToBeUpdated()
-{
-  lock = true;
-  modelsUpdateCnt++;
-}
-
-void TelemetryCustomScreen::onItemModelUpdateComplete()
-{
-  modelsUpdateCnt--;
-  if (modelsUpdateCnt < 1) {
-    //  leave updating to parent
-    lock = false;
-  }
-}
-
-/******************************************************/
 
 TelemetrySensorPanel::TelemetrySensorPanel(QWidget *parent, SensorData & sensor, int sensorIndex, int sensorCapability, ModelData & model,
                                            GeneralSettings & generalSettings, Firmware * firmware, const bool & parentLock,
@@ -755,14 +464,6 @@ TelemetryPanel::TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettin
     ui->topbarGB->hide();
   }
 
-  for (int i = 0; i < firmware->getCapability(TelemetryCustomScreens); i++) {
-    TelemetryCustomScreen * tab = new TelemetryCustomScreen(this, model, model.frsky.screens[i], generalSettings, firmware, lock,
-                                                            panelFilteredItemModels);
-    ui->customScreens->addTab(tab, tr("Telemetry screen %1").arg(i + 1));
-    telemetryCustomScreens[i] = tab;
-    connect(tab, &TelemetryCustomScreen::modified, this, &TelemetryPanel::onModified);
-  }
-
   disableMouseScrolling();
 
   setup();
@@ -796,10 +497,6 @@ void TelemetryPanel::update()
 
   for (int i = 0; i < sensorCapability; ++i) {
     sensorPanels[i]->update();
-  }
-
-  for (int i = 0; i < firmware->getCapability(TelemetryCustomScreens); i++) {
-    telemetryCustomScreens[i]->update();
   }
 
   lock = false;
@@ -901,8 +598,6 @@ void TelemetryPanel::on_frskyProtoCB_currentIndexChanged(int index)
 {
   if (!isLocked()) {
     model->frsky.usrProto = index;
-    for (int i = 0; i < firmware->getCapability(TelemetryCustomScreens); i++)
-      telemetryCustomScreens[i]->update();
     emit modified();
   }
 }

--- a/companion/src/modeledit/telemetry.h
+++ b/companion/src/modeledit/telemetry.h
@@ -27,51 +27,11 @@
 constexpr char MIMETYPE_TELE_SENSOR[] {"application/x-companion-tele-sensor"};
 
 class AutoComboBox;
-class TimerEdit;
 
 namespace Ui {
-  class TelemetryCustomScreen;
   class TelemetrySensor;
   class Telemetry;
 }
-
-class TelemetryCustomScreen: public ModelPanel
-{
-    Q_OBJECT
-
-  public:
-    TelemetryCustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings, Firmware * firmware,
-                          const bool & parentLock, FilteredItemModelFactory * panelFilteredItemModels);
-    ~TelemetryCustomScreen();
-    void update();
-
-  private slots:
-    void on_screenType_currentIndexChanged(int index);
-    void scriptNameEdited();
-    void customFieldChanged(int index);
-    void barSourceChanged(int index);
-    void barMinChanged(double value);
-    void barMaxChanged(double value);
-    void barTimeChanged();
-    void onItemModelAboutToBeUpdated();
-    void onItemModelUpdateComplete();
-
-  private:
-    void updateBar(int line);
-    Ui::TelemetryCustomScreen * ui;
-    FrSkyScreenData & screen;
-    QComboBox * fieldsCB[4][3];
-    QComboBox * barsCB[4];
-    QDoubleSpinBox * minSB[4];
-    QDoubleSpinBox * maxSB[4];
-    TimerEdit * minTime[4];
-    TimerEdit * maxTime[4];
-    int modelsUpdateCnt;
-    const bool &parentLock;
-
-    inline bool isLocked() { return lock | parentLock; }
-    void connectItemModelEvents(const FilteredItemModel * itemModel);
-};
 
 class TelemetrySensorPanel: public ModelPanel
 {
@@ -165,7 +125,6 @@ class TelemetryPanel : public ModelPanel
 
   private:
     Ui::Telemetry *ui;
-    TelemetryCustomScreen *telemetryCustomScreens[4];
     TelemetrySensorPanel *sensorPanels[CPN_MAX_SENSORS];
     int sensorCapability;
     CompoundItemModelFactory *sharedItemModels;

--- a/companion/src/modeledit/telemetry.ui
+++ b/companion/src/modeledit/telemetry.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>861</width>
-    <height>737</height>
+    <height>742</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,0,0">
    <property name="spacing">
     <number>4</number>
    </property>
@@ -1000,19 +1000,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QTabWidget" name="customScreens">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>-1</number>
-     </property>
-    </widget>
-   </item>
-   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -1059,7 +1046,6 @@
   <tabstop>frskyVoltCB</tabstop>
   <tabstop>frskyCurrentCB</tabstop>
   <tabstop>bladesCount</tabstop>
-  <tabstop>customScreens</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/companion/src/modeledit/telemetry_customscreen.ui
+++ b/companion/src/modeledit/telemetry_customscreen.ui
@@ -31,7 +31,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Custom Screen Type</string>
+        <string>Type</string>
        </property>
       </widget>
      </item>
@@ -123,6 +123,19 @@
     <widget class="QGroupBox" name="screenNums">
      <layout class="QGridLayout" name="screenNumsLayout"/>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/companion/src/modeledit/telemetry_customscreens.cpp
+++ b/companion/src/modeledit/telemetry_customscreens.cpp
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "telemetry_customscreens.h"
+#include "ui_telemetry_customscreen.h"
+#include "helpers.h"
+#include "appdata.h"
+
+#include <TimerEdit>
+
+constexpr char FIM_RAWSOURCE[]       {"Raw Source"};
+
+CustomScreen::CustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings,
+                                             Firmware * firmware, const bool & parentLock, FilteredItemModelFactory * panelFilteredItemModels):
+  ModelPanel(parent, model, generalSettings, firmware),
+  ui(new Ui::TelemetryCustomScreen),
+  screen(screen),
+  modelsUpdateCnt(0),
+  parentLock(parentLock)
+{
+  ui->setupUi(this);
+
+  FilteredItemModel * rawSourceFilteredModel = panelFilteredItemModels->getItemModel(FIM_RAWSOURCE);
+  connectItemModelEvents(rawSourceFilteredModel);
+
+  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensLines); l++) {
+    for (int c = 0; c < firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
+      fieldsCB[l][c] = new QComboBox(this);
+      fieldsCB[l][c]->setProperty("index", c + (l << 8));
+      fieldsCB[l][c]->setModel(rawSourceFilteredModel);
+      ui->screenNumsLayout->addWidget(fieldsCB[l][c], l, c, 1, 1);
+      connect(fieldsCB[l][c], SIGNAL(activated(int)), this, SLOT(customFieldChanged(int)));
+    }
+  }
+
+  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensBars); l++) {
+    barsCB[l] = new QComboBox(this);
+    barsCB[l]->setProperty("index", l);
+    barsCB[l]->setModel(rawSourceFilteredModel);
+    connect(barsCB[l], SIGNAL(activated(int)), this, SLOT(barSourceChanged(int)));
+    ui->screenBarsLayout->addWidget(barsCB[l], l+1, 0, 1, 1);
+
+    minSB[l] = new QDoubleSpinBox(this);
+    minSB[l]->setProperty("index", l);
+    connect(minSB[l], SIGNAL(valueChanged(double)), this, SLOT(barMinChanged(double)));
+    ui->screenBarsLayout->addWidget(minSB[l], l+1, 1, 1, 1);
+
+    minTime[l] = new TimerEdit(this);
+    minTime[l]->setProperty("index", l);
+    minTime[l]->setProperty("type", "min");
+    connect(minTime[l], SIGNAL(editingFinished()), this, SLOT(barTimeChanged()));
+    ui->screenBarsLayout->addWidget(minTime[l], l+1, 1, 1, 1);
+    minTime[l]->hide();
+
+    QLabel * label = new QLabel(this);
+    label->setAutoFillBackground(false);
+    label->setStyleSheet(QString::fromUtf8("Background:qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 rgba(0, 0, 128, 255), stop:0.339795 rgba(0, 0, 128, 255), stop:0.339799 rgba(255, 255, 255, 255), stop:0.662444 rgba(255, 255, 255, 255),)\n"""));
+    label->setFrameShape(QFrame::Panel);
+    label->setFrameShadow(QFrame::Raised);
+    label->setAlignment(Qt::AlignCenter);
+    ui->screenBarsLayout->addWidget(label, l+1, 2, 1, 1);
+
+    maxSB[l] = new QDoubleSpinBox(this);
+    maxSB[l]->setProperty("index", l);
+    connect(maxSB[l], SIGNAL(valueChanged(double)), this, SLOT(barMaxChanged(double)));
+    ui->screenBarsLayout->addWidget(maxSB[l], l+1, 3, 1, 1);
+
+    maxTime[l] = new TimerEdit(this);
+    maxTime[l]->setProperty("index", l);
+    maxTime[l]->setProperty("type", "max");
+    connect(maxTime[l], SIGNAL(editingFinished()), this, SLOT(barTimeChanged()));
+    ui->screenBarsLayout->addWidget(maxTime[l], l+1, 3, 1, 1);
+    maxTime[l]->hide();
+  }
+
+  disableMouseScrolling();
+
+  lock = true;
+  ui->screenType->addItem(tr("None"), TELEMETRY_SCREEN_NONE);
+  ui->screenType->addItem(tr("Numbers"), TELEMETRY_SCREEN_NUMBERS);
+  ui->screenType->addItem(tr("Bars"), TELEMETRY_SCREEN_BARS);
+  if (IS_TARANIS(firmware->getBoard()))
+    ui->screenType->addItem(tr("Script"), TELEMETRY_SCREEN_SCRIPT);
+  ui->screenType->setField(screen.type, this);
+  lock = false;
+
+  if (IS_TARANIS(firmware->getBoard())) {
+    QSet<QString> scriptsSet = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS/TELEMETRY", QStringList() << "*.lua", 6);
+    Helpers::populateFileComboBox(ui->scriptName, scriptsSet, screen.body.script.filename);
+    connect(ui->scriptName, SIGNAL(currentIndexChanged(int)), this, SLOT(scriptNameEdited()));
+    connect(ui->scriptName, SIGNAL(editTextChanged ( const QString)), this, SLOT(scriptNameEdited()));
+  }
+
+  update();
+}
+
+CustomScreen::~CustomScreen()
+{
+  delete ui;
+}
+
+void CustomScreen::update()
+{
+  lock = true;
+
+  ui->scriptName->setVisible(screen.type == TELEMETRY_SCREEN_SCRIPT);
+  ui->screenNums->setVisible(screen.type == TELEMETRY_SCREEN_NUMBERS);
+  ui->screenBars->setVisible(screen.type == TELEMETRY_SCREEN_BARS);
+
+  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensLines); l++) {
+    for (int c = 0; c < firmware->getCapability(TelemetryCustomScreensFieldsPerLine); c++) {
+      fieldsCB[l][c]->setCurrentIndex(fieldsCB[l][c]->findData(screen.body.lines[l].source[c].toValue()));
+    }
+  }
+
+  for (int l = 0; l < firmware->getCapability(TelemetryCustomScreensBars); l++) {
+    barsCB[l]->setCurrentIndex(barsCB[l]->findData(screen.body.bars[l].source.toValue()));
+  }
+
+  if (screen.type == TELEMETRY_SCREEN_BARS) {
+    for (int i = 0; i < firmware->getCapability(TelemetryCustomScreensBars); i++) {
+      updateBar(i);
+    }
+  }
+
+  lock = false;
+}
+
+void CustomScreen::updateBar(int line)
+{
+  lock = true;
+
+  RawSource source = screen.body.bars[line].source;
+
+  minTime[line]->setVisible(false);
+  maxTime[line]->setVisible(false);
+
+  if (source.type != SOURCE_TYPE_NONE) {
+    RawSourceRange range = source.getRange(model, generalSettings);
+    float minVal = range.getValue(screen.body.bars[line].barMin);
+    float maxVal = screen.body.bars[line].barMax;
+    maxVal = range.getValue(maxVal);
+
+    if (source.isTimeBased()) {
+      minTime[line]->setVisible(true);
+      minTime[line]->setTimeRange(range.min, range.max);
+      minTime[line]->setSingleStep(range.step);
+      minTime[line]->setPageStep(range.step * 60);
+      minTime[line]->setShowSeconds(range.step != 60);
+      minTime[line]->setTime((int)minVal);
+
+      maxTime[line]->setVisible(true);
+      maxTime[line]->setTimeRange(range.min, range.max);
+      maxTime[line]->setSingleStep(range.step);
+      maxTime[line]->setPageStep(range.step * 60);
+      maxTime[line]->setShowSeconds(range.step != 60);
+      maxTime[line]->setTime((int)maxVal);
+
+      minSB[line]->setVisible(false);
+      maxSB[line]->setVisible(false);
+    }
+    else {
+      minSB[line]->setVisible(true);
+      minSB[line]->setEnabled(true);
+      minSB[line]->setDecimals(range.decimals);
+      minSB[line]->setMinimum(range.min);
+      minSB[line]->setMaximum(range.max);
+      minSB[line]->setSingleStep(range.step);
+      minSB[line]->setSuffix(" " + range.unit);
+      minSB[line]->setValue(minVal);
+
+      maxSB[line]->setVisible(true);
+      maxSB[line]->setEnabled(true);
+      maxSB[line]->setDecimals(range.decimals);
+      maxSB[line]->setMinimum(range.min);
+      maxSB[line]->setMaximum(range.max);
+      maxSB[line]->setSingleStep(range.step);
+      maxSB[line]->setSuffix(" " + range.unit);
+      maxSB[line]->setValue(maxVal);
+    }
+  }
+  else {
+    minSB[line]->setDisabled(true);
+    maxSB[line]->setDisabled(true);
+  }
+
+  lock = false;
+}
+
+void CustomScreen::on_screenType_currentIndexChanged(int index)
+{
+  if (!isLocked()) {
+    memset(reinterpret_cast<void *>(&screen.body), 0, sizeof(screen.body));
+    update();
+    emit modified();
+  }
+}
+
+void CustomScreen::scriptNameEdited()
+{
+  if (!isLocked()) {
+    lock = true;
+    Helpers::getFileComboBoxValue(ui->scriptName, screen.body.script.filename, 8);
+    emit modified();
+    lock = false;
+  }
+}
+
+void CustomScreen::customFieldChanged(int value)
+{
+  if (isLocked() || !sender() || !qobject_cast<QComboBox *>(sender()))
+    return;
+
+  bool ok;
+  const int index = sender()->property("index").toInt(&ok),
+      i = index / 256,
+      m = index % 256;
+  const RawSource src(qobject_cast<QComboBox *>(sender())->itemData(value).toInt());
+  if (ok && screen.body.lines[i].source[m].toValue() != src.toValue()) {
+    screen.body.lines[i].source[m] = src;
+    emit modified();
+  }
+}
+
+void CustomScreen::barSourceChanged(int value)
+{
+  if (isLocked() || !sender() || !qobject_cast<QComboBox *>(sender()))
+    return;
+
+  bool ok;
+  const int index = sender()->property("index").toInt(&ok);
+  const RawSource src(qobject_cast<QComboBox *>(sender())->itemData(value).toInt());
+  if (!ok || screen.body.bars[index].source.toValue() == src.toValue())
+    return;
+
+  screen.body.bars[index].source = src;
+  screen.body.bars[index].barMin = 0;
+  screen.body.bars[index].barMax = 0;
+  updateBar(index);
+  emit modified();
+}
+
+void CustomScreen::barMinChanged(double value)
+{
+  if (!isLocked()) {
+    int line = sender()->property("index").toInt();
+    screen.body.bars[line].barMin = round(value / minSB[line]->singleStep());
+    // TODO set min (maxSB)
+    emit modified();
+  }
+}
+
+void CustomScreen::barMaxChanged(double value)
+{
+  if (!isLocked()) {
+    int line = sender()->property("index").toInt();
+    screen.body.bars[line].barMax = round((value) / maxSB[line]->singleStep());
+    // TODO set max (minSB)
+    emit modified();
+  }
+}
+
+void CustomScreen::barTimeChanged()
+{
+  if (!isLocked()) {
+    int line = sender()->property("index").toInt();
+    int & valRef = (sender()->property("type").toString() == "min" ? screen.body.bars[line].barMin : screen.body.bars[line].barMax);
+    TimerEdit * te = qobject_cast<TimerEdit *>(sender());
+    if (!te)
+      return;
+
+    valRef = round(te->timeInSeconds() / te->singleStep());
+
+    emit modified();
+  }
+}
+
+void CustomScreen::connectItemModelEvents(const FilteredItemModel * itemModel)
+{
+  connect(itemModel, &FilteredItemModel::aboutToBeUpdated, this, &CustomScreen::onItemModelAboutToBeUpdated);
+  connect(itemModel, &FilteredItemModel::updateComplete, this, &CustomScreen::onItemModelUpdateComplete);
+}
+
+void CustomScreen::onItemModelAboutToBeUpdated()
+{
+  lock = true;
+  modelsUpdateCnt++;
+}
+
+void CustomScreen::onItemModelUpdateComplete()
+{
+  modelsUpdateCnt--;
+  if (modelsUpdateCnt < 1) {
+    //  leave updating to parent
+    lock = false;
+  }
+}
+
+/******************************************************/
+
+TelemetryCustomScreensPanel::TelemetryCustomScreensPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                               CompoundItemModelFactory * sharedItemModels):
+  ModelPanel(parent, model, generalSettings, firmware),
+  sharedItemModels(sharedItemModels),
+  modelsUpdateCnt(0)
+{
+  panelFilteredItemModels = new FilteredItemModelFactory();
+  int id;
+
+  id = panelFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource)),
+                                                  FIM_RAWSOURCE);
+  connectItemModelEvents(id);
+
+  grid = new QGridLayout(this);
+  tabWidget = new QTabWidget(this);
+
+  for (int i = 0; i < firmware->getCapability(TelemetryCustomScreens); i++) {
+    CustomScreen * tab = new CustomScreen(this, model, model.frsky.screens[i], generalSettings, firmware, lock,
+                                                            panelFilteredItemModels);
+    tab->setProperty("index", i + 1);
+    tabWidget->addTab(tab, getTabName(i + 1));
+    panels << tab;
+    connect(tab, &CustomScreen::modified, this, &TelemetryCustomScreensPanel::onModified);
+  }
+
+  grid->addWidget(tabWidget, 0, 0, 1, 1);
+
+  addHSpring(grid, grid->columnCount(), 0);
+  addVSpring(grid, 0, grid->rowCount());
+  disableMouseScrolling();
+}
+
+TelemetryCustomScreensPanel::~TelemetryCustomScreensPanel()
+{
+  delete panelFilteredItemModels;
+  foreach(GenericPanel * gp, panels) {
+    delete gp;
+  }
+}
+
+QString TelemetryCustomScreensPanel::getTabName(int index)
+{
+  return tr("Telemetry screen %1").arg(index);
+}
+
+void TelemetryCustomScreensPanel::update()
+{
+  lock = true;
+
+  foreach(GenericPanel * pnl, panels) {
+    pnl->update();
+  }
+
+  lock = false;
+}
+
+void TelemetryCustomScreensPanel::onModified()
+{
+  emit modified();
+}
+
+void TelemetryCustomScreensPanel::on_dataModifiedSensor()
+{
+  sharedItemModels->update(AbstractItemModel::IMUE_TeleSensors);
+  emit modified();
+}
+
+void TelemetryCustomScreensPanel::connectItemModelEvents(const int id)
+{
+  FilteredItemModel * itemModel = panelFilteredItemModels->getItemModel(id);
+  connect(itemModel, &FilteredItemModel::aboutToBeUpdated, this, &TelemetryCustomScreensPanel::onItemModelAboutToBeUpdated);
+  connect(itemModel, &FilteredItemModel::updateComplete, this, &TelemetryCustomScreensPanel::onItemModelUpdateComplete);
+}
+
+void TelemetryCustomScreensPanel::onItemModelAboutToBeUpdated()
+{
+  lock = true;
+  modelsUpdateCnt++;
+}
+
+void TelemetryCustomScreensPanel::onItemModelUpdateComplete()
+{
+  modelsUpdateCnt--;
+  if (modelsUpdateCnt < 1) {
+    update();
+    lock = false;
+  }
+}

--- a/companion/src/modeledit/telemetry_customscreens.h
+++ b/companion/src/modeledit/telemetry_customscreens.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "modeledit.h"
+#include "eeprominterface.h"
+#include "filtereditemmodels.h"
+
+class AutoComboBox;
+class TimerEdit;
+
+namespace Ui {
+  class TelemetryCustomScreen;
+}
+
+class CustomScreen: public ModelPanel
+{
+    Q_OBJECT
+
+  public:
+    CustomScreen(QWidget *parent, ModelData & model, FrSkyScreenData & screen, GeneralSettings & generalSettings, Firmware * firmware,
+                          const bool & parentLock, FilteredItemModelFactory * panelFilteredItemModels);
+    ~CustomScreen();
+    void update();
+
+  private slots:
+    void on_screenType_currentIndexChanged(int index);
+    void scriptNameEdited();
+    void customFieldChanged(int index);
+    void barSourceChanged(int index);
+    void barMinChanged(double value);
+    void barMaxChanged(double value);
+    void barTimeChanged();
+    void onItemModelAboutToBeUpdated();
+    void onItemModelUpdateComplete();
+
+  private:
+    void updateBar(int line);
+    Ui::TelemetryCustomScreen * ui;
+    FrSkyScreenData & screen;
+    QComboBox * fieldsCB[4][3];
+    QComboBox * barsCB[4];
+    QDoubleSpinBox * minSB[4];
+    QDoubleSpinBox * maxSB[4];
+    TimerEdit * minTime[4];
+    TimerEdit * maxTime[4];
+    int modelsUpdateCnt;
+    const bool &parentLock;
+
+    inline bool isLocked() { return lock | parentLock; }
+    void connectItemModelEvents(const FilteredItemModel * itemModel);
+};
+
+class TelemetryCustomScreensPanel : public ModelPanel
+{
+    Q_OBJECT
+
+  public:
+    TelemetryCustomScreensPanel(QWidget *parent, ModelData & model, GeneralSettings & generalSettings, Firmware * firmware,
+                   CompoundItemModelFactory * sharedItemModels);
+    virtual ~TelemetryCustomScreensPanel();
+    virtual void update();
+
+  signals:
+    void updated();
+
+  private slots:
+    void onModified();
+    void on_dataModifiedSensor();
+    void onItemModelAboutToBeUpdated();
+    void onItemModelUpdateComplete();
+
+  private:
+    CompoundItemModelFactory *sharedItemModels;
+    FilteredItemModelFactory *panelFilteredItemModels;
+    int modelsUpdateCnt;
+
+    QTabWidget *tabWidget;
+    QGridLayout *grid;
+    QVector<GenericPanel *> panels;
+
+    QString getTabName(int index);
+
+    void setup();
+    void telBarUpdate();
+    void connectItemModelEvents(const int id);
+    inline bool isLocked() { return lock; }
+};


### PR DESCRIPTION
The telemetry screen has 60 sensors and the custom screens are at the foot and thus to access requires scrolling. Moving to own tab makes accessing the settings easier.
Note: this is a back port of the feature contained within the PR https://github.com/EdgeTX/edgetx/pull/555