### PR TITLE
fix(doc): Lua reference guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Useful links:
  * OpenTX Main Site https://www.open-tx.org/
  * OpenTx University http://open-txu.org/
  * OpenTX User Manual https://doc.open-tx.org/opentx-taranis-manual/
- * OpenTX Lua Reference Guide https://app.gitbook.com/o/-MRzpA3L4AvKH4MrPT67/s/jEsPbkQgZYrJgTifhLlf
+ * OpenTX Lua Reference Guide https://doc.open-tx.org/opentx-2-3-lua-reference-guide/


### PR DESCRIPTION
The current link is a private link, not a public-facing link, so shows an error page. 

Resolves #9013