### PR TITLE
Support GVars in calculated telemetry sources

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -382,6 +382,7 @@ PACK(struct TelemetrySensor {
     int32_t getPrecMultiplier() const;
     int32_t getPrecDivisor() const;
     bool isSameInstance(TelemetryProtocol protocol, uint8_t instance);
+    bool isOfflineFresh() const;
   );
 });
 

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -259,15 +259,42 @@ void menuModelSensor(event_t event)
       {
         drawStringWithIndex(0, y, STR_SOURCE, k-SENSOR_FIELD_PARAM1+1);
         int8_t * source = &sensor->calc.sources[k-SENSOR_FIELD_PARAM1];
+        int8_t min = -MAX_TELEMETRY_SENSORS;
+        uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
-          *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          if (event == EVT_KEY_LONG(KEY_ENTER)) {
+            *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+            s_editMode = !s_editMode;
+          }
+          if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+            int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
+            CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
+            if (idx < 0) {
+              *source = (int8_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
+            }
+            else {
+              *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
+            }
+          } else {
+            *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          }
         }
-        if (*source < 0) {
-          lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-          drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
-        }
-        else {
-          drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+        if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
+          if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '/', attr);
+            drawGVarName(lcdNextPos, y, -gvindex-1, attr);
+          } else {
+            drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
+          }
+        } else {
+          if (*source < 0) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
+            drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+          }
+          else {
+            drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+          }
         }
         break;
       }

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -262,6 +262,7 @@ void menuModelSensor(event_t event)
         int8_t min = -MAX_TELEMETRY_SENSORS;
         uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
+#if defined(GVARS)
           if (event == EVT_KEY_LONG(KEY_ENTER)) {
             *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
             s_editMode = !s_editMode;
@@ -276,8 +277,10 @@ void menuModelSensor(event_t event)
               *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
             }
           } else {
+#endif
             *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
-          }
+            }
+#if defined(GVARS)
         }
         if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
           int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
@@ -287,7 +290,9 @@ void menuModelSensor(event_t event)
           } else {
             drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
           }
-        } else {
+        } else
+#endif
+        {
           if (*source < 0) {
             lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -273,15 +273,35 @@ void menuModelSensor(event_t event)
       {
         drawStringWithIndex(0, y, STR_SOURCE, k-SENSOR_FIELD_PARAM1+1);
         int8_t * source = &sensor->calc.sources[k-SENSOR_FIELD_PARAM1];
+        int8_t min = -MAX_TELEMETRY_SENSORS;
+        uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
-          *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          if (event == EVT_KEY_LONG(KEY_ENTER)) {
+              *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+          }
+          if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+            int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
+            CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
+            if (idx < 0) {
+              *source = (int8_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
+            }
+            else {
+              *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
+            }
+          } else {
+            *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          }
         }
-        if (*source < 0) {
-          lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-          drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
-        }
-        else {
-          drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+        if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          drawGVarName(SENSOR_2ND_COLUMN, y, GV_INDEX_CALC_DELTA(*source, delta), attr);
+        } else {
+          if (*source < 0) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
+            drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+          }
+          else {
+            drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+          }
         }
         break;
       }

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -276,6 +276,7 @@ void menuModelSensor(event_t event)
         int8_t min = -MAX_TELEMETRY_SENSORS;
         uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
+#if defined(GVARS)
           if (event == EVT_KEY_LONG(KEY_ENTER)) {
               *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
               s_editMode = !s_editMode;
@@ -290,8 +291,10 @@ void menuModelSensor(event_t event)
               *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
             }
           } else {
-            *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
-          }
+#endif
+          *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+        }
+#if defined(GVARS)
         }
         if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
           int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
@@ -301,7 +304,9 @@ void menuModelSensor(event_t event)
           } else {
             drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
           }
