### PR TITLE
lcd.RGB() does not need to return a nil value when LCD usage is disabled

### DIFF
--- a/radio/src/lua/api_lcd.cpp
+++ b/radio/src/lua/api_lcd.cpp
@@ -903,8 +903,6 @@ Returns a 5/6/5 rgb color code, that can be used with lcd.setColor
 */
 static int luaRGB(lua_State *L)
 {
-  if (!luaLcdAllowed)
-    return 0;
   int r = luaL_checkinteger(L, 1);
   int g = luaL_checkinteger(L, 2);
   int b = luaL_checkinteger(L, 3);


### PR DESCRIPTION
Some people set color constants during script initialization to be used later, and since lcd.RGB() does not draw on the LCD, it does not need to be disabled when LCD usage is disabled.