### PR TITLE
LUA function flushAudio() to flush OpenTx audio queue

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1397,6 +1397,19 @@ static int luaDefaultChannel(lua_State * L)
 }
 
 /*luadoc
+@function flushAudio()
+
+flushes audio queue
+
+@status experimental
+*/
+static int luaFlushAudio(lua_State * L)
+{
+  audioQueue.flush();
+  return 0;
+}
+
+/*luadoc
 @function getRSSI()
 
 Get RSSI value as well as low and critical RSSI alarm levels (in dB)
@@ -1762,6 +1775,7 @@ const luaL_Reg opentxLib[] = {
   { "playDuration", luaPlayDuration },
   { "playTone", luaPlayTone },
   { "playHaptic", luaPlayHaptic },
+  { "flushAudio", luaFlushAudio },
   // { "popupInput", luaPopupInput },
   { "popupWarning", luaPopupWarning },
   { "popupConfirmation", luaPopupConfirmation },


### PR DESCRIPTION
Rationale:

Consider a LUA script that babbles event based low priority (informational) messages using playFile() and playNumber() to the user. PlayFile() and playNumber() are getting queued in the audio queue. This is good as no message (within the limits of the queue max length) gets interrupted or lost, so all messages with events close to each other are eventually communicated in sequence. Now if there is a high priority message to be communicated you don’t want to wait for all the low priority message waiting in the queue to be played before the high priority message comes through. 

The solution is to clear the audio queue before issuing the high priority message. This ensures the high priority message will be played right after the currently playing message as the rest of the low priority messages were flushed. 

This PR extends adds the LUA function flushAudio() to flush OpenTx audio queue. Tested on 2.3.14, working as intended.
