### PR TITLE
SD Sync set the local folder to match that set in the profile

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -851,6 +851,13 @@ void MainWindow::sdsync()
   static bool showExtraOptions = false;
   QStringList errorMsgs;
 
+  if (syncOpts.sessionId != g.sessionId()) {
+    syncOpts.reset();
+    syncOpts.folderA = QString();
+    syncOpts.folderB = QString();
+    syncOpts.sessionId = g.sessionId();
+  }
+
   if (syncOpts.folderA.isEmpty())
     syncOpts.folderA = g.profile[g.id()].sdPath();
   if (syncOpts.folderB.isEmpty())

--- a/companion/src/process_sync.h
+++ b/companion/src/process_sync.h
@@ -75,6 +75,7 @@ class SyncProcess : public QObject
         int flags;               // SyncOptionFlags
         int dirFilterFlags;      // QDir::Filters
         int logLevel;            // QtMsgType (see ProgressWidget::addMessage())
+        int sessionId;           // Last run radio profile
 
         void reset()
         {
@@ -86,6 +87,7 @@ class SyncProcess : public QObject
           logLevel = QtWarningMsg;
           flags = OPT_RECURSIVE;
           dirFilterFlags = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
+          sessionId = -1;
         }
 
         friend inline QDebug operator<<(QDebug debug, const SyncOptions &o) {


### PR DESCRIPTION
Port of https://github.com/EdgeTX/edgetx/pull/1241

On change of profile :
- default local folder to current profile
- force re-probe for an attached radio
