### PR TITLE
Issue #7795 fix Widget option type STRING

### DIFF
--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -319,7 +319,12 @@ class LuaWidgetFactory: public WidgetFactory
       lua_newtable(lsWidgets);
       int i = 0;
       for (const ZoneOption * option = options; option->name; option++, i++) {
-        l_pushtableint(option->name, persistentData->options[i].signedValue);
+        if (option->type == ZoneOption::String) {
+          lua_pushtablezstring(lsWidgets, option->name, persistentData->options[i].stringValue);
+        }
+        else {
+          l_pushtableint(option->name, persistentData->options[i].signedValue);
+        }
       }
 
       if (lua_pcall(lsWidgets, 2, 1, 0) != 0) {
@@ -349,7 +354,12 @@ void LuaWidget::update()
   lua_newtable(lsWidgets);
   int i = 0;
   for (const ZoneOption * option = getOptions(); option->name; option++, i++) {
-    l_pushtableint(option->name, persistentData->options[i].signedValue);
+    if (option->type == ZoneOption::String) {
+      lua_pushtablezstring(lsWidgets, option->name, persistentData->options[i].stringValue);
+    }
+    else {
+      l_pushtableint(option->name, persistentData->options[i].signedValue);
+    }
   }
 
   if (lua_pcall(lsWidgets, 2, 0, 0) != 0) {


### PR DESCRIPTION
Widgets options code in  [radio/src/lua/widgets.cpp](https://github.com/opentx/opentx/blob/525741cbd643d82a83fbdcd56de6b7439f373c80/radio/src/lua/widgets.cpp#L314) uses `l_pushtableint(..)` function, but it does not work with string options type.
I added the processing of string values ​​and I used the `lua_pushtablezstring(..)` macro from [radio\src\lua\lua_api.h](https://github.com/opentx/opentx/blob/525741cbd643d82a83fbdcd56de6b7439f373c80/radio/src/lua/lua_api.h#L68).
I tested this change in the simulator and on the hardware.
By the way, instead of the `l_pushtableint(..)` function in [radio/src/lua/widgets.cpp](https://github.com/opentx/opentx/blob/525741cbd643d82a83fbdcd56de6b7439f373c80/radio/src/lua/widgets.cpp#L281), it would be possible to use the `lua_pushtableinteger(..)` macro from [radio/src/lua/lua_api.h](https://github.com/opentx/opentx/blob/525741cbd643d82a83fbdcd56de6b7439f373c80/radio/src/lua/lua_api.h#L64), they repeat each other.