### PR TITLE
Fix 9XR-Pro RTC (#7421)

### DIFF
--- a/radio/src/targets/sky9x/board.cpp
+++ b/radio/src/targets/sky9x/board.cpp
@@ -390,7 +390,7 @@ void boardInit()
 
   init_SDcard();
 
-#if defined(PCBAR9X)
+#if defined(PCBAR9X) || defined(REVX)
   rtcInit();
 #endif
 }


### PR DESCRIPTION
Enable RTC on 9XR Pro. Fix for issue [#7421](https://github.com/opentx/opentx/issues/7421).