### PR TITLE
Display switches in main view according to their phhysical locations

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -520,6 +520,16 @@ void menuMainView(event_t event)
             drawSwitch(x[i], y[i], sw, 0, false);
           }
         }
+#elif defined(RADIO_TLITE)
+        static const uint8_t x[NUM_SWITCHES] = {2 * FW - 2, 16 * FW + 1, 2 * FW - 2, 16 * FW + 1};
+        static const uint8_t y[NUM_SWITCHES] = {4 * FH + 1, 4 * FH + 1, 5 * FH + 1, 5 * FH + 1};
+        for (int i = 0; i < NUM_SWITCHES; ++i) {
+          if (SWITCH_EXISTS(i)) {
+            getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
+            getvalue_t sw = ((val < 0) ? 3 * i + 1 : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
+            drawSwitch(x[i], y[i], sw, 0, false);
+          }
+        }
 #elif defined(PCBTARANIS)
         uint8_t switches = min(NUM_SWITCHES, 6);
         for (int i = 0; i < switches; ++i) {


### PR DESCRIPTION
solves point 1 in #8780 by rearranging Jumper T-Lite switches in main view according to their physical location

![screenshot_tlite_21-11-19_17-59-06](https://user-images.githubusercontent.com/94545140/142669463-8823d588-0028-42f2-81be-9272227eec89.png)

