### PR TITLE
Fix carryTrim in LUA

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -98,7 +98,7 @@ PACK(struct ExpoData {
   uint16_t mode:2;
   uint16_t scale:14;
   uint16_t srcRaw:10;
-  int16_t  carryTrim:6;
+  int16_t  trimSource:6;
   uint32_t chn:5;
   int32_t  swtch:9;
   uint32_t flightModes:9;

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -144,11 +144,11 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_TRIM:
         uint8_t notStick = (ed->srcRaw > MIXSRC_Ail);
-        int8_t carryTrim = -ed->carryTrim;
+        int8_t carryTrim = -ed->trimSource;
         lcdDrawTextAlignedLeft(y, STR_TRIM);
         lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (notStick && carryTrim == 0) ? 0 : carryTrim+1, RIGHT | (menuHorizontalPosition==0 ? attr : 0));
         if (attr)
-          ed->carryTrim = -checkIncDecModel(event, carryTrim, notStick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
+          ed->trimSource = -checkIncDecModel(event, carryTrim, notStick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
         break;
     }
     y += FH;

--- a/radio/src/gui/212x64/model_input_edit.cpp
+++ b/radio/src/gui/212x64/model_input_edit.cpp
@@ -136,10 +136,10 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_TRIM:
         uint8_t not_stick = (ed->srcRaw > MIXSRC_Ail);
-        int8_t carryTrim = -ed->carryTrim;
+        int8_t trimSource = -ed->trimSource;
         lcdDrawTextAlignedLeft(y, STR_TRIM);
-        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, menuHorizontalPosition==0 ? attr : 0);
-        if (attr) ed->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
+        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && trimSource == 0) ? 0 : trimSource + 1, menuHorizontalPosition == 0 ? attr : 0);
+        if (attr) ed->trimSource = -checkIncDecModel(event, trimSource, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
         break;
     }
     y += FH;

--- a/radio/src/gui/480x272/model_inputs.cpp
+++ b/radio/src/gui/480x272/model_inputs.cpp
@@ -264,10 +264,10 @@ bool menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_TRIM:
         uint8_t not_stick = (ed->srcRaw > MIXSRC_Ail);
-        int8_t carryTrim = -ed->carryTrim;
+        int8_t trimSource = -ed->trimSource;
         lcdDrawText(MENUS_MARGIN_LEFT, y, STR_TRIM);
