### PR TITLE
Ghost MSP Support

### DIFF
--- a/radio/src/pulses/ghost.cpp
+++ b/radio/src/pulses/ghost.cpp
@@ -177,17 +177,26 @@ uint8_t createGhostChannelsFrame12BitRaw(uint8_t * frame, int16_t * pulses)
 
 void setupPulsesGhost()
 {
-  auto & module = g_model.moduleData[EXTERNAL_MODULE];
-
   if (telemetryProtocol == PROTOCOL_TELEMETRY_GHOST) {
-    uint8_t * pulses = extmodulePulsesData.ghost.pulses;
+
+    auto &module = g_model.moduleData[EXTERNAL_MODULE];
+    auto *p_data = &extmodulePulsesData.ghost;
+
+    #if defined(LUA)
+    if (outputTelemetryBuffer.destination == TELEMETRY_ENDPOINT_SPORT) {
+      memcpy(p_data->pulses, outputTelemetryBuffer.data, outputTelemetryBuffer.size);
+      p_data->length = outputTelemetryBuffer.size;
+      outputTelemetryBuffer.reset();
+    } else
+    #endif
+
     if (moduleState[EXTERNAL_MODULE].counter == GHST_MENU_CONTROL)
-      extmodulePulsesData.ghost.length = createGhostMenuControlFrame(pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
+      p_data->length = createGhostMenuControlFrame(p_data->pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
     else {
       if (module.ghost.raw12bits)
-        extmodulePulsesData.ghost.length = createGhostChannelsFrame12BitRaw(pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
+        p_data->length = createGhostChannelsFrame12BitRaw(p_data->pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
       else
-        extmodulePulsesData.ghost.length = createGhostChannelsFrame(pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
+        p_data->length = createGhostChannelsFrame(p_data->pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
     }
 
     moduleState[EXTERNAL_MODULE].counter = GHST_FRAME_CHANNEL;

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -87,6 +87,14 @@ const GhostSensor ghostSensors[] = {
   {0x00,                     NULL,                  UNIT_RAW,               0},
 };
 
+uint8_t getGhostModuleAddr() {
+#if SPORT_MAX_BAUDRATE < 400000
+  return g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_400K ? GHST_ADDR_MODULE_SYM : GHST_ADDR_MODULE_ASYM;
+#else
+  return GHST_ADDR_MODULE_SYM;
+#endif
+}
+
 const GhostSensor *getGhostSensor(uint8_t id)
 {
   for (const GhostSensor * sensor = ghostSensors; sensor->id; sensor++) {
@@ -299,6 +307,20 @@ void processGhostTelemetryFrame()
       processGhostTelemetryValue(GHOST_ID_GPS_SATS, telemetryRxBuffer[7]);   
       break; 
     }
+    case GHST_DL_MAGBARO: {
+      // Not implemented yet
+      break;
+    }
+#if defined(LUA)
+    default:
+      if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(telemetryRxBufferCount-2) ) {
+        for (uint8_t i=1; i<telemetryRxBufferCount-1; i++) {
+          // destination address and CRC are skipped
+          luaInputTelemetryFifo->push(telemetryRxBuffer[i]);
+        }
+      }
+      break;
+#endif
   }
 }
 

--- a/radio/src/telemetry/ghost.h
+++ b/radio/src/telemetry/ghost.h
@@ -49,6 +49,8 @@
 #define GHST_DL_MENU_DESC               0x24
 #define GHST_DL_GPS_PRIMARY             0x25
 #define GHST_DL_GPS_SECONDARY           0x26
+#define GHST_DL_MAGBARO                 0x27
+#define GHST_DL_MSP_RESP                0x28
 
 #define GHST_RC_CTR_VAL_12BIT		0x7C0   // 0x3e0 << 1
 #define GHST_RC_CTR_VAL_8BIT		0x7C
@@ -105,6 +107,7 @@ enum GhstVtxBand
 
 void processGhostTelemetryData(uint8_t data);
 void ghostSetDefault(int index, uint8_t id, uint8_t subId);
+uint8_t getGhostModuleAddr();
 
 #if SPORT_MAX_BAUDRATE < 400000
 // For radios which can't support telemetry at high rates, offer baud rate choices


### PR DESCRIPTION
Add support for MSP with Ghost protocol. This is adapted from original here -> https://github.com/EdgeTX/edgetx/pull/1377

`luaGhostTelemetryPush` and `luaGhostTelemetryPop` similar to CRSF version.

Need new Ghost FW v1.0.6.0+

New features:
- Betaflight LUA Scripts will work Ghost MSP support betaflight/betaflight-tx-lua-scripts#419
- We can create LUA script for Ghost setup later

BF: betaflight/betaflight#11242

All of the work comes from @daleckystepan, I just adapt this (with @daleckystepan support) to OpenTX.

This can be seen as an extension to #8793 and should then also merged into 2.3.15.

Big thanks goes to @daleckystepan