-        } else {
+        } else
+#endif
+        {
           if (*source < 0) {
             lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -278,6 +278,7 @@ void menuModelSensor(event_t event)
         if (attr) {
           if (event == EVT_KEY_LONG(KEY_ENTER)) {
               *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+              s_editMode = !s_editMode;
           }
           if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
             int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
@@ -293,7 +294,13 @@ void menuModelSensor(event_t event)
           }
         }
         if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
-          drawGVarName(SENSOR_2ND_COLUMN, y, GV_INDEX_CALC_DELTA(*source, delta), attr);
+          int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
+          if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '/', attr);
+            drawGVarName(lcdNextPos, y, -gvindex-1, attr);
+          } else {
+            drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
+          }
         } else {
           if (*source < 0) {
             lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);

--- a/radio/src/gui/480x272/model_telemetry_sensor.cpp
+++ b/radio/src/gui/480x272/model_telemetry_sensor.cpp
@@ -279,15 +279,42 @@ bool menuModelSensor(event_t event)
       {
         drawStringWithIndex(MENUS_MARGIN_LEFT, y, STR_SOURCE, k-SENSOR_FIELD_PARAM1+1);
         int8_t * source = &sensor->calc.sources[k-SENSOR_FIELD_PARAM1];
+        int8_t min = -MAX_TELEMETRY_SENSORS;
+        uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
-          *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          if (event == EVT_KEY_LONG(KEY_ENTER)) {
+            *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+            s_editMode = !s_editMode;
+          }
+          if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+            int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
+            CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
+            if (idx < 0) {
+              *source = (int8_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
+            }
+            else {
+              *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
+            }
+          } else {
+            *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          }
         }
-        if (*source < 0) {
-          lcdDrawText(SENSOR_2ND_COLUMN, y, "-", attr);
-          drawSource(SENSOR_2ND_COLUMN+5, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
-        }
-        else {
-          drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+        if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
+          if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
+            lcdDrawText(SENSOR_2ND_COLUMN, y, "/", attr);
+            drawStringWithIndex(lcdNextPos, y, STR_GV, -gvindex-1, attr);
+          } else {
+            drawStringWithIndex(SENSOR_2ND_COLUMN, y, STR_GV, gvindex, attr, gvindex<0?"-":"");
+          }
+        } else {
+          if (*source < 0) {
+            lcdDrawText(SENSOR_2ND_COLUMN, y, "-", attr);
+            drawSource(SENSOR_2ND_COLUMN+5, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+          }
+          else {
+            drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+          }
         }
         break;
       }

--- a/radio/src/gui/480x272/model_telemetry_sensor.cpp
+++ b/radio/src/gui/480x272/model_telemetry_sensor.cpp
@@ -282,6 +282,7 @@ bool menuModelSensor(event_t event)
         int8_t min = -MAX_TELEMETRY_SENSORS;
         uint8_t delta = GV_GET_GV1_VALUE(MAX_TELEMETRY_SENSORS);
         if (attr) {
+#if defined(GVARS)
           if (event == EVT_KEY_LONG(KEY_ENTER)) {
             *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
             s_editMode = !s_editMode;
@@ -296,8 +297,10 @@ bool menuModelSensor(event_t event)
               *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
             }
           } else {
+#endif
             *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
           }
+#if defined(GVARS)
         }
         if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
           int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
@@ -307,7 +310,9 @@ bool menuModelSensor(event_t event)
           } else {
             drawStringWithIndex(SENSOR_2ND_COLUMN, y, STR_GV, gvindex, attr, gvindex<0?"-":"");
           }
-        } else {
+        } else
+#endif
+        {
           if (*source < 0) {
             lcdDrawText(SENSOR_2ND_COLUMN, y, "-", attr);
             drawSource(SENSOR_2ND_COLUMN+5, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);

--- a/radio/src/gui/480x272/model_telemetry_sensor.cpp
+++ b/radio/src/gui/480x272/model_telemetry_sensor.cpp
@@ -306,9 +306,9 @@ bool menuModelSensor(event_t event)
           int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
           if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
             lcdDrawText(SENSOR_2ND_COLUMN, y, "/", attr);
-            drawStringWithIndex(lcdNextPos, y, STR_GV, -gvindex-1, attr);
+            drawStringWithIndex(lcdNextPos, y, STR_GV, -gvindex, attr);
           } else {
-            drawStringWithIndex(SENSOR_2ND_COLUMN, y, STR_GV, gvindex, attr, gvindex<0?"-":"");
+            drawStringWithIndex(SENSOR_2ND_COLUMN, y, STR_GV, gvindex<0?-gvindex:gvindex+1, attr, gvindex<0?"-":"");
           }
         } else
 #endif

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -346,8 +346,10 @@ void telemetryInterrupt10ms()
 #if !defined(SIMU)
     telemetryData.rssi.reset();
 #endif
