### PR TITLE
Followup #8895 - actually show module info entry

### DIFF
--- a/radio/src/gui/480x272/radio_version.cpp
+++ b/radio/src/gui/480x272/radio_version.cpp
@@ -21,7 +21,7 @@
 #include "opentx.h"
 #include "options.h"
 
-#if defined(PXX2)
+#if defined(PXX2) || defined(MULTIMODULE)
 constexpr coord_t COLUMN2_X = 200;
 
 void drawPXX2Version(coord_t x, coord_t y, PXX2Version version)
@@ -212,7 +212,7 @@ bool menuRadioVersion(event_t event)
     lcdDrawText(lcdNextPos, y, option);
   }
 
-#if defined(PXX2)
+#if defined(PXX2) || defined(MULTIMODULE)
   y += FH + FH / 2;
 
   lcdDrawText(MENUS_MARGIN_LEFT, y, BUTTON(TR_MODULES_RX_VERSION), menuVerticalPosition == 0 ? INVERS : 0);


### PR DESCRIPTION
Enable the `Modules / RX version` entry if MULTIMODULE

I didn't have a OTX build environment set up when doing #8895 so only focused on the actual `menuRadioModulesVersion` code... and neglected to notice it was only active for `PXX2`. Have since tested this on TX16S hardware and the menu entry is now visible, and shows the module information.