### PR TITLE
Fixes dfu-util Unexpected argument error (replicates EdgeTX PR #844)

### DIFF
--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -50,7 +50,7 @@ QStringList getDfuArgs(const QString & cmd, const QString & filename)
   if (cmd == "-U")
     args.last().append(":" % QString::number(Boards::getFlashSize(getCurrentBoard())));
   args << "--device" << "0483:df11";
-  args << "" << cmd % filename;
+  args << cmd % filename;
   return args;
 }
 


### PR DESCRIPTION
For more details, please see https://github.com/EdgeTX/edgetx/pull/844

**Update:** As I just learned, the fix was similarly already implemented in 2.3 branch (PR #8556), but not yet in 2.4.