### PR TITLE
Implement top bar widget layout for Timer2

### DIFF
--- a/radio/sdcard/horus/WIDGETS/Timer2/main.lua
+++ b/radio/sdcard/horus/WIDGETS/Timer2/main.lua
@@ -27,6 +27,11 @@ end
 
 -- Zone size: top bar widgets
 local function refreshZoneTiny(wgt)
+  local t1 = model.getTimer(wgt.options.Timer-1)
+  local timerInfo = string.format("-- T%s --", wgt.options.Timer)
+  lcd.drawText(wgt.zone.x+14, wgt.zone.y, timerInfo, SMLSIZE + CUSTOM_COLOR)
+  lcd.drawTimer(wgt.zone.x+4, wgt.zone.y+12, t1.value, MIDSIZE + CUSTOM_COLOR)
+  return
 end
 
 --- Zone size: 160x32 1/8th


### PR DESCRIPTION
Timer2 never had the display code present for top bar, so would display nothing if used as a top bar widget.

![image](https://user-images.githubusercontent.com/5500713/134648370-80e344ad-ddf3-437f-b08f-fa194c03c12c.png)
