### PR TITLE
Companion recover memory on model edit dialog close

### DIFF
--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -48,6 +48,7 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
 
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("edit.png"));
+  setAttribute(Qt::WA_DeleteOnClose);
   restoreGeometry(g.modelEditGeo());
   ui->pushButton->setIcon(CompanionIcon("simulate.png"));
 


### PR DESCRIPTION
Partially fixes #8627
Forces memory recovery on dialog close.