-    for (auto & telemetryItem: telemetryItems) {
-      if (telemetryItem.isAvailable()) {
+    for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {
+      const TelemetrySensor & sensor = g_model.telemetrySensors[i];
+      TelemetryItem & telemetryItem = telemetryItems[i];
+      if (telemetryItem.isAvailable() && !sensor.isOfflineFresh()) {
         telemetryItem.setOld();
       }
     }

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -414,7 +414,12 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
           if (sensor.formula == TELEM_FORMULA_MULTIPLY) {
             if (source>0) {
               //divide, actually
-              value /= convertTelemetryValue(-gvarvalue, sensor.unit, 1, sensor.unit, 0);
+              int32_t divisor = convertTelemetryValue(-gvarvalue, sensor.unit, 1, sensor.unit, 0);
+              if (divisor!=0) {
+                value /= divisor;
+              } else {
+                value = 0;
+              }
             } else {
               value *= convertTelemetryValue(gvarvalue, sensor.unit, 0, sensor.unit, 0);
               mulprec += 1;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -646,6 +646,25 @@ bool TelemetrySensor::isAvailable() const
   return ZLEN(label) > 0;
 }
 
+bool TelemetrySensor::isOfflineFresh() const
+{
+  if(type == TELEM_TYPE_CALCULATED && formula <= TELEM_FORMULA_MULTIPLY) {
+    int32_t maxitems = 4;
+    if(formula == TELEM_FORMULA_MULTIPLY) {
+      maxitems = 2;
+    }
+    for(int i=0; i<maxitems; i++) {
+      int8_t source = calc.sources[i];
+      if(source && !GV_IS_GV_VALUE(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
 PACK(typedef struct {
   uint8_t unitFrom;
   uint8_t unitTo;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -412,8 +412,13 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
           int32_t gvarvalue = GET_GVAR_PREC1(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, mixerCurrentFlightMode);
 
           if (sensor.formula == TELEM_FORMULA_MULTIPLY) {
-            mulprec += 1;
-            value *= convertTelemetryValue(gvarvalue, sensor.unit, 0, sensor.unit, 0);
+            if (source>0) {
+              //divide, actually
+              value /= convertTelemetryValue(-gvarvalue, sensor.unit, 1, sensor.unit, 0);
+            } else {
+              value *= convertTelemetryValue(gvarvalue, sensor.unit, 0, sensor.unit, 0);
+              mulprec += 1;
+            }
           }
           else {
             int32_t sensorValue = convertTelemetryValue(gvarvalue, sensor.unit, 1, sensor.unit, sensor.prec);

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -409,12 +409,12 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
         int8_t source = sensor.calc.sources[i];
 #if defined(GVARS)
         if (GV_IS_GV_VALUE(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
-          int32_t gvarvalue = GET_GVAR_PREC1(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, mixerCurrentFlightMode);
+          int32_t gvarvalue = GET_GVAR(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, mixerCurrentFlightMode);
 
           if (sensor.formula == TELEM_FORMULA_MULTIPLY) {
             if (source>0) {
               //divide, actually
-              int32_t divisor = convertTelemetryValue(-gvarvalue, sensor.unit, 1, sensor.unit, 0);
+              int32_t divisor = convertTelemetryValue(-gvarvalue, sensor.unit, 0, sensor.unit, 0);
               if (divisor!=0) {
                 value /= divisor;
               } else {
@@ -422,7 +422,7 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
               }
             } else {
               value *= convertTelemetryValue(gvarvalue, sensor.unit, 0, sensor.unit, 0);
-              mulprec += 1;
+              mulprec += sensor.prec;
             }
           }
           else {


### PR DESCRIPTION
Allows calculated telemetry sources (specifically `add`, `average`, `min`, `max` and `multiply`) to use GVars as sources.
The multiply source can also divide by GVars, not just multiply.

This is useful for scaling telemetry values in ways that `ratio` does not support due to limited precision.
Additionally, GVars may be dynamically changed, further expanding the scaling capabilities.

Example:
Auto-detecting the number of cells and scaling a voltage sensor (VFAS, blheli32 telemetry) to produce average cell voltage.

See also:
https://github.com/opentx/opentx/issues/8436
https://github.com/opentx/opentx/issues/6293
https://github.com/opentx/opentx/pull/3593