-        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, menuHorizontalPosition==0 ? attr : 0);
-        if (attr) ed->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
+        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && trimSource == 0) ? 0 : trimSource + 1, menuHorizontalPosition == 0 ? attr : 0);
+        if (attr) ed->trimSource = -checkIncDecModel(event, trimSource, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
         break;
     }
     y += FH;

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -180,8 +180,8 @@ void displayExpoLine(coord_t y, ExpoData * ed)
 {
   drawSource(EXPO_LINE_SRC_POS, y, ed->srcRaw, 0);
 
-  if (ed->carryTrim != TRIM_ON) {
-    lcdDrawChar(EXPO_LINE_TRIM_POS, y, ed->carryTrim > 0 ? '-' : STR_RETA123[-ed->carryTrim]);
+  if (ed->trimSource != TRIM_ON) {
+    lcdDrawChar(EXPO_LINE_TRIM_POS, y, ed->trimSource > 0 ? '-' : STR_RETA123[-ed->trimSource]);
   }
 
   if (!ed->flightModes || ((ed->curve.value || ed->swtch) && ((get_tmr10ms() / 200) & 1)))

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -531,8 +531,8 @@ Return input data for given input and line number
  * `switch` (number) input switch index
  * `curveType` (number) curve type (function, expo, custom curve)
  * `curveValue` (number) curve index
- * `carryTrim` deprecated, please use trimSource instead
- * 'trimSource' (number) a NEGATIVE number representing trim source
+ * `carryTrim` deprecated, please use trimSource instead. WARNING: carryTrim was getting negative values (carryTrim = - trimSource)
+ * 'trimSource' (number) a positive number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
 @status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, carryTrim replaced by trimSource in 2.3.16
@@ -555,7 +555,7 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
     lua_pushtableinteger(L, "carryTrim", expo->trimSource);
-    lua_pushtableinteger(L, "trimSource", expo->trimSource);
+    lua_pushtableinteger(L, "trimSource", - expo->trimSource);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
   else {
@@ -624,7 +624,7 @@ static int luaModelInsertInput(lua_State *L)
         expo->trimSource = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "trimSource")) {
-        expo->trimSource = luaL_checkinteger(L, -1);
+        expo->trimSource = - luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "flightModes")) {
         expo->flightModes = luaL_checkinteger(L, -1);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -531,10 +531,11 @@ Return input data for given input and line number
  * `switch` (number) input switch index
  * `curveType` (number) curve type (function, expo, custom curve)
  * `curveValue` (number) curve index
- * `carryTrim` (boolean) input trims applied
+ * `carryTrim` deprecated, please use trimSource instead
+ * 'trimSource' (number) a NEGATIVE number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, carryTrim replaced by trimSource in 2.3.16
 */
 static int luaModelGetInput(lua_State *L)
 {
@@ -553,7 +554,8 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "switch", expo->swtch);
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
-    lua_pushtableinteger(L, "carryTrim", expo->carryTrim);
+    lua_pushtableinteger(L, "carryTrim", expo->trimSource);
+    lua_pushtableinteger(L, "trimSource", expo->trimSource);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
   else {
@@ -618,8 +620,11 @@ static int luaModelInsertInput(lua_State *L)
       else if (!strcmp(key, "curveValue")) {
         expo->curve.value = luaL_checkinteger(L, -1);
       }
-      else if (!strcmp(key, "carryTrim")) {
-        expo->carryTrim = lua_toboolean(L, -1);
+      else if (!strcmp(key, "carryTrim")) { // deprecated
+        expo->trimSource = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "trimSource")) {
+        expo->trimSource = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "flightModes")) {
         expo->flightModes = luaL_checkinteger(L, -1);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -531,11 +531,10 @@ Return input data for given input and line number
  * `switch` (number) input switch index
  * `curveType` (number) curve type (function, expo, custom curve)
  * `curveValue` (number) curve index
- * `carryTrim` deprecated, please use trimSource instead. WARNING: carryTrim was getting negative values (carryTrim = - trimSource)
  * 'trimSource' (number) a positive number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, carryTrim replaced by trimSource in 2.3.16
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.3.16
 */
 static int luaModelGetInput(lua_State *L)
 {
@@ -554,7 +553,6 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "switch", expo->swtch);
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
-    lua_pushtableinteger(L, "carryTrim", expo->trimSource);
     lua_pushtableinteger(L, "trimSource", - expo->trimSource);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
@@ -575,7 +573,7 @@ Insert an Input at specified line
 
 @param value (table) input data, see model.getInput()
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, broken carryTrim replaced by trimSource in 2.3.16
 */
 static int luaModelInsertInput(lua_State *L)
 {
@@ -619,9 +617,6 @@ static int luaModelInsertInput(lua_State *L)
       }
       else if (!strcmp(key, "curveValue")) {
         expo->curve.value = luaL_checkinteger(L, -1);
-      }
-      else if (!strcmp(key, "carryTrim")) { // deprecated
-        expo->trimSource = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "trimSource")) {
         expo->trimSource = - luaL_checkinteger(L, -1);

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -191,9 +191,9 @@ void applyExpos(int16_t * anas, uint8_t mode, uint8_t ovwrIdx, int16_t ovwrValue
         if (offset) v += div_and_round(calc100toRESX(offset), 10);
 
         //========== TRIMS ================
-        if (ed->carryTrim < TRIM_ON)
-          virtualInputsTrims[cur_chn] = -ed->carryTrim - 1;
-        else if (ed->carryTrim == TRIM_ON && ed->srcRaw >= MIXSRC_Rud && ed->srcRaw <= MIXSRC_Ail)
+        if (ed->trimSource < TRIM_ON)
+          virtualInputsTrims[cur_chn] = -ed->trimSource - 1;
+        else if (ed->trimSource == TRIM_ON && ed->srcRaw >= MIXSRC_Rud && ed->srcRaw <= MIXSRC_Ail)
           virtualInputsTrims[cur_chn] = ed->srcRaw - MIXSRC_Rud;
         else
           virtualInputsTrims[cur_chn] = -1;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1825,7 +1825,7 @@ void instantTrim()
         if (!EXPO_VALID(expo))
           break; // end of list
         if (stick == expo->srcRaw - MIXSRC_FIRST_STICK) {
-          if (expo->carryTrim < 0) {
+          if (expo->trimSource < 0) {
             // only default trims will be taken into account
             addTrim = false;
             break;

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -390,9 +390,9 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrossTrims)
   g_model.limitData[1].offset = 0;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   anaInValues[THR_STICK] = 0;
   setTrimValue(0, MIXSRC_TrimEle - MIXSRC_FIRST_TRIM, 100);
@@ -417,9 +417,9 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrosstrimsAndTrimIdle)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   anaInValues[THR_STICK] = -1024;  // Min stick
   setTrimValue(0, MIXSRC_TrimEle - MIXSRC_FIRST_TRIM, 100);
@@ -826,9 +826,9 @@ TEST_F(TrimsTest, throttleTrimWithCrossTrims)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   // stick max + trim max
   anaInValues[THR_STICK] = +1024;
@@ -901,9 +901,9 @@ TEST_F(TrimsTest, invertedThrottlePlusThrottleTrimWithCrossTrims)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   // stick max + trim max
   anaInValues[THR_STICK] = +1024;


### PR DESCRIPTION
- rename the  carryTrim in ExpoData to trimSource, and fix it's lua casting
- trimSource is using positive values, where carryTrim was using negative ones
- this fixes #8995 